### PR TITLE
feat: Add more entries and highlights in tutorial-gallery

### DIFF
--- a/docs/en/guide/start/tutorial-gallery.mdx
+++ b/docs/en/guide/start/tutorial-gallery.mdx
@@ -178,7 +178,12 @@ Now, let's start by creating the first image card, which will be the main part o
   defaultFile="src/FirstImageCard/index.tsx"
   img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/firstImageCard.jpeg"
   defaultEntryFile="dist/FirstImageCard.lynx.bundle"
-  highlight={{ 'src/FirstImageCard/index.tsx': '{11}' }}
+  entry="src/FirstImageCard"
+  highlight={{
+    'src/FirstImageCard/index.tsx': '{11}',
+    'src/FirstImageCard/ImageCard.tsx': '{8-12}',
+  }}
+  schema="{{{url}}}?bar_color=000000&back_button_style=dark"
 />
 
 Great, you can now see the image card displayed. Here, we use the [`<image>`](api/elements/built-in/image) element to display your image. You only need to give it a width and height (or specify the aspectRatio property as shown here), and it will automatically resize to fit the specified dimensions.
@@ -199,10 +204,13 @@ We can add a small white heart in the upper right corner and make it the like bu
   defaultFile="src/Components/LikeIcon.tsx"
   img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/LikeImageCard.gif"
   defaultEntryFile="dist/LikeImageCard.lynx.bundle"
+  entry="src/Components"
   highlight={{
     'src/LikeImageCard/index.tsx': '{9}',
+    'src/Components/LikeImageCard.tsx': '{3,14}',
     'src/Components/LikeIcon.tsx': '{7-10,13-15}',
   }}
+  schema="{{{url}}}?bar_color=000000&back_button_style=dark"
 />
 
 We want each card to know whether it has been liked, so we added isLiked, which is its internal data. It can use this internal data to save your changes.
@@ -254,9 +262,12 @@ To show all your beautiful images, you may need help from `<list>`. This way, yo
   defaultFile="src/CreateGallery/Gallery.tsx"
   img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/GalleryList.jpeg"
   defaultEntryFile="dist/CreateGallery.lynx.bundle"
+  entry="src/CreateGallery"
   highlight={{
     'src/CreateGallery/index.tsx': '{8}',
+    'src/CreateGallery/Gallery.tsx': '{11,19,24}',
   }}
+  schema="{{{url}}}?bar_color=000000&back_button_style=dark&title=Popular Furniture&title_color=ffffff"
 />
 
 :::details Special child elements of list
@@ -277,10 +288,12 @@ If you want to create a desktop photo wall, you need to add an auto-scroll featu
   example="gallery"
   defaultFile="src/AddAutoScroll/Gallery.tsx"
   img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/autoScroll.gif"
+  entry="src/AddAutoScroll"
   defaultEntryFile="dist/AddAutoScroll.lynx.bundle"
   highlight={{
     'src/AddAutoScroll/Gallery.tsx': '{10,12-22,27}',
   }}
+  schema="{{{url}}}?bar_color=000000&back_button_style=dark&title=Popular Furniture&title_color=ffffff"
 />
 
 We use the `useEffect` hook to call the [`autoScroll`](api/elements/built-in/list.html#autoscroll) method.
@@ -311,10 +324,12 @@ Like most apps, we can add a scrollbar to this page to indicate how many images 
   example="gallery"
   defaultFile="src/AddNiceScrollbar/Gallery.tsx"
   img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/scrollbar.gif"
+  entry="src/AddNiceScrollbar"
   defaultEntryFile="dist/AddNiceScrollbar.lynx.bundle"
   highlight={{
     'src/AddNiceScrollbar/Gallery.tsx': '{14-19,37,45,49}',
   }}
+  schema="{{{url}}}?bar_color=000000&back_button_style=dark&title=Popular Furniture&title_color=ffffff"
 />
 
 Similar to the `bindtap` event used to add the like functionality, we add the bindscroll event to `<list>`, which will be triggered when the `<list>` element scrolls.
@@ -423,10 +438,13 @@ To let you see the comparison more clearly, we keep both scrollbars:
   example="gallery"
   defaultFile="src/ScrollbarCompare/Gallery.tsx"
   img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/scrollbarCompare.gif"
+  entry="src/ScrollbarCompare"
   defaultEntryFile="dist/ScrollbarCompare.lynx.bundle"
   highlight={{
-    'src/ScrollbarCompare/Gallery.tsx': '{5,7,28,29}',
+    'src/ScrollbarCompare/Gallery.tsx': '{2,3,9,14,17-23,47,48}',
+    'src/ScrollbarCompare/NiceScrollbarMTS.tsx': '{5,10-13,19}',
   }}
+  schema="{{{url}}}?bar_color=000000&back_button_style=dark&title=Popular Furniture&title_color=ffffff"
 />
 
 Now you should be able to see that the scrollbar on the left, controlled with main thread scripting, is smoother and more responsive compared to the scrollbar on the right that we implemented earlier. If you encounter issues in other UIs where updates need to happen immediately, try this method.

--- a/docs/zh/guide/start/tutorial-gallery.mdx
+++ b/docs/zh/guide/start/tutorial-gallery.mdx
@@ -174,7 +174,11 @@ Lynx 支持多种样式功能，包括全局样式、CSS 模块、内联样式�
   defaultFile="src/FirstImageCard/index.tsx"
   img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/firstImageCard.jpeg"
   defaultEntryFile="dist/FirstImageCard.lynx.bundle"
-  highlight={{ 'src/FirstImageCard/index.tsx': '{11}' }}
+  entry="src/FirstImageCard"
+  highlight={{
+    'src/FirstImageCard/index.tsx': '{11}',
+    'src/FirstImageCard/ImageCard.tsx': '{8-12}',
+  }}
   schema="{{{url}}}?bar_color=000000&back_button_style=dark"
 />
 
@@ -196,8 +200,10 @@ Lynx 的 `<image>` 元件可以接收一个本地的相对路径作为 `src` 属
   defaultFile="src/Components/LikeIcon.tsx"
   img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/LikeImageCard.gif"
   defaultEntryFile="dist/LikeImageCard.lynx.bundle"
+  entry="src/Components"
   highlight={{
     'src/LikeImageCard/index.tsx': '{9}',
+    'src/Components/LikeImageCard.tsx': '{3,14}',
     'src/Components/LikeIcon.tsx': '{7-10,13-15}',
   }}
   schema="{{{url}}}?bar_color=000000&back_button_style=dark"
@@ -252,8 +258,10 @@ Lynx 的 `<image>` 元件可以接收一个本地的相对路径作为 `src` 属
   defaultFile="src/CreateGallery/Gallery.tsx"
   img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/GalleryList.jpeg"
   defaultEntryFile="dist/CreateGallery.lynx.bundle"
+  entry="src/CreateGallery"
   highlight={{
     'src/CreateGallery/index.tsx': '{8}',
+    'src/CreateGallery/Gallery.tsx': '{11,19,24}',
   }}
   schema="{{{url}}}?bar_color=000000&back_button_style=dark&title=Popular Furniture&title_color=ffffff"
 />
@@ -276,6 +284,7 @@ Lynx 的 `<image>` 元件可以接收一个本地的相对路径作为 `src` 属
   example="gallery"
   defaultFile="src/AddAutoScroll/Gallery.tsx"
   img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/autoScroll.gif"
+  entry="src/AddAutoScroll"
   defaultEntryFile="dist/AddAutoScroll.lynx.bundle"
   highlight={{
     'src/AddAutoScroll/Gallery.tsx': '{10,12-22,27}',
@@ -311,6 +320,7 @@ useEffect(() => {
   example="gallery"
   defaultFile="src/AddNiceScrollbar/Gallery.tsx"
   img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/scrollbar.gif"
+  entry="src/AddNiceScrollbar"
   defaultEntryFile="dist/AddNiceScrollbar.lynx.bundle"
   highlight={{
     'src/AddNiceScrollbar/Gallery.tsx': '{14-19,37,45,49}',
@@ -424,9 +434,11 @@ Lynx 的最大特点是双线程架构，你可以在[这篇文档](guide/script
   example="gallery"
   defaultFile="src/ScrollbarCompare/Gallery.tsx"
   img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/scrollbarCompare.gif"
+  entry="src/ScrollbarCompare"
   defaultEntryFile="dist/ScrollbarCompare.lynx.bundle"
   highlight={{
-    'src/ScrollbarCompare/Gallery.tsx': '{5,7,28,29}',
+    'src/ScrollbarCompare/Gallery.tsx': '{2,3,9,14,17-23,47,48}',
+    'src/ScrollbarCompare/NiceScrollbarMTS.tsx': '{5,10-13,19}',
   }}
   schema="{{{url}}}?bar_color=000000&back_button_style=dark&title=Popular Furniture&title_color=ffffff"
 />


### PR DESCRIPTION
Current tutorial-gallery only displayed a single file which may confuse readers.It make the tutorial hard to follow step by step. So in this PR we add more entries and highlights in Go components to make the changes and steps more clear and easy to understand.