### PR TITLE
Add missing simulator intructions

### DIFF
--- a/docs/en/guide/start/quick-start.mdx
+++ b/docs/en/guide/start/quick-start.mdx
@@ -124,7 +124,7 @@ cd <project-name>
 
 <PackageManagerTabs command="run dev" />
 
-You will see a QR code showing up in the terminal, scan with your Lynx Explorer App.
+You will see a QR code showing up in the terminal, scan with your Lynx Explorer App or if you are using the simulator, just copy the bundle URL and past it on the "Enter Card URL" input in the Lynx Explorer App and hit "Go".
 
 4. Make your first change
 


### PR DESCRIPTION
Hello everyone, I noticed that this small instruction was missing from the documentation, which is needed to run it on the simulator.

I couldn’t add the Chinese section because I don’t speak Chinese.