### PR TITLE
chore: Adds info about Lepus VM deprecation in favor of PrimJS VM

### DIFF
--- a/docs/en/guide/glossary.mdx
+++ b/docs/en/guide/glossary.mdx
@@ -60,6 +60,16 @@ The thread corresponds to the physical thread regarded as the main thread of the
 
 ### Lepus
 
+<!---
+  credit: Panda kindly explained to us the info bellow at: https://github.com/lynx-family/lynx/issues/123#issuecomment-2703249938
+-->
+
+Lepus is the previous generation of the MTS (Main Thread Script) engine, which has limited capabilities and is being phased out. Currently, the MTS uses PrimJS as its core engine.
+
 ### Lepus VM
 
+Previous generation's engine used in MTS (Main Thread Script)
+
 ### PrimJS VM
+
+The current engine used in MTS (Main Thread Script)

--- a/docs/en/guide/glossary.mdx
+++ b/docs/en/guide/glossary.mdx
@@ -61,7 +61,7 @@ The thread corresponds to the physical thread regarded as the main thread of the
 ### Lepus
 
 <!---
-  credit: Panda kindly explained to us the info bellow at: https://github.com/lynx-family/lynx/issues/123#issuecomment-2703249938
+  credit: @pandazyp kindly explained to us the info bellow at: https://github.com/lynx-family/lynx/issues/123#issuecomment-2703249938
 -->
 
 Lepus is the previous generation of the MTS (Main Thread Script) engine, which has limited capabilities and is being phased out. Currently, the MTS uses PrimJS as its core engine.


### PR DESCRIPTION
So from previous discussion, @pandazyp explained the relationship between Lepus and PrimJS so I'm adding this to the docs.

