### PR TITLE
fix: Broken Lifecycle Image URL in Markdown

### DIFF
--- a/docs/en/react/lifecycle.mdx
+++ b/docs/en/react/lifecycle.mdx
@@ -6,7 +6,7 @@ Due to Lynx's dual-thread architecture, ReactLynx's rendering process and compon
 
 ## Rendering Process
 
-![Lifecycle Flowchart](https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-websitehttps://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/lifecycle-init-render-1.png)
+![Lifecycle Flowchart](https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/lifecycle-init-render-1.png)
 
 ### First-Screen Rendering Optimization
 

--- a/docs/zh/react/lifecycle.mdx
+++ b/docs/zh/react/lifecycle.mdx
@@ -6,7 +6,7 @@ Lynx 采用双线程架构设计，这使得 ReactLynx 的渲染流程和组件�
 
 ## 渲染流程
 
-![生命周期流程图](https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-websitehttps://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/lifecycle-init-render-1.png)
+![生命周期流程图](https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/lifecycle-init-render-1.png)
 
 ### 首屏渲染优化
 


### PR DESCRIPTION
The image url was pasted twice, resulting in a broken image on the page:

https://lynxjs.org/react/lifecycle.html

![image](https://github.com/user-attachments/assets/ab469948-9967-41c9-9937-bb387bb680e8)

Correct url is just https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/lifecycle-init-render-1.png
