### PR TITLE
Updated QRCodeSVG size from default 128 to 220 for easy scan for qrcode scanner

### DIFF
--- a/docs/en/guide/start/quick-start.mdx
+++ b/docs/en/guide/start/quick-start.mdx
@@ -99,6 +99,7 @@ Scan the QR code to download the pre-built app from the [GitHub Release](https:/
 
 <QRCodeSVG
   style={{ border: '2px solid #fff' }}
+  size={220}
   value="https://github.com/lynx-family/lynx/releases/latest/download/LynxExplorer-noasan-release.apk"
 />
 

--- a/docs/zh/guide/start/quick-start.mdx
+++ b/docs/zh/guide/start/quick-start.mdx
@@ -98,6 +98,7 @@ tar -zxf LynxExplorer-x86_64.app.tar.gz -C LynxExplorer-x86_64.app/
 
 <QRCodeSVG
   style={{ border: '2px solid #fff' }}
+  size={220}
   value="https://github.com/lynx-family/lynx/releases/latest/download/LynxExplorer-noasan-release.apk"
 />
 


### PR DESCRIPTION
Updated QRCodeSVG size from default 128 to 220 for easy scan for QRCode scanners on android devices.

link: https://lynxjs.org/guide/start/quick-start.html#ios-simulator-platform=macos-arm64,explorer-platform=android

Change-Id: I0e1f3e6aedabf90fd1b5c753264c7e647e03f733