### PR TITLE
fix(config): lynx-wg -> lynx-family in DOC_GIT_BASE_URL

### DIFF
--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -47,7 +47,7 @@ export default defineConfig({
         'process.env': {
           OSS: '3.2',
           DOC_GIT_BASE_URL: JSON.stringify(
-            'https://github.com/lynx-wg/lynx-website/tree/main',
+            'https://github.com/lynx-family/lynx-website/tree/main',
           ),
         },
       },


### PR DESCRIPTION
Currently when you press the "View source" button it leads to the wrong page as it seems to go to an old reference. See:

![image](https://github.com/user-attachments/assets/cca211fb-6769-431e-b7e0-e87e8f93ef8e)

Previously it would go to: https://github.com/lynx-wg/lynx-website/tree/main/packages/lynx-compat-data/css/properties/image-rendering.json (does not exist)
Should go now to: https://github.com/lynx-family/lynx-website/blob/main/packages/lynx-compat-data/css/properties/image-rendering.json



Change-Id: Ib300ca30c7b287acd5f466ad811e934c7a48b127