### PR TITLE
[BugFix] [ui] Hero Text is overflowing out of screen for some phone and tablet devices

### DIFF
--- a/theme/index.scss
+++ b/theme/index.scss
@@ -199,6 +199,11 @@ $overview-index-color-dark: #f9f9f9;
     & > span {
       white-space: nowrap;
       overflow: hidden;
+      display: flex;
+      flex-wrap: wrap;
+      width: 90vw;
+      column-gap: 20px;
+      justify-content: center;
     }
     @media (max-width: 768px) {
       margin-top: 54px;


### PR DESCRIPTION
Change-Id: I8eedc80abaf362d1b107acfa11ab6da6a47db36e

# the Hero text <[Unlock/Toward/Ship/Render] Native for More> was overflowing out screen in some mobile & tablet devices.
- The issue was observed on the iPad mini and Redmi 12 5G. These were the only devices available for testing, so it may be occurring on other small mobile or tablet devices as well.
- PFA: Screenshots of iPad mini  


| Before             | After              |
|--------------------|--------------------|
| ![Before](https://github.com/user-attachments/assets/f70d33c4-5410-450d-956f-7c47d934cdde) | ![After](https://github.com/user-attachments/assets/729901d1-4411-4fd2-b5b1-03ebefdad17b) |


