### PR TITLE
docs(performance): unify metric terminology and documentation standards

### DIFF
--- a/docs/en/api/elements/built-in/view.mdx
+++ b/docs/en/api/elements/built-in/view.mdx
@@ -429,13 +429,9 @@ Specify whether to force trigger the [`touchend`](#touchend) event when the targ
 __lynx_timing_flag?: string;
 ```
 
-Mark and monitor the [Lynx Pipeline](guide/spec#lynx-pipeline) containing this node. When the [`__lynx_timing_flag`](guide/performance/timing-flag) changes in the Lynx Pipeline, and the Lynx Pipeline triggers the final rendering, a [`PipelineEntry`](api/lynx-api/performance-api/performance-entry/pipeline-entry) performance event will be generated, and the corresponding observer can be created through [`lynx.performance.createObserver()`](api/lynx-api/lynx/lynx-performance#createobserver).
-
-`__lynx_timing_flag` can be set to any string:
-
-- When set to `undefined` or an empty string, it has no effect.
-- When set to `__lynx_timing_actual_fmp`, it can be used to count the `ActualFmp` metric, and will generate [`MetricActualFmpEntry`](api/lynx-api/performance-api/performance-entry/metric-actual-fmp-entry) performance metric events and [`PipelineEntry`](api/lynx-api/performance-api/performance-entry/pipeline-entry) rendering pipeline performance events.
-- When set to other strings, monitor and generate [`PipelineEntry`](api/lynx-api/performance-api/performance-entry/pipeline-entry) performance events.
+Add this flag to the current element to monitor the performance of the [lynx pipeline](guide/spec#lynx-pipeline) it participates in.
+When flagged, the lynx engine generates a [`PipelineEntry`](api/lynx-api/performance-api/performance-entry/pipeline-entry) event once the element completes its final painting phase.
+This event can be observed and analyzed by registering a [`PerformanceObserver()`](api/lynx-api/performance-api/performance-observer).For more detailed usage, see the [Marking Lynx Pipeline](guide/performance/timing-flag).
 
 ## Events
 

--- a/docs/en/api/lynx-api/performance-api/framework-pipeline-timing.mdx
+++ b/docs/en/api/lynx-api/performance-api/framework-pipeline-timing.mdx
@@ -12,7 +12,7 @@ This interface describes the performance data of key stages in [framework render
 dsl: string;
 ```
 
-A string describing the DSL type, with a default value of `reactlynx3`.
+A string describing the DSL type, with a default value of `reactlynx`.
 
 ### stage
 

--- a/docs/en/api/lynx-api/performance-api/performance-entry/metric-actual-fmp-entry.mdx
+++ b/docs/en/api/lynx-api/performance-api/performance-entry/metric-actual-fmp-entry.mdx
@@ -1,10 +1,10 @@
 # MetricActualFmpEntry
 
-Actual FMP is a key performance metric that measures the time required for the rendering of the "real data" of a page to complete. It reflects how quickly users see the actual data on the page. `MetricActualFmpEntry` is the data type used to describe this metric, inheriting from [`PerformanceEntry`](../performance-entry).
+Actual FMP is a key performance metric that measures the time taken for the rendering of the "real data" of a page to complete. It reflects how quickly users see the actual data on the page. `MetricActualFmpEntry` interface provides timing information about this metric, inheriting from [`PerformanceEntry`](../performance-entry).
 
-You can generate this metric by marking the rendering completion timing of important components with [`__lynx_timing_flag="__lynx_timing_actual_fmp"`](guide/performance/timing-flag).
+You can generate this metric by marking the [lynx pipeline](guide/spec#lynx-pipeline) that contains important elements with [`__lynx_timing_flag="__lynx_timing_actual_fmp"`](guide/performance/timing-flag).
 
-In actual business rendering, the timing for Actual FMP is as follows:
+In the "real data" rendering, the timing for Actual FMP is as follows:
 
 <img src="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/doc/performance-metrics-actual-fmp.png" />
 
@@ -60,7 +60,7 @@ Calculation formula: `actualFmp = PipelineEntry.paintEnd - InitContainerEntry.pr
 lynxActualFmp: PerformanceMetric;
 ```
 
-The time taken from executing the [TemplateBundle](api/lynx-native-api/template-bundle) to the completion of rendering for components and tags marked with `__lynx_timing_flag="__lynx_timing_actual_fmp"`, with a data type of [`PerformanceMetric`](api/lynx-api/performance-api/performance-metric).
+The time taken from loading the [TemplateBundle](api/lynx-native-api/template-bundle) to the completion of rendering for components and tags marked with `__lynx_timing_flag="__lynx_timing_actual_fmp"`, with a data type of [`PerformanceMetric`](api/lynx-api/performance-api/performance-metric).
 
 Calculation formula: `lynxActualFmp = PipelineEntry.paintEnd - LoadBundleEntry.loadBundleStart`.
 

--- a/docs/en/api/lynx-api/performance-api/performance-entry/metric-fcp-entry.mdx
+++ b/docs/en/api/lynx-api/performance-api/performance-entry/metric-fcp-entry.mdx
@@ -1,8 +1,8 @@
 # MetricFcpEntry
 
-FCP is a key performance metric that measures the time required for the first rendering of a page to complete. It refers to the time taken for users to see any content (such as text or images) on a Lynx page for the first time. `MetricFcpEntry` is the data type used to describe this metric, inheriting from [`PerformanceEntry`](../performance-entry).
+FCP is a key performance metric that measures the time taken for the [first-screen rendering](guide/spec#first-screen-rendering-or-fsr) of lynx app to complete. It refers to the time taken for users to see any content (such as text or images) on a lynx app for the first time. `MetricFcpEntry` interface provides timing information about this metric, inheriting from [`PerformanceEntry`](../performance-entry).
 
-The FCP event is triggered when Lynx completes the rendering of the first frame of the page. For pages that rely on network requests or asynchronous I/O to fetch data, the typical state monitored at FCP is the loading page or a placeholder, as shown in the diagram below:
+The FCP event is triggered when Lynx completes the rendering of the first frame of the lynx app. For lynx apps that rely on network requests or asynchronous I/O to fetch data, the typical state monitored at FCP is the loading page or a placeholder, as shown in the diagram below:
 
 <img src="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/doc/performance-metrics-fcp.png" />
 
@@ -59,7 +59,7 @@ Calculation formula: `fcp = LoadBundleEntry.paintEnd - InitContainerEntry.prepar
 lynxFcp: PerformanceMetric;
 ```
 
-The time taken from executing the [TemplateBundle](api/lynx-native-api/template-bundle) to the completion of the first rendering, with a data type of [`PerformanceMetric`](api/lynx-api/performance-api/performance-metric).
+The time taken from loading the [TemplateBundle](api/lynx-native-api/template-bundle) to the completion of the first rendering, with a data type of [`PerformanceMetric`](api/lynx-api/performance-api/performance-metric).
 
 Calculation formula: `lynxFcp = LoadBundleEntry.paintEnd - LoadBundleEntry.loadBundleStart`.
 

--- a/docs/en/api/lynx-api/performance-api/performance-entry/metric-tti-entry.mdx
+++ b/docs/en/api/lynx-api/performance-api/performance-entry/metric-tti-entry.mdx
@@ -2,9 +2,9 @@ import { RuntimeBadge } from '@lynx';
 
 # MetricTtiEntry
 
-TTI is a performance metric that measures the time it takes for a page to become interactive. `MetricTtiEntry` is the data type that describes this metric, inheriting from [`PerformanceEntry`](../performance-entry).
+TTI is a performance metric that measures the time it takes for a page to become interactive. `MetricTtiEntry` interface provides timing information about this metric, inheriting from [`PerformanceEntry`](../performance-entry).
 
-In Lynx, the [Main Thread Script (MTS)](guide/spec#main-thread-script-or-mts) is responsible for rendering the UI and accepting user interactions, while the [Background Thread Script (BTS)](guide/spec#background-thread-script-or-bts) handles interaction events and business logic. Therefore, in Lynx, MTS must complete the first render and BTS must complete loading before user interactions can be responded to.
+the [Main Thread Script (MTS)](guide/spec#main-thread-script-or-mts) is responsible for rendering the UI and accepting user interactions, while the [Background Thread Script (BTS)](guide/spec#background-thread-script-or-bts) handles interaction events and business logic. Therefore, MTS must complete the [first-screen render](guide/spec#first-screen-rendering-or-fsr) and BTS must complete loading before user interactions can be responded to.
 
 Depending on different starting points, Lynx provides three metrics: `tti`, `lynxTti`, and `totalTti`. Each metric is defined in the rendering process as shown in the diagram below:
 
@@ -59,7 +59,7 @@ Calculation formula: `tti = max(LoadBundleEntry.paintEnd, LoadBundleEntry.loadBa
 lynxTti: PerformanceMetric;
 ```
 
-The time taken from executing the [TemplateBundle](api/lynx-native-api/template-bundle) to the page becoming interactive, with a data type of [`PerformanceMetric`](api/lynx-api/performance-api/performance-metric).
+The time taken from loading the [TemplateBundle](api/lynx-native-api/template-bundle) to the page becoming interactive, with a data type of [`PerformanceMetric`](api/lynx-api/performance-api/performance-metric).
 
 Calculation formula: `lynxTti = max(LoadBundleEntry.paintEnd, LoadBundleEntry.loadBackgroundEnd) - LoadBundleEntry.loadBundleStart`.
 

--- a/docs/en/api/lynx-api/performance-api/performance-entry/pipeline-entry.mdx
+++ b/docs/en/api/lynx-api/performance-api/performance-entry/pipeline-entry.mdx
@@ -2,14 +2,14 @@ import { RuntimeBadge } from '@lynx';
 
 # PipelineEntry
 
-`PipelineEntry` is responsible for recording performance data at key moments during the [Lynx Pipeline](guide/spec#lynx-pipeline), specifically for Framework Rendering (FrameworkPipeline) and Engine Rendering (PixelPipeline). It inherits from [`PerformanceEntry`](../performance-entry).
+`PipelineEntry` is responsible for recording performance data at key moments during the [Lynx Pipeline](guide/spec#lynx-pipeline), specifically for [Framework Rendering](guide/spec#framework-rendering) and [Pixel Pipeline](guide/spec#pixel-pipeline). It inherits from [`PerformanceEntry`](../performance-entry).
 
 The Lynx Pipeline refers to the complete process from the trigger of rendering to the final display. This process is divided into four main parts: Load, Parse, Framework Rendering (FrameworkPipeline), and Engine Rendering (PixelPipeline).
 
 Due to the frequent triggering of the Lynx Pipeline, the framework only records the following two cases:
 
-1. **Lynx Pipelines marked with [`__lynx_timing_flag`](guide/performance/timing-flag)**, which generate performance data as `PipelineEntry`.
-2. **Lynx Pipelines triggered by loading and executing a [TemplateBundle](api/lynx-native-api/template-bundle)**, which generate performance data as [`LoadBundleEntry`](api/lynx-api/performance-api/performance-entry/load-bundle-entry).
+1. **Lynx Pipeline marked with [`__lynx_timing_flag`](guide/performance/timing-flag)**, which generate performance data as `PipelineEntry`.
+2. **Lynx Pipeline triggered by loading and executing a [TemplateBundle](api/lynx-native-api/template-bundle)**, which generate performance data as [`LoadBundleEntry`](api/lynx-api/performance-api/performance-entry/load-bundle-entry).
 
 The following is the flowchart for `PipelineEntry`:
 

--- a/docs/en/guide/performance/timing-flag.mdx
+++ b/docs/en/guide/performance/timing-flag.mdx
@@ -14,32 +14,16 @@ When a marked Lynx Pipeline execution is completed and the screen display is ref
 1. **Marking the Node**: Set the `__lynx_timing_flag` attribute on the target component. When the node finishes rendering, the framework will automatically collect performance data for its Lynx Pipeline.
 2. **Getting Data**: Register an observer using [`lynx.performance.createObserver()`](api/lynx-api/lynx/lynx-performance#createobserver) to obtain relevant performance data (`PipelineEntry`).
 
-```ts
-{
-  this.state.actualData && (
-    <view __lynx_timing_flag="__lynx_timing_actual_fmp">
-      {/* Child component content */}
-    </view>
-  );
-}
+import { Go } from '@lynx';
 
-// 1. Create observer object
-let observer = lynx.performance.createObserver((entry: PerformanceEntry) => {
-  if (entry.entryType == 'pipeline' && entry.name != 'loadBundle') {
-    // 3. Received "pipeline" metric
-    let pipelineEntry = entry as PipelineEntry;
-    // pipelineEntry.identifier is the same as __lynx_timing_flag
-    console.log('pipelineEntry identifier : ', pipelineEntry.identifier);
-    // Get the difference between pipelineEnd and pipelineStart timestamps to calculate component display time
-    console.log(
-      'pipelineEntry duration : ',
-      pipelineEntry.pipelineEnd - pipelineEntry.pipelineStart,
-    );
-  }
-});
-// 2. Register to listen for "pipeline" metrics
-observer.observe(['pipeline']);
-```
+<Go
+  example="performance-api"
+  defaultFile="src/pipeline_entry/index.tsx"
+  defaultEntryFile="dist/pipeline_entry.lynx.bundle"
+  img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/doc/pipeline-entry-demo.jpeg"
+  entry="src/pipeline_entry"
+  highlight="{11-21,31}"
+/>
 
 ## Compatibility
 

--- a/docs/zh/api/elements/built-in/view.mdx
+++ b/docs/zh/api/elements/built-in/view.mdx
@@ -429,7 +429,7 @@ ios-enable-simultaneous-touch?: boolean
 __lynx_timing_flag?: string;
 ```
 
-标记并监控包含该节点的 [Lynx Pipeline](guide/spec#lynx-pipeline)。当 Lynx Pipeline 中出现 [`__lynx_timing_flag`](guide/performance/timing-flag) 变化, 并且该 Lynx Pipeline 触发最终渲染时，将产生 [`PipelineEntry`](api/lynx-api/performance-api/performance-entry/pipeline-entry) 性能事件，可通过 [`lynx.performance.createObserver()`](api/lynx-api/lynx/lynx-performance#createobserver) 创建相应观察者。
+标记并监控渲染该元件的 [Lynx Pipeline](guide/spec#lynx-pipeline)。当 Lynx Pipeline 中出现 [`__lynx_timing_flag`](guide/performance/timing-flag) 变化，并且该 Lynx Pipeline 触发最终渲染时，将产生 [`PipelineEntry`](api/lynx-api/performance-api/performance-entry/pipeline-entry) 性能事件，可通过 [`PerformanceObserver()`](api/lynx-api/performance-api/performance-observer) 接收相关性能事件。
 
 `__lynx_timing_flag` 可以设置为任意字符串：
 

--- a/docs/zh/api/lynx-api/performance-api/framework-pipeline-timing.mdx
+++ b/docs/zh/api/lynx-api/performance-api/framework-pipeline-timing.mdx
@@ -12,7 +12,7 @@ import { RuntimeBadge } from '@lynx';
 dsl: string;
 ```
 
-描述 DSL 类型的字符串，默认取值为：`reactlynx3`。
+描述 DSL 类型的字符串，默认取值为：`reactlynx`。
 
 ### stage
 

--- a/docs/zh/api/lynx-api/performance-api/performance-entry/metric-actual-fmp-entry.mdx
+++ b/docs/zh/api/lynx-api/performance-api/performance-entry/metric-actual-fmp-entry.mdx
@@ -4,13 +4,13 @@ import { RuntimeBadge } from '@lynx';
 
 Actual Fmp 是衡量页面“真实数据”渲染完成所需时间的关键性能指标。它反映了用户看到页面真实数据的速度。`MetricActualFmpEntry` 是用于描述该指标的数据类型，继承自 [`PerformanceEntry`](../performance-entry)。
 
-你可以通过 [`__lynx_timing_flag="__lynx_timing_actual_fmp"`](guide/performance/timing-flag) 标记重要组件的渲染完成时机，从而产生该指标。
+你可以通过 [`__lynx_timing_flag="__lynx_timing_actual_fmp"`](guide/performance/timing-flag) 标记重要元件的渲染完成时机，从而产生该指标。
 
 在实际业务渲染中，ActualFmp 的时机如下：
 
 <img src="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/doc/performance-metrics-actual-fmp.png" />
 
-根据不同起始点，Lynx 提供了 `actualFmp`、`lynxActualFmp`、`totalActualFmp` 三个指标，在渲染流程中，每个指标的定义如下图：：
+根据不同起始点，Lynx 提供了 `actualFmp`、`lynxActualFmp`、`totalActualFmp` 三个指标。在渲染流程中，每个指标的定义如下图：：
 
 <img src="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/doc/metric-actual-fmp-entry.png" />
 
@@ -63,7 +63,7 @@ actualFmp: PerformanceMetric;
 lynxActualFmp: PerformanceMetric;
 ```
 
-从执行 [TemplateBundle](api/lynx-native-api/template-bundle) 至带有 `__lynx_timing_flag="__lynx_timing_actual_fmp"` 元件与标签渲染完成的耗时，数据类型为 [`PerformanceMetric`](api/lynx-api/performance-api/performance-metric)。
+从加载 [TemplateBundle](api/lynx-native-api/template-bundle) 至带有 `__lynx_timing_flag="__lynx_timing_actual_fmp"` 元件与标签渲染完成的耗时，数据类型为 [`PerformanceMetric`](api/lynx-api/performance-api/performance-metric)。
 
 计算公式为：`lynxActualFmp = PipelineEntry.paintEnd - LoadBundleEntry.loadBundleStart`。
 

--- a/docs/zh/api/lynx-api/performance-api/performance-entry/metric-fcp-entry.mdx
+++ b/docs/zh/api/lynx-api/performance-api/performance-entry/metric-fcp-entry.mdx
@@ -8,7 +8,7 @@ FCP 事件在 Lynx 绘制完页面第一帧时触发。对于依赖网络请求�
 
 <img src="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/doc/performance-metrics-fcp.png" />
 
-根据不同起始点，Lynx 提供了 `fcp`、`lynxFcp`、`totalFcp` 三个指标，在渲染流程中，每个指标的定义如下图：
+根据不同起始点，Lynx 提供了 `fcp`、`lynxFcp`、`totalFcp` 三个指标。在渲染流程中，每个指标的定义如下图：
 
 <img src="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/doc/metric-fcp-entry.png" />
 
@@ -60,7 +60,7 @@ fcp: PerformanceMetric;
 lynxFcp: PerformanceMetric;
 ```
 
-从执行 [TemplateBundle](api/lynx-native-api/template-bundle) 至首次渲染完成的耗时，数据类型为 [`PerformanceMetric`](api/lynx-api/performance-api/performance-metric)。
+从加载 [TemplateBundle](api/lynx-native-api/template-bundle) 至首次渲染完成的耗时，数据类型为 [`PerformanceMetric`](api/lynx-api/performance-api/performance-metric)。
 
 计算公式为：`lynxFcp = LoadBundleEntry.paintEnd - LoadBundleEntry.loadBundleStart`。
 

--- a/docs/zh/api/lynx-api/performance-api/performance-entry/metric-tti-entry.mdx
+++ b/docs/zh/api/lynx-api/performance-api/performance-entry/metric-tti-entry.mdx
@@ -7,7 +7,7 @@ TTI 是衡量页面达到可交互状态所需时间的性能指标，`MetricTti
 在 Lynx 中，[Main Thread Script（MTS）](guide/spec#main-thread-script-or-mts)负责渲染 UI 和接受用户交互，[Background Thread Script（BTS）](guide/spec#background-thread-script-or-bts)负责处理交互事件和业务逻辑。
 因此，Lynx 中需要执行 MTS 完成首次绘制并且 BTS 完成加载，才可以响应用户交互。
 
-根据不同起始点，Lynx 提供了 `tti`、`lynxTti`、`totalTti` 三个指标，在渲染流程中，每个指标的定义如下图：
+根据不同起始点，Lynx 提供了 `tti`、`lynxTti`、`totalTti` 三个指标。在渲染流程中，每个指标的定义如下图：
 
 <img src="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/doc/metric-tti-entry.png" />
 
@@ -60,7 +60,7 @@ tti: PerformanceMetric;
 lynxTti: PerformanceMetric;
 ```
 
-从执行 [TemplateBundle](api/lynx-native-api/template-bundle) 至页面可交互的耗时，数据类型为 [`PerformanceMetric`](api/lynx-api/performance-api/performance-metric)。
+从加载 [TemplateBundle](api/lynx-native-api/template-bundle) 至页面可交互的耗时，数据类型为 [`PerformanceMetric`](api/lynx-api/performance-api/performance-metric)。
 
 计算公式为：`lynxTti = max(LoadBundleEntry.paintEnd, LoadBundleEntry.loadBackgroundEnd) - LoadBundleEntry.loadBundleStart`。
 

--- a/docs/zh/api/lynx-api/performance-api/performance-entry/pipeline-entry.mdx
+++ b/docs/zh/api/lynx-api/performance-api/performance-entry/pipeline-entry.mdx
@@ -2,7 +2,7 @@ import { RuntimeBadge } from '@lynx';
 
 # PipelineEntry
 
-`PipelineEntry` 负责记录 [Lynx Pipeline](guide/spec#lynx-pipeline) 中框架渲染（FrameworkPipeline）和引擎渲染（PixelPipeline）关键时刻的性能数据，继承自 [`PerformanceEntry`](../performance-entry)。
+`PipelineEntry` 负责记录 [Lynx Pipeline](guide/spec#lynx-pipeline) 中[框架渲染（Framework Rendering）](guide/spec#framework-rendering)和[引擎渲染（Pixel Pipeline）](guide/spec#pixel-pipeline)关键时刻的性能数据，继承自 [`PerformanceEntry`](../performance-entry)。
 
 Lynx Pipeline 是指从渲染触发到最终显示的完整流程。该流程分为四个主要部分：加载（Load）、解析（Parse）、框架渲染（FrameworkPipeline）、引擎渲染（PixelPipeline）。
 


### PR DESCRIPTION
- Standardize "loading TemplateBundle" terminology across docs
- Update DSL default value from reactlynx3 to reactlynx
- Refine metric generation conditions for ActualFmp/FCP/TTI
- Clarify `__lynx_timing_flag` monitoring scope