### PR TITLE
fix wrong code in integrating-lynx-with-web

### DIFF
--- a/docs/en/guide/start/fragments/web/integrating-lynx-with-web.mdx
+++ b/docs/en/guide/start/fragments/web/integrating-lynx-with-web.mdx
@@ -90,7 +90,7 @@ const App = () => {
   return (
     <lynx-view
       style={{ height: '100vh', width: '100vw' }}
-      url="/main.lynx.bundle"
+      url="/main.web.bundle"
     ></lynx-view>
   );
 };

--- a/docs/zh/guide/start/fragments/web/integrating-lynx-with-web.mdx
+++ b/docs/zh/guide/start/fragments/web/integrating-lynx-with-web.mdx
@@ -90,7 +90,7 @@ const App = () => {
   return (
     <lynx-view
       style={{ height: '100vh', width: '100vw' }}
-      url="/main.lynx.bundle"
+      url="/main.web.bundle"
     ></lynx-view>
   );
 };


### PR DESCRIPTION
According to the above steps, the URL here should be written as url="/main.web.bundle" instead of url="/main.lynx.bundle". If url="/main.lynx.bundle" is used, the page will not display correctly.