### PR TITLE
docs: Change file extension from .css to .scss for consistency with t…

### DIFF
--- a/docs/en/guide/start/tutorial-gallery.mdx
+++ b/docs/en/guide/start/tutorial-gallery.mdx
@@ -160,7 +160,7 @@ Since the focus of this tutorial is not on how to style your UI, you may just sa
 and import it as a global styles:
 
 ```js
-import './index.css';
+import './index.scss';
 ```
 
 This make sure your UI look great when you are following this tutorial.

--- a/docs/zh/guide/start/tutorial-gallery.mdx
+++ b/docs/zh/guide/start/tutorial-gallery.mdx
@@ -156,7 +156,7 @@ import { Go, CodeFold } from '@lynx';
 并将其作为全局样式导入：
 
 ```js
-import './index.css';
+import './index.scss';
 ```
 
 这确保了在你按照本教程操作时，你的 UI 看起来很棒。


### PR DESCRIPTION
This PR changes the file extension from `.css` to `.scss`. The rest of the tutorial consistently uses the `.scss` extension.. 