### PR TITLE
Use the default bundle name for web

### DIFF
--- a/docs/en/guide/start/fragments/web/integrating-lynx-with-web.mdx
+++ b/docs/en/guide/start/fragments/web/integrating-lynx-with-web.mdx
@@ -90,7 +90,7 @@ const App = () => {
   return (
     <lynx-view
       style={{ height: '100vh', width: '100vw' }}
-      url="/main.lynx.bundle"
+      url="/main.web.bundle"
     ></lynx-view>
   );
 };


### PR DESCRIPTION
Initially I tried to run the bundle as is presented in the docs `main.lynx.bundle`, it's much clearer to use `main.web.bundle` so there are no confusion to which bundle to use.

close: #55