### PR TITLE
fix: guide-ui list preview img url

### DIFF
--- a/docs/en/guide/ui/scrolling.mdx
+++ b/docs/en/guide/ui/scrolling.mdx
@@ -110,7 +110,7 @@ For some basic `<view>` element, the scrolling effect is not supported. Please u
 `<scroll-view>` is used to display a small amount of data in a simple and intuitive way. On the other hand, `<list>` is suitable for scenarios where a large amount of data needs to be presented, or in scenarios with infinite scrolling for loading more content. It can adopt an on-demand loading way, rendering only the content in the visible area.
 
 <Go
-  img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/doc/list_oss_base.gif"
+  img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/doc/list-oss-base.gif"
   example="list"
   defaultFile="src/base/index.tsx"
   defaultEntryFile="dist/base.lynx.bundle"


### PR DESCRIPTION
fix list example preview img url

![image](https://github.com/user-attachments/assets/59916383-bebf-4acd-bf39-1f3c8a70c96b)

fix: #60 