### PR TITLE
[Optimize] Clarify the timing and content of sending metric entry

### DIFF
--- a/docs/en/api/lynx-api/performance-api/performance-entry/metric-actual-fmp-entry.mdx
+++ b/docs/en/api/lynx-api/performance-api/performance-entry/metric-actual-fmp-entry.mdx
@@ -16,6 +16,8 @@ Depending on different starting points, Lynx provides three metrics: `actualFmp`
 
 This example demonstrates how to generate and obtain a `MetricActualFmpEntry`.
 
+Lynx calculates the Actual Fmp when the marked elements have finished rendering. If you have provided container-related timestamps using [LynxView.setExtraTiming](api/lynx-native-api/lynx-view/set-extra-timing), the `MetricActualFmpEntry` includes three metrics: `actualFmp`, `lynxActualFmp`, and `totalActualFmp`. Otherwise, the `MetricActualFmpEntry` only contains `lynxActualFmp`. After supplementing the container timestamp, the remaining metrics will be recalculated. Once recalculation is complete, Lynx will send a new `lynxActualFmp` containing all the metrics.
+
 import { Go } from '@lynx';
 
 <Go
@@ -47,7 +49,7 @@ The specific name of the performance event; the value for all instances of this 
 ### actualFmp
 
 ```ts
-actualFmp: PerformanceMetric;
+actualFmp?: PerformanceMetric;
 ```
 
 The time taken from preparing the [TemplateBundle](api/lynx-native-api/template-bundle) to the completion of rendering for components and tags marked with `__lynx_timing_flag="__lynx_timing_actual_fmp"`, with a data type of [`PerformanceMetric`](api/lynx-api/performance-api/performance-metric).
@@ -67,7 +69,7 @@ Calculation formula: `lynxActualFmp = PipelineEntry.paintEnd - LoadBundleEntry.l
 ### totalActualFmp
 
 ```ts
-totalActualFmp: PerformanceMetric;
+totalActualFmp?: PerformanceMetric;
 ```
 
 The time taken from the user opening the page to the completion of rendering for components and tags marked with `__lynx_timing_flag="__lynx_timing_actual_fmp"`, with a data type of [`PerformanceMetric`](api/lynx-api/performance-api/performance-metric).

--- a/docs/en/api/lynx-api/performance-api/performance-entry/metric-fcp-entry.mdx
+++ b/docs/en/api/lynx-api/performance-api/performance-entry/metric-fcp-entry.mdx
@@ -14,6 +14,8 @@ Depending on different starting points, Lynx provides three metrics: `fcp`, `lyn
 
 This example demonstrates how to obtain a `MetricFcpEntry`.
 
+Lynx calculates the FCP upon completion of the first frame rendering. If you have provided container-related timestamps using [LynxView.setExtraTiming](api/lynx-native-api/lynx-view/set-extra-timing), the `MetricFcpEntry` includes `fcp`, `lynxFcp`, and `totalFcp`. Otherwise, the `MetricFcpEntry` only contains `lynxFcp`. After supplementing the container timestamp, the remaining metrics will be recalculated. Once recalculation is complete, Lynx will send a new `MetricFcpEntry` containing all the metrics.
+
 import { Go } from '@lynx';
 
 <Go
@@ -46,7 +48,7 @@ The specific name of the performance event; the value for all instances of this 
 ### fcp
 
 ```ts
-fcp: PerformanceMetric;
+fcp?: PerformanceMetric;
 ```
 
 The time taken from preparing the [TemplateBundle](api/lynx-native-api/template-bundle) to the completion of the first rendering, with a data type of [`PerformanceMetric`](api/lynx-api/performance-api/performance-metric).
@@ -66,7 +68,7 @@ Calculation formula: `lynxFcp = LoadBundleEntry.paintEnd - LoadBundleEntry.loadB
 ### totalFcp
 
 ```ts
-totalFcp: PerformanceMetric;
+totalFcp?: PerformanceMetric;
 ```
 
 The time taken from the user opening the page to the completion of the first rendering, with a data type of [`PerformanceMetric`](api/lynx-api/performance-api/performance-metric).

--- a/docs/zh/api/lynx-api/performance-api/performance-entry/metric-actual-fmp-entry.mdx
+++ b/docs/zh/api/lynx-api/performance-api/performance-entry/metric-actual-fmp-entry.mdx
@@ -18,6 +18,8 @@ Actual Fmp 是衡量页面“真实数据”渲染完成所需时间的关键性
 
 该示例展示了如何产生和获取 `MetricActualFmpEntry`。
 
+Lynx 在被标记的元件渲染完成时计算 Actual Fmp。如果已经通过 [LynxView.setExtraTiming](api/lynx-native-api/lynx-view/set-extra-timing) 提供了容器（Container）时间戳，那么收到的 `MetricActualFmpEntry` 里会包含 `actualFmp`、`lynxActualFmp` 和 `totalActualFmp` 三项指标。否则，`MetricFcpEntry` 只包含 `lynxActualFmp`。补充容器时间戳后，其余指标将被重新计算。重新计算完成后，Lynx 将发送一个新的包含所有指标的 `MetricActualFmpEntry`。
+
 import { Go } from '@lynx';
 
 <Go
@@ -50,7 +52,7 @@ name: string;
 ### actualFmp
 
 ```ts
-actualFmp: PerformanceMetric;
+actualFmp?: PerformanceMetric;
 ```
 
 从准备 [TemplateBundle](api/lynx-native-api/template-bundle) 至带有 `__lynx_timing_flag="__lynx_timing_actual_fmp"` 元件与标签渲染完成的耗时，数据类型为 [`PerformanceMetric`](api/lynx-api/performance-api/performance-metric)。
@@ -70,7 +72,7 @@ lynxActualFmp: PerformanceMetric;
 ### totalActualFmp
 
 ```ts
-totalActualFmp: PerformanceMetric;
+totalActualFmp?: PerformanceMetric;
 ```
 
 从用户打开页面至带有 `__lynx_timing_flag="__lynx_timing_actual_fmp"` 元件与标签渲染完成的耗时，数据类型为 [`PerformanceMetric`](api/lynx-api/performance-api/performance-metric)。

--- a/docs/zh/api/lynx-api/performance-api/performance-entry/metric-fcp-entry.mdx
+++ b/docs/zh/api/lynx-api/performance-api/performance-entry/metric-fcp-entry.mdx
@@ -16,6 +16,8 @@ FCP 事件在 Lynx 绘制完页面第一帧时触发。对于依赖网络请求�
 
 该示例展示了如何获取 `MetricFcpEntry`。
 
+Lynx 在首帧渲染完成时计算 FCP。如果已经通过 [LynxView.setExtraTiming](api/lynx-native-api/lynx-view/set-extra-timing) 提供了容器（Container）时间戳，那么收到的 `MetricFcpEntry` 里会包含 `fcp`、`lynxFcp` 和 `totalFcp` 三项指标。否则，`MetricFcpEntry` 只包含 `lynxFcp`。补充容器时间戳后，其余指标将被重新计算。重新计算完成后，Lynx 将发送一个新的包含所有指标的 `MetricFcpEntry`。
+
 import { Go } from '@lynx';
 
 <Go
@@ -47,7 +49,7 @@ name: string;
 ### fcp
 
 ```ts
-fcp: PerformanceMetric;
+fcp?: PerformanceMetric;
 ```
 
 从准备 [TemplateBundle](api/lynx-native-api/template-bundle) 至首次渲染完成的耗时，数据类型为 [`PerformanceMetric`](api/lynx-api/performance-api/performance-metric)。
@@ -67,7 +69,7 @@ lynxFcp: PerformanceMetric;
 ### totalFcp
 
 ```ts
-totalFcp: PerformanceMetric;
+totalFcp?: PerformanceMetric;
 ```
 
 从用户打开页面至首次渲染完成的耗时，数据类型为 [`PerformanceMetric`](api/lynx-api/performance-api/performance-metric)。


### PR DESCRIPTION
In this CR, we have clarified the timing and content of sending metric performance entry. Due to the instability in recording container-related timestamps, we cannot guarantee that all metrics will be provided each time. Therefore, we may send metric performance entry multiple times.

Change-Id: I3076a476aaf683d9fec99767b787208ca223cefd