### PR TITLE
opt: Optimize setExtraTiming API Doc. Correct the format of 'Container'.

### DIFF
--- a/docs/en/api/lynx-api/performance-api/performance-entry.mdx
+++ b/docs/en/api/lynx-api/performance-api/performance-entry.mdx
@@ -2,7 +2,7 @@ import { RuntimeBadge } from '@lynx';
 
 # PerformanceEntry
 
-`PerformanceEntry` is a base interface used to describe the complete data of performance events. All performance events inherit from and extend it, commonly including container initialization, page loading, and rendering times.
+`PerformanceEntry` is a base interface used to describe the complete data of performance events. All performance events inherit from and extend it, commonly including [container](guide/spec#container) initialization, page loading, and rendering times.
 
 All performance events are summarized in the figure below:
 

--- a/docs/en/api/lynx-native-api/lynx-view/set-extra-timing.mdx
+++ b/docs/en/api/lynx-native-api/lynx-view/set-extra-timing.mdx
@@ -3,12 +3,16 @@
 This interface is used to supplement key performance data before loading the Lynx page, specifically including the following items from [`InitContainerEntry`](api/lynx-api/performance-api/performance-entry/init-container-entry):
 
 - Page open time (`openTime`)
-- Timestamp for the start of preparing the TemplateBundle (`prepareTemplateStart`)
+- Timestamp for the start of preparing the [TemplateBundle](api/lynx-native-api/template-bundle) (`prepareTemplateStart`)
 - Timestamp for the end of preparing the TemplateBundle (`prepareTemplateEnd`)
-- Timestamp for the start of **container** initialization (`containerInitStart`)
-- Timestamp for the end of **container** initialization (`containerInitEnd`)
+- Timestamp for the start of [container](guide/spec#container) initialization (`containerInitStart`)
+- Timestamp for the end of container initialization (`containerInitEnd`)
 
-> In an [App](guide/spec#app), a container is an independent module responsible for managing the lifecycle of [LynxView](guide/spec#lynxview). Its main responsibilities include creating, initializing, configuring, loading content, handling state changes, and destroying LynxView instances.
+Upon successfully updating all timestamps using this interface, the `InitContainerEntry` performance event will be triggered. Depending on the timing of the configuration, it may also trigger the calculation of `fcp`, `totalFcp`, `actualFmp`, and `totalActualFmp` metrics, along with dispatching new performance events for [`MetricFcpEntry`](api/lynx-api/performance-api/performance-entry/metric-fcp-entry) and [`MetricActualFmpEntry`](api/lynx-api/performance-api/performance-entry/metric-actual-fmp-entry).
+
+:::caution
+Timestamps within extraTiming cannot be overwritten, meaning that multiple calls to this interface attempting to repeatedly update a timestamp will yield no effect.
+:::
 
 ## Syntax
 

--- a/docs/zh/api/lynx-api/performance-api/performance-entry.mdx
+++ b/docs/zh/api/lynx-api/performance-api/performance-entry.mdx
@@ -2,7 +2,7 @@ import { RuntimeBadge } from '@lynx';
 
 # PerformanceEntry
 
-`PerformanceEntry` 是一个基类接口，用于描述性能事件的完整数据。所有性能事件都继承并扩展它，常见的包括容器初始化、页面加载和渲染时间等。
+`PerformanceEntry` 是一个基类接口，用于描述性能事件的完整数据。所有性能事件都继承并扩展它，常见的包括[容器](guide/spec#container)初始化、页面加载和渲染时间等。
 
 所有性能事件汇总如下图所示：
 

--- a/docs/zh/api/lynx-native-api/lynx-view/set-extra-timing.mdx
+++ b/docs/zh/api/lynx-native-api/lynx-view/set-extra-timing.mdx
@@ -3,12 +3,16 @@
 该接口用于补充加载 Lynx 页面前的关键性能数据，具体包括 [`InitContainerEntry`](api/lynx-api/performance-api/performance-entry/init-container-entry) 中的以下内容：
 
 - 页面打开时间 (`openTime`)
-- 准备 TemplateBundle 的起始时间戳 (`prepareTemplateStart`)
+- 准备 [TemplateBundle](api/lynx-native-api/template-bundle) 的起始时间戳 (`prepareTemplateStart`)
 - 准备 TemplateBundle 的结束时间戳 (`prepareTemplateEnd`)
-- **容器**初始化的起始时间戳 (`containerInitStart`)
-- **容器**初始化的结束时间戳 (`containerInitEnd`)
+- [容器](guide/spec#container)(Container)初始化的起始时间戳 (`containerInitStart`)
+- 容器初始化的结束时间戳 (`containerInitEnd`)
 
-> 在[应用程序](guide/spec#app)中，容器是一个独立的模块，它负责管理 [LynxView](guide/spec#lynxview) 的生命周期。其主要职责包括创建、初始化、配置、加载内容、处理状态变化及销毁 LynxView 实例等。
+使用该接口成功更新所有时间戳后，将触发 `InitContainerEntry` 性能事件的发送。根据配置时机的不同，还可能触发 `fcp`, `totalFcp`, `actualFmp` 和 `totalActualFmp` 指标的计算，并发送新的性能事件 [`MetricFcpEntry`](api/lynx-api/performance-api/performance-entry/metric-fcp-entry) 和 [`MetricActualFmpEntry`](api/lynx-api/performance-api/performance-entry/metric-actual-fmp-entry)。
+
+:::caution
+extraTiming 为不可覆盖项，即多次调用该接口重复更新某个时间戳不会产生效果。
+:::
 
 ## 语法
 


### PR DESCRIPTION
Added definition of special behavior for repeated calls to setExtraTiming.

Added description of possible consequences of calling setExtraTiming.

Standardized references to the term `Container` in all documents.

Change-Id: Icfaf2a844b1b3f921491cb8e1fb1d932da57c5d8