### PR TITLE
fix/docs-css-nesting-typo

### DIFF
--- a/docs/en/guide/ui/styling.mdx
+++ b/docs/en/guide/ui/styling.mdx
@@ -39,7 +39,7 @@ And you can also set the element's properties via `style` attribute directly. In
 ### Nesting
 
 With nesting syntax, you can declare classes in an easier way.
-You can get this in [Sass](rspeedy/styling.html#%E4%BD%BF%E7%94%A8-sass), which already supported in ReactLynx, or other [post css plugins](rspeedy/styling.html#using-postcss), such as [postcss-nesting](https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-nesting).
+You can get this in [Sass](rspeedy/styling.html#%E4%BD%BF%E7%94%A8-sass), which is already supported in ReactLynx, or other [post css plugins](rspeedy/styling.html#using-postcss), such as [postcss-nesting](https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-nesting).
 
 ```scss
 .a {


### PR DESCRIPTION
Case: Fix typo found in docs

fix: [#108](https://github.com/lynx-family/lynx-website/issues/108)