### PR TITLE
State Variable Fix (shouldShow to shouldDisplay)

### DIFF
--- a/docs/en/react/code-splitting.md
+++ b/docs/en/react/code-splitting.md
@@ -77,7 +77,7 @@ export function App() {
   return (
     <view>
       <view bindtap={handleClick}>Load Component</view>
-      {shouldShow && (
+      {shouldDisplay && (
         <Suspense fallback={<text>Loading...</text>}>
           <LazyComponent />
         </Suspense>


### PR DESCRIPTION
There was a typo in the conditional rendering of the lazyload component. We don't have a component called `shouldShow`. It's supposed to be `shouldDisplay`