### PR TITLE
状态变量修复（shouldShow 改为 shouldDisplay)

### DIFF
--- a/docs/zh/react/code-splitting.md
+++ b/docs/zh/react/code-splitting.md
@@ -73,7 +73,7 @@ export function App() {
   return (
     <view>
       <view bindtap={handleClick}>Load Component</view>
-      {shouldShow && (
+      {shouldDisplay && (
         <Suspense fallback={<text>Loading...</text>}>
           <LazyComponent />
         </Suspense>


### PR DESCRIPTION
lazyload 组件的条件渲染中有一个拼写错误。我们没有名为 shouldShow 的组件。应该是 shouldDisplay