### PR TITLE
fix(rspress): mdx fragments should be added to route.exclude

### DIFF
--- a/docs/en/guide/custom-native-modules/_meta.json
+++ b/docs/en/guide/custom-native-modules/_meta.json
@@ -1,13 +1,1 @@
-[
-  "use-native-modules",
-  {
-    "type": "file",
-    "name": "native-module-ios",
-    "label": "NativeModules iOS"
-  },
-  {
-    "type": "file",
-    "name": "native-module-android",
-    "label": "NativeModules Android"
-  }
-]
+[]

--- a/docs/zh/guide/custom-native-modules/_meta.json
+++ b/docs/zh/guide/custom-native-modules/_meta.json
@@ -1,1 +1,1 @@
-["use-native-modules"]
+[]

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
       'lynx-compat-data/**/*',
       '**/guide/start/fragments/**',
       '**/guide/custom-native-component/*',
+      '**/guide/custom-native-modules/*',
       '**/guide/embed-lynx-to-native/*',
     ],
   },


### PR DESCRIPTION
The document fragment should all be added to `route.exclude`

custom-native-modules uses `_meta.json`, so I misunderstood.

related https://github.com/lynx-family/lynx-website/pull/152

## Correct usage of mdx fragments

1. add imports for themselves

<img width="500" alt="image" src="https://github.com/user-attachments/assets/592f09e2-8d0e-4ff5-899d-b7d3f42623be" />

2. add to `route.exclude`

<img width="500" alt="image" src="https://github.com/user-attachments/assets/ce72086a-7afa-4bfb-88ec-e3daf3ed5c00" />




