### PR TITLE
Add missing wrapper to `Basic rendering` example in reactlynx-testing-library.mdx

### DIFF
--- a/docs/en/react/reactlynx-testing-library.mdx
+++ b/docs/en/react/reactlynx-testing-library.mdx
@@ -75,10 +75,15 @@ import { expect, it } from 'vitest';
 import { render } from '@lynx-js/react/testing-library';
 
 it('basic render', () => {
+  const WrapperComponent = ({ children }) => (
+    <view data-testid='wrapper'>{children}</view>
+  );
   const Comp = () => {
     return <view data-testid="inner" style="background-color: yellow;" />;
   };
-  const { container, getByTestId } = render(<Comp />);
+  const { container, getByTestId } = render(<Comp />, {
+    wrapper: WrapperComponent,
+  });
   expect(getByTestId('wrapper')).toBeInTheDocument();
   expect(container.firstChild).toMatchInlineSnapshot(`
     <view

--- a/docs/zh/react/reactlynx-testing-library.mdx
+++ b/docs/zh/react/reactlynx-testing-library.mdx
@@ -75,10 +75,15 @@ import { expect, it } from 'vitest';
 import { render } from '@lynx-js/react/testing-library';
 
 it('basic render', () => {
+  const WrapperComponent = ({ children }) => (
+    <view data-testid='wrapper'>{children}</view>
+  );
   const Comp = () => {
     return <view data-testid="inner" style="background-color: yellow;" />;
   };
-  const { container, getByTestId } = render(<Comp />);
+  const { container, getByTestId } = render(<Comp />, {
+    wrapper: WrapperComponent,
+  });
   expect(getByTestId('wrapper')).toBeInTheDocument();
   expect(container.firstChild).toMatchInlineSnapshot(`
     <view


### PR DESCRIPTION
Aligning testing docs with https://github.com/lynx-family/lynx-stack/blob/main/packages/react/testing-library/README.md