### PR TITLE
Update native modules documentation type mapping for Array

### DIFF
--- a/docs/en/guide/use-native-modules.mdx
+++ b/docs/en/guide/use-native-modules.mdx
@@ -105,5 +105,5 @@ Congratulations! You have successfully created a native module in Lynx Explorer!
 | `BigInt`        | `NSString`                                        | `long` (or `Number` when used inside objects)     |
 | `ArrayBuffer`   | `NSData`                                          | `byte[]`                                          |
 | `object`        | `NSDictionary`                                    | `com.lynx.react.bridge.ReadableMap`               |
-| `array`         | `NSArray`                                         | `com.lynx.react.bridge.ReadableArray`             |
+| `array`         | `NSArray`                                         | `com.lynx.react.bridge.WritableArray`             |
 | Callback `()=>` | block `void (^)(id)`                              | `com.lynx.react.bridge.Callback`                  |


### PR DESCRIPTION
When specifying ReadableArray as the return type of a function, it throws unknown return type exception, while WritableArray works fine.

Updating this doc will make people that wants to implement a native module not have the same pain i have had :)