### PR TITLE
docs: extending `IntrinsicElements`

### DIFF
--- a/docs/en/rspeedy/typescript.md
+++ b/docs/en/rspeedy/typescript.md
@@ -60,6 +60,7 @@ Lynx provides default types, but you may need to extend or customize certain typ
 
 - [`GlobalProps`](#globalprops): extends the type definition for `lynx.__globalProps`
 - [`InitData`](#initdata): extends the return type of [`useInitData()`](/api/react/Function.useInitData.mdx)
+- [`IntrinsicElements`](#intrinsicelements): extends the type definition for elements (e.g: you may have your own `<input>` element)
 
 ### GlobalProps
 
@@ -94,6 +95,26 @@ export {}; // This export makes the file a module
 ```
 
 With this extension, TypeScript will provide type checking for `useInitData().foo` and `useInitData().bar` in your components.
+
+### IntrinsicElements
+
+You can extends the `interface IntrinsicElements` from `@lynx-js/types` to add your custom [native element](/guide/custom-native-component.mdx)
+
+Here is an example for a `<input>` element with required `type` and optional `bindinput` and `value`.
+
+```ts title="src/intrinsic-element.d.ts"
+import * as Lynx from '@lynx-js/types';
+
+declare module '@lynx-js/types' {
+  interface IntrinsicElements extends Lynx.IntrinsicElements {
+    input: {
+      bindinput?: (e: { type: 'input'; detail: { value: string } }) => void;
+      type: string;
+      value?: string | undefined;
+    };
+  }
+}
+```
 
 ## TypeScript Transpilation
 

--- a/docs/zh/rspeedy/typescript.md
+++ b/docs/zh/rspeedy/typescript.md
@@ -95,6 +95,26 @@ export {}; // 这个导出使文件成为一个模块
 
 通过这个扩展，TypeScript 将为组件中的 `useInitData().foo` 和 `useInitData().bar` 提供类型检查。
 
+### IntrinsicElements
+
+你可以扩展 `@lynx-js/types` 中的 `interface IntrinsicElements` 来添加你的[自定义元件](/guide/custom-native-component.mdx)类型定义。
+
+以下是一个 `<input>` 元件的示例，它具有必需的 `type` 属性和可选的 `bindinput` 和 `value` 属性。
+
+```ts title="src/intrinsic-element.d.ts"
+import * as Lynx from '@lynx-js/types';
+
+declare module '@lynx-js/types' {
+  interface IntrinsicElements extends Lynx.IntrinsicElements {
+    input: {
+      bindinput?: (e: { type: 'input'; detail: { value: string } }) => void;
+      type: string;
+      value?: string | undefined;
+    };
+  }
+}
+```
+
 ## TypeScript 编译
 
 Rsbuild 使用 SWC 来编译 TypeScript 代码。


### PR DESCRIPTION
Follow-up on #191: Add a guide and example for extending `IntrinsicElements` (a.k.a. custom elements).

> [!NOTE]
> I didn’t include a link referencing this section because `/guide/custom-native-component.mdx` is excessively long :(

see: #183