### PR TITLE
fix: correct spelling mistake in Quick Start Guide

### DIFF
--- a/docs/en/guide/start/quick-start.mdx
+++ b/docs/en/guide/start/quick-start.mdx
@@ -124,7 +124,7 @@ cd <project-name>
 
 <PackageManagerTabs command="run dev" />
 
-You will see a QR code showing up in the terminal, scan with your Lynx Explorer App or if you are using the simulator, just copy the bundle URL and past it on the "Enter Card URL" input in the Lynx Explorer App and hit "Go".
+You will see a QR code showing up in the terminal, scan with your Lynx Explorer App or if you are using the simulator, just copy the bundle URL and paste it on the "Enter Card URL" input in the Lynx Explorer App and hit "Go".
 
 4. Make your first change
 


### PR DESCRIPTION
**Good first**
Corrected spelling mistake

Page: Quick start guide
URL: https://lynxjs.org/guide/start/quick-start.html

CHANGE:

- Previous line: "just copy the bundle URL and past it on the.." 
- Changed to: "just copy the bundle URL and paste it on the.." Word changed: "past" -> "paste"