### PR TITLE
update demo project links to point to release/3.2

### DIFF
--- a/docs/en/guide/start/fragments/android/integrating-lynx-with-existing-app-android.mdx
+++ b/docs/en/guide/start/fragments/android/integrating-lynx-with-existing-app-android.mdx
@@ -6,7 +6,7 @@ import { Tab, Tabs } from 'rspress/theme';
 
 <Info title="Lynx for Android">
   - This article assumes that you are familiar with the basic concepts of native Android application development.
-  - You can refer to the project: [integrating-lynx-demo-projects](https://github.com/lynx-family/integrating-lynx-demo-projects/tree/release/3.1) for all the code mentioned below.
+  - You can refer to the project: [integrating-lynx-demo-projects](https://github.com/lynx-family/integrating-lynx-demo-projects/tree/release/3.2) for all the code mentioned below.
 </Info>
 
 ## 1. Dependency configuration

--- a/docs/en/guide/start/fragments/ios/integrating-lynx-with-existing-app-ios.mdx
+++ b/docs/en/guide/start/fragments/ios/integrating-lynx-with-existing-app-ios.mdx
@@ -6,7 +6,7 @@ import { Tab, Tabs } from 'rspress/theme';
 
 <Info title="Lynx for iOS">
   - This article assumes that you are familiar with the basic concepts of native iOS application development.
-  - You can refer to the project: [integrating-lynx-demo-projects](https://github.com/lynx-family/integrating-lynx-demo-projects/tree/release/3.1) for all the code mentioned below.
+  - You can refer to the project: [integrating-lynx-demo-projects](https://github.com/lynx-family/integrating-lynx-demo-projects/tree/release/3.2) for all the code mentioned below.
 </Info>
 
 ## 1. Dependency configuration

--- a/docs/en/guide/start/integrate-lynx-devtool.mdx
+++ b/docs/en/guide/start/integrate-lynx-devtool.mdx
@@ -10,7 +10,7 @@ However, you need to follow these steps to integrate DevTool first.
 :::info
 
 It is recommended to integrate DevTool in non-production environments to keep your production builds lightweight.
-All code examples in this documentation can be found in the [integrating-lynx-demo-projects](https://github.com/lynx-family/integrating-lynx-demo-projects/tree/release/3.1).
+All code examples in this documentation can be found in the [integrating-lynx-demo-projects](https://github.com/lynx-family/integrating-lynx-demo-projects/tree/release/3.2).
 
 :::
 

--- a/docs/zh/guide/start/fragments/android/integrating-lynx-with-existing-app-android.mdx
+++ b/docs/zh/guide/start/fragments/android/integrating-lynx-with-existing-app-android.mdx
@@ -6,7 +6,7 @@ import { Tab, Tabs } from 'rspress/theme';
 
 <Info title="Lynx for Android">
   - 本文假设你已熟悉原生 Android 应用开发的基本概念。
-  - 下文中的所有代码，你都可以参考项目: [integrating-lynx-demo-projects](https://github.com/lynx-family/integrating-lynx-demo-projects/tree/release/3.1)
+  - 下文中的所有代码，你都可以参考项目: [integrating-lynx-demo-projects](https://github.com/lynx-family/integrating-lynx-demo-projects/tree/release/3.2)
 </Info>
 
 ## 1. 依赖配置

--- a/docs/zh/guide/start/fragments/ios/integrating-lynx-with-existing-app-ios.mdx
+++ b/docs/zh/guide/start/fragments/ios/integrating-lynx-with-existing-app-ios.mdx
@@ -6,7 +6,7 @@ import { Tab, Tabs } from 'rspress/theme';
 
 <Info title="Lynx for iOS">
   - 本文假设你已熟悉原生 iOS 应用开发的基本概念。
-  - 下文中的所有代码，你都可以参考项目: [integrating-lynx-demo-projects](https://github.com/lynx-family/integrating-lynx-demo-projects/tree/release/3.1)
+  - 下文中的所有代码，你都可以参考项目: [integrating-lynx-demo-projects](https://github.com/lynx-family/integrating-lynx-demo-projects/tree/release/3.2)
 </Info>
 
 ## 1. 依赖配置

--- a/docs/zh/guide/start/integrate-lynx-devtool.mdx
+++ b/docs/zh/guide/start/integrate-lynx-devtool.mdx
@@ -10,7 +10,7 @@ import * as NextSteps from '@lynx/NextSteps';
 :::info
 推荐在非生产环境下接入 DevTool，让生产环境的应用更轻量。
 
-下文中的所有代码，你都可以在 [integrating-lynx-demo-projects 项目](https://github.com/lynx-family/integrating-lynx-demo-projects/tree/release/3.1)中找到
+下文中的所有代码，你都可以在 [integrating-lynx-demo-projects 项目](https://github.com/lynx-family/integrating-lynx-demo-projects/tree/release/3.2)中找到
 :::
 
 <PlatformTabs hashKey="platform">


### PR DESCRIPTION
This pull request updates all documentation links that pointed to the `release/3.1` branch of the `integrating-lynx-demo-projects` repository. They now correctly point to `release/3.2`, ensuring the documentation reflects the latest release version.

This helps keep the documentation accurate and aligned with the current codebase.

Let me know if any further changes are needed. Thanks!
