### PR TITLE
refactor: remove @rspress/plugin-auto-nav-sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "@rsbuild/plugin-less": "^1.1.1",
     "@rsbuild/plugin-sass": "^1.2.2",
     "@rsbuild/plugin-svgr": "^1.0.7",
-    "@rspress/plugin-auto-nav-sidebar": "2.0.0-beta.8",
     "@rspress/plugin-llms": "2.0.0-beta.8",
     "@rspress/plugin-rss": "2.0.0-beta.8",
     "@rspress/shared": "2.0.0-beta.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,9 +120,6 @@ importers:
       '@rsbuild/plugin-svgr':
         specifier: ^1.0.7
         version: 1.0.7(@rsbuild/core@1.3.21)(typescript@5.0.4)
-      '@rspress/plugin-auto-nav-sidebar':
-        specifier: 2.0.0-beta.8
-        version: 2.0.0-beta.8
       '@rspress/plugin-llms':
         specifier: 2.0.0-beta.8
         version: 2.0.0-beta.8(@rspress/core@2.0.0-beta.8(@types/react@18.3.18)(acorn@8.14.0))

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -128,8 +128,6 @@ export default defineConfig({
         content: 'https://x.com/lynxjs_org',
       },
     ],
-    nav: [],
-    sidebar: {},
   },
   plugins: [
     pluginLlms(),
@@ -176,16 +174,13 @@ export default defineConfig({
 function rspeedyApiPlugin(): RspressPlugin {
   return {
     name: 'rspeedy:api',
-    async config(config, utils, isProd) {
-      const { pluginAutoNavSidebar } = await import(
-        '@rspress/plugin-auto-nav-sidebar'
-      );
+    // FIXME: this is hack to modify rspress.config in-place when autoNav generated
+    async beforeBuild(config, isProd) {
       const {
         transformRspeedySidebar,
         transformReactRsbuildPluginSidebar,
         transformQrcodeRsbuildPluginSidebar,
       } = await import('./api-reports/index.js');
-      config = await pluginAutoNavSidebar().config!(config, utils, isProd);
       config.themeConfig?.locales?.map((locale) => {
         if (locale.sidebar?.['/api']) {
           locale.sidebar!['/api'] =
@@ -232,7 +227,6 @@ function rspeedyApiPlugin(): RspressPlugin {
         }
         return locale;
       });
-      return config;
     },
   };
 }


### PR DESCRIPTION
Change-Id: I793d958d3e3a3635f403797da3fb066cde2b4173

`@rspress/plugin-auto-nav-sidebar` package is removed

https://github.com/web-infra-dev/rspress/issues/2306