### PR TITLE
Fix/css formal syntax in docs

### DIFF
--- a/docs/en/api/css/properties/-x-auto-font-size-preset-sizes.mdx
+++ b/docs/en/api/css/properties/-x-auto-font-size-preset-sizes.mdx
@@ -37,7 +37,7 @@ import { PropertyDefinition } from '@/components/PropertyDefinition';
 ## Formal syntax
 
 ```
--x-auto-font-size-preset-sizes = [<length>] {3}
+-x-auto-font-size-preset-sizes = (<length>){3}
 ```
 
 ## Differences from the Web

--- a/docs/en/api/css/properties/-x-auto-font-size.mdx
+++ b/docs/en/api/css/properties/-x-auto-font-size.mdx
@@ -49,7 +49,7 @@ import { PropertyDefinition } from '@/components/PropertyDefinition';
 ## Formal syntax
 
 ```
--x-auto-font-size = true [<length>] {0, 3} | false
+-x-auto-font-size = true (<length>){0,3} | false
 ```
 
 ## Differences from Web

--- a/docs/en/api/css/properties/background-image.mdx
+++ b/docs/en/api/css/properties/background-image.mdx
@@ -71,41 +71,49 @@ import { PropertyDefinition } from '@/components/PropertyDefinition';
 ## Formal Syntax
 
 ```
+background-image = <bg-image>#
+
 <bg-image> = none | <image>
 
-where
+<image> = <url()> | <gradient>
 
-<image> = <url> | <gradient>
-
-where
+<url()> = url(<string>)
 
 <gradient> = <linear-gradient()> | <radial-gradient()>
 
-where
+<linear-gradient()> = 
+  linear-gradient( [ <angle> | to <side-or-corner> ]? , <color-stop-list> )
 
-<linear-gradient()> = linear-gradient( [<angle> | to <side-or-corner>]?, <color-stop-list>)
+<radial-gradient()> = 
+  radial-gradient( [ <ending-shape> || <size> ]? [ at <position> ]? , <color-stop-list> )
 
-<radial-gradient()> = radial-gradient([<ending-shape> || <size> ] ? [ at <position> ]?, <color-stop-list>)
+<side-or-corner> = 
+  [ left | right ] || [ top | bottom ]
 
-where
+<ending-shape> = 
+  circle | ellipse
 
-<side-or-corner> = [ left | right ] || [ top || bottom ]
+<size> = 
+  closest-side       |
+  farthest-side      |
+  closest-corner     |
+  farthest-corner    |
+  <length>           |
+  <length-percentage>{2}
 
-<ending-shape> = circle | ellipse
+<position> = 
+  [ left | center | right ] || [ top | center | bottom ]                            |
+  [ left | center | right | <length-percentage> ] 
+    [ top | center | bottom | <length-percentage> ]?                                |
+  [ [ left | right ] <length-percentage> ] &&
+    [ [ top | bottom ] <length-percentage> ]
 
-<size> = closest-side | farthest-side | closest-corner | farthest-corner | <length> | <length-percentage>{2}
-
-<position> = [ [ left | center | right ] || [ top | center | bottom ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ]? | [ [ left | right ] <length-percentage> ] && [ [ top | bottom ] <length-percentage> ] ]
-
-<color-stop-list> = [ <linear-color-stop> [, <linear-color-hint> ]? ]
-
-where
+<color-stop-list> = <linear-color-stop> ( ',' <linear-color-stop> )*
 
 <linear-color-stop> = <color>
 
-<linear-color-hint> = <length-percentage>
-
 <length-percentage> = <length> | <percentage>
+
 
 ```
 

--- a/docs/en/api/css/properties/background-size.mdx
+++ b/docs/en/api/css/properties/background-size.mdx
@@ -78,7 +78,7 @@ import { PropertyDefinition } from '@/components/PropertyDefinition';
 ## Formal Syntax
 
 ```
-<bg-size> = [ <length-percentage> | auto ] {1, 2} | cover | contain
+<bg-size> = (<length-percentage> | auto){1,2} | cover | contain
 ```
 
 ## Compatibility

--- a/docs/en/api/css/properties/mask-image.mdx
+++ b/docs/en/api/css/properties/mask-image.mdx
@@ -48,31 +48,20 @@ import { PropertyDefinition } from '@/components/PropertyDefinition';
 
 ## Formal Syntax
 
-```html
-mask-image =
-<mask-reference
-  >#
+```
+mask-image = 
+  <mask-reference>#  
 
-  <mask-reference>
-    = none |
-    <image>
-      <image>
-        =
-        <url>
-          |
-          <gradient>
-            <url>
-              =
-              <url()>
-                <url()> = url( <string>) </string></url()></url()
-              ></url
-            ></gradient
-          ></url
-        ></image
-      ></image
-    ></mask-reference
-  ></mask-reference
->
+<mask-reference> = 
+  none       |
+  <image>    
+
+<image> = 
+  <url()>    |
+  <gradient>  
+
+<url()> = 
+  url( <string> )
 ```
 
 ## Difference with the Web

--- a/docs/en/api/css/properties/mask.mdx
+++ b/docs/en/api/css/properties/mask.mdx
@@ -78,89 +78,66 @@ Sets the area that is affected by the mask image. See [mask-clip]().
 
 ## Formal Syntax
 
-```html
-mask =
-<mask-layer
-  >#
+```
+mask = 
+  <mask-layer>#  
 
-  <mask-layer>
-    =
-    <mask-reference>
-      ||
-      <position>
-        [ /
-        <bg-size>
-          ]? ||
-          <repeat-style>
-            ||
-            <box>
-              || [
-              <geometry-box>
-                | no-clip ]
+<mask-layer> = 
+  <mask-reference>               ||
+  <position> [ / <bg-size> ]?    ||
+  <repeat-style>                 ||
+  <box>                          ||
+  <compositing-operator>         ||
+  <masking-mode>                
 
-                <mask-reference>
-                  = none |
-                  <image>
-                    <position>
-                      = [ left | center | right ] || [ top | center | bottom ] |
-                      [ left | center | right |
-                      <length-percentage>
-                        ] [ top | center | bottom |
-                        <length-percentage>
-                          ]? | [ [ left | right ]
-                          <length-percentage>
-                            ] && [ [ top | bottom ]
-                            <length-percentage>
-                              ]
+<mask-reference> = 
+  none       |
+  <image>    
 
-                              <bg-size>
-                                = [
-                                <length-percentage [0,∞]>
-                                  | auto ]{1,2} | cover | contain
+<image> = 
+  <url()>   |
+  <gradient>  
 
-                                  <repeat-style>
-                                    = repeat-x | repeat-y | [ repeat | space |
-                                    round | no-repeat ]{1,2}
+<url()> = 
+  url( <string> )
 
-                                    <image>
-                                      =
-                                      <url>
-                                        |
-                                        <gradient>
-                                          <url>
-                                            = url(
-                                            <string>
-                                              <url-modifier
-                                                >* )
+<position> = 
+  [ left | center | right ] && [ top | center | bottom ]            |
+  [ left | center | right | <length-percentage> ] 
+    [ top | center | bottom | <length-percentage> ]?                |
+  [ [ left | right ] <length-percentage> ] &&
+    [ [ top | bottom ] <length-percentage> ]  
 
-                                                <box>
-                                                  = border-box | padding-box |
-                                                  content-box</box
-                                                ></url-modifier
-                                              ></string
-                                            ></url
-                                          ></gradient
-                                        ></url
-                                      ></image
-                                    ></repeat-style
-                                  ></length-percentage
-                                ></bg-size
-                              ></length-percentage
-                            ></length-percentage
-                          ></length-percentage
-                        ></length-percentage
-                      ></position
-                    ></image
-                  ></mask-reference
-                ></geometry-box
-              ></box
-            ></repeat-style
-          ></bg-size
-        ></position
-      ></mask-reference
-    ></mask-layer
-  ></mask-layer
->
+<bg-size> = 
+  [ <length-percentage> | auto ]{1,2}  |
+  cover                                |
+  contain                              
+
+<repeat-style> = 
+  repeat-x                             |
+  repeat-y                             |
+  [ repeat | space | round | no-repeat ]{1,2}  
+
+<box> = 
+  border-box     |
+  padding-box    |
+  content-box    
+
+<compositing-operator> = 
+  add        |
+  subtract   |
+  intersect  |
+  exclude    
+
+<masking-mode> = 
+  alpha         |
+  luminance     |
+  match-source  
+
+<length-percentage> = 
+  <length>      |
+  <percentage>  
+
 ```
 
 ## Difference with the Web

--- a/docs/en/api/css/properties/row-gap.mdx
+++ b/docs/en/api/css/properties/row-gap.mdx
@@ -33,7 +33,11 @@ import { Go } from '@lynx';
 [`<percentage>`](/api/css/data-type/percentage.mdx) values are relative to the dimension of the element.
 
 ## Formal syntax
+```
+row-gap = <length-percentage [0,∞]>
 
+<length-percentage> = <length> | <percentage>
+```
 ## Syntax
 
 ```css

--- a/docs/zh/api/css/properties/-x-auto-font-size-preset-sizes.mdx
+++ b/docs/zh/api/css/properties/-x-auto-font-size-preset-sizes.mdx
@@ -42,7 +42,7 @@ import { PropertyDefinition } from '@/components/PropertyDefinition';
 ## 形式语法
 
 ```
--x-auto-font-size-preset-sizes = [<length>] {3}
+-x-auto-font-size-preset-sizes = (<length>){3}
 ```
 
 ## 与 Web 的区别

--- a/docs/zh/api/css/properties/-x-auto-font-size.mdx
+++ b/docs/zh/api/css/properties/-x-auto-font-size.mdx
@@ -49,7 +49,7 @@ import { PropertyDefinition } from '@/components/PropertyDefinition';
 ## 形式语法
 
 ```
--x-auto-font-size = true [<length>] {0, 3} | false
+-x-auto-font-size = true (<length>){0,3} | false
 ```
 
 ## 与 Web 的区别

--- a/docs/zh/api/css/properties/background-image.mdx
+++ b/docs/zh/api/css/properties/background-image.mdx
@@ -69,41 +69,49 @@ import { PropertyDefinition } from '@/components/PropertyDefinition';
 ## 形式语法
 
 ```
+background-image = <bg-image>#
+
 <bg-image> = none | <image>
 
-where
+<image> = <url()> | <gradient>
 
-<image> = <url> | <gradient>
-
-where
+<url()> = url(<string>)
 
 <gradient> = <linear-gradient()> | <radial-gradient()>
 
-where
+<linear-gradient()> = 
+  linear-gradient( [ <angle> | to <side-or-corner> ]? , <color-stop-list> )
 
-<linear-gradient()> = linear-gradient( [<angle> | to <side-or-corner>]?, <color-stop-list>)
+<radial-gradient()> = 
+  radial-gradient( [ <ending-shape> || <size> ]? [ at <position> ]? , <color-stop-list> )
 
-<radial-gradient()> = radial-gradient([<ending-shape> || <size> ] ? [ at <position> ]?, <color-stop-list>)
+<side-or-corner> = 
+  [ left | right ] || [ top | bottom ]
 
-where
+<ending-shape> = 
+  circle | ellipse
 
-<side-or-corner> = [ left | right ] || [ top || bottom ]
+<size> = 
+  closest-side       |
+  farthest-side      |
+  closest-corner     |
+  farthest-corner    |
+  <length>           |
+  <length-percentage>{2}
 
-<ending-shape> = circle | ellipse
+<position> = 
+  [ left | center | right ] || [ top | center | bottom ]                            |
+  [ left | center | right | <length-percentage> ] 
+    [ top | center | bottom | <length-percentage> ]?                                |
+  [ [ left | right ] <length-percentage> ] &&
+    [ [ top | bottom ] <length-percentage> ]
 
-<size> = closest-side | farthest-side | closest-corner | farthest-corner | <length> | <length-percentage>{2}
-
-<position> = [ [ left | center | right ] || [ top | center | bottom ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ]? | [ [ left | right ] <length-percentage> ] && [ [ top | bottom ] <length-percentage> ] ]
-
-<color-stop-list> = [ <linear-color-stop> [, <linear-color-hint> ]? ]
-
-where
+<color-stop-list> = <linear-color-stop> ( ',' <linear-color-stop> )*
 
 <linear-color-stop> = <color>
 
-<linear-color-hint> = <length-percentage>
-
 <length-percentage> = <length> | <percentage>
+
 
 ```
 

--- a/docs/zh/api/css/properties/background-size.mdx
+++ b/docs/zh/api/css/properties/background-size.mdx
@@ -74,7 +74,7 @@ import { PropertyDefinition } from '@/components/PropertyDefinition';
 ## 形式语法
 
 ```
-<bg-size> = [ <length-percentage> | auto ] {1, 2} | cover | contain
+<bg-size> = (<length-percentage> | auto){1,2} | cover | contain
 ```
 
 ## 兼容性

--- a/docs/zh/api/css/properties/mask-image.mdx
+++ b/docs/zh/api/css/properties/mask-image.mdx
@@ -56,31 +56,20 @@ import { PropertyDefinition } from '@/components/PropertyDefinition';
 
 ## 形式语法
 
-```html
-mask-image =
-<mask-reference
-  >#
+```
+mask-image = 
+  <mask-reference>#  
 
-  <mask-reference>
-    = none |
-    <image>
-      <image>
-        =
-        <url>
-          |
-          <gradient>
-            <url>
-              =
-              <url()>
-                <url()> = url( <string>) </string></url()></url()
-              ></url
-            ></gradient
-          ></url
-        ></image
-      ></image
-    ></mask-reference
-  ></mask-reference
->
+<mask-reference> = 
+  none       |
+  <image>    
+
+<image> = 
+  <url()>    |
+  <gradient>  
+
+<url()> = 
+  url( <string> )
 ```
 
 ## 与 Web 的区别

--- a/docs/zh/api/css/properties/mask.mdx
+++ b/docs/zh/api/css/properties/mask.mdx
@@ -113,89 +113,66 @@ import { PropertyDefinition } from '@/components/PropertyDefinition';
 
 ## 形式语法
 
-```html
-mask =
-<mask-layer
-  >#
+```
+mask = 
+  <mask-layer>#  
 
-  <mask-layer>
-    =
-    <mask-reference>
-      ||
-      <position>
-        [ /
-        <bg-size>
-          ]? ||
-          <repeat-style>
-            ||
-            <box>
-              || [
-              <geometry-box>
-                | no-clip ]
+<mask-layer> = 
+  <mask-reference>               ||
+  <position> [ / <bg-size> ]?    ||
+  <repeat-style>                 ||
+  <box>                          ||
+  <compositing-operator>         ||
+  <masking-mode>                
 
-                <mask-reference>
-                  = none |
-                  <image>
-                    <position>
-                      = [ left | center | right ] || [ top | center | bottom ] |
-                      [ left | center | right |
-                      <length-percentage>
-                        ] [ top | center | bottom |
-                        <length-percentage>
-                          ]? | [ [ left | right ]
-                          <length-percentage>
-                            ] && [ [ top | bottom ]
-                            <length-percentage>
-                              ]
+<mask-reference> = 
+  none       |
+  <image>    
 
-                              <bg-size>
-                                = [
-                                <length-percentage [0,∞]>
-                                  | auto ]{1,2} | cover | contain
+<image> = 
+  <url()>   |
+  <gradient>  
 
-                                  <repeat-style>
-                                    = repeat-x | repeat-y | [ repeat | space |
-                                    round | no-repeat ]{1,2}
+<url()> = 
+  url( <string> )
 
-                                    <image>
-                                      =
-                                      <url>
-                                        |
-                                        <gradient>
-                                          <url>
-                                            = url(
-                                            <string>
-                                              <url-modifier
-                                                >* )
+<position> = 
+  [ left | center | right ] && [ top | center | bottom ]            |
+  [ left | center | right | <length-percentage> ] 
+    [ top | center | bottom | <length-percentage> ]?                |
+  [ [ left | right ] <length-percentage> ] &&
+    [ [ top | bottom ] <length-percentage> ]  
 
-                                                <box>
-                                                  = border-box | padding-box |
-                                                  content-box</box
-                                                ></url-modifier
-                                              ></string
-                                            ></url
-                                          ></gradient
-                                        ></url
-                                      ></image
-                                    ></repeat-style
-                                  ></length-percentage
-                                ></bg-size
-                              ></length-percentage
-                            ></length-percentage
-                          ></length-percentage
-                        ></length-percentage
-                      ></position
-                    ></image
-                  ></mask-reference
-                ></geometry-box
-              ></box
-            ></repeat-style
-          ></bg-size
-        ></position
-      ></mask-reference
-    ></mask-layer
-  ></mask-layer
->
+<bg-size> = 
+  [ <length-percentage> | auto ]{1,2}  |
+  cover                                |
+  contain                              
+
+<repeat-style> = 
+  repeat-x                             |
+  repeat-y                             |
+  [ repeat | space | round | no-repeat ]{1,2}  
+
+<box> = 
+  border-box     |
+  padding-box    |
+  content-box    
+
+<compositing-operator> = 
+  add        |
+  subtract   |
+  intersect  |
+  exclude    
+
+<masking-mode> = 
+  alpha         |
+  luminance     |
+  match-source  
+
+<length-percentage> = 
+  <length>      |
+  <percentage>  
+
 ```
 
 ## 与 Web 的区别

--- a/docs/zh/api/css/properties/row-gap.mdx
+++ b/docs/zh/api/css/properties/row-gap.mdx
@@ -30,6 +30,12 @@ import { Go } from '@lynx';
 
 ## 形式语法
 
+```
+row-gap = <length-percentage [0,∞]>
+
+<length-percentage> = <length> | <percentage>
+```
+
 ## 语法
 
 ```css


### PR DESCRIPTION
### Summary
This PR fixes several invalid Formal Syntax strings in our CSS property documentation that previously failed to parse using [css-tree](https://github.com/csstree/csstree)'s definitionSyntax.parse().

Fixed properties:

-x-auto-font-size-preset-sizes
-x-auto-font-size
background-image
mask-image
mask
background-size
row-gap

Related to #213 