### PR TITLE
docs: update scroll-view docs

### DIFF
--- a/docs/en/api/elements/built-in/scroll-view.mdx
+++ b/docs/en/api/elements/built-in/scroll-view.mdx
@@ -95,7 +95,7 @@ Sets whether to allow gesture dragging to scroll. Supports dynamic switching and
 
 ```ts
 // DefaultValue: N/A
-initial-scroll-top?: string = ${number}px
+initial-scroll-offset?: number = ${number}px
 ```
 
 Sets the **absolute** content offset distance during initial rendering (different from the `offset` concept in the `scrollTo` method). The horizontal or vertical direction is determined by `scroll-orientation`, and it only takes effect during the first `render` execution, not responding to subsequent changes.
@@ -108,7 +108,7 @@ Sets the **absolute** content offset distance during initial rendering (differen
 
 ```ts
 // DefaultValue: N/A
-initial-scroll-to-index?: string = ${number}px
+initial-scroll-to-index?: number = ${number}
 ```
 
 Sets the child node to be positioned during initial rendering, only taking effect during the first `render` execution and not responding to subsequent changes.
@@ -157,8 +157,8 @@ Enables the scrollbar, supporting dynamic switching.
 
 :::tip
 
-<AndroidOnly /> Only vertical scrolling has scrollbars. `iOS` and `HarmonyOS`
-Supports both vertical and horizontal scrollbars. :::
+<AndroidOnly /> Only vertical scrolling has scrollbars. `iOS` Supports both
+vertical and horizontal scrollbars. :::
 
 ## Events
 

--- a/docs/zh/api/elements/built-in/scroll-view.mdx
+++ b/docs/zh/api/elements/built-in/scroll-view.mdx
@@ -98,7 +98,7 @@ enable-scroll?: boolean
 
 ```ts
 // DefaultValue: N/A
-initial-scroll-top?: string = ${number}px
+initial-scroll-offset?: number = ${number}px
 ```
 
 设置初次渲染时的内容**绝对**距离偏移（与 [`scrollTo`](#scrollTo) 方法中的 offset 概念有所区别），横纵向由 `scroll-orientation` 决定，仅在第一次 `render` 执行时起效，不响应后续更改。
@@ -111,7 +111,7 @@ initial-scroll-top?: string = ${number}px
 
 ```ts
 // DefaultValue: N/A
-initial-scroll-to-index?: string = ${number}px
+initial-scroll-to-index?: number = ${number}
 ```
 
 设置初次渲染时定位到的子节点，仅在第一次 `render` 执行时起效，不响应后续更改。
@@ -160,7 +160,7 @@ scroll-bar-enable?: boolean
 
 :::tip
 
-<AndroidOnly /> 仅纵向滚动有滚动条 `iOS` 和 `HarmonyOS` 支持纵向和横向滚动条 :::
+<AndroidOnly /> 仅纵向滚动有滚动条 `iOS` 支持纵向和横向滚动条 :::
 
 ## 事件
 

--- a/packages/lynx-compat-data/elements/scroll-view.json
+++ b/packages/lynx-compat-data/elements/scroll-view.json
@@ -82,6 +82,44 @@
               }
             }
           }
+        },
+        "nested_value_3": {
+          "__compat": {
+            "description": "<code>scroll-orientation</code>",
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              }
+            }
+          }
+        },
+        "nested_value_4": {
+          "__compat": {
+            "description": "<code>initial-scroll-offset</code>",
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              }
+            }
+          }
         }
       },
       "events": {


### PR DESCRIPTION
update scroll-view docs
1. Update the parameter types of `initial-scroll-offset` and `initial-scroll-to-index` from String to Number.
2. Update compatibility data,`initial-scroll-offset` and `scroll-orientation` are currently not supported on the HarmonyOS.