### PR TITLE
fix(doc-css): formal syntax, typos, defines and descs

### DIFF
--- a/docs/en/api/css/properties/filter.mdx
+++ b/docs/en/api/css/properties/filter.mdx
@@ -77,9 +77,10 @@ filter = <filter-function>
 
 ```
 
-## Difference between web
+## Differences from the Web
 
-Different number of functions supported
+- Only one filter function is allowed per declaration
+- Only supports `blur` and `grayscale` functions
 
 ## Compatibility
 

--- a/docs/en/api/css/properties/inset-inline-end.mdx
+++ b/docs/en/api/css/properties/inset-inline-end.mdx
@@ -58,7 +58,15 @@ import { PropertyDefinition } from '@/components/PropertyDefinition';
 
 ## Formal syntax
 
-takes the same as the [`left`](./left) property.
+```
+inset-inline-end = 
+  auto                 |
+  <length-percentage>  
+
+<length-percentage> = 
+  <length>      |
+  <percentage>  
+```
 
 ## Difference with the web
 

--- a/docs/en/api/css/properties/inset-inline-start.mdx
+++ b/docs/en/api/css/properties/inset-inline-start.mdx
@@ -58,7 +58,15 @@ import { PropertyDefinition } from '@/components/PropertyDefinition';
 
 ## Formal syntax
 
-takes the same as the [`left`](./left) property.
+```
+inset-inline-start = 
+  auto                 |
+  <length-percentage>  
+
+<length-percentage> = 
+  <length>      |
+  <percentage>  
+```
 
 ## Difference with the web
 

--- a/docs/en/api/css/properties/transform.mdx
+++ b/docs/en/api/css/properties/transform.mdx
@@ -130,19 +130,19 @@ scaleY( <number> )
 - **skew**
 
 ```
-scale( [ <angle> | <zero> ], [ <angle> | <zero> ] )
+skew( [ <angle> | <zero> ], [ <angle> | <zero> ] )
 ```
 
 - **skewX**
 
 ```
-scaleX( [ <angle> | <zero> ] )
+skewX( [ <angle> | <zero> ] )
 ```
 
 - **skewY**
 
 ```
-scaleY( [ <angle> | <zero> ] )
+skewY( [ <angle> | <zero> ] )
 ```
 
 - **matrix**

--- a/docs/en/api/css/properties/transition-property.mdx
+++ b/docs/en/api/css/properties/transition-property.mdx
@@ -31,7 +31,6 @@ transition-property: sliding-vertically;
 /* Multiple values */
 transition-property: test1, animation4;
 transition-property: all, height, color;
-transition-property:;
 ```
 
 ### Values
@@ -84,8 +83,15 @@ import { PropertyDefinition } from '@/components/PropertyDefinition';
 ## Formal syntax
 
 ```
-transition-property:opacity|width|height|background-color|visibility|top|right|left|bottom|transform|all|none;
+transition-property = 
+  none                           |
+  <single-transition-property>#  
+
+<single-transition-property> = 
+  all             |
+  <custom-ident>  
 ```
+
 
 ## More
 

--- a/docs/zh/api/css/properties/filter.mdx
+++ b/docs/zh/api/css/properties/filter.mdx
@@ -76,7 +76,8 @@ filter = <filter-function>
 
 ## 与 Web 的区别
 
-支持的 function 数量不同
+- 在一个声明中只能使用一个函数
+- 只支持 `blur` 和 `grayscale` 函数
 
 ## 兼容性
 

--- a/docs/zh/api/css/properties/inset-inline-end.mdx
+++ b/docs/zh/api/css/properties/inset-inline-end.mdx
@@ -55,7 +55,15 @@ import { PropertyDefinition } from '@/components/PropertyDefinition';
 
 ## 形式语法
 
-与 [`right`](./right) 属性相同。
+```
+inset-inline-end = 
+  auto                 |
+  <length-percentage>  
+
+<length-percentage> = 
+  <length>      |
+  <percentage>  
+```
 
 ## 与 Web 的区别
 

--- a/docs/zh/api/css/properties/inset-inline-start.mdx
+++ b/docs/zh/api/css/properties/inset-inline-start.mdx
@@ -40,7 +40,15 @@ inset-inline-start: calc(1px + 1px);
 
 ### 取值
 
-`inset-inline-start` 属性的取值与 [`left`](./left) 属性相同。
+```
+inset-inline-start = 
+  auto                 |
+  <length-percentage>  
+
+<length-percentage> = 
+  <length>      |
+  <percentage>  
+```
 
 ## 形式定义
 

--- a/docs/zh/api/css/properties/transform.mdx
+++ b/docs/zh/api/css/properties/transform.mdx
@@ -126,19 +126,19 @@ scaleY( <number> )
 - **skew**
 
 ```
-scale( [ <angle> | <zero> ], [ <angle> | <zero> ] )
+skew( [ <angle> | <zero> ], [ <angle> | <zero> ] )
 ```
 
 - **skewX**
 
 ```
-scaleX( [ <angle> | <zero> ] )
+skewX( [ <angle> | <zero> ] )
 ```
 
 - **skewY**
 
 ```
-scaleY( [ <angle> | <zero> ] )
+skewY( [ <angle> | <zero> ] )
 ```
 
 - **matrix**

--- a/docs/zh/api/css/properties/transition-property.mdx
+++ b/docs/zh/api/css/properties/transition-property.mdx
@@ -32,7 +32,6 @@ transition-property: sliding-vertically;
 /* Multiple values */
 transition-property: test1, animation4;
 transition-property: all, height, color;
-transition-property:;
 ```
 
 ### 取值
@@ -85,12 +84,15 @@ import { PropertyDefinition } from '@/components/PropertyDefinition';
 ## 形式语法
 
 ```
-transition-property:opacity|width|height|background-color|visibility|top|right|left|bottom|transform|all|none;
+transition-property = 
+  none                           |
+  <single-transition-property>#  
+
+<single-transition-property> = 
+  all             |
+  <custom-ident>  
 ```
 
-## 与 Web 的区别
-
-- 仅支持上述动画属性。
 
 ## 扩展阅读
 


### PR DESCRIPTION
Fixed the formal syntax, definition, and description of several CSS Properties.

Related to #213 