### PR TITLE
fix(spec): correct typo from "Running Scenary" to "Running Scenarios"

### DIFF
--- a/docs/public/living-spec/index.html
+++ b/docs/public/living-spec/index.html
@@ -2114,7 +2114,7 @@ Parts of this work may be from another specification document.  If so, those par
         <li><a href="#lynx-group"><span class="secno">2.2.7</span> <span class="content"><span>Lynx Group</span></span></a>
        </ol>
       <li>
-       <a href="#running-scenary"><span class="secno">2.3</span> <span class="content">Running Scenary</span></a>
+       <a href="#running-scenarios"><span class="secno">2.3</span> <span class="content">Running Scenarios</span></a>
        <ol class="toc">
         <li><a href="#standalone"><span class="secno">2.3.1</span> <span class="content"><span>Standalone</span></span></a>
         <li><a href="#embedded"><span class="secno">2.3.2</span> <span class="content"><span>Embedded</span></span></a>
@@ -2460,7 +2460,7 @@ This usually comprises of:</p>
     It is a binding object, offering some common capabilities to script developers. It is provided in <a data-link-type="dfn" href="#scripting-main-thread-runtime" id="ref-for-scripting-main-thread-runtime">main thread runtime</a> and <a data-link-type="dfn" href="#scripting-background-thread-runtime" id="ref-for-scripting-background-thread-runtime">background thread runtime</a>. 
    <h4 class="heading settled" data-level="2.2.7" id="lynx-group"><span class="secno">2.2.7. </span><span class="content"><dfn class="dfn-paneled" data-dfn-for="CommonInfrastructure" data-dfn-type="dfn" data-noexport id="commoninfrastructure-lynx-group">Lynx Group</dfn></span><a class="self-link" href="#lynx-group"></a></h4>
    <p>When multiple <a data-link-type="dfn" href="#commoninfrastructure-lynxview" id="ref-for-commoninfrastructure-lynxview①">LynxView</a> is hosted on a shared <a data-link-type="dfn" href="#commoninfrastructure-scripting-agent" id="ref-for-commoninfrastructure-scripting-agent">scripting agent</a>.</p>
-   <h3 class="heading settled" data-level="2.3" id="running-scenary"><span class="secno">2.3. </span><span class="content">Running Scenary</span><a class="self-link" href="#running-scenary"></a></h3>
+   <h3 class="heading settled" data-level="2.3" id="running-scenarios"><span class="secno">2.3. </span><span class="content">Running Scenarios</span><a class="self-link" href="#running-scenarios"></a></h3>
    <h4 class="heading settled" data-level="2.3.1" id="standalone"><span class="secno">2.3.1. </span><span class="content"><dfn class="dfn-paneled" data-dfn-for="CommonInfrastructure" data-dfn-type="dfn" data-noexport id="commoninfrastructure-standalone">Standalone</dfn></span><a class="self-link" href="#standalone"></a></h4>
    <p>When Lynx is used independently, i.e. not mixed with another UI system , such as:</p>
    <ul>

--- a/packages/lynx-living-spec/src/common-infrastructure.bs
+++ b/packages/lynx-living-spec/src/common-infrastructure.bs
@@ -65,7 +65,7 @@ It is a binding object, offering some common capabilities to script developers. 
 
 When multiple [=LynxView=] is hosted on a shared [=CommonInfrastructure/scripting agent=].
 
-## Running Scenary
+## Running Scenarios
 
 ### <dfn for=CommonInfrastructure>Standalone</dfn>
 


### PR DESCRIPTION
This PR fixes a minor typo in section **2.3** of the Living Spec:

- `Running Scenary` → `Running Scenarios`

This correction improves language accuracy and maintains consistency throughout the documentation.

No technical content is affected.

Related to #255 