### PR TITLE
feat: support langAlias option for `<Go />` component

### DIFF
--- a/src/components/go/example-preview/components/code-view.tsx
+++ b/src/components/go/example-preview/components/code-view.tsx
@@ -10,6 +10,7 @@ interface CodeViewProps {
   currentFile: string;
   isAssetFile: boolean;
   highlight?: string;
+  langAlias?: Record<string, string>;
 }
 
 export const CodeView = ({
@@ -17,6 +18,7 @@ export const CodeView = ({
   currentFile,
   isAssetFile,
   highlight,
+  langAlias,
 }: CodeViewProps) => {
   const [isFirstShowCode, setIsFirstShowCode] = useState(true);
   if (isAssetFile) {
@@ -33,7 +35,7 @@ export const CodeView = ({
       </div>
     );
   }
-  const language = getFileCodeLanguage(currentFileName);
+  const language = getFileCodeLanguage(currentFileName, langAlias);
 
   return (
     <Code

--- a/src/components/go/example-preview/components/index.tsx
+++ b/src/components/go/example-preview/components/index.tsx
@@ -64,6 +64,7 @@ interface ExampleContentProps {
   rightFooter?: React.ReactNode;
   schemaOptions?: SchemaOptionsData;
   exampleGitBaseUrl?: string;
+  langAlias?: Record<string, string>;
 }
 
 export const ExampleContent: FC<ExampleContentProps> = ({
@@ -86,6 +87,7 @@ export const ExampleContent: FC<ExampleContentProps> = ({
   rightFooter,
   schemaOptions,
   exampleGitBaseUrl,
+  langAlias,
 }) => {
   const { treeData, doChangeExpand, selectedKeys, expandedKeys, entryData } =
     useTreeController({ fileNames, value: currentFileName, entry });
@@ -175,6 +177,7 @@ export const ExampleContent: FC<ExampleContentProps> = ({
                   currentFile={currentFile}
                   isAssetFile={isAssetFile}
                   highlight={highlight}
+                  langAlias={langAlias}
                 />
               </div>
             </div>

--- a/src/components/go/example-preview/index.tsx
+++ b/src/components/go/example-preview/index.tsx
@@ -34,6 +34,7 @@ export interface ExamplePreviewProps {
   schema?: string;
   rightFooter?: React.ReactNode;
   schemaOptions?: SchemaOptionsData;
+  langAlias?: Record<string, string>;
 }
 
 export const ExamplePreview = ({
@@ -47,6 +48,7 @@ export const ExamplePreview = ({
   schema,
   rightFooter,
   schemaOptions,
+  langAlias,
 }: ExamplePreviewProps) => {
   const [currentName, setCurrentName] = useState(defaultFile);
   const [currentFile, setCurrentFile] = useState('');
@@ -177,6 +179,7 @@ export const ExamplePreview = ({
           ? `${EXAMPLE_BASE_URL}/${example}/${exampleData?.previewImage}`
           : '')
       }
+      langAlias={langAlias}
       currentEntryFileUrl={currentEntryFileUrl}
       currentEntry={currentEntry}
       setCurrentEntry={setCurrentEntry}

--- a/src/components/go/example-preview/utils/example-data.ts
+++ b/src/components/go/example-preview/utils/example-data.ts
@@ -28,12 +28,15 @@ export const isAssetFileType = (fileName: string) => {
   return assetExtension.some((type) => fileName.endsWith(type));
 };
 
-export const getFileCodeLanguage = (fileName: string) => {
+export const getFileCodeLanguage = (
+  fileName: string,
+  langAlias: Record<string, string> = {},
+) => {
   const fileType = fileName.split('.').pop();
   if (fileType === 'mjs') {
     return 'js';
   }
-  return fileType || 'txt';
+  return langAlias[fileType || ''] || fileType || 'txt';
 };
 
 export const getHighlightLines = (meta: string) => {


### PR DESCRIPTION
Support custom language highlighting

For example:

```js
<Go 
  langAlias={{ 'my-lang': 'html' }}
/>
```