### PR TITLE
feat: add compat data for color syntax

### DIFF
--- a/packages/lynx-compat-data/css/data-type/color.json
+++ b/packages/lynx-compat-data/css/data-type/color.json
@@ -22,14 +22,13 @@
             }
           }
         },
-        "rgb": {
+        "rgb()": {
           "__compat": {
             "description": "<code>rgb()</code> (RGB color model)",
             "status": {
               "deprecated": false,
               "experimental": false
             },
-            "lynx_path": "api/css/data-type/color#rgb-color-model",
             "support": {
               "android": {
                 "version_added": "1.0"
@@ -39,6 +38,98 @@
               },
               "web_lynx": {
                 "version_added": true
+              }
+            }
+          },
+          "legacy-rgb-syntax": {
+            "__compat": {
+              "description": "<a href='https://drafts.csswg.org/css-color/#typedef-legacy-rgb-syntax'><code>&lt;legacy-rgb-syntax&gt;</code></a>",
+              "status": {
+                "deprecated": false,
+                "experimental": false
+              },
+              "spec_url": [
+                "https://drafts.csswg.org/css-color/#typedef-legacy-rgb-syntax"
+              ],
+              "support": {
+                "android": {
+                  "version_added": "1.0"
+                },
+                "ios": {
+                  "version_added": "1.0"
+                },
+                "web_lynx": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "modern-rgb-syntax": {
+            "__compat": {
+              "description": "<a href='https://drafts.csswg.org/css-color/#typedef-modern-rgb-syntax'><code>&lt;modern-rgb-syntax&gt;</code></a>",
+              "spec_url": [
+                "https://drafts.csswg.org/css-color/#typedef-modern-rgb-syntax"
+              ],
+              "status": {
+                "deprecated": false,
+                "experimental": false
+              },
+              "support": {
+                "android": {
+                  "version_added": "3.4"
+                },
+                "ios": {
+                  "version_added": "3.4"
+                },
+                "web_lynx": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "legacy-rgba-syntax": {
+            "__compat": {
+              "description": "<a href='https://drafts.csswg.org/css-color/#typedef-legacy-rgba-syntax'><code>&lt;legacy-rgba-syntax&gt;</code></a>",
+              "status": {
+                "deprecated": false,
+                "experimental": false
+              },
+              "spec_url": [
+                "https://drafts.csswg.org/css-color/#typedef-legacy-rgba-syntax"
+              ],
+              "support": {
+                "android": {
+                  "version_added": "1.0"
+                },
+                "ios": {
+                  "version_added": "1.0"
+                },
+                "web_lynx": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "modern-rgba-syntax": {
+            "__compat": {
+              "description": "<a href='https://drafts.csswg.org/css-color/#typedef-modern-rgba-syntax'><code>&lt;modern-rgba-syntax&gt;</code></a>",
+              "spec_url": [
+                "https://drafts.csswg.org/css-color/#typedef-modern-rgba-syntax"
+              ],
+              "status": {
+                "deprecated": false,
+                "experimental": false
+              },
+              "support": {
+                "android": {
+                  "version_added": "3.4"
+                },
+                "ios": {
+                  "version_added": "3.4"
+                },
+                "web_lynx": {
+                  "version_added": true
+                }
               }
             }
           }


### PR DESCRIPTION
This PR updates the compat-data for CSS color values:

Previously only legacy `rgb()` syntax was listed (comma-separated parameters).

Added modern `rgb()` syntax (space-separated parameters with optional alpha using `/`).