### PR TITLE
feat(performance-api): add host platform timing support.

### DIFF
--- a/docs/en/api/lynx-api/performance-api/_meta.json
+++ b/docs/en/api/lynx-api/performance-api/_meta.json
@@ -30,5 +30,13 @@
     "overviewHeaders": [],
     "collapsible": true,
     "collapsed": true
+  },
+  {
+    "type": "dir",
+    "name": "host-platform-timing",
+    "label": "HostPlatformTiming",
+    "overviewHeaders": [],
+    "collapsible": true,
+    "collapsed": true
   }
 ]

--- a/docs/en/api/lynx-api/performance-api/host-platform-timing/android-host-platform-timing.mdx
+++ b/docs/en/api/lynx-api/performance-api/host-platform-timing/android-host-platform-timing.mdx
@@ -1,0 +1,89 @@
+---
+context: 'BTS'
+---
+
+import { RuntimeBadge } from '@lynx';
+
+# AndroidHostPlatformTiming
+
+This interface describes the performance data specific to Android platform's Measure, Layout, and Draw operations in the [Lynx Pipeline](/guide/spec#lynx-pipeline), as shown in the following diagram:
+
+<img src="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/plugin/static/host-platform-timing.png" />
+
+## Examples
+
+This example shows how to generate and obtain `AndroidHostPlatformTiming`.
+
+import { Go } from '@lynx';
+
+<Go
+  example="performance-api"
+  defaultFile="src/HostPlatformTiming/index.tsx"
+  defaultEntryFile="dist/HostPlatformTiming.lynx.bundle"
+  img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/plugin/static/exmaple-host-platform-timing.png"
+  entry="src/HostPlatformTiming"
+/>
+
+## Instance Properties
+
+### hostPlatformType
+
+```tsx
+hostPlatformType: string;
+```
+
+A string describing the Host Platform type, with default value: `Android`.
+
+### measureStart
+
+```tsx
+measureStart: number;
+```
+
+The timestamp when the first execution of [LynxView](/guide/spec.html#lynxview)'s [onMeasure](<https://developer.android.com/reference/android/view/View#onMeasure(int,%20int)>) starts in a Lynx Pipeline. This timestamp is a Unix timestamp represented as a floating-point number (in milliseconds), accurate to three decimal places. For example: 1739594612307.429.
+
+### measureEnd
+
+```tsx
+measureEnd: number;
+```
+
+The timestamp when the last execution of [LynxView](/guide/spec.html#lynxview)'s [`onMeasure`](<https://developer.android.com/reference/android/view/View#onMeasure(int,%20int)>) ends in a Lynx Pipeline. This timestamp is a Unix timestamp represented as a floating-point number (in milliseconds), accurate to three decimal places. For example: 1739594612307.429.
+
+### layoutStart
+
+```tsx
+layoutStart: number;
+```
+
+The timestamp when the first execution of [LynxView](/guide/spec.html#lynxview)'s [`onLayout`](<https://developer.android.com/reference/android/view/View#onLayout(boolean,%20int,%20int,%20int,%20int)>) starts in a Lynx Pipeline. This timestamp is a Unix timestamp represented as a floating-point number (in milliseconds), accurate to three decimal places. For example: 1739594612307.429.
+
+### layoutEnd
+
+```tsx
+layoutEnd: number;
+```
+
+The timestamp when the last execution of [LynxView](/guide/spec.html#lynxview)'s [`onLayout`](<https://developer.android.com/reference/android/view/View#onLayout(boolean,%20int,%20int,%20int,%20int)>) ends in a Lynx Pipeline. This timestamp is a Unix timestamp represented as a floating-point number (in milliseconds), accurate to three decimal places. For example: 1739594612307.429.
+
+### drawStart
+
+```tsx
+drawStart: number;
+```
+
+The timestamp when the execution of [LynxView](/guide/spec.html#lynxview)'s [`dispatchDraw`](<https://developer.android.com/reference/android/view/View#dispatchDraw(android.graphics.Canvas)>) starts in a Lynx Pipeline. This timestamp is a Unix timestamp represented as a floating-point number (in milliseconds), accurate to three decimal places. For example: 1739594612307.429.
+
+### drawEnd
+
+```tsx
+drawEnd: number;
+```
+
+The timestamp when the execution of [LynxView](/guide/spec.html#lynxview)'s [`dispatchDraw`](<https://developer.android.com/reference/android/view/View#dispatchDraw(android.graphics.Canvas)>) ends in a Lynx Pipeline. This timestamp is a Unix timestamp represented as a floating-point number (in milliseconds), accurate to three decimal places. For example: 1739594612307.429.
+
+## Compatibility
+
+import { LegacyCompatTable } from '@lynx';
+
+<LegacyCompatTable metadata="lynx-api/performance-api/host-platform-timing/android-host-platform-timing" />

--- a/docs/en/api/lynx-api/performance-api/host-platform-timing/harmony-host-platform-timing.mdx
+++ b/docs/en/api/lynx-api/performance-api/host-platform-timing/harmony-host-platform-timing.mdx
@@ -1,0 +1,25 @@
+---
+context: 'BTS'
+---
+
+import { RuntimeBadge } from '@lynx';
+
+# HarmonyHostPlatformTiming
+
+This interface describes performance data for Harmony platform-specific key stages in [Lynx Pipeline](/guide/spec#lynx-pipeline).
+
+## Instance Properties
+
+### hostPlatformType
+
+```tsx
+hostPlatformType: string;
+```
+
+A string describing the Host Platform type, with default value: `Harmony`.
+
+## Compatibility
+
+import { LegacyCompatTable } from '@lynx';
+
+<LegacyCompatTable metadata="lynx-api/performance-api/host-platform-timing/harmony-host-platform-timing" />

--- a/docs/en/api/lynx-api/performance-api/host-platform-timing/ios-host-platform-timing.mdx
+++ b/docs/en/api/lynx-api/performance-api/host-platform-timing/ios-host-platform-timing.mdx
@@ -1,0 +1,25 @@
+---
+context: 'BTS'
+---
+
+import { RuntimeBadge } from '@lynx';
+
+# IOSHostPlatformTiming
+
+This interface describes performance data for iOS platform-specific key stages in [Lynx Pipeline](/guide/spec#lynx-pipeline).
+
+## Instance Properties
+
+### hostPlatformType
+
+```tsx
+hostPlatformType: string;
+```
+
+A string describing the Host Platform type, with default value: `iOS`.
+
+## Compatibility
+
+import { LegacyCompatTable } from '@lynx';
+
+<LegacyCompatTable metadata="lynx-api/performance-api/host-platform-timing/ios-host-platform-timing" />

--- a/docs/en/api/lynx-api/performance-api/performance-entry/pipeline-entry.mdx
+++ b/docs/en/api/lynx-api/performance-api/performance-entry/pipeline-entry.mdx
@@ -25,7 +25,7 @@ import { Go } from '@lynx';
   example="performance-api"
   defaultFile="src/pipeline_entry/index.tsx"
   defaultEntryFile="dist/pipeline_entry.lynx.bundle"
-  img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/doc/pipeline-entry-demo.jpeg"
+  img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/plugin/static/exmaple-pipeline-entry.png"
   entry="src/pipeline_entry"
   highlight="{11-21,31}"
 />
@@ -178,6 +178,16 @@ frameworkPipelineTiming: FrameworkPipelineTiming[keyof FrameworkPipelineTiming];
 ```
 
 Performance data for key stages in [Framework Rendering](/guide/spec#framework-rendering). The type is [`FrameworkPipelineTiming`](/api/lynx-api/performance-api/framework-pipeline-timing).
+
+### hostPlatformTiming
+
+```ts
+hostPlatformTiming: AndroidHostPlatformTiming |
+  HarmonyHostPlatformTiming |
+  IOSHostPlatformTiming;
+```
+
+Performance data for platform-specific key stages in [Lynx Pipeline](/guide/spec#lynx-pipeline), with type [`AndroidHostPlatformTiming`](/api/lynx-api/performance-api/host-platform-timing/android-host-platform-timing) | [`HarmonyHostPlatformTiming`](/api/lynx-api/performance-api/host-platform-timing/harmony-host-platform-timing) | [`IOSHostPlatformTiming`](/api/lynx-api/performance-api/host-platform-timing/ios-host-platform-timing).
 
 ## Compatibility
 

--- a/docs/zh/api/lynx-api/performance-api/_meta.json
+++ b/docs/zh/api/lynx-api/performance-api/_meta.json
@@ -30,5 +30,13 @@
     "overviewHeaders": [],
     "collapsible": true,
     "collapsed": true
+  },
+  {
+    "type": "dir",
+    "name": "host-platform-timing",
+    "label": "HostPlatformTiming",
+    "overviewHeaders": [],
+    "collapsible": true,
+    "collapsed": true
   }
 ]

--- a/docs/zh/api/lynx-api/performance-api/host-platform-timing/android-host-platform-timing.mdx
+++ b/docs/zh/api/lynx-api/performance-api/host-platform-timing/android-host-platform-timing.mdx
@@ -1,0 +1,89 @@
+---
+context: 'BTS'
+---
+
+import { RuntimeBadge } from '@lynx';
+
+# AndroidHostPlatformTiming
+
+该接口描述了 [Lynx Pipeline](/guide/spec#lynx-pipeline) 中 Android 平台特有 Measure、Layout 和 Draw 的性能数据，具体如下图所示：
+
+<img src="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/plugin/static/host-platform-timing.png" />
+
+## 示例
+
+该示例展示了如何产生和获取 `PipelineEntry`。
+
+import { Go } from '@lynx';
+
+<Go
+  example="performance-api"
+  defaultFile="src/HostPlatformTiming/index.tsx"
+  defaultEntryFile="dist/HostPlatformTiming.lynx.bundle"
+  img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/plugin/static/exmaple-host-platform-timing.png"
+  entry="src/HostPlatformTiming"
+/>
+
+## 实例属性
+
+### hostPlatformType
+
+```tsx
+hostPlatformType: string;
+```
+
+描述 Host Platform 类型的字符串，默认取值为：`Android`。
+
+### measureStart
+
+```tsx
+measureStart: number;
+```
+
+在一次 Lynx Pipeline 中，首次执行 [LynxView](/guide/spec.html#lynxview) 的 [onMeasure](<https://developer.android.com/reference/android/view/View#onMeasure(int,%20int)>) 的开始时间戳。该时间戳是一个表示为浮点型的 Unix 时间戳（单位：毫秒），精确到小数点后三位。例如：1739594612307.429。
+
+### measureEnd
+
+```tsx
+measureEnd: number;
+```
+
+在一次 Lynx Pipeline 中，最后一次执行 [LynxView](/guide/spec.html#lynxview) 的 [`onMeasure`](<https://developer.android.com/reference/android/view/View#onMeasure(int,%20int)>) 的结束时间戳。该时间戳是一个表示为浮点型的 Unix 时间戳（单位：毫秒），精确到小数点后三位。例如：1739594612307.429。
+
+### layoutStart
+
+```tsx
+layoutStart: number;
+```
+
+在一次 Lynx Pipeline 中，首次执行 [LynxView](/guide/spec.html#lynxview) 的 [`onLayout`](<https://developer.android.com/reference/android/view/View#onLayout(boolean,%20int,%20int,%20int,%20int)>) 的开始时间戳。该时间戳是一个表示为浮点型的 Unix 时间戳（单位：毫秒），精确到小数点后三位。例如：1739594612307.429。
+
+### layoutEnd
+
+```tsx
+layoutEnd: number;
+```
+
+在一次 Lynx Pipeline 中，最后一次执行 [LynxView](/guide/spec.html#lynxview) 的 [`onLayout`](<https://developer.android.com/reference/android/view/View#onLayout(boolean,%20int,%20int,%20int,%20int)>) 的结束时间戳。该时间戳是一个表示为浮点型的 Unix 时间戳（单位：毫秒），精确到小数点后三位。例如：1739594612307.429。
+
+### drawStart
+
+```tsx
+drawStart: number;
+```
+
+在一次 Lynx Pipeline 中，执行 [LynxView](/guide/spec.html#lynxview) 的 [`dispatchDraw`](<https://developer.android.com/reference/android/view/View#dispatchDraw(android.graphics.Canvas)>) 的开始时间戳。该时间戳是一个表示为浮点型的 Unix 时间戳（单位：毫秒），精确到小数点后三位。例如：1739594612307.429。
+
+### drawEnd
+
+```tsx
+drawEnd: number;
+```
+
+在一次 Lynx Pipeline 中，执行 [LynxView](/guide/spec.html#lynxview) 的 [`dispatchDraw`](<https://developer.android.com/reference/android/view/View#dispatchDraw(android.graphics.Canvas)>) 的结束时间戳。该时间戳是一个表示为浮点型的 Unix 时间戳（单位：毫秒），精确到小数点后三位。例如：1739594612307.429。
+
+## 兼容性
+
+import { LegacyCompatTable } from '@lynx';
+
+<LegacyCompatTable metadata="lynx-api/performance-api/host-platform-timing/android-host-platform-timing" />

--- a/docs/zh/api/lynx-api/performance-api/host-platform-timing/harmony-host-platform-timing.mdx
+++ b/docs/zh/api/lynx-api/performance-api/host-platform-timing/harmony-host-platform-timing.mdx
@@ -1,0 +1,25 @@
+---
+context: 'BTS'
+---
+
+import { RuntimeBadge } from '@lynx';
+
+# HarmonyHostPlatformTiming
+
+该接口描述了 [Lynx Pipeline](/guide/spec#lynx-pipeline) 中 Harmony 平台特有的关键阶段的性能数据。
+
+## 实例属性
+
+### hostPlatformType
+
+```tsx
+hostPlatformType: string;
+```
+
+描述 Host Platform 类型的字符串，默认取值为：`Harmony`。
+
+## 兼容性
+
+import { LegacyCompatTable } from '@lynx';
+
+<LegacyCompatTable metadata="lynx-api/performance-api/host-platform-timing/harmony-host-platform-timing" />

--- a/docs/zh/api/lynx-api/performance-api/host-platform-timing/ios-host-platform-timing.mdx
+++ b/docs/zh/api/lynx-api/performance-api/host-platform-timing/ios-host-platform-timing.mdx
@@ -1,0 +1,25 @@
+---
+context: 'BTS'
+---
+
+import { RuntimeBadge } from '@lynx';
+
+# IOSHostPlatformTiming
+
+该接口描述了 [Lynx Pipeline](/guide/spec#lynx-pipeline) 中 iOS 平台特有的关键阶段的性能数据。
+
+## 实例属性
+
+### hostPlatformType
+
+```tsx
+hostPlatformType: string;
+```
+
+描述 Host Platform 类型的字符串，默认取值为：`iOS`。
+
+## 兼容性
+
+import { LegacyCompatTable } from '@lynx';
+
+<LegacyCompatTable metadata="lynx-api/performance-api/host-platform-timing/ios-host-platform-timing" />

--- a/docs/zh/api/lynx-api/performance-api/performance-entry/pipeline-entry.mdx
+++ b/docs/zh/api/lynx-api/performance-api/performance-entry/pipeline-entry.mdx
@@ -25,7 +25,7 @@ import { Go } from '@lynx';
   example="performance-api"
   defaultFile="src/pipeline_entry/index.tsx"
   defaultEntryFile="dist/pipeline_entry.lynx.bundle"
-  img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/doc/pipeline-entry-demo.jpeg"
+  img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/plugin/static/exmaple-pipeline-entry.png"
   entry="src/pipeline_entry"
   highlight="{11-21,31}"
 />
@@ -177,7 +177,17 @@ paintEnd: number;
 frameworkPipelineTiming:  FrameworkPipelineTiming[keyof FrameworkPipelineTiming];
 ```
 
-[框架渲染](/guide/spec#framework-rendering)中关键阶段的性能数据. 类型为 [`FrameworkPipelineTiming`](/api/lynx-api/performance-api/framework-pipeline-timing)。
+[框架渲染](/guide/spec#framework-rendering)中关键阶段的性能数据， 类型为 [`FrameworkPipelineTiming`](/api/lynx-api/performance-api/framework-pipeline-timing)。
+
+### hostPlatformTiming
+
+```ts
+hostPlatformTiming: AndroidHostPlatformTiming |
+  HarmonyHostPlatformTiming |
+  IOSHostPlatformTiming;
+```
+
+[Lynx Pipeline](/guide/spec#lynx-pipeline) 中不同平台特有的关键阶段的性能数据， 类型为 [`AndroidHostPlatformTiming`](/api/lynx-api/performance-api/host-platform-timing/android-host-platform-timing) | [`HarmonyHostPlatformTiming`](/api/lynx-api/performance-api/host-platform-timing/harmony-host-platform-timing) | [`IOSHostPlatformTiming`](/api/lynx-api/performance-api/host-platform-timing/ios-host-platform-timing)。
 
 ## 兼容性
 

--- a/packages/lynx-compat-data/lynx-api/performance-api/host-platform-timing/android-host-platform-timing.json
+++ b/packages/lynx-compat-data/lynx-api/performance-api/host-platform-timing/android-host-platform-timing.json
@@ -1,0 +1,27 @@
+{
+  "lynx-api": {
+    "performance-api": {
+      "host-platform-timing": {
+        "android-host-platform-timing": {
+          "AndroidHostPlatformTiming": {
+            "__compat": {
+              "description": "",
+              "lynx_path": "api/lynx-api/performance-api/host-platform-timing/android-host-platform-timing",
+              "support": {
+                "android": {
+                  "version_added": "3.4"
+                },
+                "ios": {
+                  "version_added": "3.4"
+                },
+                "web_lynx": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/lynx-compat-data/lynx-api/performance-api/host-platform-timing/harmony-host-platform-timing.json
+++ b/packages/lynx-compat-data/lynx-api/performance-api/host-platform-timing/harmony-host-platform-timing.json
@@ -1,0 +1,27 @@
+{
+  "lynx-api": {
+    "performance-api": {
+      "host-platform-timing": {
+        "harmony-host-platform-timing": {
+          "HarmonyHostPlatformTiming": {
+            "__compat": {
+              "description": "",
+              "lynx_path": "api/lynx-api/performance-api/host-platform-timing/harmony-host-platform-timing",
+              "support": {
+                "android": {
+                  "version_added": "3.4"
+                },
+                "ios": {
+                  "version_added": "3.4"
+                },
+                "web_lynx": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/lynx-compat-data/lynx-api/performance-api/host-platform-timing/ios-host-platform-timing.json
+++ b/packages/lynx-compat-data/lynx-api/performance-api/host-platform-timing/ios-host-platform-timing.json
@@ -1,0 +1,27 @@
+{
+  "lynx-api": {
+    "performance-api": {
+      "host-platform-timing": {
+        "ios-host-platform-timing": {
+          "IOSHostPlatformTiming": {
+            "__compat": {
+              "description": "",
+              "lynx_path": "api/lynx-api/performance-api/host-platform-timing/ios-host-platform-timing",
+              "support": {
+                "android": {
+                  "version_added": "3.4"
+                },
+                "ios": {
+                  "version_added": "3.4"
+                },
+                "web_lynx": {
+                  "version_added": false
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/lynx-compat-data/lynx-api/performance-api/performance-entry/pipeline-entry.json
+++ b/packages/lynx-compat-data/lynx-api/performance-api/performance-entry/pipeline-entry.json
@@ -274,6 +274,23 @@
                 }
               }
             }
+          },
+          "hostPlatformTiming": {
+            "__compat": {
+              "description": "",
+              "lynx_path": "api/lynx-api/performance-api/performance-entry/pipeline-entry",
+              "support": {
+                "android": {
+                  "version_added": "3.4"
+                },
+                "ios": {
+                  "version_added": "3.4"
+                },
+                "web_lynx": {
+                  "version_added": false
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
Add new host platform timing interfaces for Android, iOS, and Harmony platforms to track platform-specific performance metrics in Lynx Pipeline. Includes documentation updates, compatibility data, and example images.

Update PipelineEntry to include hostPlatformTiming property and modify related documentation. Add new mdx files for each platform's timing interface with detailed property descriptions and examples.

Change-Id: I35c6bfb37b55749505471e34d0e9ad7b998919ae