### PR TITLE
fix: inconsistent between zh and en for hsla syntax

### DIFF
--- a/docs/en/api/css/data-type/color.mdx
+++ b/docs/en/api/css/data-type/color.mdx
@@ -187,7 +187,7 @@ The HSL color model defines a given color according to its hue, saturation, and 
 
 HSL colors are expressed through the functional `hsl()` and `hsla()` notations.
 
-`hsl()` or `hsla()`:`hsl[a](H, S, L[, A])` or `hsl[a](H S L[ / A])`
+`hsl()` or `hsla()`:`hsl[a](H, S, L[, A])`
 
 - `H` (hue) is an [`<angle>`](./angle) of the color circle given in `deg`s, `rad`s, `grad`s. When written as a unitless [`<number>`](./number), it is interpreted as degrees. By definition, red=0deg=360deg, with the other colors spread around the circle, so green=120deg, blue=240deg, etc.
 - `S` (saturation) and `L` (lightness) are percentages. `100%` **saturation** is completely saturated, while `0%` is completely unsaturated (gray). `100%` **lightness** is white, `0%` lightness is black, and `50%` lightness is "normal".

--- a/packages/lynx-compat-data/css/data-type/color.json
+++ b/packages/lynx-compat-data/css/data-type/color.json
@@ -22,14 +22,13 @@
             }
           }
         },
-        "rgb": {
+        "rgb()": {
           "__compat": {
             "description": "<code>rgb()</code> (RGB color model)",
             "status": {
               "deprecated": false,
               "experimental": false
             },
-            "lynx_path": "api/css/data-type/color#rgb-color-model",
             "support": {
               "android": {
                 "version_added": "1.0"
@@ -39,6 +38,98 @@
               },
               "web_lynx": {
                 "version_added": true
+              }
+            }
+          },
+          "legacy-rgb-syntax": {
+            "__compat": {
+              "description": "<a href='https://drafts.csswg.org/css-color/#typedef-legacy-rgb-syntax'><code>&lt;legacy-rgb-syntax&gt;</code></a>",
+              "status": {
+                "deprecated": false,
+                "experimental": false
+              },
+              "spec_url": [
+                "https://drafts.csswg.org/css-color/#typedef-legacy-rgb-syntax"
+              ],
+              "support": {
+                "android": {
+                  "version_added": "1.0"
+                },
+                "ios": {
+                  "version_added": "1.0"
+                },
+                "web_lynx": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "modern-rgb-syntax": {
+            "__compat": {
+              "description": "<a href='https://drafts.csswg.org/css-color/#typedef-modern-rgb-syntax'><code>&lt;modern-rgb-syntax&gt;</code></a>",
+              "spec_url": [
+                "https://drafts.csswg.org/css-color/#typedef-modern-rgb-syntax"
+              ],
+              "status": {
+                "deprecated": false,
+                "experimental": false
+              },
+              "support": {
+                "android": {
+                  "version_added": "3.4"
+                },
+                "ios": {
+                  "version_added": "3.4"
+                },
+                "web_lynx": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "legacy-rgba-syntax": {
+            "__compat": {
+              "description": "<a href='https://drafts.csswg.org/css-color/#typedef-legacy-rgba-syntax'><code>&lt;legacy-rgba-syntax&gt;</code></a>",
+              "status": {
+                "deprecated": false,
+                "experimental": false
+              },
+              "spec_url": [
+                "https://drafts.csswg.org/css-color/#typedef-legacy-rgba-syntax"
+              ],
+              "support": {
+                "android": {
+                  "version_added": "1.0"
+                },
+                "ios": {
+                  "version_added": "1.0"
+                },
+                "web_lynx": {
+                  "version_added": true
+                }
+              }
+            }
+          },
+          "modern-rgba-syntax": {
+            "__compat": {
+              "description": "<a href='https://drafts.csswg.org/css-color/#typedef-modern-rgba-syntax'><code>&lt;modern-rgba-syntax&gt;</code></a>",
+              "spec_url": [
+                "https://drafts.csswg.org/css-color/#typedef-modern-rgba-syntax"
+              ],
+              "status": {
+                "deprecated": false,
+                "experimental": false
+              },
+              "support": {
+                "android": {
+                  "version_added": "3.4"
+                },
+                "ios": {
+                  "version_added": "3.4"
+                },
+                "web_lynx": {
+                  "version_added": true
+                }
               }
             }
           }


### PR DESCRIPTION
hsla dosen't support modern syntax