### PR TITLE
docs: use shiki diff and focus

### DIFF
--- a/docs/en/guide/inclusion/internationalization.mdx
+++ b/docs/en/guide/inclusion/internationalization.mdx
@@ -97,10 +97,10 @@ If you import `*.json` in TypeScript file, you may need to set `compilerOptions.
 
 Then, the `i18n.t` function can be used for translations:
 
-```tsx title="src/App.tsx" {3,12}
+```tsx title="src/App.tsx"
 import { useEffect } from '@lynx-js/react';
 
-import { i18n } from './i18n.js';
+import { i18n } from './i18n.js'; // [!code highlight]
 
 export function App() {
   useEffect(() => {

--- a/docs/en/guide/start/integrate-lynx-dev-version.mdx
+++ b/docs/en/guide/start/integrate-lynx-dev-version.mdx
@@ -5,7 +5,7 @@ import { Details, PlatformTabs, CodeFold } from '@lynx';
 # Integrate Lynx development version
 
 During Lynx page development, you can use the Lynx Trace and Lynx Recorder tools for debugging, analysis, and locate issues.
-To avoid impacting production performance, the official release version of Lynx does not include Lynx Trace and Lynx Recorder features.  
+To avoid impacting production performance, the official release version of Lynx does not include Lynx Trace and Lynx Recorder features.
 For developer convenience, Lynx also provides a development version (with a `-dev` suffix in the version number). Starting from `release/3.4`, Lynx provides a dev version for each release version (the dev version uses the same release version number with a `-dev` suffix). You can integrate the Lynx development version by following the steps below.
 
 :::info
@@ -31,14 +31,12 @@ Refer to the [Lynx Devtool integration guide](/guide/start/integrate-lynx-devtoo
 
 Update your `Podfile` to use the dev version of the Lynx component.
 
-```ruby title="Podfile" {8,11}
+```ruby title="Podfile"
+pod 'Lynx', '3.4.0-rc.0' # [!code --]
+pod 'Lynx', '3.4.0-rc.0-dev' # [!code ++]
 
-- pod 'Lynx', '3.4.0-rc.0'
-+ pod 'Lynx', '3.4.0-rc.0-dev'
-
-- pod 'LynxDevtool', '3.4.0-rc.0'
-+ pod 'LynxDevtool', '3.4.0-rc.0-dev'
-
+pod 'LynxDevtool', '3.4.0-rc.0' # [!code --]
+pod 'LynxDevtool', '3.4.0-rc.0-dev' # [!code ++]
 ```
 
 ### Install Dependencies

--- a/docs/en/rspeedy/typescript.md
+++ b/docs/en/rspeedy/typescript.md
@@ -148,7 +148,7 @@ Unlike the native TypeScript compiler, tools like SWC and Babel compile each fil
 ```json title="tsconfig.json"
 {
   "compilerOptions": {
-    "isolatedModules": true
+    "isolatedModules": true // [!code focus]
   }
 }
 ```

--- a/docs/zh/guide/inclusion/internationalization.mdx
+++ b/docs/zh/guide/inclusion/internationalization.mdx
@@ -93,10 +93,10 @@ export { localI18nInstance as i18n };
 
 接下来，可以直接使用 `i18n.t` 函数来进行文案翻译：
 
-```tsx title="src/App.tsx" {3,12}
+```tsx title="src/App.tsx"
 import { useEffect } from '@lynx-js/react';
 
-import { i18n } from './i18n.js';
+import { i18n } from './i18n.js'; // [!code highlight]
 
 export function App() {
   useEffect(() => {

--- a/docs/zh/guide/start/integrate-lynx-dev-version.mdx
+++ b/docs/zh/guide/start/integrate-lynx-dev-version.mdx
@@ -3,7 +3,7 @@ import { PlatformTabs } from '@lynx';
 
 # 集成 Lynx 开发版本
 
-在 Lynx 页面开发过程中，你可以使用 Lynx Trace 和 Lynx Recorder 工具进行调试、分析和定位问题。为避免影响线上性能，Lynx 正式版本（release）并不包含 Lynx Trace 和 Lynx Recorder 功能。  
+在 Lynx 页面开发过程中，你可以使用 Lynx Trace 和 Lynx Recorder 工具进行调试、分析和定位问题。为避免影响线上性能，Lynx 正式版本（release）并不包含 Lynx Trace 和 Lynx Recorder 功能。
 为了方便开发者使用 Lynx Trace 和 Lynx Recorder 工具，Lynx 同时提供了开发版本(版本号带 `-dev` 后缀)。
 从 `release/3.4` 版本开始，Lynx 会为每一个 release 版本提供对应的开发版本（版本号为 release 版本号加上“-dev”后缀）。你可以按照以下步骤集成 Lynx 的开发版本。
 你可以按照以下步骤集成 Lynx 的开发版本。
@@ -31,14 +31,12 @@ import { PlatformTabs } from '@lynx';
 
 在 `Podfile` 里，将 Lynx 组件版本号改为开发版本：
 
-```ruby title="Podfile" {8,11}
+```ruby title="Podfile"
+pod 'Lynx', '3.4.0-rc.0' # [!code --]
+pod 'Lynx', '3.4.0-rc.0-dev' # [!code ++]
 
-- pod 'Lynx', '3.4.0-rc.0'
-+ pod 'Lynx', '3.4.0-rc.0-dev'
-
-- pod 'LynxDevtool', '3.4.0-rc.0'
-+ pod 'LynxDevtool', '3.4.0-rc.0-dev'
-
+pod 'LynxDevtool', '3.4.0-rc.0' # [!code --]
+pod 'LynxDevtool', '3.4.0-rc.0-dev' # [!code ++]
 ```
 
 ### 安装依赖

--- a/docs/zh/rspeedy/typescript.md
+++ b/docs/zh/rspeedy/typescript.md
@@ -148,7 +148,7 @@ Rsbuild 使用 SWC 来编译 TypeScript 代码。
 ```json title="tsconfig.json"
 {
   "compilerOptions": {
-    "isolatedModules": true
+    "isolatedModules": true // [!code focus]
   }
 }
 ```
@@ -192,7 +192,7 @@ import { defineConfig } from '@lynx-js/rspeedy';
 export default defineConfig({
   plugins: [
     pluginTypeCheck({
-      enable: true,
+      enable: true, // [!code focus],
     }),
   ],
 });

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -7,6 +7,7 @@ import { pluginClientRedirects } from '@rspress/plugin-client-redirects';
 import {
   transformerNotationHighlight,
   transformerNotationDiff,
+  transformerNotationFocus,
 } from '@shikijs/transformers';
 import * as path from 'node:path';
 import { pluginGoogleAnalytics } from 'rsbuild-plugin-google-analytics';
@@ -209,6 +210,7 @@ export default defineConfig({
         transformerCompatibleMetaHighlight(),
         transformerNotationHighlight(),
         transformerNotationDiff(),
+        transformerNotationFocus(),
       ],
     },
   },


### PR DESCRIPTION
Use `[!code ++]`, `[!code --]`, `[!code highlight]` and `[!code focus]` to make better looking documentation.

See: 
- diff: https://shiki.style/packages/transformers#transformernotationdiff
- highlight: https://shiki.style/packages/transformers#transformernotationhighlight
- focus: https://shiki.style/packages/transformers#transformernotationfocus