### PR TITLE
fix(search): change `maxResultsPerGroup` to 5

### DIFF
--- a/theme/index.tsx
+++ b/theme/index.tsx
@@ -174,7 +174,7 @@ function HomeLayout() {
   );
 }
 
-const Search = (props: Partial<SearchProps> | undefined) => {
+const Search = (props?: Partial<SearchProps> | undefined) => {
   const lang = useLang();
   return (
     <PluginAlgoliaSearch


### PR DESCRIPTION
This defaults to `20` in `@rspress/plugin-algolia/runtime`. Since we would have much more groups than Rstack, we switch to `5` to get better search experience.