### PR TITLE
fix: developers should use event bubbles

### DIFF
--- a/docs/en/react/main-thread-script.mdx
+++ b/docs/en/react/main-thread-script.mdx
@@ -35,7 +35,7 @@ Synchronizing events using main thread script is very simple. Here we try to mod
 First, we inform the framework that we want to handle this event on the main thread by adding a main-thread namespace to the event attribute name:
 
 ```tsx
-<view main-thread:global-bindscroll={onScroll} />
+<view main-thread:bindscroll={onScroll} />
 ```
 
 Since the onScroll function is now a main thread event handler, we also need to declare the event handler as a main thread function.

--- a/docs/zh/react/main-thread-script.mdx
+++ b/docs/zh/react/main-thread-script.mdx
@@ -35,7 +35,7 @@ import { Go } from '@lynx';
 首先，我们通过在事件属性名称中添加 `main-thread` 命名空间来通知框架我们想要在主线程上处理此事件：
 
 ```tsx
-<view main-thread:global-bindscroll={onScroll} />
+<view main-thread:bindscroll={onScroll} />
 ```
 
 我们还需要将 `onScroll` 函数声明为主线程函数。实现方式是：在函数体的首行添加一个 `'main thread'` 指令。


### PR DESCRIPTION
Developers should use event bubbles.

The global-bind is not supported on web platform.