### PR TITLE
chore: change flag name

### DIFF
--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -80,6 +80,7 @@ export default defineConfig({
         'process.env': {
           // This marks the first open sourced version of Lynx.
           OSS: '3.2',
+          COMPAT_TABLE_HIDE_CLAY: true,
           DOC_GIT_BASE_URL: JSON.stringify(
             'https://github.com/lynx-family/lynx-website/tree/main',
           ),

--- a/src/components/api-table/compat-table/index.tsx
+++ b/src/components/api-table/compat-table/index.tsx
@@ -46,7 +46,7 @@ function gatherPlatformsAndBrowsers(
   const hasNodeJSData = data.__compat && 'nodejs' in data.__compat.support;
   const hasDenoData = data.__compat && 'deno' in data.__compat.support;
 
-  const platforms: BCD.PlatformType[] = !!process.env.OSS
+  const platforms: BCD.PlatformType[] = !!process.env.COMPAT_TABLE_HIDE_CLAY
     ? ['native', 'web']
     : ['native', 'clay', 'web'];
   let browsers: BCD.PlatformName[] = [];


### PR DESCRIPTION
This pull request updates the configuration and logic for displaying platform support in the compatibility table. The main change is the introduction of a new environment variable to control whether the "clay" platform is shown, improving flexibility for different deployments.

**Configuration and feature flag changes:**

* Added a new environment variable `COMPAT_TABLE_HIDE_CLAY` to the `process.env` config in `rspress.config.ts` to control the visibility of the "clay" platform in compatibility tables.

**Compatibility table logic updates:**

* Updated the logic in `gatherPlatformsAndBrowsers` in `src/components/api-table/compat-table/index.tsx` to use the new `COMPAT_TABLE_HIDE_CLAY` environment variable instead of `OSS` for determining which platforms to display.Change-Id: I78cadf779c40d6f5cf43d713d5faf8f4cdb79dfe