### PR TITLE
fix: theme color change in flash

### DIFF
--- a/theme/index.tsx
+++ b/theme/index.tsx
@@ -4,6 +4,7 @@ import {
   useLang,
   useLocation,
   usePageData,
+  Head,
 } from '@rspress/core/runtime';
 import {
   HomeLayout as BaseHomeLayout,
@@ -29,23 +30,36 @@ import AfterNavTitle from './AfterNavTitle';
 import BeforeSidebar from './BeforeSidebar';
 import { useBlogBtnDom } from './hooks/use-blog-btn-dom';
 
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      htmlAttrs: unknown;
+    }
+  }
+}
+
 function Layout() {
   const { pathname } = useLocation();
 
-  useEffect(() => {
-    const subsite = SUBSITES_CONFIG.find((s) => pathname.includes(s.value));
-    document.documentElement.setAttribute(
-      'data-subsite',
-      subsite ? subsite.value : 'guide',
-    );
-  }, [pathname]);
+  const subsite = SUBSITES_CONFIG.find((s) => pathname.includes(s.value));
+  // useEffect(() => {
+  //   document.documentElement.setAttribute(
+  //     'data-subsite',
+  //     subsite ? subsite.value : 'guide',
+  //   );
+  // }, [pathname]);
 
   return (
-    <BaseLayout
-      afterNavTitle={<AfterNavTitle />}
-      beforeSidebar={<BeforeSidebar />}
-      bottom={<Footer />}
-    />
+    <>
+      <Head>
+        <htmlAttrs data-subsite={subsite ? subsite.value : 'guide'} />
+      </Head>
+      <BaseLayout
+        afterNavTitle={<AfterNavTitle />}
+        beforeSidebar={<BeforeSidebar />}
+        bottom={<Footer />}
+      />
+    </>
   );
 }
 


### PR DESCRIPTION
This pull request updates the way the `data-subsite` attribute is set on the HTML element in the `theme/index.tsx` file. Instead of using a `useEffect` to directly modify the DOM, it now uses the `Head` component to declaratively set the attribute. Additionally, TypeScript types are extended to support the new usage.

The most important changes are:

**Declarative HTML attribute management:**

* The `data-subsite` attribute is now set using a `<Head><htmlAttrs ... /></Head>` pattern, replacing the previous imperative `useEffect` approach that manually set the attribute on `document.documentElement`.

**TypeScript and JSX support:**

* The global JSX namespace is extended to include an `htmlAttrs` intrinsic element, ensuring TypeScript recognizes the new usage in JSX.

**Dependency updates:**

* The `Head` component is imported from `@rspress/core/runtime` to support the new declarative approach.

before: theme color is controlled by useEffect hook which in not
  triggered in ssg environment. it flashes when hydrate

after: use Head component from unhead/react. helps update html
  attributes in ssg runtime.
Change-Id: I7482eead170cc292a4e26ef4f45549f46812ea85