### PR TITLE
fix: home page zh link

### DIFF
--- a/docs/zh/index.mdx
+++ b/docs/zh/index.mdx
@@ -7,8 +7,8 @@ hero:
   actions:
     - theme: brand
       text: 介绍
-      link: /blog/lynx-unlock-native-for-more
+      link: /zh/blog/lynx-unlock-native-for-more
     - theme: alt
       text: 快速开始
-      link: /guide/start/quick-start
+      link: /zh/guide/start/quick-start
 ---


### PR DESCRIPTION
This pull request updates internal documentation links in the Chinese homepage to ensure they point to the correct localized blog and guide pages.

Documentation link corrections:

* Updated the "介绍" link in the `hero` section of `docs/zh/index.mdx` to use the Chinese blog URL.
* Updated the "快速开始" link in the `hero` section of `docs/zh/index.mdx` to use the Chinese quick start guide URL.
Change-Id: I9de674262973ff278accbbfed8272b4aef921fd3