### PR TITLE
fix: Remove redundant symbols from image documentation.

### DIFF
--- a/docs/en/api/elements/built-in/image.mdx
+++ b/docs/en/api/elements/built-in/image.mdx
@@ -499,4 +499,3 @@ Read the API reference of [`MediaResourceFetcher`](/api/lynx-native-api/lynx-med
 import { LegacyCompatTable } from '@lynx';
 
 <LegacyCompatTable metadata="elements/image" />
-```

--- a/docs/zh/api/elements/built-in/image.mdx
+++ b/docs/zh/api/elements/built-in/image.mdx
@@ -510,4 +510,3 @@ export class ExampleMediaResourceFetcher extends LynxMediaResourceFetcher {
 import { LegacyCompatTable } from '@lynx';
 
 <LegacyCompatTable metadata="elements/image" />
-```


### PR DESCRIPTION
Remove redundant symbol '```' at the end of the image documentation.