### PR TITLE
fix: home-create on mobile; typos in spec

### DIFF
--- a/packages/lynx-living-spec/src/common-infrastructure.bs
+++ b/packages/lynx-living-spec/src/common-infrastructure.bs
@@ -57,8 +57,8 @@ Similar to WebView in native developing. Renders [=bundle=] within host applicat
 ### Page
 Similar to the document in W3C. It is the root [=ElementsComponents/element=] of Lynx [=App=].
 
-### The Lynx Object
-It is a binding object, offering some common capabilities to script developers. It is provided in [=main thread runtime=] and [=background thread runtime=].
+### The `Lynx` Object
+A binding object, offering some common capabilities to script developers. It is provided in [=main thread runtime=] and [=background thread runtime=].
 
 
 ### <dfn for=CommonInfrastructure>Lynx Group</dfn>

--- a/packages/lynx-living-spec/src/scripting.bs
+++ b/packages/lynx-living-spec/src/scripting.bs
@@ -26,10 +26,10 @@ A kind of [=Scripting/scripting engine=] that can execute [=Scripting/JavaScript
 These are some of the industry-acknowledged [=Scripting/JavaScript engine=].
 
 #### <dfn for=Scripting>PrimJS VM</dfn>
-This is a [=Scripting/scripting engine=] forked from QuickJS.
+An [open-sourced](https://github.com/lynx-family/primjs) [=Scripting/scripting engine=] designed specifically for Lynx.
 
 ## <dfn for=Scripting>JavaScript FFI</dfn>
-A foreign function interface (FFI) is a mechanism by which a program written in one programming language can call routines or make use of services written or compiled in another one.
+A Foreign Function Interface (FFI) is a mechanism by which a program written in one programming language can call routines or make use of services written or compiled in another one.
 JavaScript FFI here refers to the mechanism by which JavaScript calls to Native.
 
 ### <dfn for=Scripting>Node-API</dfn> (or <dfn for=Scripting>N-API</dfn>)
@@ -44,17 +44,17 @@ The PrimJS API is the API provided by PrimJS for native developers to implement 
 It offers a special HostRef that can be created and held at high performance.
 This HostRef is not an Object in JavaScript, and script developers cannot manipulate the HostRef directly; they can only pass it as a parameter to the FFI.
 
-## Scripting Runtime Enviroment
+## Scripting Runtime Environment
 
-### <dfn for=Scripting>Scripting Runtime Enviroment</dfn>
+### <dfn for=Scripting>Scripting Runtime Environment</dfn>
 
-An abstract enviroment comprises a [=Scripting/scripting engine=] that executes [=Scripting/scripts=], along with a series of APIs and libraries accessible to the [=Scripting/scripts=].
+An abstract environment comprises a [=Scripting/scripting engine=] that executes [=Scripting/scripts=], along with a series of APIs and libraries accessible to the [=Scripting/scripts=].
 
 ### Main Thread Scripting
 
 #### <dfn for=Scripting>Main Thread Runtime</dfn>
 
-The [=Scripting/scripting runtime enviroment=] used by the [=Threading/main thread=]. It comprises of
+The [=Scripting/scripting runtime environment=] used by the [=Threading/main thread=]. It comprises of
 
 - [=Scripting/PrimJS VM=], and
 - APIs exposed from [=EnginePixeling/pixel pipeline=], such as [=ElementsComponents/Element PAPI=].
@@ -72,7 +72,7 @@ A kind of [=Scripting/script=] intended to be executed on the [=Scripting/main t
 
 #### <dfn for=Scripting>Background Thread Runtime</dfn>
 
-A [=Scripting/scripting runtime enviroment=] comprises of
+A [=Scripting/scripting runtime environment=] comprises of
 
 - An instance of [=Scripting/JavaScript engine=], and
 - Extended scripting APIs such as those exposed by JSB (JavaScript Bridge, to be further defined).
@@ -84,7 +84,7 @@ A kind of [=Scripting/script=] that is intended to be executed under the [=Scrip
 - e.g. app-service.js, background.js, worker.js
 
 ## <dfn for=Scripting>Procedure Call</dfn> (or <dfn for=Scripting>Call</dfn>)
-In Lynx Engine, there are dual threads and dual [=scripting runtime enviroment=]. And there are FFI calls from Runtime to Native, as well as calls from Native to Runtime. These cross-environment or cross-thread calls are referred to as Procedure Call, or simply as Call.
+In Lynx Engine, there are dual threads and dual [=scripting runtime environment=]. And there are FFI calls from Runtime to Native, as well as calls from Native to Runtime. These cross-environment or cross-thread calls are referred to as Procedure Call, or simply as Call.
 
 ### <dfn for=Scripting>Sync Call</dfn>
 Sync call specifically refers to cross-environment [=calls=] that occur in the same thread, including calls from runtime to native and from native to runtime.

--- a/theme/index.scss
+++ b/theme/index.scss
@@ -207,6 +207,12 @@ $overview-index-color-dark: #f9f9f9;
 
 .home-layout-create-block {
   background-color: rgb(from var(--rp-code-block-bg) r g b / 50%) !important;
+
+  @media (max-width: 640px) {
+    margin: 6px 0 !important;
+    background-color: transparent !important;
+    font-size: 0.75rem !important;
+  }
 }
 
 :lang(cn) em {


### PR DESCRIPTION
Other than fixing typos, this PR improves the visual of the create block at home on mobile to be lighter and cleaner

Before:

<img width="411" height="537" alt="image" src="https://github.com/user-attachments/assets/d9e5a4c5-e387-41dd-8e1c-d9648ba64de7" />


After:

<img width="407" height="467" alt="image" src="https://github.com/user-attachments/assets/219f5a3b-c5f8-48d9-b042-f434fb3b194f" />

