### PR TITLE
update event.stopPropgation version number

### DIFF
--- a/packages/lynx-compat-data/lynx-api/event/Event.json
+++ b/packages/lynx-compat-data/lynx-api/event/Event.json
@@ -157,13 +157,13 @@
             "lynx_path": "api/lynx-api/event/event",
             "support": {
               "android": {
-                "version_added": "2.14"
+                "version_added": "3.5"
               },
               "ios": {
-                "version_added": "2.14"
+                "version_added": "3.5"
               },
               "harmony": {
-                "version_added": "3.4"
+                "version_added": "3.5"
               },
               "web_lynx": {
                 "version_added": false
@@ -176,13 +176,13 @@
             "lynx_path": "api/lynx-api/event/event",
             "support": {
               "android": {
-                "version_added": "2.14"
+                "version_added": "3.5"
               },
               "ios": {
-                "version_added": "2.14"
+                "version_added": "3.5"
               },
               "harmony": {
-                "version_added": "3.4"
+                "version_added": "3.5"
               },
               "web_lynx": {
                 "version_added": false


### PR DESCRIPTION
This commit update `event.stopPropgation` and `event.stopImmediatePropgation` 's supporting table, to make it match the actual version