### PR TITLE
feat: remove stopPropgation in event

### DIFF
--- a/docs/en/api/lynx-api/event/event.mdx
+++ b/docs/en/api/lynx-api/event/event.mdx
@@ -68,28 +68,6 @@ A collection of attribute values ​​of `element` that listens to events.
 - `uid`: `element`'s unique identifier in Lynx Engine.
 - `dataset`: A collection of custom attributes starting with [`data-`](../../elements/built-in/view.mdx#data-) on `element`.
 
-## Instance method
-
-### stopPropagation
-
-```ts
-stopPropagation(): void;
-```
-
-Stop bubbling and prevent the event from continuing to bubble up the touch response chain.
-
-This method is only implemented in the [main thread script](../../../react/main-thread-script.mdx). Calling it in the [main thread script](../../../react/main-thread-script.mdx) can affect both event bubbling and event handler triggering in `JS`.
-
-### stopImmediatePropagation
-
-```ts
-stopImmediatePropagation(): void;
-```
-
-Stop bubbling, prevent the event from continuing to bubble in the event response chain, and prevent other event handlers of the same event on the current node from being triggered.
-
-This method is only implemented in the [main thread script](../../../react/main-thread-script.mdx). Calling it in the [main thread script](../../../react/main-thread-script.mdx) can affect both event bubbling and event handler triggering in `JS`.
-
 ## Compatibility
 
 import { LegacyCompatTable } from '@lynx';

--- a/docs/zh/api/lynx-api/event/event.mdx
+++ b/docs/zh/api/lynx-api/event/event.mdx
@@ -68,28 +68,6 @@ currentTarget: {
 - `uid`: `element` 在 Lynx Engine 中的唯一标识符。
 - `dataset`: `element` 上由 [`data-`](../../elements/built-in/view.mdx#data-) 开头的自定义属性组成的集合。
 
-## 实例方法
-
-### stopPropagation
-
-```ts
-stopPropagation(): void;
-```
-
-停止冒泡，阻止事件在触摸响应链上继续冒泡。
-
-该方法只在[主线程脚本](../../../react/main-thread-script.mdx)中实现，在[主线程脚本](../../../react/main-thread-script.mdx)中调用可以同时影响 `JS` 中的事件冒泡和事件处理函数触发。
-
-### stopImmediatePropagation
-
-```ts
-stopImmediatePropagation(): void;
-```
-
-停止冒泡，阻止事件在事件响应链上继续冒泡，并且阻止当前节点上其他相同事件的事件处理函数被触发。
-
-该方法只在[主线程脚本](../../../react/main-thread-script.mdx)中实现，在[主线程脚本](../../../react/main-thread-script.mdx)中调用可以同时影响 `JS` 中的事件冒泡和事件处理函数触发。
-
 ## 兼容性
 
 import { LegacyCompatTable } from '@lynx';

--- a/packages/lynx-compat-data/lynx-api/event/Event.json
+++ b/packages/lynx-compat-data/lynx-api/event/Event.json
@@ -151,44 +151,6 @@
               }
             }
           }
-        },
-        "stopPropagation": {
-          "__compat": {
-            "lynx_path": "api/lynx-api/event/event",
-            "support": {
-              "android": {
-                "version_added": "2.14"
-              },
-              "ios": {
-                "version_added": "2.14"
-              },
-              "harmony": {
-                "version_added": "3.4"
-              },
-              "web_lynx": {
-                "version_added": false
-              }
-            }
-          }
-        },
-        "stopImmediatePropagation": {
-          "__compat": {
-            "lynx_path": "api/lynx-api/event/event",
-            "support": {
-              "android": {
-                "version_added": "2.14"
-              },
-              "ios": {
-                "version_added": "2.14"
-              },
-              "harmony": {
-                "version_added": "3.4"
-              },
-              "web_lynx": {
-                "version_added": false
-              }
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
Remove `event.stopPropgation` and `event.stopImmediatPropgation`, cause these method doesn't exist prior Lynx 3.5