### PR TITLE
fix: disable Rspress builtin styles in `<APITable />`

### DIFF
--- a/src/components/api-table/APITable.tsx
+++ b/src/components/api-table/APITable.tsx
@@ -36,5 +36,9 @@ export default function APITable(props: APITableProps) {
     query = frontmatter.api as string;
   }
 
-  return <FetchingCompatTable query={query} />;
+  return (
+    <div className="rp-not-doc">
+      <FetchingCompatTable query={query} />
+    </div>
+  );
 }


### PR DESCRIPTION
Fix a regression from #432.

<img width="669" height="575" alt="image" src="https://github.com/user-attachments/assets/f09e2b3a-bbf3-4b29-8193-6c033abe6789" />

Related Rspress change: https://github.com/web-infra-dev/rspress/pull/2600