### PR TITLE
fix: disable Rspress builtin styles in `<APITable />`

### DIFF
--- a/src/components/api-table/APITable.tsx
+++ b/src/components/api-table/APITable.tsx
@@ -36,5 +36,9 @@ export default function APITable(props: APITableProps) {
     query = frontmatter.api as string;
   }
 
-  return <FetchingCompatTable query={query} />;
+  return (
+    <div className="rp-not-doc">
+      <FetchingCompatTable query={query} />
+    </div>
+  );
 }


### PR DESCRIPTION
This is cherry-picked from #434.