### PR TITLE
Update link class name form `[class^='link']` to `.rp-link`

### DIFF
--- a/theme/index.scss
+++ b/theme/index.scss
@@ -147,12 +147,12 @@ $overview-index-color-dark: #f9f9f9;
   }
   .rspress-doc {
     & > *:not(.next-steps, .rspress-directive.tip) {
-      [class^='link']:not(.header-anchor),
-      summary [class^='link']:not(.header-anchor) {
+      .rp-link:not(.header-anchor),
+      summary .rp-link:not(.header-anchor) {
         color: var(--custom-link-color);
       }
-      [class^='link']:hover,
-      summary [class^='link']:hover,
+      .rp-link:hover,
+      summary .rp-link:hover,
       summary a:hover {
         border-bottom: 1px solid var(--custom-link-color);
       }


### PR DESCRIPTION
In previous [rspress upgrade)(https://github.com/lynx-family/lynx-website/pull/433), link class name changed from `link_abcd` liked to a fixed name `.rp-link`.

So the selector `[class^='link']` cannot match the new class name.

Here we change the selector to the fixed class name

Change-Id: I02116c3f373a3f6d090107f6296a94137796acb2