### PR TITLE
docs: update kotlin kapt setup, fix:androidx appcompat not found

### DIFF
--- a/docs/en/guide/custom-native-component/custom-component-android.mdx
+++ b/docs/en/guide/custom-native-component/custom-component-android.mdx
@@ -26,18 +26,13 @@ annotationProcessor project('org.lynxsdk.lynx:lynx-processor:3.4.1')
 
 <Tab label="Kotlin">
 
-
 ```kotlin
-// add `kotlin-kapt` to build.gradle(kts) plugins
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.kotlin.android)
     id("kotlin-kapt")
 }
-
-```
-```kotlin
-//inside dependency, add appcompat for `AppCompatEditText` widget usage in our custom element
+//dependency
 kapt('org.lynxsdk.lynx:lynx-processor:3.4.1')
 implementation("androidx.appcompat:appcompat:1.7.0")
 ```

--- a/docs/zh/guide/custom-native-component/custom-component-android.mdx
+++ b/docs/zh/guide/custom-native-component/custom-component-android.mdx
@@ -25,7 +25,14 @@ annotationProcessor project('org.lynxsdk.lynx:lynx-processor:3.4.1')
 <Tab label="Kotlin">
 
 ```kotlin
-kapt project('org.lynxsdk.lynx:lynx-processor:3.4.1')
+plugins {
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.jetbrains.kotlin.android)
+    id("kotlin-kapt")
+}
+
+kapt('org.lynxsdk.lynx:lynx-processor:3.4.1')
+implementation("androidx.appcompat:appcompat:1.7.0")
 ```
 
 </Tab>


### PR DESCRIPTION
the docs setup for kotlin version of kapt was wrong. also androidx appcompat wasn't setup causing build failures. this fixes both