### PR TITLE
fix: padding of API pages on mobile

### DIFF
--- a/theme/index.scss
+++ b/theme/index.scss
@@ -17,15 +17,8 @@
   }
 }
 
-@media (max-width: 640px) {
-  .rspress-home-hero-image {
-    width: 160px;
-  }
-
-  .overview-index {
-    padding: 0px 2px;
-    margin-top: -8px;
-  }
+.overview-index {
+  padding-top: 48px;
 }
 
 $major-brand-color: #ff351a;


### PR DESCRIPTION
Change-Id: I882f2c68ceead92ea83feb66b0c17a9e08cadfc3

Before:

<img width="392" height="820" alt="image" src="https://github.com/user-attachments/assets/920574eb-d312-450b-8da7-0ed2398c8956" />


After:

<img width="402" height="851" alt="image" src="https://github.com/user-attachments/assets/bf446890-831c-4c61-bcb8-f14d81913855" />
