### PR TITLE
fix: CSS filename inconsistency in tutorial gallery docs (#134)

### DIFF
--- a/docs/en/guide/start/tutorial-gallery.mdx
+++ b/docs/en/guide/start/tutorial-gallery.mdx
@@ -37,7 +37,7 @@ Since the focus of this tutorial is not on how to style your UI, you may just sa
 
 <CodeFold toggle>
 
-```css title="index.scss"
+```css title="index.css"
 .gallery-wrapper {
   height: 100vh;
   background-color: black;
@@ -245,7 +245,7 @@ Finally, we use `isLiked` to control the like effect. Because isLiked is a state
 ...
 ```
 
-To give this like a better visual interaction effect, we added animations, which are all in index.scss. You can also learn more about animations in the [Animation](/guide/styling/animation) section. Then replace it with your preferred style!
+To give this like a better visual interaction effect, we added animations, which are all in index.css. You can also learn more about animations in the [Animation](/guide/styling/animation) section. Then replace it with your preferred style!
 
 ## Displaying More Images with `<list>`
 

--- a/docs/zh/guide/start/tutorial-gallery.mdx
+++ b/docs/zh/guide/start/tutorial-gallery.mdx
@@ -33,7 +33,7 @@ import { Go, CodeFold } from '@lynx';
 
 <CodeFold toggle>
 
-```css title="index.scss"
+```css title="index.css"
 .gallery-wrapper {
   height: 100vh;
   background-color: black;
@@ -241,7 +241,7 @@ Lynx 的 `<image>` 元件可以接收一个本地的相对路径作为 `src` 属
 ...
 ```
 
-为了让这个点赞有更好的视觉互动效果，我们给它添加了动画，这些效果都在 `index.scss` 中，你也可以在[动画](/guide/styling/animation)中了解更多关于动画的内容。然后将它替换成你更喜欢的样式！
+为了让这个点赞有更好的视觉互动效果，我们给它添加了动画，这些效果都在 `index.css` 中，你也可以在[动画](/guide/styling/animation)中了解更多关于动画的内容。然后将它替换成你更喜欢的样式！
 
 ## 使用 `<list>` 展示更多图片
 


### PR DESCRIPTION
Change-Id: Id15de77b4efea7b9110ea3345b89f98a2a2abfad

## Description
Fixes CSS filename inconsistency in the tutorial gallery documentation where code block titles used `index.scss` but the text and import statements referenced `index.css`.

## Changes
- Updated code block titles from `index.scss` to `index.css` in both EN and ZH versions

## Files Changed
- `docs/en/guide/start/tutorial-gallery.mdx`
- `docs/zh/guide/start/tutorial-gallery.mdx`

## Testing
- [x] Verified all references now consistently use `index.css`
- [x] Checked both EN and ZH documentation versions
- [x] Confirmed import statements match the referenced filename

Fixes #134