### PR TITLE
fix: PlatformTabs content should be visible for ssg-md

### DIFF
--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -224,7 +224,9 @@ export default defineConfig({
   },
   llms: {
     remarkSplitMdxOptions: {
-      includes: [[['Go', 'LegacyCompatTable', 'APITable'], '@lynx']],
+      includes: [
+        [['Go', 'LegacyCompatTable', 'APITable', 'PlatformTabs'], '@lynx'],
+      ],
     },
   },
 });

--- a/src/components/platform-tabs/PlatformTabs.tsx
+++ b/src/components/platform-tabs/PlatformTabs.tsx
@@ -108,6 +108,15 @@ interface PlatformTabProps {
  * ```
  */
 const PlatformTab = ({ platform, children }: PlatformTabProps) => {
+  if (process.env.__SSR_MD__) {
+    return (
+      <>
+        <>{`\n**${platform} specific content start**\n`}</>
+        {children}
+        <>{`\n**${platform} specific content end**\n`}</>
+      </>
+    );
+  }
   return <div data-platform={platform}>{children}</div>;
 };
 
@@ -178,6 +187,9 @@ export const PlatformTabs = ({
   className,
   queryKey,
 }: PlatformTabsProps) => {
+  if (process.env.__SSR_MD__) {
+    return <>{children}</>;
+  }
   // Get available platforms from children
   const availablePlatforms = React.Children.toArray(children).reduce<
     Platform[]

--- a/theme/index.tsx
+++ b/theme/index.tsx
@@ -10,6 +10,7 @@ import {
   Layout as BaseLayout,
   getCustomMDXComponent,
   Link as BaseLink,
+  Tabs as BaseTabs,
 } from '@rspress/core/theme';
 import type { SearchProps } from '@rspress/plugin-algolia/runtime';
 import {
@@ -232,8 +233,6 @@ const Search = (props?: Partial<SearchProps> | undefined) => {
   );
 };
 
-export { HomeLayout, Layout, Search };
-
 const Link = (props: React.ComponentProps<typeof BaseLink>) => {
   const { href, children, className, ...restProps } = props;
   const getLangPrefix = (lang: string) => (lang === 'en' ? '' : `/${lang}`);
@@ -255,6 +254,14 @@ const Link = (props: React.ComponentProps<typeof BaseLink>) => {
   );
 };
 
-export { Link }; // override Link from @rspress/core/theme
+/* FIXME: overrides builtin Tabs for avoid "window is not defined" warning inner Tabs component, remove this line in the future when upgrading Rspress  */
+const Tabs = (props: any) => {
+  if (process.env.__SSR_MD__) {
+    return <>{props.children}</>;
+  }
 
+  return <BaseTabs {...props} />;
+};
+
+export { HomeLayout, Layout, Search, Link, Tabs };
 export * from '@rspress/core/theme';


### PR DESCRIPTION
`Change-Id:` I091939219c4c5131e37e6b134a4d4b87076b8672


close https://github.com/lynx-family/lynx-website/pull/530

## before

<img width="900" height="418" alt="image" src="https://github.com/user-attachments/assets/ceaacabc-b09b-4527-9bfd-ecdabb8dda4e" />


https://lynxjs.org/next/guide/start/integrate-with-existing-apps.md

## after

<img width="1208" height="916" alt="image" src="https://github.com/user-attachments/assets/e0ab255a-a5ec-4b8d-9774-dced31a28597" />

https://deploy-preview-533--lynx-doc.netlify.app/next/guide/start/integrate-with-existing-apps.md

