### PR TITLE
docs: add version badge for WebAssembly guide

### DIFF
--- a/docs/en/guide/scripting-runtime/webassembly.mdx
+++ b/docs/en/guide/scripting-runtime/webassembly.mdx
@@ -2,7 +2,11 @@
 description: 'WebAssembly support in Lynx via the PrimJS runtime on Android.'
 ---
 
+import { VersionBadge } from '@lynx';
+
 # WebAssembly
+
+<VersionBadge v={3.8} />
 
 Starting from Lynx 3.8, Lynx provides basic WebAssembly support on Android through the PrimJS runtime integration.
 

--- a/docs/zh/guide/scripting-runtime/webassembly.mdx
+++ b/docs/zh/guide/scripting-runtime/webassembly.mdx
@@ -2,7 +2,11 @@
 description: 'Lynx 3.8 起通过 PrimJS 支持 WebAssembly。'
 ---
 
+import { VersionBadge } from '@lynx';
+
 # WebAssembly
+
+<VersionBadge v={3.8} />
 
 从 Lynx 3.8 开始，Lynx 基于 PrimJS 集成为 Android 提供了基础的 WebAssembly 支持。
 


### PR DESCRIPTION
## Summary

- follow up on review feedback from #891
- add `VersionBadge` to the WebAssembly guide title in English and Chinese docs

## Testing

- npx pnpm@9.15.2 exec prettier --check docs/en/guide/scripting-runtime/webassembly.mdx docs/zh/guide/scripting-runtime/webassembly.mdx
- npx pnpm@9.15.2 exec cspell lint -c cspell.json --no-must-find-files docs/en/guide/scripting-runtime/webassembly.mdx docs/zh/guide/scripting-runtime/webassembly.mdx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Add `VersionBadge` component to WebAssembly guide titles in English and Chinese documentation

- Display version badge for Lynx 3.8 in the WebAssembly guide
- Import and place `VersionBadge` component on separate line below "WebAssembly" section heading in both `docs/en/guide/scripting-runtime/webassembly.mdx` and `docs/zh/guide/scripting-runtime/webassembly.mdx`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/893)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->