### PR TITLE
chore: auto-sort package.json via Prettier + clean up Python check-docs env

### DIFF
--- a/.cspell/dictionary.txt
+++ b/.cspell/dictionary.txt
@@ -87,3 +87,4 @@ yari
 OBJCXX
 dylib
 rpath
+pycache

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 *.local
 *.log*
 !*.log*.mdx
+**/__pycache__/
+*.py[cod]
 
 # Dist
 node_modules

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
+  "plugins": ["prettier-plugin-packagejson"],
   "singleQuote": true
 }

--- a/package.json
+++ b/package.json
@@ -2,22 +2,26 @@
   "name": "@lynx-js/lynx-doc",
   "version": "1.0.0",
   "scripts": {
-    "start": "rspress dev",
-    "dev": "rspress dev",
     "build": "NODE_OPTIONS=--max-old-space-size=8192 RSPRESS_SSG_WORKER_THREAD_COUNT=4 rspress build",
-    "prepare": "husky && pnpm --filter @lynx-js/lynx-compat-data run lint:keys && pnpm --filter @lynx-js/lynx-compat-data run gen-stats && pnpm prepare:lynx-compat-data && pnpm prepare:lynx-example-data",
+    "check-docs": "python3 -m scripts.check_api_doc.index",
+    "cspell:check": "cspell lint -c cspell.json \"docs/**/*.md(x)\"",
+    "dev": "rspress dev",
+    "fix-docs": "python3 -m scripts.check_api_doc.index --fix",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "format:zhlint": "zhlint 'docs/zh/**/*.{md,mdx}' --fix",
     "gen:living-spec": "node scripts/lynx-living-spec.js",
+    "prepare": "husky && pnpm --filter @lynx-js/lynx-compat-data run lint:keys && pnpm --filter @lynx-js/lynx-compat-data run gen-stats && pnpm prepare:lynx-compat-data && pnpm prepare:lynx-example-data",
     "prepare:lynx-compat-data": "rm -rf docs/public/lynx-compat-data && ln -s $(pwd)/packages/lynx-compat-data docs/public/lynx-compat-data",
     "prepare:lynx-example-data": "node scripts/lynx-example.js",
     "preview": "rspress preview",
-    "format": "prettier --write .",
-    "format:check": "prettier --check .",
-    "cspell:check": "cspell lint -c cspell.json \"docs/**/*.md(x)\"",
-    "check-docs": "python3 -m scripts.check_api_doc.index",
-    "fix-docs": "python3 -m scripts.check_api_doc.index --fix",
-    "zhlint": "zhlint 'docs/zh/**/*.{md,mdx}'",
-    "format:zhlint": "zhlint 'docs/zh/**/*.{md,mdx}' --fix",
-    "typedoc": "tsx ./scripts/typedoc/index.ts"
+    "start": "rspress dev",
+    "typedoc": "tsx ./scripts/typedoc/index.ts",
+    "zhlint": "zhlint 'docs/zh/**/*.{md,mdx}'"
+  },
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx,md,mdx,json,yml,yaml,css,scss}": "prettier --write",
+    "*.{md,mdx}": "cspell lint -c cspell.json --no-must-find-files"
   },
   "dependencies": {
     "@douyinfe/semi-icons": "^2.74.0",
@@ -56,10 +60,6 @@
     "vaul": "^1.1.2",
     "vscode-icons-js": "^11.6.1"
   },
-  "lint-staged": {
-    "*.{js,jsx,ts,tsx,md,mdx,json,yml,yaml,css,scss}": "prettier --write",
-    "*.{md,mdx}": "cspell lint -c cspell.json --no-must-find-files"
-  },
   "devDependencies": {
     "@lynx-js/lynx-compat-data": "workspace:*",
     "@lynx-js/react": "^0.107.1",
@@ -84,6 +84,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^15.3.0",
     "prettier": "^3.4.2",
+    "prettier-plugin-packagejson": "^3.0.2",
     "react-render-to-markdown": "18.3.1",
     "rsbuild-plugin-google-analytics": "^1.0.3",
     "rsbuild-plugin-open-graph": "^1.0.2",

--- a/packages/lynx-compat-data/api-stats.json
+++ b/packages/lynx-compat-data/api-stats.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-08T07:43:42.097Z",
+  "generated_at": "2026-04-08T11:56:24.007Z",
   "summary": {
     "total_apis": 1006,
     "platform_api_total": 917,

--- a/packages/lynx-compat-data/package.json
+++ b/packages/lynx-compat-data/package.json
@@ -21,8 +21,8 @@
   "scripts": {
     "build": "npm run lint && (npm run gen-platforms & npm run gen-types)",
     "gen-platforms": "node --loader=ts-node/esm --no-warnings=ExperimentalWarning scripts/gen-platforms.ts",
-    "gen-types": "node --loader=ts-node/esm --no-warnings=ExperimentalWarning scripts/gen-types.ts",
     "gen-stats": "node --loader=ts-node/esm --no-warnings=ExperimentalWarning scripts/generate-stats.ts",
+    "gen-types": "node --loader=ts-node/esm --no-warnings=ExperimentalWarning scripts/gen-types.ts",
     "lint": "node --loader=ts-node/esm --no-warnings=ExperimentalWarning scripts/validate.ts",
     "lint:keys": "node --loader=ts-node/esm --no-warnings=ExperimentalWarning scripts/lint-key-names.ts",
     "test": "vitest"

--- a/packages/lynx-example-packages/package.json
+++ b/packages/lynx-example-packages/package.json
@@ -41,7 +41,6 @@
     "@lynx-example/performance-api": "0.7.0",
     "@lynx-example/react-lifecycle": "0.5.6",
     "@lynx-example/refresh": "^0.6.9",
-    "@lynx-example/viewpager": "0.6.12",
     "@lynx-example/scroll-view": "0.6.5",
     "@lynx-example/svg": "^0.6.8",
     "@lynx-example/swiper": "0.5.6",
@@ -50,6 +49,7 @@
     "@lynx-example/text": "0.6.6",
     "@lynx-example/textarea": "0.6.7",
     "@lynx-example/title-bar-view": "^0.6.11",
-    "@lynx-example/view": "0.6.5"
+    "@lynx-example/view": "0.6.5",
+    "@lynx-example/viewpager": "0.6.12"
   }
 }

--- a/plugins/llms-postprocess/package.json
+++ b/plugins/llms-postprocess/package.json
@@ -2,7 +2,6 @@
   "name": "@lynx-js/rspress-plugin-llms-postprocess",
   "version": "0.1.0",
   "type": "module",
-  "module": "./src/index.ts",
   "exports": {
     ".": {
       "types": "./src/index.ts",
@@ -10,6 +9,7 @@
       "default": "./src/index.ts"
     }
   },
+  "module": "./src/index.ts",
   "dependencies": {
     "mdast-util-from-markdown": "2.0.2",
     "mdast-util-to-markdown": "2.1.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@lynx-js/go-web':
         specifier: github:lynx-community/go-web
-        version: https://codeload.github.com/lynx-community/go-web/tar.gz/38c0a3a7cd05db7b1b942e7ffc4a9496fd507266(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core-canary@0.19.9-canary-20260317-2efecc25(@lynx-js/lynx-core@0.1.3)(@lynx-js/web-elements@0.11.0(tslib@2.8.1)))(@lynx-js/web-elements@0.11.0(tslib@2.8.1))(@rspress/core@2.0.6(@types/mdast@4.0.4)(@types/react@18.3.18)(core-js@3.46.0)(micromark-util-types@2.0.1)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)
+        version: https://codeload.github.com/lynx-community/go-web/tar.gz/39e47ff7267d49b11dcb45325ebf1fee7530e437(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core-canary@0.19.9-canary-20260317-2efecc25(@lynx-js/lynx-core@0.1.3)(@lynx-js/web-elements@0.11.0(tslib@2.8.1)))(@lynx-js/web-elements@0.11.0(tslib@2.8.1))(@rspress/core@2.0.6(@types/mdast@4.0.4)(@types/react@18.3.18)(core-js@3.46.0)(micromark-util-types@2.0.1)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)
       '@lynx-js/lynx-core':
         specifier: ^0.1.3
         version: 0.1.3
@@ -183,6 +183,9 @@ importers:
       prettier:
         specifier: ^3.4.2
         version: 3.8.1
+      prettier-plugin-packagejson:
+        specifier: ^3.0.2
+        version: 3.0.2(prettier@3.8.1)
       react-render-to-markdown:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
@@ -1391,8 +1394,8 @@ packages:
   '@lynx-example/viewpager@0.6.12':
     resolution: {integrity: sha512-meYoMU69PNBHZL1Dv+holU6YCL/PWYhgsPVVyDQOjUfXY/9+zwL8WJOKoopOMQPDdsDz4MiImfczIwrNmhTjmA==}
 
-  '@lynx-js/go-web@https://codeload.github.com/lynx-community/go-web/tar.gz/38c0a3a7cd05db7b1b942e7ffc4a9496fd507266':
-    resolution: {tarball: https://codeload.github.com/lynx-community/go-web/tar.gz/38c0a3a7cd05db7b1b942e7ffc4a9496fd507266}
+  '@lynx-js/go-web@https://codeload.github.com/lynx-community/go-web/tar.gz/39e47ff7267d49b11dcb45325ebf1fee7530e437':
+    resolution: {tarball: https://codeload.github.com/lynx-community/go-web/tar.gz/39e47ff7267d49b11dcb45325ebf1fee7530e437}
     version: 0.1.0
     peerDependencies:
       '@douyinfe/semi-icons': '>=2.74.0'
@@ -3319,9 +3322,17 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
+  detect-indent@7.0.2:
+    resolution: {integrity: sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A==}
+    engines: {node: '>=12.20'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  detect-newline@4.0.1:
+    resolution: {integrity: sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
@@ -3585,6 +3596,9 @@ packages:
 
   get-tsconfig@4.10.0:
     resolution: {integrity: sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==}
+
+  git-hooks-list@4.2.1:
+    resolution: {integrity: sha512-WNvqJjOxxs/8ZP9+DWdwWJ7cDsd60NHf39XnD82pDVrKO5q7xfPqpkK6hwEAmBa/ZSEE4IOoR75EzbbIuwGlMw==}
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
@@ -4589,6 +4603,14 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prettier-plugin-packagejson@3.0.2:
+    resolution: {integrity: sha512-kmoj3hEynXwoHDo8ZhmWAIjRBoQWCDUVackiWfSDWdgD0rS3LGB61T9zoVbume/cotYdCoadUh4sqViAmXvpBQ==}
+    peerDependencies:
+      prettier: ^3
+    peerDependenciesMeta:
+      prettier:
+        optional: true
+
   prettier@3.8.1:
     resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
     engines: {node: '>=14'}
@@ -5156,6 +5178,14 @@ packages:
     peerDependencies:
       react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
       react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+
+  sort-object-keys@2.1.0:
+    resolution: {integrity: sha512-SOiEnthkJKPv2L6ec6HMwhUcN0/lppkeYuN1x63PbyPRrgSPIuBJCiYxYyvWRTtjMlOi14vQUCGUJqS6PLVm8g==}
+
+  sort-package-json@3.6.1:
+    resolution: {integrity: sha512-Chgejw1+10p2D0U2tB7au1lHtz6TkFnxmvZktyBCRyV0GgmF6nl1IxXxAsPtJVsUyg/fo+BfCMAVVFUVRkAHrQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -6825,7 +6855,7 @@ snapshots:
       - '@lynx-js/types'
       - '@types/react'
 
-  '@lynx-js/go-web@https://codeload.github.com/lynx-community/go-web/tar.gz/38c0a3a7cd05db7b1b942e7ffc4a9496fd507266(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core-canary@0.19.9-canary-20260317-2efecc25(@lynx-js/lynx-core@0.1.3)(@lynx-js/web-elements@0.11.0(tslib@2.8.1)))(@lynx-js/web-elements@0.11.0(tslib@2.8.1))(@rspress/core@2.0.6(@types/mdast@4.0.4)(@types/react@18.3.18)(core-js@3.46.0)(micromark-util-types@2.0.1)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)':
+  '@lynx-js/go-web@https://codeload.github.com/lynx-community/go-web/tar.gz/39e47ff7267d49b11dcb45325ebf1fee7530e437(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core-canary@0.19.9-canary-20260317-2efecc25(@lynx-js/lynx-core@0.1.3)(@lynx-js/web-elements@0.11.0(tslib@2.8.1)))(@lynx-js/web-elements@0.11.0(tslib@2.8.1))(@rspress/core@2.0.6(@types/mdast@4.0.4)(@types/react@18.3.18)(core-js@3.46.0)(micromark-util-types@2.0.1)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)':
     dependencies:
       '@douyinfe/semi-icons': 2.74.0(react@18.3.1)
       '@douyinfe/semi-ui': 2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -8876,8 +8906,12 @@ snapshots:
 
   dequal@2.0.3: {}
 
+  detect-indent@7.0.2: {}
+
   detect-libc@2.1.2:
     optional: true
+
+  detect-newline@4.0.1: {}
 
   detect-node-es@1.1.0: {}
 
@@ -9169,6 +9203,8 @@ snapshots:
   get-tsconfig@4.10.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  git-hooks-list@4.2.1: {}
 
   github-slugger@2.0.0: {}
 
@@ -10657,6 +10693,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prettier-plugin-packagejson@3.0.2(prettier@3.8.1):
+    dependencies:
+      sort-package-json: 3.6.1
+    optionalDependencies:
+      prettier: 3.8.1
+
   prettier@3.8.1: {}
 
   prismjs@1.30.0: {}
@@ -11291,6 +11333,18 @@ snapshots:
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  sort-object-keys@2.1.0: {}
+
+  sort-package-json@3.6.1:
+    dependencies:
+      detect-indent: 7.0.2
+      detect-newline: 4.0.1
+      git-hooks-list: 4.2.1
+      is-plain-obj: 4.1.0
+      semver: 7.7.4
+      sort-object-keys: 2.1.0
+      tinyglobby: 0.2.15
 
   source-map-js@1.2.1: {}
 

--- a/scripts/check_api_doc/utils.py
+++ b/scripts/check_api_doc/utils.py
@@ -1,5 +1,3 @@
-import yaml
-
 KNOWN_COMPONENTS = {
     'APITable', 'APISummary', 'CodeFold', 'Go',
     'VersionBadge', 'PlatformBadge', 'StatusBadge', 'RuntimeBadge', 'Badge',
@@ -24,12 +22,6 @@ def parse_frontmatter(content):
 
     frontmatter = {}
     try:
-        # Use yaml loader for better parsing if available, but fallback to simple parsing if needed
-        # The original script used simple splitting, but fix_duplicate_imports used yaml
-        # Let's stick to the simple one from check-and-fix-docs-simple.py for now to avoid dependency issues if yaml isn't there
-        # But wait, fix-duplicate-imports imported yaml. 
-        # I'll use simple parsing to be robust against missing deps, or try yaml.
-        # Actually, let's just use the logic from check-and-fix-docs-simple.py as it seemed to work well.
         for line in fm_text.split('\n'):
             if ':' in line:
                 key, val = line.split(':', 1)


### PR DESCRIPTION
**Background**
- Some `package.json` files are edited manually, so dependency ordering is inconsistent and not enforced by the current pre-commit setup.
- `pnpm run check-docs` fails on machines without `PyYAML` (`ModuleNotFoundError: No module named 'yaml'`) and running the script can generate `__pycache__` artifacts that show up in git status.

**Changes**
- Enable deterministic `package.json` ordering by adding `prettier-plugin-packagejson` and loading it via Prettier config, so the existing husky + lint-staged `prettier --write` step will auto-sort `package.json` on commit. ([.prettierrc](file:///Users/bytedance/Project/src/lynx-family/clone-test/lynx-website-fix/.prettierrc#L1-L4))
- Remove the hard dependency on `PyYAML` from the docs checker by dropping the unused `yaml` import. ([utils.py](file:///Users/bytedance/Project/src/lynx-family/clone-test/lynx-website-fix/scripts/check_api_doc/utils.py#L1-L32))
- Ignore Python bytecode/cache artifacts to avoid noisy untracked files (`**/__pycache__/`, `*.py[cod]`). ([.gitignore](file:///Users/bytedance/Project/src/lynx-family/clone-test/lynx-website-fix/.gitignore#L1-L8))

**Validation**
- `pnpm run check-docs` no longer fails due to missing `PyYAML` (it still reports actual doc issues like missing imports as expected).
- Editing any `package.json` and committing triggers automatic sorting/formatting via pre-commit.


Change-Id: Ib3f5866a0f0fd391ed8d26c51d52cdfac1854f51