### PR TITLE
fix(docs): skip markdown files in fix-docs

### DIFF
--- a/scripts/check_api_doc/index.py
+++ b/scripts/check_api_doc/index.py
@@ -25,15 +25,21 @@ def main():
             
         for root, dirs, files in os.walk(base_dir):
             for file in files:
-                if file.endswith('.mdx'):
-                    file_path = os.path.join(root, file)
-                    try:
-                        error_count = process_file(file_path, fix=args.fix)
-                        if error_count > 0:
-                            total_errors += 1
-                        checked_files += 1
-                    except Exception as e:
-                        print(f"Error processing {file_path}: {e}")
+                file_name = file.lower()
+                if file_name.endswith('.md'):
+                    # `fix-docs` should not mutate plain markdown files.
+                    continue
+                if not file_name.endswith('.mdx'):
+                    continue
+
+                file_path = os.path.join(root, file)
+                try:
+                    error_count = process_file(file_path, fix=args.fix)
+                    if error_count > 0:
+                        total_errors += 1
+                    checked_files += 1
+                except Exception as e:
+                    print(f"Error processing {file_path}: {e}")
 
     print(f"\nChecked {checked_files} files.")
     if total_errors > 0:


### PR DESCRIPTION
### Motivation
- Prevent `pnpm run fix-docs` (the docs fixer) from mutating plain Markdown files and limit automatic fixes to API MDX documents only.

### Description
- Update `scripts/check_api_doc/index.py` to normalize filenames to lower case, explicitly skip files ending with `.md`, and only process `.mdx` files when walking `docs/en/api` and `docs/zh/api`.

### Testing
- Ran `python3 -m scripts.check_api_doc.index --help` which executed successfully and shows the `--fix` flag as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6540ec75883318dede06887e77695)