### PR TITLE
fix: preserve reactlynx-testing-library mdx docs in package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 .DS_Store
 *.local
-*.log*
+*.log
+*.log.*
 
 # Dist
 node_modules


### PR DESCRIPTION
## Summary
- narrow the `.npmignore` log patterns from `*.log*` to `*.log` and `*.log.*`
- stop excluding API docs whose filenames contain `.log`, including `Function.logDOM.mdx`, `Function.logRoles.mdx`, and `Interface.LogRolesOptions.mdx`
- keep ignoring actual log files while allowing the MDX docs to ship in the published package

## Root Cause
The previous `*.log*` rule matched any filename segment starting with `.log`, so it incorrectly filtered out MDX docs like `Function.logDOM.mdx` and `Function.logRoles.mdx` during packaging.

## Verification
- ran `npm pack --dry-run --ignore-scripts --json`
- confirmed the packed file list includes:
  - `docs/en/api/reactlynx-testing-library/Function.logDOM.mdx`
  - `docs/en/api/reactlynx-testing-library/Function.logRoles.mdx`
  - `docs/en/api/reactlynx-testing-library/Interface.LogRolesOptions.mdx`