### PR TITLE
chore: ignore built-in api docs from prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -18,6 +18,9 @@ src/components/ui
 /docs/en/api/lynx-native-api/**
 /docs/zh/api/lynx-native-api/**
 
+/docs/en/api/elements/built-in/**
+/docs/zh/api/elements/built-in/**
+
 /docs/zh/internal/docs-contribution-guide/**
 
 /docs/en/guide/start/fragments/android/**


### PR DESCRIPTION
## Summary

Adds `docs/en/api/elements/built-in/**` and `docs/zh/api/elements/built-in/**` to `.prettierignore`, consistent with the existing treatment of `lynx-native-api/` docs.

## Problem

Prettier mishandles these MDX files in two ways:

**1. Code fence corruption**
Prettier incorrectly upgrades ` ``` ` to ` ```` `, breaking rendering in Rspress.

**2. Indentation reformatting**
Code blocks use deliberate indentation to align method chaining params:
```ts
// intended
lynx.createSelectorQuery()
     .select('#id')
     .invoke({
      method: 'autoScroll',
      params: { ... }
    })
    .exec();
```

Prettier collapses this to 2-space indentation, reducing readability.

Without this fix, any commit touching these files causes lint-staged to reformat them, introducing unintended changes into unrelated PRs.

## Testing
```bash
npx prettier --check docs/en/api/elements/built-in/
# Before: 10 files warn
# After:  No files matched
```

Change-Id: I2299bf2b16d81bc7e16e10f49516451d7b42477c