### PR TITLE
fix(release-3.7): remove broken customized message links

### DIFF
--- a/docs/en/api/lynx-devtool-native-api/customized-message.mdx
+++ b/docs/en/api/lynx-devtool-native-api/customized-message.mdx
@@ -10,7 +10,7 @@ import { APISummary, APITable } from '@lynx';
 
 Encapsulates the debugging message to be sent.
 
-To learn how to send debugging messages, please refer to [`sendMessage`](/api/lynx-devtool-native-api/lynx-base-inspector-owner/send-message).
+Debugging messages are sent through the `sendMessage` method of `LynxBaseInspectorOwner`.
 
 ## Syntax
 

--- a/docs/zh/api/lynx-devtool-native-api/customized-message.mdx
+++ b/docs/zh/api/lynx-devtool-native-api/customized-message.mdx
@@ -10,7 +10,7 @@ import { APISummary, APITable } from '@lynx';
 
 封装待发送的调试消息。
 
-关于如何发送调试消息，请参考 [`sendMessage`](/api/lynx-devtool-native-api/lynx-base-inspector-owner/send-message)。
+调试消息通过 `LynxBaseInspectorOwner` 的 `sendMessage` 方法发送。
 
 ## 语法
 


### PR DESCRIPTION
## Summary
- remove the dead `sendMessage` links from the English and Chinese `CustomizedMessage` docs on `release/3.7`
- keep the guidance as plain text so the docs still explain how the message is sent
- unblock `pnpm build` on `release/3.7` by avoiding references to pages that do not exist on that branch

## Test Plan
- [x] `pnpm build`