### PR TITLE
docs: sync release 3.7 website updates

### DIFF
--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -111,7 +111,7 @@ export default defineConfig({
       'https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/lynx-dark-logo.svg',
     dark: 'https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/lynx-light-logo.svg',
   },
-  base: '/3.7',
+  base: '/',
   themeConfig: {
     editLink: {
       docRepoBaseUrl:


### PR DESCRIPTION
## Summary\n- update the Lynx 3.7 website and blog content for the release branch\n- sync missing ai and external-bundle documentation updates from main\n- keep 3.7 version redirects while resetting the site build base to /\n\n## Notes\n- hide CapCut-related homepage references\n- include the external-bundle example dependency fix for site generation\n