### PR TITLE
fix(theme): show numeric versions in version indicator

### DIFF
--- a/theme/VersionIndicator.tsx
+++ b/theme/VersionIndicator.tsx
@@ -23,8 +23,7 @@ function shouldHideVersion(version: string) {
     return false;
   }
 
-  const parsed = Number(version);
-  return !Number.isNaN(parsed);
+  return false;
 }
 
 export function VersionIndicator() {


### PR DESCRIPTION
## Summary\n- fix version filtering in the version indicator dropdown\n- keep hiding only 3.2 and 3.3\n- allow numeric versions from /next/version.json to appear on docs pages\n\n## Context\n- /next and versioned docs pages were only showing 'next' and 'All Versions'\n- the dropdown data source is correct; the regression was caused by filtering out all numeric versions\n