### PR TITLE
fix(docs): correct layout typos in docs and examples

### DIFF
--- a/docs/en/guide/ui/layout/index.mdx
+++ b/docs/en/guide/ui/layout/index.mdx
@@ -104,7 +104,7 @@ You can align the elements laid out by a [`<view>`] with [`align-items`], [`alig
   highlight="{10,13,18,29}"
 />
 
-## Offseting and Absolute Positioning
+## Offsetting and Absolute Positioning
 
 You can offset the elements with [`top`], [`left`], [`bottom`], and [`right`] properties. And you can make elements absolutely positioned with [`position`] property.
 

--- a/scripts/lynx-example.js
+++ b/scripts/lynx-example.js
@@ -56,6 +56,14 @@ const isPackCopy = true;
 const linkPath = path.join(currentDir, 'docs/public', 'lynx-examples');
 const ignoreDirs = ['node_modules', '.git', '.turbo'];
 const ignoreFiles = ['.DS_Store', 'LICENSE'];
+const exampleFixups = {
+  layout: [
+    {
+      from: 'gird item 3',
+      to: 'grid item 3',
+    },
+  ],
+};
 
 /**
  * Get all files in the specified directory
@@ -115,6 +123,55 @@ function lnExampleFiles(exampleDir, lnExampleDir) {
       } else {
         fs.symlinkSync(fullPath, targetPath);
       }
+    }
+  });
+}
+
+function replaceBufferContent(buffer, from, to) {
+  const fromBuffer = Buffer.from(from);
+  const toBuffer = Buffer.from(to);
+
+  if (fromBuffer.length !== toBuffer.length) {
+    throw new Error(
+      `Fixup replacement length mismatch: "${from}" -> "${to}"`,
+    );
+  }
+
+  let index = buffer.indexOf(fromBuffer);
+  if (index === -1) {
+    return { buffer, changed: false };
+  }
+
+  const nextBuffer = Buffer.from(buffer);
+  while (index !== -1) {
+    toBuffer.copy(nextBuffer, index);
+    index = nextBuffer.indexOf(fromBuffer, index + toBuffer.length);
+  }
+
+  return { buffer: nextBuffer, changed: true };
+}
+
+function applyExampleFixups(example, exampleDir) {
+  const fixups = exampleFixups[example];
+  if (!fixups?.length) {
+    return;
+  }
+
+  const files = getAllFiles(exampleDir, []);
+  files.forEach((filePath) => {
+    let buffer = fs.readFileSync(filePath);
+    let changed = false;
+
+    fixups.forEach(({ from, to }) => {
+      const result = replaceBufferContent(buffer, from, to);
+      if (result.changed) {
+        changed = true;
+        buffer = result.buffer;
+      }
+    });
+
+    if (changed) {
+      fs.writeFileSync(filePath, buffer);
     }
   });
 }
@@ -191,6 +248,7 @@ function parseExampleData() {
     const packageJSON = JSON.parse(fs.readFileSync(packageJSONPath, 'utf8'));
     // ln example files
     lnExampleFiles(exampleDir, lnExampleDir);
+    applyExampleFixups(example, lnExampleDir);
     // get all files
     const allFiles = getAllFiles(exampleDir, []);
 


### PR DESCRIPTION
## Summary
- fix the layout guide heading typo from `Offseting` to `Offsetting`
- patch generated layout example files during example sync so `gird item 3` becomes `grid item 3`
- keep the fix in the example generation pipeline instead of committing ignored generated output

Closes #111