### PR TITLE
fix(release-3.6): unblock site build

### DIFF
--- a/docs/en/api/elements/built-in/list.mdx
+++ b/docs/en/api/elements/built-in/list.mdx
@@ -930,8 +930,8 @@ First, set an appropriate value for the [`lower-threshold-item-count`](#lower-th
 <Go
   img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/doc/list-oss-loadmore.gif"
   example="list"
-  defaultFile="src/loadMore/index.tsx"
-  defaultEntryFile="dist/loadMore.lynx.bundle"
+  defaultFile="src/loadmore/index.tsx"
+  defaultEntryFile="dist/loadmore.lynx.bundle"
   entry="src/loadmore"
   highlight="{44-47}"
 />
@@ -947,8 +947,8 @@ Example of vertical orientation:
 <Go
   img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/doc/list-oss-item-snap.gif"
   example="list"
-  defaultFile="src/itemSnap/index.tsx"
-  defaultEntryFile="dist/itemSnap.lynx.bundle"
+  defaultFile="src/itemsnap/index.tsx"
+  defaultEntryFile="dist/itemsnap.lynx.bundle"
   entry="src/itemsnap"
   highlight="{20}"
 />

--- a/theme/index.tsx
+++ b/theme/index.tsx
@@ -81,7 +81,19 @@ const enWords = ['Unlock', 'Render', 'Toward', 'Ship'];
 const zhWords = ['迈向', '更快的', '更多平台的', '更多人的'];
 const zhSuffix = '原生体验';
 
+declare global {
+  interface ImportMetaEnv {
+    SSG_MD?: boolean;
+  }
+  interface ImportMeta {
+    readonly env: ImportMetaEnv;
+  }
+}
+
 function HomeLayout(props: Parameters<typeof BaseHomeLayout>[0]) {
+  if (import.meta.env.SSG_MD) {
+    return <BaseHomeLayout {...props} />;
+  }
   const { pathname } = useLocation();
   const isZh = pathname.startsWith('/zh/');
   const { page } = usePageData();


### PR DESCRIPTION
Summary:
- fix outdated list example paths in the English docs so SSG can find generated example files
- skip the custom home layout during SSG to avoid window and document access during markdown rendering

Verification:
- node scripts/lynx-example.js succeeded after wiring the worktree to the existing example packages
- the previous ENOENT and window/document failures no longer reproduced before build moved on to an unrelated local dependency mismatch in this temporary worktree