### PR TITLE
fix: route blog nav through /next

### DIFF
--- a/theme/index.tsx
+++ b/theme/index.tsx
@@ -1,7 +1,6 @@
 import {
   Head,
   removeBase,
-  withBase,
   useLang,
   useLocation,
   usePageData,
@@ -275,14 +274,14 @@ const Link = forwardRef(
     const getLangPrefix = (lang: string) => (lang === 'en' ? '' : `/${lang}`);
     if (href && href.startsWith(`${getLangPrefix(useLang())}/blog`)) {
       return (
-        <BaseLink
-          href={withBase(removeBase(href))}
+        <a
+          href={`/next${removeBase(href)}`}
           className={`rp-link ${className}`}
           ref={ref}
           {...restProps}
         >
           {children}
-        </BaseLink>
+        </a>
       );
     }
     return (


### PR DESCRIPTION
## Summary
- update the blog nav override in theme/index.tsx to route blog links through /next on release/3.7
- remove the now-unused withBase import

## Testing
- not run (not requested)