### PR TITLE
chore(release-3.7): upgrade go-web to 0.2.1 and web-core to 0.20.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,9 @@
   "dependencies": {
     "@douyinfe/semi-icons": "^2.74.0",
     "@douyinfe/semi-ui": "^2.75.0",
-    "@lynx-js/go-web": "github:lynx-community/go-web",
+    "@lynx-js/go-web": "^0.2.1",
     "@lynx-js/lynx-core": "^0.1.3",
-    "@lynx-js/web-core": "npm:@lynx-js/web-core-canary@0.19.7-canary-20260126-5e7e43c5",
-    "@lynx-js/web-elements": "^0.11.0",
+    "@lynx-js/web-core": "^0.20.1",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.5",
     "@radix-ui/react-dropdown-menu": "^2.1.5",

--- a/packages/lynx-compat-data/api-stats.json
+++ b/packages/lynx-compat-data/api-stats.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-16T13:04:34.772Z",
+  "generated_at": "2026-04-17T08:56:03.271Z",
   "summary": {
     "total_apis": 1047,
     "platform_api_total": 953,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,17 +15,14 @@ importers:
         specifier: ^2.75.0
         version: 2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@lynx-js/go-web':
-        specifier: github:lynx-community/go-web
-        version: https://codeload.github.com/lynx-community/go-web/tar.gz/38c0a3a7cd05db7b1b942e7ffc4a9496fd507266(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core-canary@0.19.9-canary-20260317-2efecc25(@lynx-js/lynx-core@0.1.3)(@lynx-js/web-elements@0.11.0(tslib@2.8.1)))(@lynx-js/web-elements@0.11.0(tslib@2.8.1))(@rspress/core@2.0.6(@types/mdast@4.0.4)(@types/react@18.3.18)(core-js@3.46.0)(micromark-util-types@2.0.1)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)
+        specifier: ^0.2.1
+        version: 0.2.1(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core@0.20.1(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.6(@types/mdast@4.0.4)(@types/react@18.3.18)(core-js@3.46.0)(micromark-util-types@2.0.1)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)
       '@lynx-js/lynx-core':
         specifier: ^0.1.3
         version: 0.1.3
       '@lynx-js/web-core':
-        specifier: npm:@lynx-js/web-core-canary@0.19.7-canary-20260126-5e7e43c5
-        version: '@lynx-js/web-core-canary@0.19.9-canary-20260317-2efecc25(@lynx-js/lynx-core@0.1.3)(@lynx-js/web-elements@0.11.0(tslib@2.8.1))'
-      '@lynx-js/web-elements':
-        specifier: ^0.11.0
-        version: 0.11.0(tslib@2.8.1)
+        specifier: ^0.20.1
+        version: 0.20.1(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)
       '@radix-ui/react-collapsible':
         specifier: ^1.1.12
         version: 1.1.12(@types/react-dom@18.3.7(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1392,14 +1389,13 @@ packages:
     resolution: {integrity: sha512-dSs0FhogEiuemWhV9QTFfPIQoKu+LW9wQN+JKxWbKvi1/eYP6PgZXm4ohDlSqBKdSVhw2Ok0LNgpPWmwdLV9HA==}
     engines: {node: '>=18'}
 
-  '@lynx-js/go-web@https://codeload.github.com/lynx-community/go-web/tar.gz/38c0a3a7cd05db7b1b942e7ffc4a9496fd507266':
-    resolution: {tarball: https://codeload.github.com/lynx-community/go-web/tar.gz/38c0a3a7cd05db7b1b942e7ffc4a9496fd507266}
-    version: 0.1.0
+  '@lynx-js/go-web@0.2.1':
+    resolution: {integrity: sha512-r/M0KfxVmS7aEjcxCDa1TGpEy6cA1S7OhS3k0lse95SSbhj9x/SFR06iquPvcQmS6tyxpJC6U/nR/5tWrY1dYw==}
+    engines: {node: ^22 || ^24}
     peerDependencies:
       '@douyinfe/semi-icons': '>=2.74.0'
       '@douyinfe/semi-ui': '>=2.75.0'
-      '@lynx-js/web-core': '*'
-      '@lynx-js/web-elements': '*'
+      '@lynx-js/web-core': '>=0.20.0'
       '@rspress/core': '*'
       '@shikijs/transformers': '>=3.0.0'
       qrcode.react: '>=4.0.0'
@@ -1417,9 +1413,6 @@ packages:
 
   '@lynx-js/lynx-core@0.1.3':
     resolution: {integrity: sha512-uWzKKYJUK4Q09ZRZxWSAFINnmZb9piWPbvWF9SkLn+3snBl9u/BJa4ekPRcKWAhBmpbtxWH1x27fxe3Q3p5l3Q==}
-
-  '@lynx-js/offscreen-document-canary@0.1.4':
-    resolution: {integrity: sha512-yqJmCBjKGq4Eil7IgBk5LKIbxN/KSn61KKxmPyrrz1MAiBmfyHLhHrd3V8XXKvI4JpmOG5q67BQY9VEuX5u0ZA==}
 
   '@lynx-js/react-use@0.1.3':
     resolution: {integrity: sha512-48NX1DZfIqdpcFPKR3SdI/E0D2INJzgMDtl9IK0vbqWKPgj6LgUPZN0iqIDd7Juy3in5c2bv6E9jCpoq5ONeVw==}
@@ -1474,30 +1467,27 @@ packages:
   '@lynx-js/test-environment@0.0.1':
     resolution: {integrity: sha512-tas/ilXoOjF6AQ3BzkFH85aFFnLS03zjHiKg38BGlU2U7QhCDrC9SFYuXSVaix0I1uprorjeELG63HXX2Z9Bgw==}
 
-  '@lynx-js/web-constants-canary@0.19.9-canary-20260317-2efecc25':
-    resolution: {integrity: sha512-rUi/2DziZAnGXpckEV2X0uMortNiGSmlPiya3pmS0oWrZimAhMQZ6nZO/5kzQTppvHyBnNB91GGNPQjqBQ+ccQ==}
-
-  '@lynx-js/web-core-canary@0.19.9-canary-20260317-2efecc25':
-    resolution: {integrity: sha512-IkCZEK2n+OZTeys9j4q5RpXncKX5c09uXEjfAcvJ0jlaDX3D/99D3iXEg6iG6LgyXKsIzzwUpSkm6oU1arXAdw==}
+  '@lynx-js/web-core@0.20.1':
+    resolution: {integrity: sha512-oC3fbxezP5P8Qj6JxyPnWioHNwk/YL5uivm+L2OwpnxajM7jyCUMBkTms4FdIHmRsFcN/f8pZ49+M1RVIleBBw==}
     peerDependencies:
+      '@lynx-js/css-serializer': 0.1.5
       '@lynx-js/lynx-core': 0.1.3
-      '@lynx-js/web-elements': '*'
+      tslib: ^2.5.0
+    peerDependenciesMeta:
+      '@lynx-js/css-serializer':
+        optional: true
+      '@lynx-js/lynx-core':
+        optional: true
+      tslib:
+        optional: true
 
-  '@lynx-js/web-elements@0.11.0':
-    resolution: {integrity: sha512-cWI0gc7RCr1c53X8yjQC8vI8z/UJj9gsggHQ15COzhX2NV53soCX27EoOftMkH6oMu1J5YCXADFb6IdTNh9BBw==}
+  '@lynx-js/web-elements@0.12.0':
+    resolution: {integrity: sha512-7z8PQQSDMUWrxoizySOg1pKGIiSDeGGomOr5FV0Tx9gniHNJYx0e7/h6wQmwhyHdAZYyihyaBks88QkX8DRNEw==}
     peerDependencies:
       tslib: ^2.5.0
 
-  '@lynx-js/web-mainthread-apis-canary@0.19.9-canary-20260317-2efecc25':
-    resolution: {integrity: sha512-xbFHnY2K+aV90WTZvzTlNKXeFdjZJlcFAYHvgBqHWqrqtbDO/ynExWaXfOlRP3Cp7zq4HfK3Q9hc60307GmpHA==}
-
-  '@lynx-js/web-worker-rpc-canary@0.19.9-canary-20260317-2efecc25':
-    resolution: {integrity: sha512-a7mskAAdGRj4ApqW6rcfpWjGIE4TXO88oVrdgb6UIHnQ/hq5No5x4HZTtMzH2vUP+GawhJc6tnkyLhq3f+3YhQ==}
-
-  '@lynx-js/web-worker-runtime-canary@0.19.9-canary-20260317-2efecc25':
-    resolution: {integrity: sha512-hsDpzkLoKHdrGaOWnUs4oZglKDG09K8ubFDhxgJIGQ9wLIPaHoD5y1q2SJPQXVaAz6BjPTieEEywe3MGvJJhBA==}
-    peerDependencies:
-      '@lynx-js/lynx-core': 0.1.3
+  '@lynx-js/web-worker-rpc@0.20.1':
+    resolution: {integrity: sha512-6tXsBghwKRCeF7DXESykzUBvMKBdshF97gFsy8bAYdwt5YphZltp41zBCazV4fzqChp43yeo/CmNuHuu7kJP7w==}
 
   '@mdn/minimalist@2.0.4':
     resolution: {integrity: sha512-jocePw/fsGcBxO67D+iWQLZ0TQjwNVonaME2BFN98QIm/e1kTY1/k2s4fOqH5MMa3QYURxa098bI4sChn6s/7Q==}
@@ -6826,12 +6816,11 @@ snapshots:
       - '@lynx-js/types'
       - '@types/react'
 
-  '@lynx-js/go-web@https://codeload.github.com/lynx-community/go-web/tar.gz/38c0a3a7cd05db7b1b942e7ffc4a9496fd507266(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core-canary@0.19.9-canary-20260317-2efecc25(@lynx-js/lynx-core@0.1.3)(@lynx-js/web-elements@0.11.0(tslib@2.8.1)))(@lynx-js/web-elements@0.11.0(tslib@2.8.1))(@rspress/core@2.0.6(@types/mdast@4.0.4)(@types/react@18.3.18)(core-js@3.46.0)(micromark-util-types@2.0.1)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)':
+  '@lynx-js/go-web@0.2.1(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core@0.20.1(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.6(@types/mdast@4.0.4)(@types/react@18.3.18)(core-js@3.46.0)(micromark-util-types@2.0.1)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)':
     dependencies:
       '@douyinfe/semi-icons': 2.74.0(react@18.3.1)
       '@douyinfe/semi-ui': 2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lynx-js/web-core': '@lynx-js/web-core-canary@0.19.9-canary-20260317-2efecc25(@lynx-js/lynx-core@0.1.3)(@lynx-js/web-elements@0.11.0(tslib@2.8.1))'
-      '@lynx-js/web-elements': 0.11.0(tslib@2.8.1)
+      '@lynx-js/web-core': 0.20.1(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)
       '@shikijs/transformers': 4.0.2
       qrcode.react: 4.2.0(react@18.3.1)
       react: 18.3.1
@@ -6845,8 +6834,6 @@ snapshots:
   '@lynx-js/internal-preact@10.28.4-ee7bb26': {}
 
   '@lynx-js/lynx-core@0.1.3': {}
-
-  '@lynx-js/offscreen-document-canary@0.1.4': {}
 
   '@lynx-js/react-use@0.1.3(@lynx-js/react@0.115.3(@types/react@19.2.14))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -6885,39 +6872,20 @@ snapshots:
 
   '@lynx-js/test-environment@0.0.1': {}
 
-  '@lynx-js/web-constants-canary@0.19.9-canary-20260317-2efecc25':
+  '@lynx-js/web-core@0.20.1(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)':
     dependencies:
-      '@lynx-js/web-worker-rpc': '@lynx-js/web-worker-rpc-canary@0.19.9-canary-20260317-2efecc25'
-
-  '@lynx-js/web-core-canary@0.19.9-canary-20260317-2efecc25(@lynx-js/lynx-core@0.1.3)(@lynx-js/web-elements@0.11.0(tslib@2.8.1))':
-    dependencies:
+      '@lynx-js/web-elements': 0.12.0(tslib@2.8.1)
+      '@lynx-js/web-worker-rpc': 0.20.1
+      wasm-feature-detect: 1.8.0
+    optionalDependencies:
       '@lynx-js/lynx-core': 0.1.3
-      '@lynx-js/offscreen-document': '@lynx-js/offscreen-document-canary@0.1.4'
-      '@lynx-js/web-constants': '@lynx-js/web-constants-canary@0.19.9-canary-20260317-2efecc25'
-      '@lynx-js/web-elements': 0.11.0(tslib@2.8.1)
-      '@lynx-js/web-mainthread-apis': '@lynx-js/web-mainthread-apis-canary@0.19.9-canary-20260317-2efecc25'
-      '@lynx-js/web-worker-rpc': '@lynx-js/web-worker-rpc-canary@0.19.9-canary-20260317-2efecc25'
-      '@lynx-js/web-worker-runtime': '@lynx-js/web-worker-runtime-canary@0.19.9-canary-20260317-2efecc25(@lynx-js/lynx-core@0.1.3)'
+      tslib: 2.8.1
 
-  '@lynx-js/web-elements@0.11.0(tslib@2.8.1)':
+  '@lynx-js/web-elements@0.12.0(tslib@2.8.1)':
     dependencies:
       tslib: 2.8.1
 
-  '@lynx-js/web-mainthread-apis-canary@0.19.9-canary-20260317-2efecc25':
-    dependencies:
-      '@lynx-js/web-constants': '@lynx-js/web-constants-canary@0.19.9-canary-20260317-2efecc25'
-      hyphenate-style-name: 1.1.0
-      wasm-feature-detect: 1.8.0
-
-  '@lynx-js/web-worker-rpc-canary@0.19.9-canary-20260317-2efecc25': {}
-
-  '@lynx-js/web-worker-runtime-canary@0.19.9-canary-20260317-2efecc25(@lynx-js/lynx-core@0.1.3)':
-    dependencies:
-      '@lynx-js/lynx-core': 0.1.3
-      '@lynx-js/offscreen-document': '@lynx-js/offscreen-document-canary@0.1.4'
-      '@lynx-js/web-constants': '@lynx-js/web-constants-canary@0.19.9-canary-20260317-2efecc25'
-      '@lynx-js/web-mainthread-apis': '@lynx-js/web-mainthread-apis-canary@0.19.9-canary-20260317-2efecc25'
-      '@lynx-js/web-worker-rpc': '@lynx-js/web-worker-rpc-canary@0.19.9-canary-20260317-2efecc25'
+  '@lynx-js/web-worker-rpc@0.20.1': {}
 
   '@mdn/minimalist@2.0.4': {}
 


### PR DESCRIPTION
Backport dependency upgrades to align with the web-core 0.20 WASM architecture, reducing memory usage by ~40%.

## Changes
- `@lynx-js/go-web`(github:lynx-community/go-web(0.1.0)→ 0.2.1
- `@lynx-js/web-core` → 0.20.1

### Why pin to npm release

Previously `@lynx-js/go-web` was referenced as `github:lynx-community/go-web` with no commit or tag pin. Deleting the lock file would silently pull HEAD, potentially breaking the` web-core >= 0.20.0` compatibility requirement. Switching to the npm-published version makes the constraint explicit and lock-file-independent.

## Migration notes
`@lynx-js/go-web` 0.2.0 drops the `@lynx-js/web-elements` peer dependency and requires `web-core >= 0.20.0`.

## Related
- Backport of #913

Change-Id: Icb05ba1df03c7dc3bfb8ffc1ff381d2eeb13dcfb