### PR TITLE
docs(rspress): standardize tabs usage

### DIFF
--- a/docs/en/guide/scripting-runtime/index.mdx
+++ b/docs/en/guide/scripting-runtime/index.mdx
@@ -1,5 +1,7 @@
 # JavaScript Runtime and WebAssembly
 
+import { Tab, Tabs } from '@rspress/core/theme';
+
 ## JavaScript Runtime
 
 One of biggest features of Lynx is [Dual-Thread Architecture](/guide/spec.html#scripting-facing-threading-abstraction)(read [Thinking in ReactLynx](/react/thinking-in-reactlynx.html) for more information), JavaScript code runs on two threads: the [main thread](/guide/spec.html#main-thread-or-lynx-main-thread) and the [background thread](/guide/spec.html#background-thread-aka-off-main-thread). The two threads use different JavaScript engines as their runtime.
@@ -177,16 +179,8 @@ Both ESModule and CommonJS, a module name needs to be specified. It can be one o
 
 CommonJS uses `require(path)` to import a module. Uses `module.exports` or `exports` to export a module.
 
-import { Tab, Tabs } from '@theme';
-
-<Tabs
-  defaultValue="common"
-  groupId="install-script"
-  values={[
-    { label: 'common.js', value: 'common' },
-    { label: 'ReactLynx', value: 'react' },
-  ]}>
-  <Tab value="common">
+<Tabs>
+  <Tab label="common.js">
 
 ```js title="common.js" {1,10-11}
 const lodash = require('lodash'); // can require npm packages
@@ -203,7 +197,7 @@ exports.goodbye = goodbye;
 ```
 
   </Tab>
-  <Tab value="react">
+  <Tab label="ReactLynx">
 
 ```jsx {1,6,10}
 const { Component } = require('@lynx-js/react'); // can require npm packages
@@ -248,14 +242,8 @@ ESModule uses `import` to import a module. Uses `export` to export a module.
 
 ESModule can also use `import()` to dynamically import a module.
 
-<Tabs
-  defaultValue="utils"
-  groupId="install-script"
-  values={[
-    { label: 'utils.js', value: 'utils' },
-    { label: 'ReactLynx', value: 'react' },
-  ]}>
-  <Tab value="utils">
+<Tabs>
+  <Tab label="utils.js">
 
 ```js title="utils.js"
 export function getAge() {
@@ -268,7 +256,7 @@ export default function (add1, add2) {
 ```
 
   </Tab>
-  <Tab value="react">
+  <Tab label="ReactLynx">
 
 ```jsx {1-2,8,13}
 import { Component } from '@lynx-js/react'; // can import npm packages

--- a/docs/zh/guide/scripting-runtime/index.mdx
+++ b/docs/zh/guide/scripting-runtime/index.mdx
@@ -1,6 +1,6 @@
 # JavaScript 运行时与 WebAssembly
 
-import { Tab, Tabs } from '@theme';
+import { Tab, Tabs } from '@rspress/core/theme';
 
 ## JavaScript 运行时
 
@@ -179,14 +179,8 @@ Lynx 双线程运行时支持最高的 ECMAScript 版本分别是：
 
 CommonJS 使用 `require(path)` 来引入一个模块。使用 `module.exports` 或 `exports` 来导出一个模块。
 
-<Tabs
-  defaultValue="common"
-  groupId="install-script"
-  values={[
-    { label: 'common.js', value: 'common' },
-    { label: 'ReactLynx', value: 'react' },
-  ]}>
-  <Tab value="common">
+<Tabs>
+  <Tab label="common.js">
 
 ```js title="common.js" {1,10-11}
 const lodash = require('lodash'); // can require npm packages
@@ -203,7 +197,7 @@ exports.goodbye = goodbye;
 ```
 
   </Tab>
-  <Tab value="react">
+  <Tab label="ReactLynx">
 
 ```jsx {1,6,10}
 const { Component } = require('@lynx-js/react'); // can require npm packages
@@ -248,14 +242,8 @@ ESModule 使用 `import` 来引入一个模块。使用 `export` 来导出一个
 
 同时 ESModule 可以使用 `import()` 来进行动态导入模块。
 
-<Tabs
-  defaultValue="utils"
-  groupId="install-script"
-  values={[
-    { label: 'utils.js', value: 'utils' },
-    { label: 'ReactLynx', value: 'react' },
-  ]}>
-  <Tab value="utils">
+<Tabs>
+  <Tab label="utils.js">
 
 ```js title="utils.js"
 export function getAge() {
@@ -268,7 +256,7 @@ export default function (add1, add2) {
 ```
 
   </Tab>
-  <Tab value="react">
+  <Tab label="ReactLynx">
 
 ```jsx {1-2,8,13}
 import { Component } from '@lynx-js/react'; // can import npm packages


### PR DESCRIPTION
## Summary
- standardize the scripting runtime docs to use the current Rspress `Tabs`/`Tab` API
- replace deprecated `@theme` imports with `@rspress/core/theme`
- simplify tab declarations in both English and Chinese docs

## Testing
- [ ] `npm run preflight` (not available in this repository)
- [x] commit hooks ran `prettier` and `cspell` on the staged files during commit
- [ ] `npm run format:check` (repo-wide check is currently affected by unrelated `.lynx-ui-cache/` files)
- [ ] `npm run zhlint` (repo-wide check currently reports many unrelated existing doc issues)
