### PR TITLE
docs: align Native API desktop docs

### DIFF
--- a/docs/api-desktop-spec-cleanup.md
+++ b/docs/api-desktop-spec-cleanup.md
@@ -1,0 +1,164 @@
+# Native API Desktop Documentation Cleanup Ledger
+
+This document records Native API alignment issues between compat desktop support and MDX Desktop-specific documentation. Do not remove entries while cleaning; mark resolved entries in place so the cleanup history remains reviewable.
+
+## Cleanup Rules
+
+- Source code reference: `https://github.com/lynx-family/lynx/tree/develop/platform/embedder/public`.
+- The source code reference is useful when verifying API ownership, but it is not the primary scan criterion for this ledger.
+- Primary check: compat data says whether Desktop is supported; the corresponding MDX page should have Desktop-specific documentation when Desktop is supported.
+- Scope is Native API only: `docs/{en,zh}/api/lynx-native-api` and `packages/lynx-compat-data/lynx-native-api`.
+- Out of scope: `css/*`, `elements/*`, `lynx-api/*`, `lynx-devtool-native-api/*`, framework/tooling/testing/engine/error docs.
+- Desktop compat platforms: `clay_macos` and `clay_windows`.
+- Desktop support rule: `version_added` is not `false`, `null`, or absent for at least one desktop platform.
+- Desktop MDX supplement rule: the corresponding MDX contains Desktop-specific content such as `### Desktop (C++)`, `<Tab label="Desktop C++">`, `Desktop-only`, or Desktop public API wording.
+- When an item is cleaned, change the line from `- [ ] ...` to `- [x] ~~...~~` and append a short note if useful, for example `-- added Desktop section`, `-- corrected desktop support`, or `-- not Native API`.
+- Keep the original scan entry text readable inside the strikethrough; do not delete completed entries.
+
+## Case Examples
+
+These examples show the shape of each cleanup case. The real cleanup checklist starts in the sections below.
+
+### Compat Desktop Supported But MDX Desktop Docs Missing
+
+Example item:
+
+```md
+- [ ] feature: `lynx-native-api.lynx-view.add-lynx-view-client` | compat: `packages/lynx-compat-data/lynx-native-api/lynx-view/add-lynx-view-client.json` | query: `lynx-native-api/lynx-view/add-lynx-view-client` | desktop: clay_macos=3.7, clay_windows=3.7 | mdx_desktop: en=no, zh=no | docs: docs/en/api/lynx-native-api/lynx-view/add-lynx-view-client.mdx, docs/zh/api/lynx-native-api/lynx-view/add-lynx-view-client.mdx | desc: register lifecycle observer for lynxView
+```
+
+Example after cleanup:
+
+```md
+- [x] ~~feature: `lynx-native-api.lynx-view.add-lynx-view-client` | compat: `packages/lynx-compat-data/lynx-native-api/lynx-view/add-lynx-view-client.json` | query: `lynx-native-api/lynx-view/add-lynx-view-client` | desktop: clay_macos=3.7, clay_windows=3.7 | mdx_desktop: en=no, zh=no | docs: docs/en/api/lynx-native-api/lynx-view/add-lynx-view-client.mdx, docs/zh/api/lynx-native-api/lynx-view/add-lynx-view-client.mdx | desc: register lifecycle observer for lynxView~~ -- added Desktop section
+```
+
+### Compat Desktop Supported But Only Some MDX Locales Have Desktop Docs
+
+No items were found in this scan. If one appears in a later scan, it should look like this:
+
+```md
+- [ ] feature: `lynx-native-api.example` | compat: `packages/lynx-compat-data/lynx-native-api/example.json` | query: `lynx-native-api/example` | desktop: clay_macos=3.7, clay_windows=3.7 | mdx_desktop: en=yes, zh=no | docs: docs/en/api/lynx-native-api/example.mdx desktop_line=20, docs/zh/api/lynx-native-api/example.mdx
+```
+
+Example after cleanup:
+
+```md
+- [x] ~~feature: `lynx-native-api.example` | compat: `packages/lynx-compat-data/lynx-native-api/example.json` | query: `lynx-native-api/example` | desktop: clay_macos=3.7, clay_windows=3.7 | mdx_desktop: en=yes, zh=no | docs: docs/en/api/lynx-native-api/example.mdx desktop_line=20, docs/zh/api/lynx-native-api/example.mdx~~ -- added zh Desktop section
+```
+
+### MDX Desktop Docs Present But Compat Has No Desktop Support
+
+No items were found in this scan. If one appears in a later scan, it should look like this:
+
+```md
+- [ ] feature: `lynx-native-api.example` | compat: `packages/lynx-compat-data/lynx-native-api/example.json` | query: `lynx-native-api/example` | desktop: clay_macos=false, clay_windows=false | mdx_desktop: en=yes, zh=yes | docs: docs/en/api/lynx-native-api/example.mdx desktop_line=30, docs/zh/api/lynx-native-api/example.mdx desktop_line=30
+```
+
+Example after cleanup:
+
+```md
+- [x] ~~feature: `lynx-native-api.example` | compat: `packages/lynx-compat-data/lynx-native-api/example.json` | query: `lynx-native-api/example` | desktop: clay_macos=false, clay_windows=false | mdx_desktop: en=yes, zh=yes | docs: docs/en/api/lynx-native-api/example.mdx desktop_line=30, docs/zh/api/lynx-native-api/example.mdx desktop_line=30~~ -- corrected desktop support or removed Desktop docs
+```
+
+### MDX Desktop Docs Present But Compat Desktop Support Is Partial
+
+No items were found in this scan. If one appears in a later scan, it should look like this:
+
+```md
+- [ ] feature: `lynx-native-api.example` | compat: `packages/lynx-compat-data/lynx-native-api/example.json` | query: `lynx-native-api/example` | desktop: clay_macos=3.7, clay_windows=false | mdx_desktop: en=yes, zh=yes | docs: docs/en/api/lynx-native-api/example.mdx desktop_line=30, docs/zh/api/lynx-native-api/example.mdx desktop_line=30
+```
+
+Example after cleanup:
+
+```md
+- [x] ~~feature: `lynx-native-api.example` | compat: `packages/lynx-compat-data/lynx-native-api/example.json` | query: `lynx-native-api/example` | desktop: clay_macos=3.7, clay_windows=false | mdx_desktop: en=yes, zh=yes | docs: docs/en/api/lynx-native-api/example.mdx desktop_line=30, docs/zh/api/lynx-native-api/example.mdx desktop_line=30~~ -- corrected desktop platform support
+```
+
+## Scan Scope
+
+- Scan report source: `/tmp/lynx-native-api-desktop-doc-alignment-report.json`
+- Ledger generated at: `2026-04-21T06:09:35.488Z`
+- Docs roots: `docs/en/api/lynx-native-api`, `docs/zh/api/lynx-native-api`
+- Compat root: `packages/lynx-compat-data/lynx-native-api`
+- Code source reference: `https://github.com/lynx-family/lynx/tree/develop/platform/embedder/public`
+- Desktop platforms: `clay_macos`, `clay_windows`
+
+## Scan Summary
+
+| Metric | Count |
+| --- | ---: |
+| Unique Native API doc queries | 86 |
+| Compat entries for doc queries | 86 |
+| Missing compat entries | 0 |
+| Compat desktop supported but no MDX Desktop docs | 5 |
+| Compat desktop supported but some locale MDX lacks Desktop docs | 0 |
+| MDX Desktop docs present but no compat desktop support | 0 |
+| MDX Desktop docs present but compat desktop support is partial | 0 |
+| Compat desktop supported and MDX has Desktop docs | 26 |
+
+## Cleanup Verification
+
+After applying the cleanup, the same Native API alignment scan reports:
+
+| Metric | Count |
+| --- | ---: |
+| Compat desktop supported but no MDX Desktop docs | 0 |
+| Compat desktop supported but some locale MDX lacks Desktop docs | 0 |
+| MDX Desktop docs present but no compat desktop support | 0 |
+| MDX Desktop docs present but compat desktop support is partial | 0 |
+
+## Group Counts
+
+### Compat Desktop Supported But No MDX Desktop Docs By Module
+
+| Group | Count |
+| --- | ---: |
+| `lynx-native-api/lynx-view` | 4 |
+| `lynx-native-api` | 1 |
+
+### Compat Desktop Supported But Some Locale MDX Lacks Desktop Docs By Module
+
+| Group | Count |
+| --- | ---: |
+| _none_ | 0 |
+
+### MDX Desktop Docs Present But No Compat Desktop Support By Module
+
+| Group | Count |
+| --- | ---: |
+| _none_ | 0 |
+
+### MDX Desktop Docs Present But Partial Compat Desktop Support By Module
+
+| Group | Count |
+| --- | ---: |
+| _none_ | 0 |
+
+## Compat Desktop Supported But No MDX Desktop Docs
+
+Native API items where at least one desktop platform is supported in compat data, but none of the corresponding MDX pages has a Desktop-specific documentation supplement.
+
+- [x] ~~feature: `lynx-native-api.lynx-view.add-lynx-view-client` | compat: `packages/lynx-compat-data/lynx-native-api/lynx-view/add-lynx-view-client.json` | query: `lynx-native-api/lynx-view/add-lynx-view-client` | desktop: clay_macos=3.7, clay_windows=3.7 | mdx_desktop: en=no, zh=no | docs: docs/en/api/lynx-native-api/lynx-view/add-lynx-view-client.mdx, docs/zh/api/lynx-native-api/lynx-view/add-lynx-view-client.mdx | desc: register lifecycle observer for lynxView~~ -- added Desktop C++ section
+- [x] ~~feature: `lynx-native-api.lynx-view.destroy` | compat: `packages/lynx-compat-data/lynx-native-api/lynx-view/destroy.json` | query: `lynx-native-api/lynx-view/destroy` | desktop: clay_macos=3.7, clay_windows=3.7 | mdx_desktop: en=no, zh=no | docs: docs/en/api/lynx-native-api/lynx-view/destroy.mdx, docs/zh/api/lynx-native-api/lynx-view/destroy.mdx | desc: manually destroy lynxView instance~~ -- documented Desktop C++ object destruction
+- [x] ~~feature: `lynx-native-api.lynx-view.lynx-view-custom-element` | compat: `packages/lynx-compat-data/lynx-native-api/lynx-view/lynx-view-custom-element.json` | query: `lynx-native-api/lynx-view/lynx-view-custom-element` | desktop: clay_macos=3.7, clay_windows=3.7 | mdx_desktop: en=no, zh=missing-doc | docs: docs/en/api/lynx-native-api/lynx-view/lynx-view.mdx | desc: <code>lynx-view</code> The custom element of LynxView.~~ -- corrected desktop support; Web custom element is not public embedder Native API
+- [x] ~~feature: `lynx-native-api.lynx-view.remove-lynx-view-client` | compat: `packages/lynx-compat-data/lynx-native-api/lynx-view/remove-lynx-view-client.json` | query: `lynx-native-api/lynx-view/remove-lynx-view-client` | desktop: clay_macos=3.7, clay_windows=3.7 | mdx_desktop: en=no, zh=no | docs: docs/en/api/lynx-native-api/lynx-view/remove-lynx-view-client.mdx, docs/zh/api/lynx-native-api/lynx-view/remove-lynx-view-client.mdx | desc: remove lifecycle observer of lynxView~~ -- added Desktop C++ section
+- [x] ~~feature: `lynx-native-api.trace-event` | compat: `packages/lynx-compat-data/lynx-native-api/trace-event.json` | query: `lynx-native-api/trace-event` | desktop: clay_macos=3.7, clay_windows=3.7 | mdx_desktop: en=no, zh=no | docs: docs/en/api/lynx-native-api/trace-event.mdx, docs/zh/api/lynx-native-api/trace-event.mdx | desc: TraceEvent~~ -- added Desktop C API section
+
+## Compat Desktop Supported But Some Locale MDX Lacks Desktop Docs
+
+Native API items where desktop is supported in compat data, but only some existing locale docs have Desktop-specific content.
+
+_No items found._
+
+## MDX Desktop Docs Present But No Compat Desktop Support
+
+Native API items where the MDX page has Desktop-specific documentation, but neither `clay_macos` nor `clay_windows` is supported in compat data.
+
+_No items found._
+
+## MDX Desktop Docs Present But Compat Desktop Support Is Partial
+
+Native API items where the MDX page has Desktop-specific documentation, but only one of `clay_macos` or `clay_windows` is supported in compat data.
+
+_No items found._

--- a/docs/en/api/lynx-native-api/lynx-view/add-lynx-view-client.mdx
+++ b/docs/en/api/lynx-native-api/lynx-view/add-lynx-view-client.mdx
@@ -59,6 +59,16 @@ struct Index {
 }
 ```
 
+### Desktop (C++)
+
+```cpp
+void AddClient(std::shared_ptr<lynx::pub::LynxViewClient> client);
+```
+
+#### Parameters
+
+- `client`: The lifecycle observer registered to the `LynxView` instance. The same client instance is retained by `LynxView` until it is removed.
+
 ## Compatibility
 
 <APITable />

--- a/docs/en/api/lynx-native-api/lynx-view/destroy.mdx
+++ b/docs/en/api/lynx-native-api/lynx-view/destroy.mdx
@@ -1,5 +1,4 @@
 ---
-tag: Android
 api: lynx-native-api/lynx-view/destroy
 ---
 
@@ -17,6 +16,16 @@ After `LynxView` becomes unavailable, you need to actively call this method to r
 
 ```java
 public void destroy();
+```
+
+### Desktop (C++)
+
+Desktop C++ API does not expose a standalone `destroy()` method. Release the `LynxView` by destroying or resetting the owning C++ object.
+
+```cpp
+std::unique_ptr<lynx::pub::LynxView> view = builder.Build();
+// ...
+view.reset();
 ```
 
 ## Compatibility

--- a/docs/en/api/lynx-native-api/lynx-view/remove-lynx-view-client.mdx
+++ b/docs/en/api/lynx-native-api/lynx-view/remove-lynx-view-client.mdx
@@ -22,6 +22,16 @@ public void removeLynxViewClient(LynxViewClient client);
 
 - `client`: The structure implemented by the client and registered to the `LynxView` instance is used to obtain the callbacks of each process in the LynxView life cycle.
 
+### Desktop (C++)
+
+```cpp
+void RemoveClient(std::shared_ptr<lynx::pub::LynxViewClient> client);
+```
+
+#### Parameters
+
+- `client`: The lifecycle observer previously registered with `AddClient`. Passing the same shared client instance removes it from the `LynxView` lifecycle observer list.
+
 ## Compatibility
 
 <APITable />

--- a/docs/en/api/lynx-native-api/trace-event.mdx
+++ b/docs/en/api/lynx-native-api/trace-event.mdx
@@ -305,6 +305,55 @@ const args: Record<string, string> = {
 TraceEvent.instant(TraceCategory.Other, "request-finished", args);
 ```
 
+## Desktop (C API)
+
+Desktop public embedder API exposes trace helpers through C API macros.
+
+### beginSection
+
+Marks the start of a trace section. It must be paired with `LYNX_CAPI_TRACE_END` using the same category and name.
+
+```c
+LYNX_CAPI_TRACE_BEGIN(category, name);
+```
+
+### endSection
+
+Marks the end of a trace section.
+
+```c
+LYNX_CAPI_TRACE_END(category, name);
+```
+
+### instant
+
+Records an instant trace event.
+
+```c
+LYNX_CAPI_TRACE_INSTANT(category, name);
+```
+
+### counter
+
+Records a counter trace event.
+
+```c
+LYNX_CAPI_TRACE_COUNTER(category, name, value, incremental);
+```
+
+#### Examples
+
+```c
+void DecodeImage() {
+  LYNX_CAPI_TRACE_BEGIN("image", "DecodeImage");
+  // ... your code ...
+  LYNX_CAPI_TRACE_END("image", "DecodeImage");
+}
+
+LYNX_CAPI_TRACE_INSTANT("network", "RequestStarted");
+LYNX_CAPI_TRACE_COUNTER("cache", "EntryCount", 42, false);
+```
+
 ## Compatibility
 
 <APITable />

--- a/docs/zh/api/lynx-native-api/lynx-view/add-lynx-view-client.mdx
+++ b/docs/zh/api/lynx-native-api/lynx-view/add-lynx-view-client.mdx
@@ -59,6 +59,16 @@ struct Index {
 }
 ```
 
+### Desktop (C++)
+
+```cpp
+void AddClient(std::shared_ptr<lynx::pub::LynxViewClient> client);
+```
+
+#### 参数说明
+
+- `client`: 注册到 `LynxView` 实例上的生命周期监听对象。同一个 client 实例会被 `LynxView` 持有，直到被移除。
+
 ## 兼容性
 
 <APITable />

--- a/docs/zh/api/lynx-native-api/lynx-view/destroy.mdx
+++ b/docs/zh/api/lynx-native-api/lynx-view/destroy.mdx
@@ -1,5 +1,4 @@
 ---
-tag: Android
 api: lynx-native-api/lynx-view/destroy
 ---
 
@@ -17,6 +16,16 @@ import { APISummary, APITable } from '@lynx';
 
 ```java
 public void destroy();
+```
+
+### Desktop (C++)
+
+Desktop C++ API 没有单独暴露 `destroy()` 方法。销毁或 reset 持有的 C++ 对象即可释放 `LynxView`。
+
+```cpp
+std::unique_ptr<lynx::pub::LynxView> view = builder.Build();
+// ...
+view.reset();
 ```
 
 ## 兼容性

--- a/docs/zh/api/lynx-native-api/lynx-view/remove-lynx-view-client.mdx
+++ b/docs/zh/api/lynx-native-api/lynx-view/remove-lynx-view-client.mdx
@@ -22,6 +22,16 @@ public void removeLynxViewClient(LynxViewClient client);
 
 - `client`: 客户端实现的结构，并注册给 `LynxView` 实例，用于获取 `LynxView` 生命周期各流程回调。
 
+### Desktop (C++)
+
+```cpp
+void RemoveClient(std::shared_ptr<lynx::pub::LynxViewClient> client);
+```
+
+#### 参数说明
+
+- `client`: 此前通过 `AddClient` 注册的生命周期监听对象。传入同一个 shared client 实例会将其从 `LynxView` 生命周期监听列表中移除。
+
 ## 兼容性
 
 <APITable />

--- a/docs/zh/api/lynx-native-api/trace-event.mdx
+++ b/docs/zh/api/lynx-native-api/trace-event.mdx
@@ -299,6 +299,55 @@ const args: Record<string, string> = {
 TraceEvent.instant(TraceCategory.Other, "request-finished", args);
 ```
 
+## Desktop (C API)
+
+Desktop public embedder API 通过 C API 宏暴露 trace 辅助能力。
+
+### beginSection
+
+标记 trace section 的开始。需要使用相同的 category 和 name 与 `LYNX_CAPI_TRACE_END` 成对调用。
+
+```c
+LYNX_CAPI_TRACE_BEGIN(category, name);
+```
+
+### endSection
+
+标记 trace section 的结束。
+
+```c
+LYNX_CAPI_TRACE_END(category, name);
+```
+
+### instant
+
+记录即时 trace event。
+
+```c
+LYNX_CAPI_TRACE_INSTANT(category, name);
+```
+
+### counter
+
+记录 counter trace event。
+
+```c
+LYNX_CAPI_TRACE_COUNTER(category, name, value, incremental);
+```
+
+#### 示例
+
+```c
+void DecodeImage() {
+  LYNX_CAPI_TRACE_BEGIN("image", "DecodeImage");
+  // ... 你的代码 ...
+  LYNX_CAPI_TRACE_END("image", "DecodeImage");
+}
+
+LYNX_CAPI_TRACE_INSTANT("network", "RequestStarted");
+LYNX_CAPI_TRACE_COUNTER("cache", "EntryCount", 42, false);
+```
+
 ## 兼容性
 
 <APITable />

--- a/packages/lynx-compat-data/lynx-native-api/lynx-view/lynx-view-custom-element.json
+++ b/packages/lynx-compat-data/lynx-native-api/lynx-view/lynx-view-custom-element.json
@@ -23,10 +23,10 @@
               "version_added": true
             },
             "clay_macos": {
-              "version_added": "3.7"
+              "version_added": false
             },
             "clay_windows": {
-              "version_added": "3.7"
+              "version_added": false
             }
           }
         }


### PR DESCRIPTION
## Summary
- add Desktop C++ sections for LynxView client registration/removal and object release docs in en/zh Native API pages
- add Desktop C API trace macro docs for TraceEvent where no C++ wrapper exists
- correct lynx-view custom element desktop compat to unsupported and record the cleanup ledger

## Verification
- Native API desktop/doc alignment rescan: 0 remaining mismatches across all four tracked categories
- Modified lynx-view-custom-element compat JSON validates against the compat schema
- pnpm run check-docs currently fails on pre-existing elements/* APISummary import issues, unrelated to this Native API cleanup
- pnpm --filter @lynx-js/lynx-compat-data run lint currently fails locally with an opaque Node/ts-node error before reporting file-level validation output