### PR TITLE
docs: tag desktop-only Native APIs

### DIFF
--- a/docs/en/api/_meta.json
+++ b/docs/en/api/_meta.json
@@ -1457,6 +1457,7 @@
     "type": "dir",
     "name": "lynx-native-api/lynx-env",
     "label": "LynxEnv",
+    "tag": "Desktop",
     "collapsible": true,
     "collapsed": true
   },
@@ -1464,6 +1465,7 @@
     "type": "file",
     "name": "lynx-native-api/lynx-extension-module",
     "label": "LynxExtensionModule",
+    "tag": "Desktop",
     "overviewHeaders": [],
     "collapsible": true,
     "collapsed": true

--- a/docs/en/api/lynx-native-api/lynx-env.mdx
+++ b/docs/en/api/lynx-native-api/lynx-env.mdx
@@ -1,4 +1,5 @@
 ---
+tag: Desktop
 overview: true
 overviewHeaders: [2]
 ---

--- a/docs/en/api/lynx-native-api/lynx-extension-module.mdx
+++ b/docs/en/api/lynx-native-api/lynx-extension-module.mdx
@@ -1,4 +1,5 @@
 ---
+tag: Desktop
 api: lynx-native-api/lynx-extension-module
 ---
 

--- a/docs/zh/api/_meta.json
+++ b/docs/zh/api/_meta.json
@@ -1457,6 +1457,7 @@
     "type": "dir",
     "name": "lynx-native-api/lynx-env",
     "label": "LynxEnv",
+    "tag": "Desktop",
     "collapsible": true,
     "collapsed": true
   },
@@ -1464,6 +1465,7 @@
     "type": "file",
     "name": "lynx-native-api/lynx-extension-module",
     "label": "LynxExtensionModule",
+    "tag": "Desktop",
     "overviewHeaders": [],
     "collapsible": true,
     "collapsed": true

--- a/docs/zh/api/lynx-native-api/lynx-env.md
+++ b/docs/zh/api/lynx-native-api/lynx-env.md
@@ -1,5 +1,6 @@
 ---
 title: LynxEnv
+tag: Desktop
 overview: true
 overviewHeaders: [2]
 ---

--- a/docs/zh/api/lynx-native-api/lynx-extension-module.mdx
+++ b/docs/zh/api/lynx-native-api/lynx-extension-module.mdx
@@ -1,4 +1,5 @@
 ---
+tag: Desktop
 api: lynx-native-api/lynx-extension-module
 ---
 


### PR DESCRIPTION
## Summary
- mark LynxEnv as Desktop-only in en/zh page frontmatter and sidebar metadata
- mark LynxExtensionModule as Desktop-only in en/zh page frontmatter and sidebar metadata

## Verification
- Confirmed LynxEnv docs only describe Desktop public embedder C++ API
- Scanned Native API compat data for entries supported only on clay_macos/clay_windows; LynxExtensionModule is the only compat-backed Desktop-only API missing the tag
- Rescan result: no Desktop-only Native API docs are missing the Desktop tag
- Parsed docs/en/api/_meta.json and docs/zh/api/_meta.json successfully