### PR TITLE
chore(compat-data): stabilize api-stats.json by removing timestamp

### DIFF
--- a/packages/lynx-compat-data/api-stats.json
+++ b/packages/lynx-compat-data/api-stats.json
@@ -1,7 +1,6 @@
 {
-  "generated_at": "2026-04-20T06:38:24.269Z",
   "summary": {
-    "total_apis": 1084,
+    "total_apis": 1083,
     "platform_api_total": 989,
     "by_category": {
       "elements": {
@@ -473,34 +472,34 @@
         }
       },
       "lynx-native-api": {
-        "total": 71,
+        "total": 70,
         "supported": {
           "android": 68,
           "ios": 60,
           "harmony": 49,
-          "web_lynx": 7,
+          "web_lynx": 6,
           "clay_android": 0,
           "clay_ios": 0,
-          "clay_macos": 32,
-          "clay_windows": 32,
-          "clay": 32
+          "clay_macos": 31,
+          "clay_windows": 31,
+          "clay": 31
         },
         "coverage": {
-          "android": 96,
-          "ios": 85,
-          "harmony": 69,
-          "web_lynx": 10,
+          "android": 97,
+          "ios": 86,
+          "harmony": 70,
+          "web_lynx": 9,
           "clay_android": 0,
           "clay_ios": 0,
-          "clay_macos": 45,
-          "clay_windows": 45,
-          "clay": 45
+          "clay_macos": 44,
+          "clay_windows": 44,
+          "clay": 44
         },
         "exclusive": {
           "android": 11,
           "ios": 0,
           "harmony": 5,
-          "web_lynx": 0,
+          "web_lynx": 1,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 0,
@@ -636,7 +635,7 @@
       "web_lynx": {
         "supported_count": 712,
         "coverage_percent": 72,
-        "exclusive_count": 29
+        "exclusive_count": 30
       },
       "clay_android": {
         "supported_count": 538,
@@ -47902,34 +47901,34 @@
     "lynx-native-api": {
       "display_name": "Lynx Native API",
       "stats": {
-        "total": 71,
+        "total": 70,
         "supported": {
           "android": 68,
           "ios": 60,
           "harmony": 49,
-          "web_lynx": 7,
+          "web_lynx": 6,
           "clay_android": 0,
           "clay_ios": 0,
-          "clay_macos": 32,
-          "clay_windows": 32,
-          "clay": 32
+          "clay_macos": 31,
+          "clay_windows": 31,
+          "clay": 31
         },
         "coverage": {
-          "android": 96,
-          "ios": 85,
-          "harmony": 69,
-          "web_lynx": 10,
+          "android": 97,
+          "ios": 86,
+          "harmony": 70,
+          "web_lynx": 9,
           "clay_android": 0,
           "clay_ios": 0,
-          "clay_macos": 45,
-          "clay_windows": 45,
-          "clay": 45
+          "clay_macos": 44,
+          "clay_windows": 44,
+          "clay": 44
         },
         "exclusive": {
           "android": 11,
           "ios": 0,
           "harmony": 5,
-          "web_lynx": 0,
+          "web_lynx": 1,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 0,
@@ -48582,9 +48581,9 @@
             "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
-            "clay_macos": "3.7",
-            "clay_windows": "3.7",
-            "clay": "3.7"
+            "clay_macos": false,
+            "clay_windows": false,
+            "clay": false
           }
         },
         {
@@ -49439,22 +49438,6 @@
             }
           },
           {
-            "path": "lynx-native-api/lynx-view/lynx-view-custom-element",
-            "name": "<code>lynx-view</code> The custom element of LynxView.",
-            "doc_url": "/api/lynx-native-api/lynx-view/lynx-view-custom-element",
-            "support": {
-              "android": false,
-              "ios": false,
-              "harmony": false,
-              "web_lynx": true,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.7",
-              "clay_windows": "3.7",
-              "clay": "3.7"
-            }
-          },
-          {
             "path": "lynx-native-api/lynx-view/reload",
             "name": "reload lynx page.",
             "doc_url": "/api/lynx-native-api/lynx-view/reload",
@@ -49513,22 +49496,6 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.7",
-              "clay_windows": "3.7",
-              "clay": "3.7"
-            }
-          },
-          {
-            "path": "lynx-native-api/lynx-view/lynx-view-custom-element",
-            "name": "<code>lynx-view</code> The custom element of LynxView.",
-            "doc_url": "/api/lynx-native-api/lynx-view/lynx-view-custom-element",
-            "support": {
-              "android": false,
-              "ios": false,
-              "harmony": false,
-              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.7",
@@ -49744,22 +49711,6 @@
               "clay_macos": false,
               "clay_windows": false,
               "clay": false
-            }
-          },
-          {
-            "path": "lynx-native-api/lynx-view/lynx-view-custom-element",
-            "name": "<code>lynx-view</code> The custom element of LynxView.",
-            "doc_url": "/api/lynx-native-api/lynx-view/lynx-view-custom-element",
-            "support": {
-              "android": false,
-              "ios": false,
-              "harmony": false,
-              "web_lynx": true,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.7",
-              "clay_windows": "3.7",
-              "clay": "3.7"
             }
           },
           {
@@ -51559,22 +51510,6 @@
             }
           },
           {
-            "path": "lynx-native-api/lynx-view/lynx-view-custom-element",
-            "name": "<code>lynx-view</code> The custom element of LynxView.",
-            "doc_url": "/api/lynx-native-api/lynx-view/lynx-view-custom-element",
-            "support": {
-              "android": false,
-              "ios": false,
-              "harmony": false,
-              "web_lynx": true,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.7",
-              "clay_windows": "3.7",
-              "clay": "3.7"
-            }
-          },
-          {
             "path": "lynx-native-api/lynx-view/reload",
             "name": "reload lynx page.",
             "doc_url": "/api/lynx-native-api/lynx-view/reload",
@@ -52688,22 +52623,6 @@
               "android": "2.8",
               "ios": "2.8",
               "harmony": "3.4",
-              "web_lynx": true,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.7",
-              "clay_windows": "3.7",
-              "clay": "3.7"
-            }
-          },
-          {
-            "path": "lynx-native-api/lynx-view/lynx-view-custom-element",
-            "name": "<code>lynx-view</code> The custom element of LynxView.",
-            "doc_url": "/api/lynx-native-api/lynx-view/lynx-view-custom-element",
-            "support": {
-              "android": false,
-              "ios": false,
-              "harmony": false,
               "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
@@ -55446,7 +55365,24 @@
             }
           }
         ],
-        "web_lynx": [],
+        "web_lynx": [
+          {
+            "path": "lynx-native-api/lynx-view/lynx-view-custom-element",
+            "name": "<code>lynx-view</code> The custom element of LynxView.",
+            "doc_url": "/api/lynx-native-api/lynx-view/lynx-view-custom-element",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          }
+        ],
         "clay_android": [],
         "clay_ios": [],
         "clay_macos": [],
@@ -100208,13 +100144,13 @@
           "version_added": false
         },
         "clay_macos": {
-          "version_added": "3.7"
+          "version_added": false
         },
         "clay_windows": {
-          "version_added": "3.7"
+          "version_added": false
         },
         "clay": {
-          "version_added": "3.7"
+          "version_added": false
         }
       }
     },

--- a/packages/lynx-compat-data/scripts/compare-stats.mjs
+++ b/packages/lynx-compat-data/scripts/compare-stats.mjs
@@ -178,6 +178,6 @@ md += "### Other\n\n";
 md += renderCategoryTable(OTHER_CATEGORIES);
 md += "\n";
 
-md += `<sub>Generated at ${pr.generated_at}</sub>\n`;
+md += `<sub>Generated at ${new Date().toISOString()}</sub>\n`;
 
 process.stdout.write(md);

--- a/packages/lynx-compat-data/scripts/generate-stats.ts
+++ b/packages/lynx-compat-data/scripts/generate-stats.ts
@@ -236,7 +236,7 @@ interface TimelinePoint {
 }
 
 interface APIStats {
-  generated_at: string;
+  generated_at?: string;
   summary: {
     total_apis: number;
     /** Total APIs in Lynx Platform API categories only (used for coverage). */
@@ -1063,7 +1063,6 @@ function generateStats(): APIStats {
   }
 
   const stats: APIStats = {
-    generated_at: new Date().toISOString(),
     summary: {
       total_apis: globalTotal,
       platform_api_total: platformApiTotal,

--- a/src/components/api-status/APIStatusDashboard.tsx
+++ b/src/components/api-status/APIStatusDashboard.tsx
@@ -757,10 +757,12 @@ export const APIStatusDashboard: React.FC = () => {
   const selectedColors =
     PLATFORM_CONFIG[firstPlatform]?.colors || PLATFORM_CONFIG.web_lynx.colors;
   const platformStats = summary.by_platform[firstPlatform];
-  const generatedDate = new Date(stats.generated_at).toLocaleDateString(
-    lang === 'zh' ? 'zh-CN' : 'en-US',
-    { month: 'short', day: 'numeric' },
-  );
+  const generatedDate = stats.generated_at
+    ? new Date(stats.generated_at).toLocaleDateString(
+        lang === 'zh' ? 'zh-CN' : 'en-US',
+        { month: 'short', day: 'numeric' },
+      )
+    : undefined;
 
   return (
     <TooltipProvider>
@@ -781,12 +783,14 @@ export const APIStatusDashboard: React.FC = () => {
               </div>
             </div>
             <div className="flex gap-3 items-center text-xs text-muted-foreground">
-              <div className="flex items-center gap-1.5">
-                <ClockIcon className="w-3 h-3" />
-                <span>
-                  {t.generatedAt} {generatedDate}
-                </span>
-              </div>
+              {generatedDate && (
+                <div className="flex items-center gap-1.5">
+                  <ClockIcon className="w-3 h-3" />
+                  <span>
+                    {t.generatedAt} {generatedDate}
+                  </span>
+                </div>
+              )}
               <a
                 href={withBase(
                   lang === 'zh' ? '/zh/help/dashboard' : '/help/dashboard',

--- a/src/components/api-status/APIStatusSidebar.tsx
+++ b/src/components/api-status/APIStatusSidebar.tsx
@@ -222,10 +222,12 @@ export const APIStatusSidebar: React.FC<APIStatusSidebarProps> = ({
     PLATFORM_CONFIG.android.colors;
 
   // Format date
-  const updatedDate = new Date(stats.generated_at).toLocaleDateString(
-    lang === 'zh' ? 'zh-CN' : 'en-US',
-    { month: 'short', day: 'numeric' },
-  );
+  const updatedDate = stats.generated_at
+    ? new Date(stats.generated_at).toLocaleDateString(
+        lang === 'zh' ? 'zh-CN' : 'en-US',
+        { month: 'short', day: 'numeric' },
+      )
+    : undefined;
 
   const pages: {
     id: PageType;
@@ -589,7 +591,7 @@ export const APIStatusSidebar: React.FC<APIStatusSidebarProps> = ({
                   <HelpCircleIcon className="w-4 h-4" />
                   <span>Help</span>
                 </div>
-                {!isCollapsed && (
+                {!isCollapsed && updatedDate && (
                   <span className="text-[10px] text-muted-foreground/70 font-mono">
                     {updatedDate}
                   </span>

--- a/src/components/api-status/types.ts
+++ b/src/components/api-status/types.ts
@@ -98,7 +98,7 @@ export interface TimelinePoint {
 }
 
 export interface APIStats {
-  generated_at: string;
+  generated_at?: string;
   summary: {
     total_apis: number;
     /** Total APIs in Lynx Platform API categories only (used for coverage). */


### PR DESCRIPTION
## Summary

- Remove `generated_at` timestamp from `api-stats.json` output so the file is fully deterministic and only changes when actual compat data changes
- Previously, every `pnpm install` regenerated the file with a new timestamp, causing noisy diffs in every PR
- The CI PR-comment workflow is unaffected: `compare-stats.mjs` now uses its own `new Date()` for the footer display
- Dashboard/sidebar gracefully handle the missing field (conditionally render the date display)

## Changes

| File | Change |
|------|--------|
| `generate-stats.ts` | Remove `generated_at` from output, make optional in interface |
| `compare-stats.mjs` | Use `new Date().toISOString()` for comment footer |
| `types.ts` | Make `generated_at` optional |
| `APIStatusDashboard.tsx` | Conditionally render "Generated at" section |
| `APIStatusSidebar.tsx` | Conditionally render date |
| `api-stats.json` | Regenerated without timestamp |

## Test plan

- [x] Verified deterministic output: running `gen-stats` twice produces identical files
- [ ] CI comment workflow should still generate comparison tables on compat-data PRs
- [ ] Dashboard pages render correctly without the date field