### PR TITLE
docs(ai): reorder sidebar and restructure index to lead with AGENTS.md

### DIFF
--- a/docs/en/ai/_meta.json
+++ b/docs/en/ai/_meta.json
@@ -9,21 +9,6 @@
   },
   {
     "type": "section-header",
-    "label": "MCPs"
-  },
-  {
-    "type": "file",
-    "name": "lynx-docs-mcp.mdx"
-  },
-  {
-    "type": "file",
-    "name": "lynx-devtool-mcp.mdx"
-  },
-  {
-    "type": "divider"
-  },
-  {
-    "type": "section-header",
     "label": "Agents"
   },
   {
@@ -60,5 +45,20 @@
   {
     "type": "file",
     "name": "skills/debug-info-remapping.mdx"
+  },
+  {
+    "type": "divider"
+  },
+  {
+    "type": "section-header",
+    "label": "MCPs"
+  },
+  {
+    "type": "file",
+    "name": "lynx-docs-mcp.mdx"
+  },
+  {
+    "type": "file",
+    "name": "lynx-devtool-mcp.mdx"
   }
 ]

--- a/docs/en/ai/index.mdx
+++ b/docs/en/ai/index.mdx
@@ -1,37 +1,33 @@
 # Lynx for AI
 
-LLMs are trained on public web data, which means they often lack awareness of the latest Lynx features and best practices. The Lynx team and community are developing a suite of tools to help LLMs understand and develop Lynx more effectively.
+LLMs are trained on public web data, which means they often lack awareness of the latest Lynx features and best practices. The Lynx team and community are developing a suite of tools to help coding agents understand and develop Lynx more effectively.
 
-## Teaching LLMs about Lynx
+## Set Up Your Project with `AGENTS.md`
 
-### Using Lynx Docs MCP
+The [`AGENTS.md`](https://agents.md) file is similar to `README.md`, but written for coding agents. It gives agents the project-specific context they need to work effectively in your Lynx codebase, with zero dependencies and immediate value.
 
-[Model Context Protocol](https://modelcontextprotocol.io/docs/getting-started/intro) is a standard for connecting LLMs to external tools. Lynx Docs MCP allows the agent fetch accurate guides, API references directly from the Lynx documentation site, to ensure its answers stay correct and up to date.
+Learn how to add a suitable `AGENTS.md` for your Lynx project in [AGENTS.md for Lynx](agentsmd.mdx).
 
-Read more about Lynx Docs MCP in [Lynx Docs MCP](lynx-docs-mcp.mdx).
+## Add Domain Expertise with Agent Skills
 
-### Using `llms.txt`
+[Agent Skills](https://agentskills.io/home) are reusable rule sets that give coding agents domain-specific knowledge about Lynx's dual-thread architecture, common patterns, and debugging techniques. Install the community collection with:
 
-[llms.txt](https://llmstxt.org/) is a standard to help LLMs use a website as a knowledge base. The Lynx website fully supports it, so you can either copy the Markdown or provide its URL to any LLM with web-browsing. For every page, you can get the original Markdown by replacing the `.html` extension with `.md`. For example:
+```bash
+npx skills add lynx-community/skills
+```
+
+Read more in [Agent Skills for Lynx](https://github.com/lynx-community/skills).
+
+## Connect Tools with MCP
+
+[Model Context Protocol](https://modelcontextprotocol.io/docs/getting-started/intro) is a standard for connecting coding agents to external tools.
+
+- [**Lynx Docs MCP**](lynx-docs-mcp.mdx) allows agents to fetch accurate guides and API references directly from the Lynx documentation site, ensuring answers stay correct and up to date.
+- [**Lynx DevTool MCP**](lynx-devtool-mcp.mdx) lets coding agents _**control, operate and preview**_ Lynx pages, just like a human does in DevTool.
+
+## Using `llms.txt`
+
+The Lynx website also supports the [llms.txt](https://llmstxt.org/) standard, which is useful for feeding Lynx documentation into any LLM with web browsing. For every page, you can get the original Markdown by replacing the `.html` extension with `.md`. For example:
 
 - [https://lynxjs.org/llms.txt](https://lynxjs.org/llms.txt)
 - [https://lynxjs.org/react/introduction.md](https://lynxjs.org/react/introduction.md)
-
-## Developing with Agents
-
-### Using `AGENTS.md`
-
-The [`AGENTS.md`](https://agents.md) file is similar to `README.md`, but it's for agents. Learn how to add a suitable `AGENTS.md` for your Lynx project in [AGENTS.md for Lynx](agentsmd.mdx).
-
-### Lynx DevTool MCP
-
-[Lynx DevTool MCP](lynx-devtool-mcp.mdx) is the Lynx DevTool for coding agents.
-It lets coding agents _**control, operate and preview**_ Lynx pages, just like human does in DevTool.
-
-Read more in [Lynx DevTool MCP](lynx-devtool-mcp.mdx).
-
-### Agent Skills
-
-[Agent Skills](https://agentskills.io/home) are reusable rule sets that give coding agents domain-specific knowledge about Lynx's dual-thread architecture, common patterns, and debugging techniques. Install the community collection with `npx skills add lynx-community/skills`.
-
-Read more in [Agent Skills for Lynx](https://github.com/lynx-community/skills).

--- a/docs/zh/ai/_meta.json
+++ b/docs/zh/ai/_meta.json
@@ -9,21 +9,6 @@
   },
   {
     "type": "section-header",
-    "label": "MCPs"
-  },
-  {
-    "type": "file",
-    "name": "lynx-docs-mcp.mdx"
-  },
-  {
-    "type": "file",
-    "name": "lynx-devtool-mcp.mdx"
-  },
-  {
-    "type": "divider"
-  },
-  {
-    "type": "section-header",
     "label": "Agents"
   },
   {
@@ -60,5 +45,20 @@
   {
     "type": "file",
     "name": "skills/debug-info-remapping.mdx"
+  },
+  {
+    "type": "divider"
+  },
+  {
+    "type": "section-header",
+    "label": "MCPs"
+  },
+  {
+    "type": "file",
+    "name": "lynx-docs-mcp.mdx"
+  },
+  {
+    "type": "file",
+    "name": "lynx-devtool-mcp.mdx"
   }
 ]

--- a/docs/zh/ai/index.mdx
+++ b/docs/zh/ai/index.mdx
@@ -1,37 +1,33 @@
 # 面向 AI 的 Lynx
 
-大语言模型基于公开网络数据训练，因此通常缺乏对最新 Lynx 功能和最佳实践的了解。Lynx 团队和社区正在开发一套工具，帮助大语言模型更有效地理解和开发 Lynx。
+大语言模型基于公开网络数据训练，因此通常缺乏对最新 Lynx 功能和最佳实践的了解。Lynx 团队和社区正在开发一套工具，帮助 coding agent 更有效地理解和开发 Lynx。
 
-## 帮助大模型了解 Lynx
+## 使用 `AGENTS.md` 配置项目
 
-### 使用 Lynx Docs MCP
+[`AGENTS.md`](https://agents.md) 类似于 `README.md`，但面向 coding agent 编写。它为 agent 提供在 Lynx 代码库中高效工作所需的项目级上下文，无需任何依赖即可立即生效。
 
-[Model Context Protocol](https://modelcontextprotocol.io/docs/getting-started/intro) 是一个连接大语言模型与外部工具的标准。Lynx Docs MCP 让智能体能够直接从 Lynx 文档站点获取准确的指南、API 参考，确保其答案保持正确和最新。
+在 [Lynx 下的 AGENTS.md](agentsmd.mdx) 中了解如何为你的 Lynx 项目添加合适的 `AGENTS.md`。
 
-在 [Lynx Docs MCP](lynx-docs-mcp.mdx) 中了解更多信息。
+## 使用 Agent Skills 添加领域知识
 
-### 使用 `llms.txt`
+[Agent Skills](https://agentskills.io/home) 是可复用的规则集，为 coding agent 提供关于 Lynx 双线程架构、常见模式和调试技巧的领域知识。使用以下命令安装社区集合：
 
-[llms.txt](https://llmstxt.org/) 是一个帮助大语言模型将网站用作知识库的标准。Lynx 网站完全支持它，因此你可以复制 Markdown 或将其 URL 提供给任何具有网页浏览功能的大语言模型。对于每个页面，你可以通过将 `.html` 扩展名替换为 `.md` 来获取原始 Markdown。例如：
+```bash
+npx skills add lynx-community/skills
+```
+
+在 [Lynx Agent Skills](https://github.com/lynx-community/skills) 中了解更多信息。
+
+## 使用 MCP 连接工具
+
+[Model Context Protocol](https://modelcontextprotocol.io/docs/getting-started/intro) 是一个连接 coding agent 与外部工具的标准。
+
+- [**Lynx Docs MCP**](lynx-docs-mcp.mdx) 让 agent 能够直接从 Lynx 文档站点获取准确的指南和 API 参考，确保答案保持正确和最新。
+- [**Lynx DevTool MCP**](lynx-devtool-mcp.mdx) 让 coding agent 能够 _**控制、操作和预览**_ Lynx 页面，就像人类在 DevTool 中一样。
+
+## 使用 `llms.txt`
+
+Lynx 网站还支持 [llms.txt](https://llmstxt.org/) 标准，适合将 Lynx 文档提供给任何具有网页浏览功能的大语言模型。对于每个页面，你可以通过将 `.html` 扩展名替换为 `.md` 来获取原始 Markdown。例如：
 
 - [https://lynxjs.org/llms.txt](https://lynxjs.org/llms.txt)
 - [https://lynxjs.org/react/introduction.md](https://lynxjs.org/react/introduction.md)
-
-## 使用智能体进行开发
-
-### 使用 `AGENTS.md`
-
-[`AGENTS.md`](https://agents.md) 类似于 `README.md`，但适用于 agent。在 [Lynx 下的 AGENTS.md](agentsmd.mdx) 中了解如何为你的 Lynx 项目添加合适的 `AGENTS.md`。
-
-### Lynx DevTool MCP
-
-[Lynx DevTool MCP](lynx-devtool-mcp.mdx) 是面向 coding agent 的 Lynx DevTool。
-它让 coding agent 能够 _**控制、操作和预览**_ Lynx 页面，就像人类在 DevTool 中一样。
-
-在 [Lynx DevTool MCP](lynx-devtool-mcp.mdx) 中了解更多信息。
-
-### Agent Skills
-
-[Agent Skills](https://agentskills.io/home) 是可复用的规则集，为 coding agent 提供关于 Lynx 双线程架构、常见模式和调试技巧的领域知识。使用 `npx skills add lynx-community/skills` 安装社区集合。
-
-在 [Lynx Agent Skills](https://github.com/lynx-community/skills) 中了解更多信息。


### PR DESCRIPTION
## Summary

- Reorder the /ai sidebar from MCPs → Agents → Skills to Agents → Skills → MCPs, reflecting the current agentic coding workflow where AGENTS.md and skills are the primary entry points over MCP
- Restructure the index page to organize by developer workflow steps (project setup → domain expertise → tool connections → reference) rather than abstract categories ("Teaching LLMs" vs "Developing with Agents")
- Apply changes to both EN and ZH versions

## Test plan

- [ ] Verify sidebar renders in the correct order: Agents, Skills, MCPs
- [ ] Verify the index page content and links are correct in both EN and ZH