### PR TITLE
docs(ai): rewrite AGENTS.md guide for clarity

### DIFF
--- a/docs/en/ai/agentsmd.mdx
+++ b/docs/en/ai/agentsmd.mdx
@@ -1,109 +1,56 @@
 # `AGENTS.md` for Lynx
 
-The [`AGENTS.md`](https://agents.md) file is similar to `README.md`, but it's for agents.
+[`AGENTS.md`](https://agents.md) is a project-level instruction file for coding agents, similar to how `README.md` is for human developers.
 
-In this document, you'll learn how to add a suitable `AGENTS.md` for your Lynx project, ensuring your agents can perform at their best within your Lynx project.
+## Getting Started
 
-## Creating a New Project
-
-We've included `AGENTS.md` in the initial project template. You can refer to [Quick Start](/guide/start/quick-start#create-a-new-lynx-project) to create a new Lynx project. The project's root directory will contain a pre-written `AGENTS.md` file.
-
-## Adding `AGENTS.md` to an Existing Project
-
-For Lynx projects, you can start with this file and then modify it according to your project needs:
+New Lynx projects created via [Quick Start](/guide/start/quick-start#create-a-new-lynx-project) already include an `AGENTS.md`. For existing projects, copy the template and adapt it to your project:
 
 - [`AGENTS.md` in Lynx Template Project](https://github.com/lynx-family/lynx-stack/blob/main/packages/rspeedy/create-rspeedy/template-common/AGENTS.md)
 
-## Modifying the existing `AGENTS.md`
+## Point Agents to Lynx Docs
 
-Below is an example; please add the "Read in Advance" section to your project's `AGENTS.md`:
-
-:::info No Magic Spell
-
-This section isn't a magic spell; it works because:
-
-1. It provides the agent with the LLM-friendly Lynx website: [llms.txt](https://lynxjs.org/llms.txt).
-
-2. It explicitly emphasizes the importance of reading [llms.txt](https://lynxjs.org/llms.txt) in `AGENTS.md` to agents.
-
-:::
+The most important thing to add is a pointer to [llms.txt](https://lynxjs.org/llms.txt), which serves as an entry point to all Lynx documentation in an LLM-friendly format. Add a section like this to your `AGENTS.md`:
 
 ```markdown
-# My Awesome Project
-
-<!-- Here goes your original project description -->
-
-<!-- Insert the section below -->
-
 ## Read in Advance
 
 Read the docs below in advance to help you understand the library or frameworks this project depends on.
 
 - Lynx: [llms.txt](https://lynxjs.org/llms.txt).
   While dealing with a Lynx task, an agent **MUST** read this doc because it is an entry point of all available docs about Lynx.
-
-<!-- Below goes your original content -->
-
-## Build Instructions
-
-<!-- ... -->
-
-## Test Instructions
-
-<!-- ... -->
 ```
 
-## Using `AGENTS.md` in a Monorepo
-
-In a monorepo, you can add an `AGENTS.md` file to each subproject to provide specific guidance and information to agents for each subproject. This helps ensure that agents can optimize and adapt to the needs and characteristics of their respective sub-projects.
-
-However, you can use `AGENTS.md` in the monorepo root directory as a global guideline file, providing general information and guiding principles.
-
-For example:
+If agents still ignore the documentation, you can inline the full contents of `llms.txt` directly into your `AGENTS.md`:
 
 ```bash
+curl https://lynxjs.org/llms.txt > AGENTS.md
+```
 
+To keep it up-to-date automatically, add this command to your `prepare` script in `package.json` and gitignore the generated file.
+
+## Monorepo Setup
+
+In a monorepo, place a root `AGENTS.md` for global guidelines and per-package files for project-specific context. Agents read the closest file first, then walk up.
+
+```bash
 $ tree
 .
-├── AGENTS.md # the global AGENTS.md
+├── AGENTS.md           # global guidelines
 ├── README.md
 └── packages
     ├── web
-    │   ├── AGENTS.md # the AGENTS.md for web project
+    │   ├── AGENTS.md   # web-specific
     │   ├── package-a
     │   │   └── AGENTS.md
     │   └── package-b
     │       └── AGENTS.md
     └── lynx
-        ├── AGENTS.md # the AGENTS.md for lynx project
+        ├── AGENTS.md   # lynx-specific
         ├── package-c
         │   └── AGENTS.md
         └── package-d
-            └── AGENTS.md # the AGENTS.md for d subproject
+            └── AGENTS.md
 ```
 
-In this example, you should place Lynx-specific guidance and information in `packages/lynx/AGENTS.md`.
-
-For example, when agents process tasks under package-d, they should first refer to `packages/lynx/package-d/AGENTS.md`, then `packages/lynx/AGENTS.md`, and finally the `AGENTS.md` in the root directory.
-
-Organizing the `AGENTS.md` files in a tree structure avoids repetitive writing of the same information and ensures that agents can access the most relevant and up-to-date guidance. However, developers should ensure that the information in the various `AGENTS.md` files does not conflict with each other to avoid causing abnormal agent behavior.
-
-## Using `llms.txt` as `AGENTS.md`
-
-If agents are not reading the Lynx documentation as required, consider inlining or overwriting the contents of `llms.txt` into `AGENTS.md`.
-
-```bash
-curl https://lynxjs.org/llms.txt > packages/lynx/AGENTS.md
-```
-
-It is recommended to use this method only for public `AGENTS.md` files to avoid duplicate content across multiple files and to override customized instructions for specific subprojects.
-
-If you want to keep `llms.txt` up-to-date, you can add the above command to the prepare script in your package.json (or root package.json for monorepo). Remember to gitignore the generated `AGENTS.md` file to avoid committing it to version control.
-
-## Troubleshooting
-
-### Agents Not Reading Lynx Documentation as Required
-
-Ensure that the "Read in Advance" section is correctly added to `AGENTS.md`, explicitly stating that agents must read [llms.txt](https://lynxjs.org/llms.txt).
-
-If the problem persists, consider inlining the contents of `llms.txt` directly into `AGENTS.md`, as shown in the example above.
+Place Lynx-specific guidance in `packages/lynx/AGENTS.md`. Keep information consistent across files to avoid conflicting instructions.

--- a/docs/en/ai/agentsmd.mdx
+++ b/docs/en/ai/agentsmd.mdx
@@ -21,6 +21,8 @@ Read the docs below in advance to help you understand the library or frameworks 
   While dealing with a Lynx task, an agent **MUST** read this doc because it is an entry point of all available docs about Lynx.
 ```
 
+This isn't a magic incantation. It works because the snippet gives the agent a concrete URL to fetch, and the strong language ("MUST") tells it to prioritize the docs over guessing from training data.
+
 If agents still ignore the documentation, you can inline the full contents of `llms.txt` directly into your `AGENTS.md`:
 
 ```bash

--- a/docs/zh/ai/agentsmd.mdx
+++ b/docs/zh/ai/agentsmd.mdx
@@ -1,107 +1,56 @@
 # Lynx 下的 `AGENTS.md`
 
-[`AGENTS.md`](https://agents.md) 类似于 `README.md`，但适用于 agent。
+[`AGENTS.md`](https://agents.md) 是面向 coding agent 的项目级指令文件，类似于 `README.md` 面向人类开发者的作用。
 
-在这篇文档中，你将了解如何添加一个适合 Lynx 项目的 `AGENTS.md`，继而确保你的 agents 可以在 Lynx 的项目上，最大限度的发挥出其能力。
+## 快速开始
 
-## 创建全新项目
-
-我们已经在初始化项目模版中内置了 `AGENTS.md`，你可以参考 [Quick Start](/guide/start/quick-start#create-a-new-lynx-project) 来创建一个全新的 Lynx 项目，项目的根目录会有一个我们预先编写好的 `AGENTS.md` 文件。
-
-## 现有项目中添加 `AGENTS.md`
-
-对于 Lynx 项目，你可以从此文件开始，然后根据你的项目需求进行修改：
+通过 [Quick Start](/guide/start/quick-start#create-a-new-lynx-project) 创建的新 Lynx 项目已经包含 `AGENTS.md`。对于已有项目，可以复制模板并根据你的项目进行调整：
 
 - [`AGENTS.md` in Lynx Template Project](https://github.com/lynx-family/lynx-stack/blob/main/packages/rspeedy/create-rspeedy/template-common/AGENTS.md)
 
-## 修改现有的 `AGENTS.md` 文件
+## 引导 Agent 阅读 Lynx 文档
 
-下面是一个示例，请将 "Read in Advance" 小节添加在你的项目的 `AGENTS.md` 里：
-
-:::info 没有魔法咒语
-
-这个小节不是什么魔法咒语，它可以工作是因为：
-
-1. 将 LLM 友好的 Lynx官网，也就是 [llms.txt](https://lynxjs.org/llms.txt)，提供给 agent
-2. 在 `AGENTS.md` 中明确强调 agent 阅读 [llms.txt](https://lynxjs.org/llms.txt) 的重要性
-
-:::
+最重要的是添加一个指向 [llms.txt](https://lynxjs.org/llms.txt) 的引用，它是所有 Lynx 文档的 LLM 友好格式入口。在你的 `AGENTS.md` 中添加如下内容：
 
 ```markdown
-# My Awesome Project
-
-<!-- Here goes your original project description -->
-
-<!-- Insert this section -->
-
 ## Read in Advance
 
-Read docs below in advance to help you understand the library or frameworks this project depends on.
+Read the docs below in advance to help you understand the library or frameworks this project depends on.
 
 - Lynx: [llms.txt](https://lynxjs.org/llms.txt).
-  While dealing with a Lynx task, an agent **MUST** read this doc because it is an entrypoint of all available docs about Lynx.
-
-<!-- Here goes your original content -->
-
-## Build Instructions
-
-<!-- ... -->
-
-## Test Instructions
-
-<!-- ... -->
+  While dealing with a Lynx task, an agent **MUST** read this doc because it is an entry point of all available docs about Lynx.
 ```
 
-## 在 monorepo 中使用 `AGENTS.md`
+如果 agent 仍然忽略文档，可以将 `llms.txt` 的完整内容直接内联到 `AGENTS.md` 中：
 
-在 monorepo 中，你可以在每个子项目中添加一个 `AGENTS.md` 文件，以便为每个子项目的 agents 提供特定的指导和信息。这有助于确保 agents 能够根据各自子项目的需求和特点进行优化和调整。
+```bash
+curl https://lynxjs.org/llms.txt > AGENTS.md
+```
 
-但是你可以将 monorepo 根目录下的 `AGENTS.md` 作为一个全局的指导文件，提供一些通用的信息和指导原则。
+如需自动保持最新，可以将此命令添加到 `package.json` 的 `prepare` 脚本中，并将生成的文件加入 gitignore。
 
-例如：
+## Monorepo 配置
+
+在 monorepo 中，根目录放置全局 `AGENTS.md` 用于通用指导，各子包放置各自的文件用于项目特定上下文。Agent 会优先读取最近的文件，然后向上查找。
 
 ```bash
 $ tree
 .
-├── AGENTS.md # 全局 AGENTS.md
+├── AGENTS.md           # 全局指导
 ├── README.md
 └── packages
     ├── web
-    │   ├── AGENTS.md # 专为 Web 项目的 AGENTS.md
+    │   ├── AGENTS.md   # Web 项目专用
     │   ├── package-a
     │   │   └── AGENTS.md
     │   └── package-b
     │       └── AGENTS.md
     └── lynx
-        ├── AGENTS.md # 专为 Lynx 项目的 AGENTS.md
+        ├── AGENTS.md   # Lynx 项目专用
         ├── package-c
         │   └── AGENTS.md
         └── package-d
-            └── AGENTS.md # d 子项目的 AGENTS.md
+            └── AGENTS.md
 ```
 
-在这个例子中，你应该将 Lynx 特有的指导和信息放在 `packages/lynx/AGENTS.md` 中。
-
-例如：当 agents 处理 package-d 下的任务时，它们应该优先参考 `packages/lynx/package-d/AGENTS.md`，然后是 `packages/lynx/AGENTS.md`，最后是根目录下的 `AGENTS.md`。
-
-按照树状结构组织 `AGENTS.md` 文件，可以避免重复编写相同的信息，同时确保 agents 能够访问到最相关和最新的指导内容。但开发者应该确保各个 `AGENTS.md` 文件之间的信息不要相互冲突，以免导致 agents 行为异常。
-
-## 将 `llms.txt` 作为 `AGENTS.md`
-
-如果 agents 没有按照要求阅读 Lynx 文档，可以考虑"内联"或"覆盖" `llms.txt` 内容到 `AGENTS.md` 中。
-
-```bash
-curl https://lynxjs.org/llms.txt > packages/lynx/AGENTS.md
-```
-
-建议只针对公共 `AGENTS.md` 文件使用此方法，以避免在多个文件中重复内容，以及覆盖特定子项目的定制化指导。
-
-如果你希望保持 `llms.txt` 的最新状态，可以将上述命令添加到 package.json（对于 monorepo，则是根 package.json） 的 prepare 脚本中。请记住将生成的 `AGENTS.md` 文件添加到 .gitignore 中，以避免将其提交到版本控制系统中。
-
-## Troubleshooting
-
-### Agents 不按照要求阅读 Lynx 文档
-
-确保在 `AGENTS.md` 中正确添加了 "Read in Advance" 小节，并明确指出 agents 必须阅读 [llms.txt](https://lynxjs.org/llms.txt)。
-
-如果问题仍然存在，考虑将 `llms.txt` 的内容直接内联到 `AGENTS.md` 中，参考上面的示例。
+将 Lynx 特有的指导放在 `packages/lynx/AGENTS.md` 中。确保各文件之间的信息不要相互冲突。

--- a/docs/zh/ai/agentsmd.mdx
+++ b/docs/zh/ai/agentsmd.mdx
@@ -21,6 +21,8 @@ Read the docs below in advance to help you understand the library or frameworks 
   While dealing with a Lynx task, an agent **MUST** read this doc because it is an entry point of all available docs about Lynx.
 ```
 
+这并不是什么魔法咒语。它之所以有效，是因为这段内容给了 agent 一个可以直接获取的具体 URL，而强调性的措辞（"MUST"）会让 agent 优先阅读文档，而非依赖训练数据进行猜测。
+
 如果 agent 仍然忽略文档，可以将 `llms.txt` 的完整内容直接内联到 `AGENTS.md` 中：
 
 ```bash


### PR DESCRIPTION
## Summary

- Consolidate three overlapping "how to add AGENTS.md" sections into a single getting started path (new project uses template, existing project copies it)
- Remove redundant troubleshooting section and "No Magic Spell" callout
- Streamline the monorepo section, keeping the tree diagram but cutting repetitive prose
- Fold the `llms.txt` inline workaround into the main "Point agents to Lynx docs" section as a fallback
- Net reduction: 140 lines removed, 36 added

## Test plan

- [ ] Verify EN and ZH pages render correctly
- [ ] Verify all links (template, llms.txt, Quick Start) resolve