### PR TITLE
fix(ui-api-table): support zh rich text summaries

### DIFF
--- a/scripts/typedoc/utils/tpl-data.ts
+++ b/scripts/typedoc/utils/tpl-data.ts
@@ -1,5 +1,9 @@
 import * as fs from 'node:fs';
 
+const doGetTagContent = (tagObject) => {
+  return Array.isArray(tagObject?.content) ? tagObject.content : [];
+};
+
 const doFindObjectWithTagValue = (obj, tagName, tagValue) => {
   function recursiveSearch(currentObj) {
     for (let key in currentObj) {
@@ -181,19 +185,30 @@ const doMoreForItem = (item) => {
     ? true
     : false;
   // 描述信息
-  const summary = doFindObjectWithTag(item, 'summary');
+  const summary = doFindObjectWithTag(item, 'summary') ?? [];
+  // 中文描述信息
+  const summary_zh_tag = doFindObjectWithTagValue(item, 'tag', '@zh');
+  const summary_zh = summary_zh_tag ? doGetTagContent(summary_zh_tag) : [];
   // 默认值
   const defaultValue = doFindObjectWithTagValue(item, 'tag', '@defaultValue');
+  // typeDoc 复杂类型的 fallback 处理
+  const docTypeFallback = doFindObjectWithTagValue(
+    item,
+    'tag',
+    '@docTypeFallback',
+  );
 
   return {
     name,
     type: doTypeCalc(type),
     summary,
+    summary_zh,
     defaultValue: doDefaultValueCalc(defaultValue),
     isOption,
     isSupportIOS,
     isSupportAndroid,
     isSupportHarmony,
+    docTypeFallback,
   };
 };
 

--- a/src/components/ui-api-table/index.tsx
+++ b/src/components/ui-api-table/index.tsx
@@ -1,49 +1,153 @@
-import { Space, Table, Typography } from '@douyinfe/semi-ui';
+import React from 'react';
+import { Space, Table, Typography, Popover } from '@douyinfe/semi-ui';
+import { useLang } from '@rspress/core/runtime';
 import { PlatformBadge } from '../api-badge';
 
 const { Paragraph, Title } = Typography;
 
-const UIApiTable = ({ source }: { source: Record<string, unknown>[] }) => {
+type SummaryToken = {
+  kind: 'text' | 'code';
+  text: string;
+};
+
+type DocTypeFallback = {
+  content?: Array<{ text?: string }>;
+};
+
+type UIApiTableItem = {
+  name?: string;
+  type?: unknown;
+  summary?: unknown;
+  summary_zh?: unknown;
+  docTypeFallback?: DocTypeFallback | null;
+  defaultValue?: string;
+  isSupportIOS?: boolean;
+  isSupportAndroid?: boolean;
+  isSupportHarmony?: boolean;
+  [key: string]: unknown;
+};
+
+function normalizeSummary(summary: unknown): SummaryToken[] {
+  if (typeof summary === 'string') {
+    return summary.length > 0 ? [{ kind: 'text', text: summary }] : [];
+  }
+
+  if (!Array.isArray(summary)) {
+    return [];
+  }
+
+  return summary.filter((item): item is SummaryToken => {
+    return Boolean(
+      item &&
+        typeof item === 'object' &&
+        'kind' in item &&
+        'text' in item &&
+        (item.kind === 'text' || item.kind === 'code') &&
+        typeof item.text === 'string',
+    );
+  });
+}
+
+function renderSummary(summary: SummaryToken[]) {
+  return summary.map((item, index) => {
+    if (item.kind === 'code') {
+      return <code key={index}>{item.text.replaceAll('`', '')}</code>;
+    }
+
+    return <React.Fragment key={index}>{item.text}</React.Fragment>;
+  });
+}
+
+function normalizeType(
+  type: unknown,
+  docTypeFallback?: DocTypeFallback | null,
+): React.ReactNode {
+  if (docTypeFallback?.content?.length) {
+    return docTypeFallback.content[0]?.text ?? '';
+  }
+
+  if (typeof type === 'string' || typeof type === 'number') {
+    return type;
+  }
+
+  if (
+    type &&
+    typeof type === 'object' &&
+    'value' in type &&
+    typeof type.value === 'string'
+  ) {
+    return type.value;
+  }
+
+  return '';
+}
+
+const UIApiTable = ({ source }: { source: UIApiTableItem[] }) => {
+  const isZh = useLang() === 'zh';
+
   const columns = [
     {
-      title: '名称',
+      title: isZh ? '名称' : 'Name',
       dataIndex: 'name',
-      render: (title, record) => {
+      render: (title: string, record: UIApiTableItem) => {
         return (
           <Space>
-            <Title
-              heading={6}
-              ellipsis={{ showTooltip: true }}
-              style={{ maxWidth: 200 }}
+            <Popover
+              content={
+                <div>
+                  {record?.isSupportIOS && <PlatformBadge platform="ios" />}
+                  {record?.isSupportAndroid && (
+                    <PlatformBadge platform="android" />
+                  )}
+                  {record?.isSupportHarmony && (
+                    <PlatformBadge platform="harmony" />
+                  )}
+                </div>
+              }
             >
-              {title}
-            </Title>
-            {record?.isSupportIOS && <PlatformBadge platform="ios" />}
-            {record?.isSupportAndroid && <PlatformBadge platform="android" />}
+              <Title
+                heading={6}
+                ellipsis={{ showTooltip: true }}
+                style={{ maxWidth: 200 }}
+              >
+                {title}
+              </Title>
+            </Popover>
           </Space>
         );
       },
     },
     {
-      title: '说明',
+      title: isZh ? '说明' : 'Description',
       dataIndex: 'summary',
-      render: (summary) => {
-        const paraCollection = summary?.map((p) => p.text).join('') || '-';
-        return <Paragraph>{paraCollection}</Paragraph>;
+      render: (_summary: unknown, record: UIApiTableItem) => {
+        const zhSummary = normalizeSummary(record.summary_zh);
+        const paraCollection = isZh
+          ? zhSummary.length > 0
+            ? zhSummary
+            : normalizeSummary(record.summary)
+          : normalizeSummary(record.summary);
+
+        if (paraCollection.length === 0) {
+          return '-';
+        }
+
+        return <Paragraph>{renderSummary(paraCollection)}</Paragraph>;
       },
     },
     {
-      title: '类型',
+      title: isZh ? '类型' : 'Type',
       dataIndex: 'type',
-      render: (type) => {
-        return <code>{type}</code>;
+      render: (type: unknown, record: UIApiTableItem) => {
+        const normalizedType = normalizeType(type, record.docTypeFallback);
+        return normalizedType ? <code>{normalizedType}</code> : '-';
       },
     },
     {
-      title: '默认值',
+      title: isZh ? '默认值' : 'Default Value',
       width: 100,
       dataIndex: 'defaultValue',
-      render: (defaultValue) => {
+      render: (defaultValue: string) => {
         return defaultValue && defaultValue !== 'undefined' ? (
           <code>{defaultValue}</code>
         ) : (


### PR DESCRIPTION
## Summary
- preserve `@zh` typedoc content as structured summary tokens in the OSS typedoc exporter
- teach `UIApiTable` to render tokenized rich text summaries, including inline code
- add zh-aware summary selection and `docTypeFallback` handling so complex prop types render correctly in OSS docs

## Why
The internal `lynx-ui` docs generator now emits richer `api_table` payloads for zh content, but `lynx-website` still assumed the old plain-text shape. As a result, zh API table descriptions in the OSS site dropped rich-text formatting and could not use the richer data safely.

## Root Cause
`lynx-website` flattened `@zh` content to plain strings in `scripts/typedoc/utils/tpl-data.ts`, and `src/components/ui-api-table/index.tsx` only concatenated `summary[].text` values without understanding token kinds or zh-specific summary fields.

## Impact
This keeps the OSS website aligned with the updated `api_table` payload used by `lynx-ui`, so zh API docs can render rich text consistently instead of losing inline formatting.

## Validation
- `git diff --check`
