### PR TITLE
feat: standardize sdk version configuration in mdx (cherry-pick #931)

### DIFF
--- a/docs/en/api/lynx-native-api/lynx-service.mdx
+++ b/docs/en/api/lynx-native-api/lynx-service.mdx
@@ -3,6 +3,7 @@ api: lynx-native-api/lynx-service/lynx-service
 ---
 
 import { APISummary, APITable, CodeFold } from '@lynx';
+import versionJson from '@site/docs/public/version.json';
 
 # LynxService API
 
@@ -215,8 +216,8 @@ Lynx Service has an automatic registration mechanism in iOS. In the implementati
 
 If you use your own implementation of Lynx Service, please delete the [default implementation](/guide/start/integrate-with-existing-apps#platform=ios) provided by Lynx.
 
-```diff title="Podfile"
-pod 'LynxService', '3.4.1', :subspecs => [
+```diff title="Podfile" {1-5}
+pod 'LynxService', '{versionJson.LYNX_VERSION}', :subspecs => [
       'Image',
 -     'Log',
       'Http',

--- a/docs/en/guide/custom-native-component/custom-component-android.mdx
+++ b/docs/en/guide/custom-native-component/custom-component-android.mdx
@@ -1,5 +1,6 @@
 import { Steps, Tabs, Tab } from '@theme';
 import { CodeFold } from '@lynx';
+import versionJson from '@site/docs/public/version.json';
 
 ### Custom Native element Implementation Process
 
@@ -18,8 +19,8 @@ Add the following to your module's build.gradle(.kts) file:
 <Tab label="Java">
 
 ```java
-compileOnly project('org.lynxsdk.lynx:lynx-processor:3.4.1')
-annotationProcessor project('org.lynxsdk.lynx:lynx-processor:3.4.1')
+compileOnly project('org.lynxsdk.lynx:lynx-processor:{versionJson.LYNX_VERSION}')
+annotationProcessor project('org.lynxsdk.lynx:lynx-processor:{versionJson.LYNX_VERSION}')
 ```
 
 </Tab>
@@ -33,7 +34,7 @@ plugins {
     id("kotlin-kapt")
 }
 //dependency
-kapt('org.lynxsdk.lynx:lynx-processor:3.4.1')
+kapt('org.lynxsdk.lynx:lynx-processor:{versionJson.LYNX_VERSION}')
 implementation("androidx.appcompat:appcompat:1.7.0")
 ```
 

--- a/docs/en/guide/start/fragments/android/integrating-lynx-with-existing-app-android.mdx
+++ b/docs/en/guide/start/fragments/android/integrating-lynx-with-existing-app-android.mdx
@@ -4,7 +4,7 @@ import { Info, CodeFold } from '@lynx';
 import { Steps } from '@theme';
 import { Tab, Tabs } from '@theme';
 import { Link } from '@theme';
-import versionJson from '../../../../../public/version.json';
+import versionJson from '@site/docs/public/version.json';
 
 <Info title="Lynx for Android">
   - This article assumes that you are familiar with the basic concepts of native Android application development.
@@ -26,10 +26,10 @@ The core capabilities of [Lynx Engine](/guide/spec.html#engine) include basic ca
 ```groovy title=build.gradle {3-6}
 dependencies {
     // lynx dependencies
-    implementation "org.lynxsdk.lynx:lynx:3.6.0"
-    implementation "org.lynxsdk.lynx:lynx-jssdk:3.6.0"
-    implementation "org.lynxsdk.lynx:lynx-trace:3.6.0"
-    implementation "org.lynxsdk.lynx:primjs:3.6.1"
+    implementation "org.lynxsdk.lynx:lynx:{versionJson.LYNX_VERSION}"
+    implementation "org.lynxsdk.lynx:lynx-jssdk:{versionJson.LYNX_VERSION}"
+    implementation "org.lynxsdk.lynx:lynx-trace:{versionJson.LYNX_VERSION}"
+    implementation "org.lynxsdk.lynx:primjs:{versionJson.PRIMJS_VERSION}"
 }
 ```
 </Tab>
@@ -37,10 +37,10 @@ dependencies {
 ```groovy title=build.gradle.kts {3-6}
 dependencies {
     // lynx dependencies
-    implementation("org.lynxsdk.lynx:lynx:3.6.0")
-    implementation("org.lynxsdk.lynx:lynx-jssdk:3.6.0")
-    implementation("org.lynxsdk.lynx:lynx-trace:3.6.0")
-    implementation("org.lynxsdk.lynx:primjs:3.6.1")
+    implementation("org.lynxsdk.lynx:lynx:{versionJson.LYNX_VERSION}")
+    implementation("org.lynxsdk.lynx:lynx-jssdk:{versionJson.LYNX_VERSION}")
+    implementation("org.lynxsdk.lynx:lynx-trace:{versionJson.LYNX_VERSION}")
+    implementation("org.lynxsdk.lynx:primjs:{versionJson.PRIMJS_VERSION}")
 }
 ```
 </Tab>
@@ -66,13 +66,13 @@ android.useAndroidX=true
 ```groovy title=build.gradle {8-24}
 dependencies {
     // lynx dependencies
-    implementation "org.lynxsdk.lynx:lynx:3.6.0"
-    implementation "org.lynxsdk.lynx:lynx-jssdk:3.6.0"
-    implementation "org.lynxsdk.lynx:lynx-trace:3.6.0"
-    implementation "org.lynxsdk.lynx:primjs:3.6.1"
+    implementation "org.lynxsdk.lynx:lynx:{versionJson.LYNX_VERSION}"
+    implementation "org.lynxsdk.lynx:lynx-jssdk:{versionJson.LYNX_VERSION}"
+    implementation "org.lynxsdk.lynx:lynx-trace:{versionJson.LYNX_VERSION}"
+    implementation "org.lynxsdk.lynx:primjs:{versionJson.PRIMJS_VERSION}"
 
     // integrating image-service
-    implementation "org.lynxsdk.lynx:lynx-service-image:3.6.0"
+    implementation "org.lynxsdk.lynx:lynx-service-image:{versionJson.LYNX_VERSION}"
 
     // image-service dependencies, if not added, images cannot be loaded; if the host APP needs to use other image libraries, you can customize the image-service and remove this dependency
     implementation "com.facebook.fresco:fresco:2.3.0"
@@ -84,10 +84,10 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:4.9.0"
 
     // integrating log-service
-    implementation "org.lynxsdk.lynx:lynx-service-log:3.6.0"
+    implementation "org.lynxsdk.lynx:lynx-service-log:{versionJson.LYNX_VERSION}"
 
     // integrating http-service
-    implementation "org.lynxsdk.lynx:lynx-service-http:3.6.0"
+    implementation "org.lynxsdk.lynx:lynx-service-http:{versionJson.LYNX_VERSION}"
 }
 ```
 </CodeFold>
@@ -98,13 +98,13 @@ dependencies {
 ```groovy title=build.gradle.kts {8-24}
 dependencies {
     // lynx dependencies
-    implementation("org.lynxsdk.lynx:lynx:3.6.0")
-    implementation("org.lynxsdk.lynx:lynx-jssdk:3.6.0")
-    implementation("org.lynxsdk.lynx:lynx-trace:3.6.0")
-    implementation("org.lynxsdk.lynx:primjs:3.6.1")
+    implementation("org.lynxsdk.lynx:lynx:{versionJson.LYNX_VERSION}")
+    implementation("org.lynxsdk.lynx:lynx-jssdk:{versionJson.LYNX_VERSION}")
+    implementation("org.lynxsdk.lynx:lynx-trace:{versionJson.LYNX_VERSION}")
+    implementation("org.lynxsdk.lynx:primjs:{versionJson.PRIMJS_VERSION}")
 
     // integrating image-service
-    implementation("org.lynxsdk.lynx:lynx-service-image:3.6.0")
+    implementation("org.lynxsdk.lynx:lynx-service-image:{versionJson.LYNX_VERSION}")
 
     // image-service dependencies, if not added, images cannot be loaded; if the host APP needs to use other image libraries, you can customize the image-service and remove this dependency
     implementation("com.facebook.fresco:fresco:2.3.0")
@@ -114,10 +114,10 @@ dependencies {
     implementation("com.facebook.fresco:animated-base:2.3.0")
 
     // integrating log-service
-    implementation("org.lynxsdk.lynx:lynx-service-log:3.6.0")
+    implementation("org.lynxsdk.lynx:lynx-service-log:{versionJson.LYNX_VERSION}")
 
     // integrating http-service
-    implementation("org.lynxsdk.lynx:lynx-service-http:3.6.0")
+    implementation("org.lynxsdk.lynx:lynx-service-http:{versionJson.LYNX_VERSION}")
 
     implementation("com.squareup.okhttp3:okhttp:4.9.0")
 }
@@ -565,12 +565,12 @@ class MainActivity : Activity() {
 ```groovy title=build.gradle {26-28}
 dependencies {
     // lynx dependencies
-    implementation "org.lynxsdk.lynx:lynx:3.6.0"
-    implementation "org.lynxsdk.lynx:lynx-jssdk:3.6.0"
-    implementation "org.lynxsdk.lynx:lynx-trace:3.6.0"
-    implementation "org.lynxsdk.lynx:primjs:3.6.1"
+    implementation "org.lynxsdk.lynx:lynx:{versionJson.LYNX_VERSION}"
+    implementation "org.lynxsdk.lynx:lynx-jssdk:{versionJson.LYNX_VERSION}"
+    implementation "org.lynxsdk.lynx:lynx-trace:{versionJson.LYNX_VERSION}"
+    implementation "org.lynxsdk.lynx:primjs:{versionJson.PRIMJS_VERSION}"
     // integrating image-service
-    implementation "org.lynxsdk.lynx:lynx-service-image:3.6.0"
+    implementation "org.lynxsdk.lynx:lynx-service-image:{versionJson.LYNX_VERSION}"
     // image-service dependencies, if not added, images cannot be loaded; if the host APP needs to use other image libraries, you can customize the image-service and remove this dependency
     implementation "com.facebook.fresco:fresco:2.3.0"
     implementation "com.facebook.fresco:animated-gif:2.3.0"
@@ -579,12 +579,12 @@ dependencies {
     implementation "com.facebook.fresco:animated-base:2.3.0"
     implementation "com.squareup.okhttp3:okhttp:4.9.0"
     // integrating log-service
-    implementation "org.lynxsdk.lynx:lynx-service-log:3.6.0"
+    implementation "org.lynxsdk.lynx:lynx-service-log:{versionJson.LYNX_VERSION}"
     // integrating http-service
-    implementation "org.lynxsdk.lynx:lynx-service-http:3.6.0"
+    implementation "org.lynxsdk.lynx:lynx-service-http:{versionJson.LYNX_VERSION}"
     // integrating XElement
-    implementation "org.lynxsdk.lynx:xelement:3.6.0"
-    implementation "org.lynxsdk.lynx:xelement-input:3.6.0"
+    implementation "org.lynxsdk.lynx:xelement:{versionJson.LYNX_VERSION}"
+    implementation "org.lynxsdk.lynx:xelement-input:{versionJson.LYNX_VERSION}"
 }
 ```
 
@@ -597,13 +597,13 @@ dependencies {
 ```groovy title=build.gradle.kts {26-28}
 dependencies {
     // lynx dependencies
-    implementation("org.lynxsdk.lynx:lynx:3.6.0")
-    implementation("org.lynxsdk.lynx:lynx-jssdk:3.6.0")
-    implementation("org.lynxsdk.lynx:lynx-trace:3.6.0")
-    implementation("org.lynxsdk.lynx:primjs:3.6.1")
+    implementation("org.lynxsdk.lynx:lynx:{versionJson.LYNX_VERSION}")
+    implementation("org.lynxsdk.lynx:lynx-jssdk:{versionJson.LYNX_VERSION}")
+    implementation("org.lynxsdk.lynx:lynx-trace:{versionJson.LYNX_VERSION}")
+    implementation("org.lynxsdk.lynx:primjs:{versionJson.PRIMJS_VERSION}")
 
     // integrating image-service
-    implementation("org.lynxsdk.lynx:lynx-service-image:3.6.0")
+    implementation("org.lynxsdk.lynx:lynx-service-image:{versionJson.LYNX_VERSION}")
 
     // image-service dependencies, if not added, images cannot be loaded; if the host APP needs to use other image libraries, you can customize the image-service and remove this dependency
     implementation("com.facebook.fresco:fresco:2.3.0")
@@ -613,16 +613,16 @@ dependencies {
     implementation("com.facebook.fresco:animated-base:2.3.0")
 
     // integrating log-service
-    implementation("org.lynxsdk.lynx:lynx-service-log:3.6.0")
+    implementation("org.lynxsdk.lynx:lynx-service-log:{versionJson.LYNX_VERSION}")
 
     // integrating http-service
-    implementation("org.lynxsdk.lynx:lynx-service-http:3.6.0")
+    implementation("org.lynxsdk.lynx:lynx-service-http:{versionJson.LYNX_VERSION}")
 
     implementation("com.squareup.okhttp3:okhttp:4.9.0")
 
     // integrating XElement
-    implementation("org.lynxsdk.lynx:xelement:3.6.0")
-    implementation("org.lynxsdk.lynx:xelement-input:3.6.0")
+    implementation("org.lynxsdk.lynx:xelement:{versionJson.LYNX_VERSION}")
+    implementation("org.lynxsdk.lynx:xelement-input:{versionJson.LYNX_VERSION}")
 }
 ```
 

--- a/docs/en/guide/start/fragments/ios/integrating-lynx-with-existing-app-ios.mdx
+++ b/docs/en/guide/start/fragments/ios/integrating-lynx-with-existing-app-ios.mdx
@@ -4,7 +4,7 @@ import { Info, CodeFold } from '@lynx';
 import { Steps } from '@theme';
 import { Tab, Tabs } from '@theme';
 import { Link } from '@theme';
-import versionJson from '../../../../../public/version.json';
+import versionJson from '@site/docs/public/version.json';
 
 <Info title="Lynx for iOS">
   - This article assumes that you are familiar with the basic concepts of native iOS application development.
@@ -40,11 +40,11 @@ source 'https://cdn.cocoapods.org/'
 platform :ios, '10.0'
 
 target 'YourTarget' do
-  pod 'Lynx', '3.6.0', :subspecs => [
+  pod 'Lynx', '{versionJson.LYNX_VERSION}', :subspecs => [
     'Framework',
   ]
 
-  pod 'PrimJS', '3.6.1', :subspecs => ['quickjs', 'napi']
+  pod 'PrimJS', '{versionJson.PRIMJS_VERSION}', :subspecs => ['quickjs', 'napi']
 end
 ```
 
@@ -65,14 +65,14 @@ source 'https://cdn.cocoapods.org/'
 platform :ios, '10.0'
 
 target 'YourTarget' do
-  pod 'Lynx', '3.6.0', :subspecs => [
+  pod 'Lynx', '{versionJson.LYNX_VERSION}', :subspecs => [
     'Framework',
   ]
 
-  pod 'PrimJS', '3.6.1', :subspecs => ['quickjs', 'napi']
+  pod 'PrimJS', '{versionJson.PRIMJS_VERSION}', :subspecs => ['quickjs', 'napi']
 
   # integrate image-service, log-service, and http-service
-  pod 'LynxService', '3.6.0', :subspecs => [
+  pod 'LynxService', '{versionJson.LYNX_VERSION}', :subspecs => [
       'Image',
       'Log',
       'Http',
@@ -97,14 +97,14 @@ source 'https://cdn.cocoapods.org/'
 platform :ios, '10.0'
 
 target 'YourTarget' do
-  pod 'Lynx', '3.6.0', :subspecs => [
+  pod 'Lynx', '{versionJson.LYNX_VERSION}', :subspecs => [
     'Framework',
   ]
 
-  pod 'PrimJS', '3.6.1', :subspecs => ['quickjs', 'napi']
+  pod 'PrimJS', '{versionJson.PRIMJS_VERSION}', :subspecs => ['quickjs', 'napi']
 
   # integrate image-service, log-service, and http-service
-  pod 'LynxService', '3.6.0', :subspecs => [
+  pod 'LynxService', '{versionJson.LYNX_VERSION}', :subspecs => [
       'Image',
       'Log',
       'Http',
@@ -114,7 +114,7 @@ target 'YourTarget' do
   pod 'SDWebImage','5.15.5'
   pod 'SDWebImageWebPCoder', '0.11.0'
 
-  pod 'XElement', '3.6.0'
+  pod 'XElement', '{versionJson.LYNX_VERSION}'
 end
 ```
 </CodeFold>

--- a/docs/en/guide/start/fragments/macos/integrating-lynx-with-existing-app-macos.mdx
+++ b/docs/en/guide/start/fragments/macos/integrating-lynx-with-existing-app-macos.mdx
@@ -4,12 +4,11 @@ import { Info, CodeFold } from '@lynx';
 import { Steps } from '@theme';
 import { Tab, Tabs } from '@theme';
 import { Link } from '@theme';
-import versionJson from '../../../../../public/version.json';
+import versionJson from '@site/docs/public/version.json';
 
 <Info title="Lynx for macOS">
   - This article assumes that you are familiar with the basic concepts of native
-  macOS application development.
-  - You can also refer to the official
+  macOS application development. - You can also refer to the official
   [LynxExplorer](https://github.com/lynx-family/lynx/tree/develop/explorer/darwin/macos/lynx_explorer)
   project.
 </Info>
@@ -103,12 +102,12 @@ target_link_options(${PROJECT_NAME} PRIVATE
 
 // Implements the http service if needed.
 class LynxHttpServiceImpl : public lynx::pub::LynxHttpService {
- public:
-  LynxHttpServiceImpl() = default;
-  ~LynxHttpServiceImpl() = default;
-  void Request(std::shared_ptr<lynx::pub::LynxHttpRequest> request, std::shared_ptr<lynx::pub::LynxHttpResponse> response) override {
-    // TODO
-  }
+public:
+LynxHttpServiceImpl() = default;
+~LynxHttpServiceImpl() = default;
+void Request(std::shared_ptr<lynx::pub::LynxHttpRequest> request, std::shared_ptr<lynx::pub::LynxHttpResponse> response) override {
+// TODO
+}
 };
 
 @interface AppDelegate ()
@@ -117,7 +116,7 @@ class LynxHttpServiceImpl : public lynx::pub::LynxHttpService {
 @implementation AppDelegate {
 }
 
-- (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
+- (void)applicationDidFinishLaunching:(NSNotification \*)aNotification {
   // Register http service for lynx.fetch.
   lynx::pub::LynxServiceCenter::GetInstance().RegisterService(std::make_shared<LynxHttpServiceImpl>());
 
@@ -188,8 +187,8 @@ Impl Resource Fetcher
 #import "lynx_generic_resource_fetcher.h"
 
 class ExampleGenericResourceFetcher : public lynx::pub::LynxGenericResourceFetcher {
- public:
-  void FetchResource(std::shared_ptr<lynx::pub::LynxResourceRequest> request, std::shared_ptr<lynx::pub::LynxResourceResponse> response) override;
+public:
+void FetchResource(std::shared_ptr<lynx::pub::LynxResourceRequest> request, std::shared_ptr<lynx::pub::LynxResourceResponse> response) override;
 };
 
 ````
@@ -256,9 +255,9 @@ void ExampleGenericResourceFetcher::FetchResource(std::shared_ptr<lynx::pub::Lyn
 
   lynx::pub::LynxView::Builder builder;
   builder.SetScreenSize(self.view.frame.size.width, self.view.frame.size.height, 1.0)
-    .SetFrame(0, 0, self.view.frame.size.width, self.view.frame.size.height)
-    .SetParent((__bridge NativeWindow)self.view)
-    .SetGenericResourceFetcher(std::make_shared<ExampleGenericResourceFetcher>());
+  .SetFrame(0, 0, self.view.frame.size.width, self.view.frame.size.height)
+  .SetParent((\_\_bridge NativeWindow)self.view)
+  .SetGenericResourceFetcher(std::make_shared<ExampleGenericResourceFetcher>());
   self.lynxView = builder.Build();
   }
 
@@ -332,3 +331,4 @@ Congratulations, you have now completed all the work of rendering the LynxView!
 ## 4. Now what?
 
 At this stage, you have successfully integrated Lynx into your App. Refer to our [developing](/guide/start/quick-start) and [debugging](/guide/devtool/panels) docs for in-depth insights on working with Lynx.
+````

--- a/docs/en/guide/start/fragments/windows/integrating-lynx-with-existing-app-windows.mdx
+++ b/docs/en/guide/start/fragments/windows/integrating-lynx-with-existing-app-windows.mdx
@@ -4,12 +4,11 @@ import { Info, CodeFold } from '@lynx';
 import { Steps } from '@theme';
 import { Tab, Tabs } from '@theme';
 import { Link } from '@theme';
-import versionJson from '../../../../../public/version.json';
+import versionJson from '@site/docs/public/version.json';
 
 <Info title="Lynx for Windows">
   - This article assumes that you are familiar with the basic concepts of native
-  Windows application development.
-  - You can also refer to the official
+  Windows application development. - You can also refer to the official
   [LynxExplorer](https://github.com/lynx-family/lynx/tree/develop/explorer/windows/lynx_explorer)
   project.
 </Info>
@@ -295,3 +294,4 @@ Congratulations, you have now completed all the work of rendering the LynxView!
 ## 4. Now what?
 
 At this stage, you have successfully integrated Lynx into your App. Refer to our [developing](/guide/start/quick-start) and [debugging](/guide/devtool/panels) docs for in-depth insights on working with Lynx.
+```

--- a/docs/en/guide/start/integrate-lynx-dev-version.mdx
+++ b/docs/en/guide/start/integrate-lynx-dev-version.mdx
@@ -1,6 +1,7 @@
 import { Steps } from '@theme';
 import { Tab, Tabs } from '@theme';
 import { Details, PlatformTabs, CodeFold } from '@lynx';
+import versionJson from '@site/docs/public/version.json';
 
 # Integrate Lynx development version
 
@@ -32,11 +33,11 @@ Refer to the [Lynx DevTool integration guide](/guide/start/integrate-lynx-devtoo
 Update your `Podfile` to use the dev version of the Lynx component.
 
 ```ruby title="Podfile"
-pod 'Lynx', '3.4.1' # [!code --]
-pod 'Lynx', '3.4.1-dev' # [!code ++]
+pod 'Lynx', '{versionJson.LYNX_VERSION}' # [!code --]
+pod 'Lynx', '{versionJson.LYNX_VERSION}-dev' # [!code ++]
 
-pod 'LynxDevtool', '3.4.1' # [!code --]
-pod 'LynxDevtool', '3.4.1-dev' # [!code ++]
+pod 'LynxDevtool', '{versionJson.LYNX_VERSION}' # [!code --]
+pod 'LynxDevtool', '{versionJson.LYNX_VERSION}-dev' # [!code ++]
 ```
 
 ### Install Dependencies
@@ -66,45 +67,42 @@ Update your `build.gradle` or `build.gradle.kts` to use the dev versions:
 <Tab label="build.gradle">
 
 ```groovy
-- implementation ("org.lynxsdk.lynx:lynx:3.4.1")
-+ implementation ("org.lynxsdk.lynx:lynx:3.4.1-dev") {
+- implementation ("org.lynxsdk.lynx:lynx:{versionJson.LYNX_VERSION}")
++ implementation ("org.lynxsdk.lynx:lynx:{versionJson.LYNX_VERSION}-dev") {
 +   // Exclude the lynx-trace module to avoid including it transitively
 +  exclude group: 'org.lynxsdk.lynx', module: 'lynx-trace'
 + }
 
-- implementation ("org.lynxsdk.lynx:lynx-trace:3.4.1")
-+ implementation ("org.lynxsdk.lynx:lynx-trace:3.4.1-dev")
+- implementation ("org.lynxsdk.lynx:lynx-trace:{versionJson.LYNX_VERSION}")
++ implementation ("org.lynxsdk.lynx:lynx-trace:{versionJson.LYNX_VERSION}-dev")
 
-- implementation ("org.lynxsdk.lynx:lynx-devtool:3.4.1")
-+ implementation ("org.lynxsdk.lynx:lynx-devtool:3.4.1") {
+- implementation ("org.lynxsdk.lynx:lynx-devtool:{versionJson.LYNX_VERSION}")
++ implementation ("org.lynxsdk.lynx:lynx-devtool:{versionJson.LYNX_VERSION}") {
 +   // Exclude the lynx-trace and lynx module to avoid including it transitively
 +   exclude group: 'org.lynxsdk.lynx', module: 'lynx-trace'
 +   exclude group: 'org.lynxsdk.lynx', module: 'lynx'
 + }
-
 ```
 
 </Tab>
 <Tab label="build.gradle.kts">
 
 ```kotlin
-
-- implementation ("org.lynxsdk.lynx:lynx:3.4.1")
-+ implementation ("org.lynxsdk.lynx:lynx:3.4.1-dev") {
+- implementation ("org.lynxsdk.lynx:lynx:{versionJson.LYNX_VERSION}")
++ implementation ("org.lynxsdk.lynx:lynx:{versionJson.LYNX_VERSION}-dev") {
 +   // Exclude the lynx-trace module to avoid including it transitively
 +  exclude(group = "org.lynxsdk.lynx", module = "lynx-trace")
 + }
 
-- implementation ("org.lynxsdk.lynx:lynx-trace:3.4.1")
-+ implementation ("org.lynxsdk.lynx:lynx-trace:3.4.1-dev")
+- implementation ("org.lynxsdk.lynx:lynx-trace:{versionJson.LYNX_VERSION}")
++ implementation ("org.lynxsdk.lynx:lynx-trace:{versionJson.LYNX_VERSION}-dev")
 
-- implementation ("org.lynxsdk.lynx:lynx-devtool:3.4.1")
-+ implementation ("org.lynxsdk.lynx:lynx-devtool:3.4.1") {
+- implementation ("org.lynxsdk.lynx:lynx-devtool:{versionJson.LYNX_VERSION}")
++ implementation ("org.lynxsdk.lynx:lynx-devtool:{versionJson.LYNX_VERSION}") {
 +   // Exclude the lynx-trace and lynx module to avoid including it transitively
 +   exclude(group = "org.lynxsdk.lynx", module = "lynx-trace")'
 +   exclude(group = 'org.lynxsdk.lynx', module = 'lynx')
 + }
-
 ```
 
 </Tab>

--- a/docs/en/guide/start/integrate-lynx-devtool.mdx
+++ b/docs/en/guide/start/integrate-lynx-devtool.mdx
@@ -1,6 +1,7 @@
 import { Tab, Tabs, Steps } from '@theme';
 import { Details, PlatformTabs, CodeFold } from '@lynx';
 import * as NextSteps from '@lynx/NextSteps';
+import versionJson from '@site/docs/public/version.json';
 
 # Integrating Lynx DevTool
 
@@ -25,13 +26,13 @@ All code examples in this documentation can be found in the [integrating-lynx-de
 
 You need to add these components: the `Devtool` subcomponent of `LynxService`, `LynxDevTool`, and `DebugRouter`.
 
-```ruby title="Podfile"
+```ruby title="Podfile" {2-8}
 # Ensure Lynx DevTool version matches the Lynx version when integrating
 target 'YourTarget' do
-  pod 'LynxService', '3.4.1', :subspecs => [
+  pod 'LynxService', '{versionJson.LYNX_VERSION}', :subspecs => [
       'Devtool',
   ]
-  pod 'LynxDevtool', '3.4.1'
+  pod 'LynxDevtool', '{versionJson.LYNX_VERSION}'
 
   pod 'DebugRouter', '5.0.15'
   pod 'DebugRouter/MessageTransceiverEnable', '5.0.15'
@@ -134,8 +135,8 @@ You need to integrate these two components: `lynx-service-devtool` and `lynx-dev
 ```groovy
 // Ensure Lynx DevTool version matches the Lynx version when integrating
 dependencies {
-  implementation "org.lynxsdk.lynx:lynx-devtool:3.4.1"
-  implementation "org.lynxsdk.lynx:lynx-service-devtool:3.4.1"
+  implementation "org.lynxsdk.lynx:lynx-devtool:{versionJson.LYNX_VERSION}"
+  implementation "org.lynxsdk.lynx:lynx-service-devtool:{versionJson.LYNX_VERSION}"
 }
 ```
 
@@ -145,8 +146,8 @@ dependencies {
 ```kotlin
 // Ensure Lynx DevTool version matches the Lynx version when integrating
 dependencies {
-  implementation ("org.lynxsdk.lynx:lynx-devtool:3.4.1")
-  implementation ("org.lynxsdk.lynx:lynx-service-devtool:3.4.1")
+  implementation ("org.lynxsdk.lynx:lynx-devtool:{versionJson.LYNX_VERSION}")
+  implementation ("org.lynxsdk.lynx:lynx-service-devtool:{versionJson.LYNX_VERSION}")
 }
 ```
 

--- a/docs/public/version.json
+++ b/docs/public/version.json
@@ -1,4 +1,6 @@
 {
   "current_version": "3.7",
+  "LYNX_VERSION": "3.7.0",
+  "PRIMJS_VERSION": "3.7.0",
   "versions": []
 }

--- a/docs/zh/api/lynx-native-api/lynx-service.mdx
+++ b/docs/zh/api/lynx-native-api/lynx-service.mdx
@@ -3,6 +3,7 @@ api: lynx-native-api/lynx-service/lynx-service
 ---
 
 import { APISummary, APITable, CodeFold } from '@lynx';
+import versionJson from '@site/docs/public/version.json';
 
 # LynxService API
 
@@ -215,8 +216,8 @@ Lynx Service 在 iOS 中有自动注册机制。在实现阶段，`LynxServiceRe
 
 如果您使用自己实现的 Lynx Service，请删除 Lynx 提供的[默认实现](/guide/start/integrate-with-existing-apps#platform=ios)。
 
-```diff title="Podfile"
-pod 'LynxService', '3.4.1', :subspecs => [
+```diff title="Podfile" {1-5}
+pod 'LynxService', '{versionJson.LYNX_VERSION}', :subspecs => [
       'Image',
 -     'Log',
       'Http',

--- a/docs/zh/guide/custom-native-component/custom-component-android.mdx
+++ b/docs/zh/guide/custom-native-component/custom-component-android.mdx
@@ -1,7 +1,8 @@
 import { Steps, Tabs, Tab } from '@theme';
 import { CodeFold } from '@lynx';
+import versionJson from '@site/docs/public/version.json';
 
-自定义元件的实现分为几个步骤，包括：声明并注册元件、创建原生视图、处理样式与属性、事件绑定等。接下来以一个简单的自定义输入框元件 `<explorer-input>` 为例，简要介绍自定义元件的实现流程。
+### 自定义元件的实现分为几个步骤，包括：声明并注册元件、创建原生视图、处理样式与属性、事件绑定等。接下来以一个简单的自定义输入框元件 `<explorer-input>` 为例，简要介绍自定义元件的实现流程。
 
 完整实现参见 [LynxExplorer/input 模块](https://github.com/lynx-family/lynx/tree/develop/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/input)查看。通过编译运行 [LynxExplorer 示例项目](https://github.com/lynx-family/lynx/tree/develop/explorer/android)可实时预览自定义元件效果。
 
@@ -16,8 +17,8 @@ import { CodeFold } from '@lynx';
 <Tab label="Java">
 
 ```java
-compileOnly project('org.lynxsdk.lynx:lynx-processor:3.4.1')
-annotationProcessor project('org.lynxsdk.lynx:lynx-processor:3.4.1')
+compileOnly project('org.lynxsdk.lynx:lynx-processor:{versionJson.LYNX_VERSION}')
+annotationProcessor project('org.lynxsdk.lynx:lynx-processor:{versionJson.LYNX_VERSION}')
 ```
 
 </Tab>
@@ -30,8 +31,8 @@ plugins {
     alias(libs.plugins.jetbrains.kotlin.android)
     id("kotlin-kapt")
 }
-
-kapt('org.lynxsdk.lynx:lynx-processor:3.4.1')
+//dependency
+kapt('org.lynxsdk.lynx:lynx-processor:{versionJson.LYNX_VERSION}')
 implementation("androidx.appcompat:appcompat:1.7.0")
 ```
 

--- a/docs/zh/guide/start/fragments/android/integrating-lynx-with-existing-app-android.mdx
+++ b/docs/zh/guide/start/fragments/android/integrating-lynx-with-existing-app-android.mdx
@@ -1,8 +1,8 @@
 ### 将 Lynx 集成到 Android 平台
 
 import { CodeFold, Info } from '@lynx';
-import { Link, Steps, Tab, Tabs } from '@theme';
-import versionJson from '../../../../../public/version.json';
+import { Link, Steps, Tabs, Tab } from '@theme';
+import versionJson from '@site/docs/public/version.json';
 
 <Info title="Lynx for Android">
   - 本文假设你已熟悉原生 Android 应用开发的基本概念。
@@ -26,10 +26,10 @@ import versionJson from '../../../../../public/version.json';
 ```groovy title=build.gradle {3-6}
 dependencies {
     // lynx dependencies
-    implementation "org.lynxsdk.lynx:lynx:3.6.0"
-    implementation "org.lynxsdk.lynx:lynx-jssdk:3.6.0"
-    implementation "org.lynxsdk.lynx:lynx-trace:3.6.0"
-    implementation "org.lynxsdk.lynx:primjs:3.6.1"
+    implementation "org.lynxsdk.lynx:lynx:{versionJson.LYNX_VERSION}"
+    implementation "org.lynxsdk.lynx:lynx-jssdk:{versionJson.LYNX_VERSION}"
+    implementation "org.lynxsdk.lynx:lynx-trace:{versionJson.LYNX_VERSION}"
+    implementation "org.lynxsdk.lynx:primjs:{versionJson.PRIMJS_VERSION}"
 }
 ```
 
@@ -39,10 +39,10 @@ dependencies {
 ```groovy title=build.gradle.kts {3-6}
 dependencies {
     // lynx dependencies
-    implementation("org.lynxsdk.lynx:lynx:3.6.0")
-    implementation("org.lynxsdk.lynx:lynx-jssdk:3.6.0")
-    implementation("org.lynxsdk.lynx:lynx-trace:3.6.0")
-    implementation("org.lynxsdk.lynx:primjs:3.6.1")
+    implementation("org.lynxsdk.lynx:lynx:{versionJson.LYNX_VERSION}")
+    implementation("org.lynxsdk.lynx:lynx-jssdk:{versionJson.LYNX_VERSION}")
+    implementation("org.lynxsdk.lynx:lynx-trace:{versionJson.LYNX_VERSION}")
+    implementation("org.lynxsdk.lynx:primjs:{versionJson.PRIMJS_VERSION}")
 }
 ```
 
@@ -70,13 +70,13 @@ android.useAndroidX=true
 ```groovy title=build.gradle {8-24}
 dependencies {
     // lynx dependencies
-    implementation "org.lynxsdk.lynx:lynx:3.6.0"
-    implementation "org.lynxsdk.lynx:lynx-jssdk:3.6.0"
-    implementation "org.lynxsdk.lynx:lynx-trace:3.6.0"
-    implementation "org.lynxsdk.lynx:primjs:3.6.1"
+    implementation "org.lynxsdk.lynx:lynx:{versionJson.LYNX_VERSION}"
+    implementation "org.lynxsdk.lynx:lynx-jssdk:{versionJson.LYNX_VERSION}"
+    implementation "org.lynxsdk.lynx:lynx-trace:{versionJson.LYNX_VERSION}"
+    implementation "org.lynxsdk.lynx:primjs:{versionJson.PRIMJS_VERSION}"
 
     // integrating image-service
-    implementation "org.lynxsdk.lynx:lynx-service-image:3.6.0"
+    implementation "org.lynxsdk.lynx:lynx-service-image:{versionJson.LYNX_VERSION}"
 
     // image-service dependencies, if not added, images cannot be loaded; if the host APP needs to use other image libraries, you can customize the image-service and remove this dependency
     implementation "com.facebook.fresco:fresco:2.3.0"
@@ -88,10 +88,10 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:4.9.0"
 
     // integrating log-service
-    implementation "org.lynxsdk.lynx:lynx-service-log:3.6.0"
+    implementation "org.lynxsdk.lynx:lynx-service-log:{versionJson.LYNX_VERSION}"
 
     // integrating http-service
-    implementation "org.lynxsdk.lynx:lynx-service-http:3.6.0"
+    implementation "org.lynxsdk.lynx:lynx-service-http:{versionJson.LYNX_VERSION}"
 }
 ```
 
@@ -104,13 +104,13 @@ dependencies {
 ```groovy title=build.gradle.kts {8-24}
 dependencies {
     // lynx dependencies
-    implementation("org.lynxsdk.lynx:lynx:3.6.0")
-    implementation("org.lynxsdk.lynx:lynx-jssdk:3.6.0")
-    implementation("org.lynxsdk.lynx:lynx-trace:3.6.0")
-    implementation("org.lynxsdk.lynx:primjs:3.6.1")
+    implementation("org.lynxsdk.lynx:lynx:{versionJson.LYNX_VERSION}")
+    implementation("org.lynxsdk.lynx:lynx-jssdk:{versionJson.LYNX_VERSION}")
+    implementation("org.lynxsdk.lynx:lynx-trace:{versionJson.LYNX_VERSION}")
+    implementation("org.lynxsdk.lynx:primjs:{versionJson.PRIMJS_VERSION}")
 
     // integrating image-service
-    implementation("org.lynxsdk.lynx:lynx-service-image:3.6.0")
+    implementation("org.lynxsdk.lynx:lynx-service-image:{versionJson.LYNX_VERSION}")
 
     // image-service dependencies, if not added, images cannot be loaded; if the host APP needs to use other image libraries, you can customize the image-service and remove this dependency
     implementation("com.facebook.fresco:fresco:2.3.0")
@@ -120,10 +120,10 @@ dependencies {
     implementation("com.facebook.fresco:animated-base:2.3.0")
 
     // integrating log-service
-    implementation("org.lynxsdk.lynx:lynx-service-log:3.6.0")
+    implementation("org.lynxsdk.lynx:lynx-service-log:{versionJson.LYNX_VERSION}")
 
     // integrating http-service
-    implementation("org.lynxsdk.lynx:lynx-service-http:3.6.0")
+    implementation("org.lynxsdk.lynx:lynx-service-http:{versionJson.LYNX_VERSION}")
 
     implementation("com.squareup.okhttp3:okhttp:4.9.0")
 }
@@ -147,12 +147,12 @@ XElement 是 Lynx 团队维护的客户端扩展元件集合，提供更丰富�
 ```groovy title=build.gradle {26-28}
 dependencies {
     // lynx dependencies
-    implementation "org.lynxsdk.lynx:lynx:3.6.0"
-    implementation "org.lynxsdk.lynx:lynx-jssdk:3.6.0"
-    implementation "org.lynxsdk.lynx:lynx-trace:3.6.0"
-    implementation "org.lynxsdk.lynx:primjs:3.6.1"
+    implementation "org.lynxsdk.lynx:lynx:{versionJson.LYNX_VERSION}"
+    implementation "org.lynxsdk.lynx:lynx-jssdk:{versionJson.LYNX_VERSION}"
+    implementation "org.lynxsdk.lynx:lynx-trace:{versionJson.LYNX_VERSION}"
+    implementation "org.lynxsdk.lynx:primjs:{versionJson.PRIMJS_VERSION}"
     // integrating image-service
-    implementation "org.lynxsdk.lynx:lynx-service-image:3.6.0"
+    implementation "org.lynxsdk.lynx:lynx-service-image:{versionJson.LYNX_VERSION}"
     // image-service dependencies, if not added, images cannot be loaded; if the host APP needs to use other image libraries, you can customize the image-service and remove this dependency
     implementation "com.facebook.fresco:fresco:2.3.0"
     implementation "com.facebook.fresco:animated-gif:2.3.0"
@@ -161,12 +161,12 @@ dependencies {
     implementation "com.facebook.fresco:animated-base:2.3.0"
     implementation "com.squareup.okhttp3:okhttp:4.9.0"
     // integrating log-service
-    implementation "org.lynxsdk.lynx:lynx-service-log:3.6.0"
+    implementation "org.lynxsdk.lynx:lynx-service-log:{versionJson.LYNX_VERSION}"
     // integrating http-service
-    implementation "org.lynxsdk.lynx:lynx-service-http:3.6.0"
+    implementation "org.lynxsdk.lynx:lynx-service-http:{versionJson.LYNX_VERSION}"
     // integrating XElement
-    implementation "org.lynxsdk.lynx:xelement:3.6.0"
-    implementation "org.lynxsdk.lynx:xelement-input:3.6.0"
+    implementation "org.lynxsdk.lynx:xelement:{versionJson.LYNX_VERSION}"
+    implementation "org.lynxsdk.lynx:xelement-input:{versionJson.LYNX_VERSION}"
 }
 ```
 
@@ -179,13 +179,13 @@ dependencies {
 ```groovy title=build.gradle.kts {26-28}
 dependencies {
     // lynx dependencies
-    implementation("org.lynxsdk.lynx:lynx:3.6.0")
-    implementation("org.lynxsdk.lynx:lynx-jssdk:3.6.0")
-    implementation("org.lynxsdk.lynx:lynx-trace:3.6.0")
-    implementation("org.lynxsdk.lynx:primjs:3.6.1")
+    implementation("org.lynxsdk.lynx:lynx:{versionJson.LYNX_VERSION}")
+    implementation("org.lynxsdk.lynx:lynx-jssdk:{versionJson.LYNX_VERSION}")
+    implementation("org.lynxsdk.lynx:lynx-trace:{versionJson.LYNX_VERSION}")
+    implementation("org.lynxsdk.lynx:primjs:{versionJson.PRIMJS_VERSION}")
 
     // integrating image-service
-    implementation("org.lynxsdk.lynx:lynx-service-image:3.6.0")
+    implementation("org.lynxsdk.lynx:lynx-service-image:{versionJson.LYNX_VERSION}")
 
     // image-service dependencies, if not added, images cannot be loaded; if the host APP needs to use other image libraries, you can customize the image-service and remove this dependency
     implementation("com.facebook.fresco:fresco:2.3.0")
@@ -195,16 +195,16 @@ dependencies {
     implementation("com.facebook.fresco:animated-base:2.3.0")
 
     // integrating log-service
-    implementation("org.lynxsdk.lynx:lynx-service-log:3.6.0")
+    implementation("org.lynxsdk.lynx:lynx-service-log:{versionJson.LYNX_VERSION}")
 
     // integrating http-service
-    implementation("org.lynxsdk.lynx:lynx-service-http:3.6.0")
+    implementation("org.lynxsdk.lynx:lynx-service-http:{versionJson.LYNX_VERSION}")
 
     implementation("com.squareup.okhttp3:okhttp:4.9.0")
 
     // integrating XElement
-    implementation("org.lynxsdk.lynx:xelement:3.6.0")
-    implementation("org.lynxsdk.lynx:xelement-input:3.6.0")
+    implementation("org.lynxsdk.lynx:xelement:{versionJson.LYNX_VERSION}")
+    implementation("org.lynxsdk.lynx:xelement-input:{versionJson.LYNX_VERSION}")
 }
 ```
 

--- a/docs/zh/guide/start/fragments/ios/integrating-lynx-with-existing-app-ios.mdx
+++ b/docs/zh/guide/start/fragments/ios/integrating-lynx-with-existing-app-ios.mdx
@@ -2,7 +2,7 @@
 
 import { CodeFold, Info } from '@lynx';
 import { Link, Steps, Tab, Tabs } from '@theme';
-import versionJson from '../../../../../public/version.json';
+import versionJson from '@site/docs/public/version.json';
 
 <Info title="Lynx for iOS">
   - 本文假设你已熟悉原生 iOS 应用开发的基本概念。
@@ -37,11 +37,11 @@ source 'https://cdn.cocoapods.org/'
 platform :ios, '10.0'
 
 target 'YourTarget' do
-  pod 'Lynx', '3.6.0', :subspecs => [
+  pod 'Lynx', '{versionJson.LYNX_VERSION}', :subspecs => [
     'Framework',
   ]
 
-  pod 'PrimJS', '3.6.1', :subspecs => ['quickjs', 'napi']
+  pod 'PrimJS', '{versionJson.PRIMJS_VERSION}', :subspecs => ['quickjs', 'napi']
 end
 ```
 </CodeFold>
@@ -60,14 +60,14 @@ source 'https://cdn.cocoapods.org/'
 platform :ios, '10.0'
 
 target 'YourTarget' do
-  pod 'Lynx', '3.6.0', :subspecs => [
+  pod 'Lynx', '{versionJson.LYNX_VERSION}', :subspecs => [
     'Framework',
   ]
 
-  pod 'PrimJS', '3.6.1', :subspecs => ['quickjs', 'napi']
+  pod 'PrimJS', '{versionJson.PRIMJS_VERSION}', :subspecs => ['quickjs', 'napi']
 
   # integrate image-service, log-service, and http-service
-  pod 'LynxService', '3.6.0', :subspecs => [
+  pod 'LynxService', '{versionJson.LYNX_VERSION}', :subspecs => [
       'Image',
       'Log',
       'Http',
@@ -93,14 +93,14 @@ source 'https://cdn.cocoapods.org/'
 platform :ios, '10.0'
 
 target 'YourTarget' do
-  pod 'Lynx', '3.6.0', :subspecs => [
+  pod 'Lynx', '{versionJson.LYNX_VERSION}', :subspecs => [
     'Framework',
   ]
 
-  pod 'PrimJS', '3.6.1', :subspecs => ['quickjs', 'napi']
+  pod 'PrimJS', '{versionJson.PRIMJS_VERSION}', :subspecs => ['quickjs', 'napi']
 
   # integrate image-service, log-service, and http-service
-  pod 'LynxService', '3.6.0', :subspecs => [
+  pod 'LynxService', '{versionJson.LYNX_VERSION}', :subspecs => [
       'Image',
       'Log',
       'Http',
@@ -110,7 +110,7 @@ target 'YourTarget' do
   pod 'SDWebImage','5.15.5'
   pod 'SDWebImageWebPCoder', '0.11.0'
 
-  pod 'XElement', '3.6.0'
+  pod 'XElement', '{versionJson.LYNX_VERSION}'
 end
 ```
 </CodeFold>

--- a/docs/zh/guide/start/fragments/macos/integrating-lynx-with-existing-app-macos.mdx
+++ b/docs/zh/guide/start/fragments/macos/integrating-lynx-with-existing-app-macos.mdx
@@ -4,11 +4,10 @@ import { Info, CodeFold } from '@lynx';
 import { Steps } from '@theme';
 import { Tab, Tabs } from '@theme';
 import { Link } from '@theme';
-import versionJson from '../../../../../public/version.json';
+import versionJson from '@site/docs/public/version.json';
 
 <Info title="Lynx for macOS">
-  - 本文假设你已熟悉原生 macOS 应用开发的基本概念。
-  - 你也可以参考官方的
+  - 本文假设你已熟悉原生 macOS 应用开发的基本概念。 - 你也可以参考官方的
   [LynxExplorer](https://github.com/lynx-family/lynx/tree/develop/explorer/darwin/macos/lynx_explorer)
   项目。
 </Info>
@@ -102,12 +101,12 @@ target_link_options(${PROJECT_NAME} PRIVATE
 
 // Implements the http service if needed.
 class LynxHttpServiceImpl : public lynx::pub::LynxHttpService {
- public:
-  LynxHttpServiceImpl() = default;
-  ~LynxHttpServiceImpl() = default;
-  void Request(std::shared_ptr<lynx::pub::LynxHttpRequest> request, std::shared_ptr<lynx::pub::LynxHttpResponse> response) override {
-    // TODO
-  }
+public:
+LynxHttpServiceImpl() = default;
+~LynxHttpServiceImpl() = default;
+void Request(std::shared_ptr<lynx::pub::LynxHttpRequest> request, std::shared_ptr<lynx::pub::LynxHttpResponse> response) override {
+// TODO
+}
 };
 
 @interface AppDelegate ()
@@ -116,7 +115,7 @@ class LynxHttpServiceImpl : public lynx::pub::LynxHttpService {
 @implementation AppDelegate {
 }
 
-- (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
+- (void)applicationDidFinishLaunching:(NSNotification \*)aNotification {
   // Register http service for lynx.fetch.
   lynx::pub::LynxServiceCenter::GetInstance().RegisterService(std::make_shared<LynxHttpServiceImpl>());
   }
@@ -187,8 +186,8 @@ Bundle 示例:
 #import "lynx_generic_resource_fetcher.h"
 
 class ExampleGenericResourceFetcher : public lynx::pub::LynxGenericResourceFetcher {
- public:
-  void FetchResource(std::shared_ptr<lynx::pub::LynxResourceRequest> request, std::shared_ptr<lynx::pub::LynxResourceResponse> response) override;
+public:
+void FetchResource(std::shared_ptr<lynx::pub::LynxResourceRequest> request, std::shared_ptr<lynx::pub::LynxResourceResponse> response) override;
 };
 
 ````
@@ -255,9 +254,9 @@ LynxView 是 Lynx Engine 提供的渲染基本单元，你可以快速的构造�
 
   lynx::pub::LynxView::Builder builder;
   builder.SetScreenSize(self.view.frame.size.width, self.view.frame.size.height, 1.0)
-    .SetFrame(0, 0, self.view.frame.size.width, self.view.frame.size.height)
-    .SetParent((__bridge NativeWindow)self.view)
-    .SetGenericResourceFetcher(std::make_shared<ExampleGenericResourceFetcher>());
+  .SetFrame(0, 0, self.view.frame.size.width, self.view.frame.size.height)
+  .SetParent((\_\_bridge NativeWindow)self.view)
+  .SetGenericResourceFetcher(std::make_shared<ExampleGenericResourceFetcher>());
   self.lynxView = builder.Build();
   }
 
@@ -331,3 +330,4 @@ LynxView 是 Lynx Engine 提供的渲染基本单元，你可以快速的构造�
 ## 4. 进入 Lynx 世界
 
 现在你已经将 Lynx 集成到你的应用中了。请参考[开发](/guide/start/quick-start)和[调试](/guide/devtool/panels)文档进一步在 Lynx 的世界里遨游吧！
+````

--- a/docs/zh/guide/start/fragments/windows/integrating-lynx-with-existing-app-windows.mdx
+++ b/docs/zh/guide/start/fragments/windows/integrating-lynx-with-existing-app-windows.mdx
@@ -4,11 +4,10 @@ import { Info, CodeFold } from '@lynx';
 import { Steps } from '@theme';
 import { Tab, Tabs } from '@theme';
 import { Link } from '@theme';
-import versionJson from '../../../../../public/version.json';
+import versionJson from '@site/docs/public/version.json';
 
 <Info title="Lynx for Windows">
-  - 本文假设你已熟悉原生 Windows 应用开发的基本概念。
-  - 你也可以参考官方的
+  - 本文假设你已熟悉原生 Windows 应用开发的基本概念。 - 你也可以参考官方的
   [LynxExplorer](https://github.com/lynx-family/lynx/tree/develop/explorer/windows/lynx_explorer)
   项目。
 </Info>
@@ -294,3 +293,4 @@ return 0;
 ## 4. 进入 Lynx 世界
 
 现在你已经将 Lynx 集成到你的应用中了。请参考[开发](/guide/start/quick-start)和[调试](/guide/devtool/panels)文档进一步在 Lynx 的世界里遨游吧！
+```

--- a/docs/zh/guide/start/integrate-lynx-dev-version.mdx
+++ b/docs/zh/guide/start/integrate-lynx-dev-version.mdx
@@ -1,5 +1,6 @@
 import { Tab, Tabs, Steps } from '@theme';
 import { PlatformTabs } from '@lynx';
+import versionJson from '@site/docs/public/version.json';
 
 # 集成 Lynx 开发版本
 
@@ -32,11 +33,11 @@ import { PlatformTabs } from '@lynx';
 在 `Podfile` 里，将 Lynx 组件版本号改为开发版本：
 
 ```ruby title="Podfile"
-pod 'Lynx', '3.4.1' # [!code --]
-pod 'Lynx', '3.4.1-dev' # [!code ++]
+pod 'Lynx', '{versionJson.LYNX_VERSION}' # [!code --]
+pod 'Lynx', '{versionJson.LYNX_VERSION}-dev' # [!code ++]
 
-pod 'LynxDevtool', '3.4.1' # [!code --]
-pod 'LynxDevtool', '3.4.1-dev' # [!code ++]
+pod 'LynxDevtool', '{versionJson.LYNX_VERSION}' # [!code --]
+pod 'LynxDevtool', '{versionJson.LYNX_VERSION}-dev' # [!code ++]
 ```
 
 ### 安装依赖
@@ -66,46 +67,42 @@ pod 'LynxDevtool', '3.4.1-dev' # [!code ++]
 <Tab label="build.gradle">
 
 ```groovy
-
-- implementation ("org.lynxsdk.lynx:lynx:3.4.1")
-+ implementation ("org.lynxsdk.lynx:lynx:3.4.1-dev") {
+- implementation ("org.lynxsdk.lynx:lynx:{versionJson.LYNX_VERSION}")
++ implementation ("org.lynxsdk.lynx:lynx:{versionJson.LYNX_VERSION}-dev") {
 +   // 排除 lynx-trace 模块，防止版本冲突
 +  exclude group: 'org.lynxsdk.lynx', module: 'lynx-trace'
 + }
 
-- implementation ("org.lynxsdk.lynx:lynx-trace:3.4.1")
-+ implementation ("org.lynxsdk.lynx:lynx-trace:3.4.1-dev")
+- implementation ("org.lynxsdk.lynx:lynx-trace:{versionJson.LYNX_VERSION}")
++ implementation ("org.lynxsdk.lynx:lynx-trace:{versionJson.LYNX_VERSION}-dev")
 
-- implementation ("org.lynxsdk.lynx:lynx-devtool:3.4.1")
-+ implementation ("org.lynxsdk.lynx:lynx-devtool:3.4.1") {
+- implementation ("org.lynxsdk.lynx:lynx-devtool:{versionJson.LYNX_VERSION}")
++ implementation ("org.lynxsdk.lynx:lynx-devtool:{versionJson.LYNX_VERSION}") {
 +   // 排除 lynx-trace 和 lynx 模块，防止版本冲突
 +   exclude group: 'org.lynxsdk.lynx', module: 'lynx-trace'
 +   exclude group: 'org.lynxsdk.lynx', module: 'lynx'
 + }
-
 ```
 
 </Tab>
 <Tab label="build.gradle.kts">
 
 ```kotlin
-
-- implementation ("org.lynxsdk.lynx:lynx:3.4.1")
-+ implementation ("org.lynxsdk.lynx:lynx:3.4.1-dev") {
+- implementation ("org.lynxsdk.lynx:lynx:{versionJson.LYNX_VERSION}")
++ implementation ("org.lynxsdk.lynx:lynx:{versionJson.LYNX_VERSION}-dev") {
 +   // 排除 lynx-trace 模块，防止版本冲突
 +  exclude(group = "org.lynxsdk.lynx", module = "lynx-trace")
 + }
 
-- implementation ("org.lynxsdk.lynx:lynx-trace:3.4.1")
-+ implementation ("org.lynxsdk.lynx:lynx-trace:3.4.1-dev")
+- implementation ("org.lynxsdk.lynx:lynx-trace:{versionJson.LYNX_VERSION}")
++ implementation ("org.lynxsdk.lynx:lynx-trace:{versionJson.LYNX_VERSION}-dev")
 
-- implementation ("org.lynxsdk.lynx:lynx-devtool:3.4.1")
-+ implementation ("org.lynxsdk.lynx:lynx-devtool:3.4.1") {
+- implementation ("org.lynxsdk.lynx:lynx-devtool:{versionJson.LYNX_VERSION}")
++ implementation ("org.lynxsdk.lynx:lynx-devtool:{versionJson.LYNX_VERSION}") {
 +   // 排除 lynx-trace 和 lynx 模块，防止版本冲突
 +   exclude(group = "org.lynxsdk.lynx", module = "lynx-trace")'
 +   exclude(group = 'org.lynxsdk.lynx', module = 'lynx')
 + }
-
 ```
 
 </Tab>

--- a/docs/zh/guide/start/integrate-lynx-devtool.mdx
+++ b/docs/zh/guide/start/integrate-lynx-devtool.mdx
@@ -1,6 +1,7 @@
 import { Tab, Tabs, Steps } from '@theme';
 import { Details, PlatformTabs, CodeFold } from '@lynx';
 import * as NextSteps from '@lynx/NextSteps';
+import versionJson from '@site/docs/public/version.json';
 
 # 接入 Lynx DevTool
 
@@ -25,12 +26,13 @@ import * as NextSteps from '@lynx/NextSteps';
 
 你需要新增以下组件：`LynxService` 的 `Devtool` 子组件、 `LynxDevTool` 和 `DebugRouter`。
 
-```ruby title="Podfile"
+```ruby title="Podfile" {2-8}
 target 'YourTarget' do
-  pod 'LynxService', '3.4.1', :subspecs => [
+  pod 'LynxService', '{versionJson.LYNX_VERSION}', :subspecs => [
       'Devtool',
   ]
-  pod 'LynxDevtool', '3.4.1'
+  pod 'LynxDevtool', '{versionJson.LYNX_VERSION}'
+
   pod 'DebugRouter', '5.0.15'
   pod 'DebugRouter/MessageTransceiverEnable', '5.0.15'
 end
@@ -132,8 +134,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 ```groovy
 // Lynx DevTool 接入时请保证和 Lynx 相同版本
 dependencies {
-  implementation "org.lynxsdk.lynx:lynx-devtool:3.4.1"
-  implementation "org.lynxsdk.lynx:lynx-service-devtool:3.4.1"
+  implementation "org.lynxsdk.lynx:lynx-devtool:{versionJson.LYNX_VERSION}"
+  implementation "org.lynxsdk.lynx:lynx-service-devtool:{versionJson.LYNX_VERSION}"
 }
 ```
 
@@ -143,8 +145,8 @@ dependencies {
 ```kotlin
 // Lynx DevTool 接入时请保证和 Lynx 相同版本
 dependencies {
-  implementation ("org.lynxsdk.lynx:lynx-devtool:3.4.1")
-  implementation ("org.lynxsdk.lynx:lynx-service-devtool:3.4.1")
+  implementation ("org.lynxsdk.lynx:lynx-devtool:{versionJson.LYNX_VERSION}")
+  implementation ("org.lynxsdk.lynx:lynx-service-devtool:{versionJson.LYNX_VERSION}")
 }
 ```
 

--- a/docs/zh/internal/docs-contribution-guide/doc-lang.mdx
+++ b/docs/zh/internal/docs-contribution-guide/doc-lang.mdx
@@ -1,3 +1,5 @@
+import versionJson from '@site/docs/public/version.json';
+
 # 文档编程语言验证
 
 对于文档中中的编程语言，补齐独立的引用展示，保证在 doc 文档中通过组件使用时可以支持正常语法高亮等。
@@ -108,11 +110,11 @@ source 'https://cdn.cocoapods.org/'
 platform :ios, '10.0'
 
 target 'YourTarget' do
-  pod 'Lynx', '3.4.1', :subspecs => [
+  pod 'Lynx', '{versionJson.LYNX_VERSION}', :subspecs => [
     'Framework',
   ]
 
-  pod 'PrimJS', '2.14.1', :subspecs => ['quickjs', 'napi']
+  pod 'PrimJS', '{versionJson.PRIMJS_VERSION}', :subspecs => ['quickjs', 'napi']
 end
 ```
 
@@ -120,9 +122,9 @@ end
 ```groovy title=build.gradle {3-6}
 dependencies {
     // lynx dependencies
-    implementation "org.lynxsdk.lynx:lynx:3.4.1"
-    implementation "org.lynxsdk.lynx:lynx-jssdk:3.4.1"
-    implementation "org.lynxsdk.lynx:lynx-trace:3.4.1"
-    implementation "org.lynxsdk.lynx:primjs:2.14.1"
+    implementation "org.lynxsdk.lynx:lynx:{versionJson.LYNX_VERSION}"
+    implementation "org.lynxsdk.lynx:lynx-jssdk:{versionJson.LYNX_VERSION}"
+    implementation "org.lynxsdk.lynx:lynx-trace:{versionJson.LYNX_VERSION}"
+    implementation "org.lynxsdk.lynx:primjs:{versionJson.PRIMJS_VERSION}"
 }
 ```

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -15,6 +15,8 @@ import {
   transformerNotationHighlight,
 } from '@shikijs/transformers';
 import * as path from 'node:path';
+import versionJson from './docs/public/version.json';
+import { visit } from 'unist-util-visit';
 import { pluginGoogleAnalytics } from 'rsbuild-plugin-google-analytics';
 import { pluginOpenGraph } from 'rsbuild-plugin-open-graph';
 import {
@@ -197,6 +199,10 @@ export default defineConfig({
   ],
   markdown: {
     defaultWrapCode: false,
+    // Replace "{versionJson.X}" placeholders inside fenced/inline code.
+    // MDX does not evaluate JS expressions inside code fences, so without this
+    // users would see the raw placeholder text in the rendered output.
+    remarkPlugins: [remarkReplaceVersionJsonPlaceholders],
     link: {
       checkDeadLinks: {
         excludes: ['/guide/spec.html?ts=1743416098203#element%E2%91%A0'],
@@ -213,6 +219,32 @@ export default defineConfig({
   },
   llms: true,
 });
+
+function remarkReplaceVersionJsonPlaceholders() {
+  const replacements: Array<[string, string]> = [
+    ['{versionJson.LYNX_VERSION}', String(versionJson.LYNX_VERSION ?? '')],
+    ['{versionJson.PRIMJS_VERSION}', String(versionJson.PRIMJS_VERSION ?? '')],
+  ];
+
+  const applyReplacements = (input: string) => {
+    let out = input;
+    for (const [from, to] of replacements) {
+      if (from && to) out = out.split(from).join(to);
+    }
+    return out;
+  };
+
+  return (tree: unknown) => {
+    visit(tree as any, (node: any) => {
+      if (
+        (node?.type === 'code' || node?.type === 'inlineCode') &&
+        typeof node.value === 'string'
+      ) {
+        node.value = applyReplacements(node.value);
+      }
+    });
+  };
+}
 
 function mapNonGuideSharedSectionsToGuide(
   lang: string,


### PR DESCRIPTION
## Summary
- Cherry-pick of #931 to `release/3.7`
- Standardizes SDK version configuration in mdx files by introducing `LYNX_VERSION` / `PRIMJS_VERSION` fields in `version.json` and a remark plugin that replaces `{versionJson.X}` placeholders inside code fences
- Conflict resolution: kept `current_version: "3.7"` and empty `versions` array appropriate for the release branch, while adding the new version fields and remark plugin

## Test plan
- [ ] Verify docs build succeeds on `release/3.7`
- [ ] Confirm `{versionJson.LYNX_VERSION}` placeholders render as `3.7.0` in code blocks