### PR TITLE
chore: upgrade go-web to 0.5.0 and web-core to 0.20.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   "dependencies": {
     "@douyinfe/semi-icons": "^2.74.0",
     "@douyinfe/semi-ui": "^2.75.0",
-    "@lynx-js/go-web": "^0.2.1",
+    "@lynx-js/go-web": "^0.5.0",
     "@lynx-js/lynx-core": "^0.1.3",
-    "@lynx-js/web-core": "^0.20.1",
+    "@lynx-js/web-core": "^0.20.3",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.5",
     "@radix-ui/react-dropdown-menu": "^2.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,14 +15,14 @@ importers:
         specifier: ^2.75.0
         version: 2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@lynx-js/go-web':
-        specifier: ^0.2.1
-        version: 0.2.1(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core@0.20.1(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.6(@types/mdast@4.0.4)(@types/react@18.3.18)(core-js@3.46.0)(micromark-util-types@2.0.1)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)
+        specifier: ^0.5.0
+        version: 0.5.0(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core@0.20.3(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.6(@types/mdast@4.0.4)(@types/react@18.3.18)(core-js@3.46.0)(micromark-util-types@2.0.1)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)
       '@lynx-js/lynx-core':
         specifier: ^0.1.3
         version: 0.1.3
       '@lynx-js/web-core':
-        specifier: ^0.20.1
-        version: 0.20.1(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)
+        specifier: ^0.20.3
+        version: 0.20.3(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)
       '@radix-ui/react-collapsible':
         specifier: ^1.1.12
         version: 1.1.12(@types/react-dom@18.3.7(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1404,8 +1404,8 @@ packages:
   '@lynx-example/viewpager@0.6.12':
     resolution: {integrity: sha512-meYoMU69PNBHZL1Dv+holU6YCL/PWYhgsPVVyDQOjUfXY/9+zwL8WJOKoopOMQPDdsDz4MiImfczIwrNmhTjmA==}
 
-  '@lynx-js/go-web@0.2.1':
-    resolution: {integrity: sha512-r/M0KfxVmS7aEjcxCDa1TGpEy6cA1S7OhS3k0lse95SSbhj9x/SFR06iquPvcQmS6tyxpJC6U/nR/5tWrY1dYw==}
+  '@lynx-js/go-web@0.5.0':
+    resolution: {integrity: sha512-JU1PA6GPBtmBpScWt3veO8nHMlYORzPOdt6c4OHnDqlAFQAlNMzPxRRWnzmGfUqrxE+UnfheTuwboAg1T+vrew==}
     engines: {node: ^22 || ^24}
     peerDependencies:
       '@douyinfe/semi-icons': '>=2.74.0'
@@ -1482,10 +1482,10 @@ packages:
   '@lynx-js/test-environment@0.0.1':
     resolution: {integrity: sha512-tas/ilXoOjF6AQ3BzkFH85aFFnLS03zjHiKg38BGlU2U7QhCDrC9SFYuXSVaix0I1uprorjeELG63HXX2Z9Bgw==}
 
-  '@lynx-js/web-core@0.20.1':
-    resolution: {integrity: sha512-oC3fbxezP5P8Qj6JxyPnWioHNwk/YL5uivm+L2OwpnxajM7jyCUMBkTms4FdIHmRsFcN/f8pZ49+M1RVIleBBw==}
+  '@lynx-js/web-core@0.20.3':
+    resolution: {integrity: sha512-bvdokoxpNj62JYCWn9YqmCZCWfWgE2LO9wWJhlagEjbOZ2XFC79fI78W7RaVIi4pmVGuHvihsNpF5qrOc4tAGw==}
     peerDependencies:
-      '@lynx-js/css-serializer': 0.1.5
+      '@lynx-js/css-serializer': 0.1.6
       '@lynx-js/lynx-core': 0.1.3
       tslib: ^2.5.0
     peerDependenciesMeta:
@@ -1496,13 +1496,13 @@ packages:
       tslib:
         optional: true
 
-  '@lynx-js/web-elements@0.12.0':
-    resolution: {integrity: sha512-7z8PQQSDMUWrxoizySOg1pKGIiSDeGGomOr5FV0Tx9gniHNJYx0e7/h6wQmwhyHdAZYyihyaBks88QkX8DRNEw==}
+  '@lynx-js/web-elements@0.12.1':
+    resolution: {integrity: sha512-fdojPbJWelBa+psrWZRB5jSvJiGDpUS5kPFqGZoJ++Zgutl5gRInQTRFjWmMJ+5y0HDLnxWyoZwNC5NpkhGn/A==}
     peerDependencies:
       tslib: ^2.5.0
 
-  '@lynx-js/web-worker-rpc@0.20.1':
-    resolution: {integrity: sha512-6tXsBghwKRCeF7DXESykzUBvMKBdshF97gFsy8bAYdwt5YphZltp41zBCazV4fzqChp43yeo/CmNuHuu7kJP7w==}
+  '@lynx-js/web-worker-rpc@0.20.3':
+    resolution: {integrity: sha512-08Eq9777EXU42MUKX9N3CZeMRdG8jHlEN06quB707TydyEYsYKdimzZCMxN2l3GzQybM46t5p/5p61iKLpOmzA==}
 
   '@mdn/minimalist@2.0.4':
     resolution: {integrity: sha512-jocePw/fsGcBxO67D+iWQLZ0TQjwNVonaME2BFN98QIm/e1kTY1/k2s4fOqH5MMa3QYURxa098bI4sChn6s/7Q==}
@@ -6872,11 +6872,11 @@ snapshots:
       - '@lynx-js/types'
       - '@types/react'
 
-  '@lynx-js/go-web@0.2.1(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core@0.20.1(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.6(@types/mdast@4.0.4)(@types/react@18.3.18)(core-js@3.46.0)(micromark-util-types@2.0.1)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)':
+  '@lynx-js/go-web@0.5.0(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core@0.20.3(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.6(@types/mdast@4.0.4)(@types/react@18.3.18)(core-js@3.46.0)(micromark-util-types@2.0.1)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)':
     dependencies:
       '@douyinfe/semi-icons': 2.74.0(react@18.3.1)
       '@douyinfe/semi-ui': 2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lynx-js/web-core': 0.20.1(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)
+      '@lynx-js/web-core': 0.20.3(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)
       '@shikijs/transformers': 4.0.2
       qrcode.react: 4.2.0(react@18.3.1)
       react: 18.3.1
@@ -6928,20 +6928,22 @@ snapshots:
 
   '@lynx-js/test-environment@0.0.1': {}
 
-  '@lynx-js/web-core@0.20.1(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)':
+  '@lynx-js/web-core@0.20.3(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)':
     dependencies:
-      '@lynx-js/web-elements': 0.12.0(tslib@2.8.1)
-      '@lynx-js/web-worker-rpc': 0.20.1
+      '@lynx-js/web-elements': 0.12.1(tslib@2.8.1)
+      '@lynx-js/web-worker-rpc': 0.20.3
       wasm-feature-detect: 1.8.0
     optionalDependencies:
       '@lynx-js/lynx-core': 0.1.3
       tslib: 2.8.1
 
-  '@lynx-js/web-elements@0.12.0(tslib@2.8.1)':
+  '@lynx-js/web-elements@0.12.1(tslib@2.8.1)':
     dependencies:
+      dompurify: 3.3.3
+      markdown-it: 14.1.1
       tslib: 2.8.1
 
-  '@lynx-js/web-worker-rpc@0.20.1': {}
+  '@lynx-js/web-worker-rpc@0.20.3': {}
 
   '@mdn/minimalist@2.0.4': {}
 


### PR DESCRIPTION
**@lynx-js/go-web** (0.2.1 → 0.5.0):
- `webPreview` prop to disable the Web preview tab per example
- `webPreviewMode` / `designWidth` / `designHeight` / `fitThresholdScale` / `fitMinScale` / `fit` props for viewport rendering control (`fit` / `responsive` / `auto`)
- Improve fit-mode rendering and auto-fit transitions
- Fix white flash when switching to the Web preview tab

Default behavior remains unchanged: web preview still uses `responsive` mode by default.
Consumers can opt into `fit` or `auto` explicitly when they want the new fit pipeline.

**@lynx-js/web-core** (→ 0.20.3):
- Reduce memory usage

## Related

- lynx-community/go-web#40
- lynx-community/go-web#45
- lynx-community/go-web#48
- lynx-community/go-web#50
- lynx-community/go-web#54
- lynx-community/go-web#55

## Before / After

| Before | After |
|---|---|
| <img height="300" alt="before" src="https://github.com/user-attachments/assets/52a2a2bb-08e8-4cda-94b7-936c9f67dacd" /> | <img height="300" alt="after" src="https://github.com/user-attachments/assets/5b5749d0-7833-457b-8ab1-656fe1eefd1d" /> |
| <img height="300" alt="before" src="https://github.com/user-attachments/assets/ea2fcdbe-ee91-4dbd-896c-ac489f31f870" /> | <img height="300" alt="after" src="https://github.com/user-attachments/assets/b74c5139-431f-4f97-a011-3255ab7f7015" /> |

## webPreviewMode: `auto`
[go-web-auto.webm](https://github.com/user-attachments/assets/cbe995e6-e15d-4dfc-931a-a4723df4243b)
