### PR TITLE
fix(docs): migrate internal asset URLs to public CDN

### DIFF
--- a/docs/en/api/elements/built-in/frame.mdx
+++ b/docs/en/api/elements/built-in/frame.mdx
@@ -27,7 +27,7 @@ The following is an example of a main page loading an embedded page via the `<fr
 ### Main Page
 
 <Go
-  img="https://tosv-sg.tiktok-row.org/obj/lynx-artifacts-oss-sg/lynx-website/assets/frame-example.jpg"
+  img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/frame-example.jpg"
   example="frame"
   defaultFile="src/frame/index.tsx"
   highlight="{35-41}"
@@ -36,7 +36,7 @@ The following is an example of a main page loading an embedded page via the `<fr
 ### Embedded Page
 
 <Go
-  img="https://tosv-sg.tiktok-row.org/obj/lynx-artifacts-oss-sg/lynx-website/assets/in-frame-example.jpg"
+  img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/in-frame-example.jpg"
   example="frame"
   defaultFile="src/in_frame/index.tsx"
 />

--- a/docs/en/blog/lynx-3-4.mdx
+++ b/docs/en/blog/lynx-3-4.mdx
@@ -25,7 +25,7 @@ In line with the [technical roadmap](/blog/lynx-open-source-roadmap-2025) announ
 Lynx now officially supports the [HarmonyOS](https://www.harmonyos.com/en/) platform. Developers can integrate Lynx into their HarmonyOS applications by following our [Integration Guide](/guide/start/integrate-with-existing-apps.html#platform=harmony).
 Additionally, we will soon be publishing a dedicated blog that takes a closer look at Lynx on HarmonyOS. Stay tuned.
 
-![](https://tosv-sg.tiktok-row.org/obj/lynx-artifacts-oss-sg/lynx-website/assets/blog/lynx-harmony/background.png)
+![](https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/blog/lynx-harmony/background.png)
 
 ### Support for Windows Development
 

--- a/docs/zh/api/elements/built-in/frame.mdx
+++ b/docs/zh/api/elements/built-in/frame.mdx
@@ -27,7 +27,7 @@ import {
 ### 主页面
 
 <Go
-  img="https://tosv-sg.tiktok-row.org/obj/lynx-artifacts-oss-sg/lynx-website/assets/frame-example.jpg"
+  img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/frame-example.jpg"
   example="frame"
   defaultFile="src/frame/index.tsx"
   highlight="{35-41}"
@@ -36,7 +36,7 @@ import {
 ### frame 内嵌页面
 
 <Go
-  img="https://tosv-sg.tiktok-row.org/obj/lynx-artifacts-oss-sg/lynx-website/assets/in-frame-example.jpg"
+  img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/in-frame-example.jpg"
   example="frame"
   defaultFile="src/in_frame/index.tsx"
 />

--- a/docs/zh/blog/lynx-3-4.mdx
+++ b/docs/zh/blog/lynx-3-4.mdx
@@ -24,7 +24,7 @@ Lynx 3.4 新增对 HarmonyOS 的适配支持、支持 Windows 作为 Lynx 开发
 
 Lynx 现已正式支持 [HarmonyOS](https://www.harmonyos.com/) 平台。开发者可参考 [接入现有应用](/guide/start/integrate-with-existing-apps.html#platform=harmony)，将 Lynx 集成进 HarmonyOS 应用中。我们也将很快发布技术博客，深入介绍 Lynx 在 HarmonyOS 上的实现与优化，敬请期待。
 
-![](https://tosv-sg.tiktok-row.org/obj/lynx-artifacts-oss-sg/lynx-website/assets/blog/lynx-harmony/background.png)
+![](https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/blog/lynx-harmony/background.png)
 
 ### Windows 开发环境支持
 


### PR DESCRIPTION
Replace internal asset URLs (`tosv-sg.tiktok-row.org`) with the public CDN domain (`lf-lynx.tiktok-cdns.com`) in docs.

- Keeps documentation accessible in the OSS environment
- Unblocks/aligns with the CI Asset URL gate

Files:
- docs/en/api/elements/built-in/frame.mdx
- docs/zh/api/elements/built-in/frame.mdx
- docs/en/blog/lynx-3-4.mdx
- docs/zh/blog/lynx-3-4.mdx

No functional changes intended.

## Related
- #958 

Change-Id: I6f7f61d5dad7b16466fdf9eea1cc02eb1f8d0862