### PR TITLE
fix(blog): eliminate blog-list navigation flicker

### DIFF
--- a/src/components/blog-header/index.tsx
+++ b/src/components/blog-header/index.tsx
@@ -1,4 +1,5 @@
 import { useLang, usePageData } from '@rspress/core/runtime';
+import { getLatestBlogIndexPath } from '@site/src/lib/utils';
 import { LlmsContainer, LlmsCopyButton, LlmsViewOptions } from '@theme';
 import { BlogAvatar } from '../blog-avatar';
 import styles from './index.module.less';
@@ -7,6 +8,7 @@ export function BlogHeader() {
   const lang = useLang();
   const { page } = usePageData();
   const authors = (page.frontmatter?.authors as string[]) ?? [];
+  const blogIndexPath = getLatestBlogIndexPath(lang);
   const date = page.frontmatter?.date
     ? new Date(page.frontmatter.date as string)
     : undefined;
@@ -21,7 +23,7 @@ export function BlogHeader() {
 
   return (
     <>
-      <a href=".." className={styles.backLink}>
+      <a href={blogIndexPath} className={styles.backLink}>
         ← {lang === 'zh' ? '所有文章' : 'All Posts'}
       </a>
       <div className={styles.blogHeader}>

--- a/src/components/blog-list/index.module.less
+++ b/src/components/blog-list/index.module.less
@@ -62,6 +62,27 @@
   }
 }
 
+.card > :not(.beam) {
+  position: relative;
+  z-index: 1;
+}
+
+.beam {
+  opacity: 0;
+  z-index: 0;
+  transition: opacity 0.2s ease;
+}
+
+.card:focus-visible .beam {
+  opacity: 1;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .card:hover .beam {
+    opacity: 1;
+  }
+}
+
 /* ── Featured Post Card ── */
 .featuredSection {
   margin-bottom: 20px;

--- a/src/components/blog-list/index.module.less
+++ b/src/components/blog-list/index.module.less
@@ -68,19 +68,7 @@
 }
 
 .beam {
-  opacity: 0;
   z-index: 0;
-  transition: opacity 0.2s ease;
-}
-
-.card:focus-visible .beam {
-  opacity: 1;
-}
-
-@media (hover: hover) and (pointer: fine) {
-  .card:hover .beam {
-    opacity: 1;
-  }
 }
 
 /* ── Featured Post Card ── */

--- a/src/components/blog-list/index.tsx
+++ b/src/components/blog-list/index.tsx
@@ -1,11 +1,8 @@
 import { useLang } from '@rspress/core/runtime';
-import {
-  getCustomMDXComponent,
-  renderInlineMarkdown,
-} from '@rspress/core/theme';
+import { renderInlineMarkdown } from '@rspress/core/theme';
 import useIfMobile from '@site/theme/hooks/use-if-mobile';
 import { useBlogPages, useTiltEffect } from '@site/src/hooks';
-import { useState } from 'react';
+import { toLatestBlogPath } from '@site/src/lib/utils';
 import { BlogAvatar } from '../blog-avatar';
 import { MeteorsBackground } from '../home-comps/meteors-background';
 import { BorderBeam } from '../home-comps/border-beam';
@@ -29,7 +26,6 @@ function BlogCard({
   title,
   authors,
   lang,
-  A,
   variant = 'grid',
 }: {
   date?: Date;
@@ -38,20 +34,23 @@ function BlogCard({
   title?: string;
   authors?: string[];
   lang: string;
-  A: React.ComponentType<React.AnchorHTMLAttributes<HTMLAnchorElement>>;
   variant?: 'featured' | 'grid';
 }) {
-  const [isHovered, setIsHovered] = useState(false);
   const isFeatured = variant === 'featured';
+  const latestBlogPath = toLatestBlogPath(link);
 
   return (
-    <A
-      href={link}
+    <a
+      href={latestBlogPath}
       className={`${styles.card} ${isFeatured ? styles.featured : styles.gridItem}`}
       data-tilt-card
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
     >
+      <BorderBeam
+        className={styles.beam}
+        color="#3b82f6"
+        size={2}
+        duration={3}
+      />
       {date && (
         <span className={styles.date}>
           {new Intl.DateTimeFormat(lang, {
@@ -84,13 +83,11 @@ function BlogCard({
           />
         </div>
       )}
-      {isHovered && <BorderBeam size={2} duration={3} />}
-    </A>
+    </a>
   );
 }
 
 export function BlogList({ limit }: { limit?: number }) {
-  const { a: A } = getCustomMDXComponent();
   const blogPages = useBlogPages();
   const lang = useLang() as 'en' | 'zh';
   const isMobile = useIfMobile();
@@ -131,7 +128,7 @@ export function BlogList({ limit }: { limit?: number }) {
 
       {featuredPost && (
         <section className={styles.featuredSection}>
-          <BlogCard {...featuredPost} lang={lang} A={A} variant="featured" />
+          <BlogCard {...featuredPost} lang={lang} variant="featured" />
         </section>
       )}
 
@@ -142,7 +139,6 @@ export function BlogList({ limit }: { limit?: number }) {
               key={post.link || index}
               {...post}
               lang={lang}
-              A={A}
               variant="grid"
             />
           ))}

--- a/src/components/blog-list/index.tsx
+++ b/src/components/blog-list/index.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useLang } from '@rspress/core/runtime';
 import { renderInlineMarkdown } from '@rspress/core/theme';
 import useIfMobile from '@site/theme/hooks/use-if-mobile';
@@ -38,19 +39,26 @@ function BlogCard({
 }) {
   const isFeatured = variant === 'featured';
   const latestBlogPath = toLatestBlogPath(link);
+  const [isBeamActive, setIsBeamActive] = useState(false);
 
   return (
     <a
       href={latestBlogPath}
       className={`${styles.card} ${isFeatured ? styles.featured : styles.gridItem}`}
       data-tilt-card
+      onMouseEnter={() => setIsBeamActive(true)}
+      onMouseLeave={() => setIsBeamActive(false)}
+      onFocus={() => setIsBeamActive(true)}
+      onBlur={() => setIsBeamActive(false)}
     >
-      <BorderBeam
-        className={styles.beam}
-        color="#3b82f6"
-        size={2}
-        duration={3}
-      />
+      {isBeamActive && (
+        <BorderBeam
+          className={styles.beam}
+          color="#3b82f6"
+          size={2}
+          duration={3}
+        />
+      )}
       {date && (
         <span className={styles.date}>
           {new Intl.DateTimeFormat(lang, {

--- a/src/components/home-comps/border-beam/index.tsx
+++ b/src/components/home-comps/border-beam/index.tsx
@@ -168,7 +168,10 @@ const BorderBeam: React.FC<BorderBeamProps> = ({
   }, [color, size, duration]);
 
   return (
-    <div ref={containerRef} className={styles['border-beam-frame']}>
+    <div
+      ref={containerRef}
+      className={`${styles['border-beam-frame']} ${className}`.trim()}
+    >
       <canvas
         ref={canvasRef}
         className="absolute top-0 left-0 w-full h-full pointer-events-none"

--- a/src/components/home-comps/meteors-background.tsx
+++ b/src/components/home-comps/meteors-background.tsx
@@ -153,6 +153,7 @@ const MeteorsBackground: React.FC<GridBackgroundProps> = ({
       { length: meteorCount },
       () => new Meteor(gridSize, canvas),
     );
+    let animationFrameId = 0;
 
     const animate = () => {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
@@ -179,13 +180,14 @@ const MeteorsBackground: React.FC<GridBackgroundProps> = ({
         meteor.draw(ctx);
       });
 
-      requestAnimationFrame(animate);
+      animationFrameId = requestAnimationFrame(animate);
     };
 
-    animate();
+    animationFrameId = requestAnimationFrame(animate);
 
     return () => {
       window.removeEventListener('resize', setCanvasSize);
+      cancelAnimationFrame(animationFrameId);
     };
   }, [gridSize, meteorCount]);
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,19 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export function toLatestBlogPath(link?: string) {
+  if (!link) {
+    return '/next/blog/';
+  }
+
+  if (/^(https?:)?\/\//.test(link) || link.startsWith('/next/')) {
+    return link;
+  }
+
+  return `/next${link.startsWith('/') ? link : `/${link}`}`;
+}
+
+export function getLatestBlogIndexPath(lang: string) {
+  return lang === 'zh' ? '/next/zh/blog/' : '/next/blog/';
+}

--- a/theme/hooks/use-blog-btn-dom.ts
+++ b/theme/hooks/use-blog-btn-dom.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import { useLang, useNavigate, usePageData } from '@rspress/core/runtime';
 import { useLatestBlog, type LatestBlogConfig } from '@site/src/hooks';
+import { toLatestBlogPath } from '@site/src/lib/utils';
 
 type ConfigKey = '/' | '/react/' | '/rspeedy/';
 
@@ -78,7 +79,7 @@ const useBlogBtnDom = (src: string) => {
     if (isExternal) {
       window.open(blogLink, '_blank');
     } else {
-      navigate(blogLink);
+      navigate(toLatestBlogPath(blogLink));
     }
   }, [navigate, blogLink, isExternal]);
 

--- a/theme/hooks/use-blog-btn-dom.ts
+++ b/theme/hooks/use-blog-btn-dom.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import { useLang, useNavigate, usePageData } from '@rspress/core/runtime';
 import { useLatestBlog, type LatestBlogConfig } from '@site/src/hooks';
-import { toLatestBlogPath } from '@site/src/lib/utils';
 
 type ConfigKey = '/' | '/react/' | '/rspeedy/';
 
@@ -79,7 +78,7 @@ const useBlogBtnDom = (src: string) => {
     if (isExternal) {
       window.open(blogLink, '_blank');
     } else {
-      navigate(toLatestBlogPath(blogLink));
+      navigate(blogLink);
     }
   }, [navigate, blogLink, isExternal]);
 


### PR DESCRIPTION
## Summary

This PR fixes blog-specific navigation inconsistencies and addresses the visible flicker/FOUC observed when opening blog detail pages from the blog list.

**visible flicker** + **broken `← All Posts` pointer**

https://github.com/user-attachments/assets/150cca73-02d6-4a23-859d-c9685a86d308

## Changes

- switch blog-list cards to same-tab native `<a href>` navigation targeting explicit latest `/next/...` blog routes
- keep the existing BorderBeam hover decoration with conditional mount on the active card
- fix blog detail "All Posts" to return to the latest blog index
- keep centralized blog-link normalization as a compatibility fallback for existing raw `/blog/...` links

## Why

During investigation, the remaining flicker was narrowed down to the blog-list initiated SPA navigation path rather than the target blog detail page itself.

The following were tested and are no longer believed to be the root cause:

- `enableContentAnimation`
- Go / web-core usage inside specific blog posts
- `featuredPost` rendering alone
- `MeteorsBackground`
- `BorderBeam` itself
- delayed CSS for the target page as the main explanation

The strongest signal was that direct document navigation to the same blog detail page did not flicker, while navigation triggered from the blog list did. Reverting the blog-list cards to native same-tab anchors removed the issue in current verification.

## Files

- `src/components/blog-list/index.tsx`
- `src/components/blog-list/index.module.less`
- `src/components/blog-header/index.tsx`
- `theme/hooks/use-blog-btn-dom.ts`
- `src/lib/utils.ts`
- `theme/index.tsx`

## Verification

Confirmed during local validation:

- blog detail -> All Posts now consistently returns to the latest blog index instead of the home page
- blog-list -> detail no longer reproduces the previously observed flicker after switching cards to same-tab native anchors
- updated dynamic blog entry points generate explicit latest-version `/next/...` routes

## Notes

This change intentionally prefers document navigation for blog-list cards over the previous SPA link path, because that path was the reproducible source of the remaining flicker.

## Not Addressed in This PR

- broader `Blog -> Guide` flicker scenarios outside the blog-list card navigation path
- homepage latest blog badge normalization to explicit latest `/next/...` routes
- repo-wide migration of existing MDX/nav raw `/blog/...` links to explicit `/next/...` targets
- removal of the theme-level blog `Link` rewrite fallback, which is still needed for compatibility with existing content links


## Related
- Solving (partially) #961


Change-Id: I6acde5c7583befcd08abe6d37dd57cc0809bc709