### PR TITLE
docs(lynx-ui): align intro & contributing guides for OSS

### DIFF
--- a/docs/en/lynx-ui/Guides/contributing.mdx
+++ b/docs/en/lynx-ui/Guides/contributing.mdx
@@ -13,7 +13,7 @@ Pnpm: Run `corepack enable`
 ```
 npm install turbo --global
 
-git clone git@code.byted.org:lynx/lynx-ui.git
+git clone https://github.com/lynx-family/lynx-ui.git
 
 cd lynx-ui
 
@@ -142,19 +142,6 @@ Component documentation is located in `packages/<component-name>/README.md`. The
 
 Focus on the Guide section of the documentation, including component introduction, usage methods, examples, etc.
 
-You can use `internal-website` components (like `Go`) in markdown
-
-```markdown
-<Go
-  img="https://lf0-fast-deliver-inner.bytedance.net/obj/eden-internal/zalzzh-ukj-lapzild-shpjpmmv-eufs/ljhwZthlaukjlkulzlp/lynx_ui_action_sheet_customized.webp"
-  example="ActionSheet"
-  defaultEntryFile="dist/ActionSheetCustomized/template.js"
-  entry="Customized"
-/>
-```
-
-For details, refer to [internal-website](https://bits.bytedance.net/code/lynx/internal_website/)
-
 #### 5. Add Tests
 
 Basic element checks for components are done using headless lynx. Please add the component samples that need to be tested to TEST_COMPONENTS in apps/examples/tests/headless.test.ts.
@@ -171,64 +158,12 @@ Run `pnpm dlx sherif@latest` to check the dependencies. If it fails, run `pnpm d
 
 #### 7. Submit Code
 
-### Generate Component Documentation
+1. Create a branch from `master` and make your changes
+2. Run tests and lint locally
+3. Run `pnpm changeset` if your change affects published packages
+4. Open a pull request on GitHub
 
-> Requires local `internal-website` project for documentation preview, refer to [Generate Document](https://bits.bytedance.net/code/lynx/internal_website/blob/master/scripts/typedoc/README.md). If any new components are added, please manually add them to the [config file](https://code.byted.org/lynx/internal_website/blob/master/scripts/typedoc/packages/lynx-ui.ts).
-
-## MR Standards
-
-- Each MR should have exactly 1 commit
-
-## Submission Process
-
-### Feature
-
-> Usually used for new features, follows `master` branch release
-
-1. Branch out from `master`, modify code
-2. Run `pnpm changeset`, select packages to upgrade (choose patch or minor based on changes), write description
-3. Submit code along with generated `changeset` file
-4. Find Code Owner and Release Owner for review
-5. Merge into `master` branch
-6. Release Owner will release periodically (weekly)
-
-### Hotfix
-
-> Code Submitter
-
-1. Branch out from `master`, modify code
-2. Run `pnpm changeset`, select packages to upgrade, choose patch upgrade, write Change description
-3. Submit code along with generated `changeset` file
-4. Find Code Owner and Release Owner for review
-5. Merge into `master` branch
-
-> Release Owner
-
-6. Periodically (daily or immediately) branch out from `master`
-7. Run `pnpm changeset version`, check if version number changes meet expectations
-8. Submit changes to `package.json` and `CHANGELOG.md`
-
-## Version Release
-
-### Snapshot Version
-
-After submitting MR, CI will automatically publish Snapshot version
-
-Snapshot versions can be used for testing, not recommended for production use.
-
-Snapshot versions use different package names with `-canary` suffix, e.g., `@lynx-js/lynx-ui-button-canary` for `@lynx-js/lynx-ui-button`.
-
-After merging, CI interface will show Snapshot version report, Lark will also receive notification
-![ci_report](https://lf0-fast-deliver-inner.bytedance.net/obj/eden-internal/uhfyeh7nuhfnuhd/tmp/ci_report.jpeg)
-![lark_report](https://lf0-fast-deliver-inner.bytedance.net/obj/eden-internal/uhfyeh7nuhfnuhd/tmp/lark_report.jpeg)
-
-### Release Version
-
-Release versions need to be released by Release Owner.
-
-After features or bugfixes merge into master, CI will sync changes to `changeset-release/next` branch and generate version and changelog
-
-Release Owner only needs to merge `changeset-release/next` branch, CI will automatically publish release version and Lark will receive notification
+Releases are handled by maintainers. For testing pre-release builds, use CI artifacts or canary builds if available.
 
 ## FAQ
 

--- a/docs/en/lynx-ui/Guides/introduction.mdx
+++ b/docs/en/lynx-ui/Guides/introduction.mdx
@@ -1,23 +1,42 @@
 import { PackageManagerTabs } from '@theme';
-import { Tab, Tabs } from '@rspress/core/theme';
 
 # What is lynx-ui
 
-lynx-ui will be your first stop for integrating Lynx components. As a **Headless** UI library long-term maintained by the Lynx team, we provide maximally flexible, universal and high-performance UI solutions.
+`@lynx-js/lynx-ui` is the official headless UI library for ReactLynx, provided as a reference for building flexible, universal, and high-performance ReactLynx components.
 
-We aim to complement native components' adaptation capabilities through frontend components, building a high-performance, native-like Lynx component ecosystem with excellent compatibility.
+We extend native components' capabilities through frontend components, toward a high-performance, native-like Lynx component ecosystem with broad compatibility.
 
-UI characteristics within the same platform often exhibit significant differences in behavior, APIs, and even design philosophies—especially for advanced features. Cross-platform frameworks must strive to reconcile these discrepancies, and Lynx is no exception.
+UI characteristics on the same platform often differ in behavior, APIs, and even design philosophy, especially for advanced features. Cross-platform frameworks must bridge these gaps, and Lynx is no exception.
 
-Frontend components will organize and standardize these numerous underlying atomic APIs, reconciling their behaviors and limitations to achieve ultimate consistency on the frontend layer.
+This is where `lynx-ui` comes in, streamlining and unifying disparate atomic APIs to reconcile underlying behaviors and limitations, delivering a consistent experience across platforms.
 
 ## Quick Start
 
-lynx-ui supports both individual component imports and full-library imports.
+`lynx-ui` supports both full-library imports and individual component imports.
+
+### Full-Library Import (Recommended)
+
+Import the entire `lynx-ui` package. Tree-shaking is supported, so unused components won't increase your final build size.
+
+<PackageManagerTabs command="install @lynx-js/lynx-ui" />
+
+Use in projects:
+
+```jsx {1}
+import { Button } from '@lynx-js/lynx-ui';
+
+export default function App() {
+  return (
+    <view>
+      <Button />
+    </view>
+  );
+}
+```
 
 ### Importing Individual Components
 
-Each lynx-ui component is published as a separate package, allowing you to import only what you need.
+Each `lynx-ui` component is published as a separate package. Use this approach for compatibility or specific requirements.
 
 Example with `<Button>`:
 
@@ -37,67 +56,28 @@ export default function App() {
 }
 ```
 
-### Full-Library Import
-
-You can also import the entire lynx-ui package. Don't worry about bundle size—lynx-ui supports tree-shaking, so unused components won't increase your final build size.
-
-<PackageManagerTabs command="install @lynx-js/lynx-ui" />
-
-Use in projects:
-
-```jsx {1}
-import { Button } from '@lynx-js/lynx-ui';
-
-export default function App() {
-  return (
-    <view>
-      <Button />
-    </view>
-  );
-}
-```
-
 :::details Which way should I choose
-We recommend importing individual components:
+We recommend full-library import by default:
 
-1. Safer upgrades. Upgrade individual components without affecting others
+1. Simpler installs and usage
 
-2. Leaner dependencies - Only meet requirements for components you actually use
+2. Tree-shaking keeps bundle size small
 
 :::
 
 ## Configuration
 
-<Tabs>
-  <Tab value="rspeedy" label="rspeedy">
 ```typescript
 export default defineConfig({
   ...
   plugins: [
     pluginReactLynx({
       ...
-      targetSdkVersion: '2.14',
       enableNewGesture: true,
     }),
   ],
 })
 ```
-  </Tab>
-  <Tab value="speedy" label="speedy">
-```typescript
-module.exports = {
-  ...
-  pageConfig: {
-    enableNewGesture: true,
-  },
-  encode: {
-    useLepusNG: true,
-    targetSdkVersion: '2.14',
-  },
-}
-```
-  </Tab>
-</Tabs>
 
 :::details Concerned about configuration changes affecting other pages?
 This documentation lists all component requirements. For looser constraints, check your specific component's configuration needs.
@@ -105,7 +85,7 @@ This documentation lists all component requirements. For looser constraints, che
 
 ## Compatibility
 
-LynxSDK > 2.16，[Host Version Matrix](https://lynx.bytedance.net/guide/versioning/2-host-version.html)
+- LynxSDK: >= 3.2
 
 :::details Version not supported?
 These are full-library requirements. Individual components may have lower version requirements.
@@ -122,7 +102,7 @@ Whether you're developing e-commerce, social, live-streaming apps, or have disco
 We're committed to pushing the boundaries of interaction design - let's brainstorm, iterate, and implement the most innovative solutions together.
 
 🤝 **Grow the Lynx Ecosystem**
-Your Lynx development expertise is vital to advancing the ecosystem. We sincerely invite and need your input - your active participation and generous help will showcase ByteDance's engineering excellence and Lynx's thriving ecosystem.
+Your Lynx development expertise is vital to advancing the ecosystem. We sincerely invite and need your input - your active participation and generous help will showcase the community's engineering excellence and Lynx's thriving ecosystem.
 
 :::info
 [Repository](https://github.com/lynx-family/lynx-ui) | [Contribution Guide](https://github.com/lynx-family/lynx-ui/blob/main/CONTRIBUTING.md)

--- a/docs/zh/lynx-ui/Guides/contributing.mdx
+++ b/docs/zh/lynx-ui/Guides/contributing.mdx
@@ -13,7 +13,7 @@ Pnpm: 执行 `corepack enable` 即可
 ```
 npm install turbo --global
 
-git clone git@code.byted.org:lynx/lynx-ui.git
+git clone https://github.com/lynx-family/lynx-ui.git
 
 cd lynx-ui
 
@@ -142,19 +142,6 @@ turbo watch dev
 
 主要是文档的 Guide 部分, 包含组件介绍，使用方法，示例等
 
-markdown 中可以使用`internal-website`的组件(比如`Go`)
-
-```
-<Go
-  img="https://lf0-fast-deliver-inner.bytedance.net/obj/eden-internal/zalzzh-ukj-lapzild-shpjpmmv-eufs/ljhwZthlaukjlkulzlp/lynx_ui_action_sheet_customized.webp"
-  example="ActionSheet"
-  defaultEntryFile="dist/ActionSheetCustomized/template.js"
-  entry="Customized"
-/>
-```
-
-详情参考[internal-website](https://bits.bytedance.net/code/lynx/internal_website/)
-
 #### 5. 添加测试
 
 组件使用 headless lynx 进行基本的元素检查，请在 apps/examples/**tests**/headless.test.ts 中的 `TEST_COMPONENTS` 添加需要测试的组件样例
@@ -165,64 +152,12 @@ markdown 中可以使用`internal-website`的组件(比如`Go`)
 
 #### 6. 提交代码
 
-### 生成组件文档
+1. 从 `master` 分支切出新分支并完成修改
+2. 本地运行测试与 lint
+3. 如果改动影响发布包，执行 `pnpm changeset` 并提交生成的 changeset 文件
+4. 在 GitHub 上发起 Pull Request
 
-> 需要本地有`internal-website`项目用于文档预览， refer to [Generate Document](https://bits.bytedance.net/code/lynx/internal_website/blob/master/scripts/typedoc/README.md)，如有新增组件，请在[配置文件](https://code.byted.org/lynx/internal_website/blob/master/scripts/typedoc/packages/lynx-ui.ts)中手动添加
-
-## MR 规范
-
-- 每个 MR 有且仅有 1 个 commit
-
-## 提交流程
-
-### feature
-
-> 通常新 feature 使用，跟车 `master` 发版
-
-1. 从 `master` 分支切出，修改代码
-2. 执行 `pnpm changeset`，选择需要升级的包（根据提交内容来选择 patch 或者 minor），编写描述信息
-3. 将代码和生成的`changeset`文件一起提交
-4. 找 Code Owner 和 Release Owner 进行 review
-5. 合入 `master` 分支
-6. Release Owner 会定时(每周)发版
-
-### hotfix
-
-> 代码提交者
-
-1. 从 `master` 分支切出，修改代码
-2. 执行 `pnpm changeset`，选择需要升级的包，选择 patch 升级，编写该 Change 的描述信息
-3. 将代码和生成的`changeset`文件一起提交
-4. 找 Code Owner 和 Release Owner 进行 review
-5. 合入 `master` 分支
-
-> Release Owner
-
-6. 定时（每天或立即）从 `master` 分支切出
-7. 执行 `pnpm changeset version`，检查版本号变更是否符合预期
-8. 提交`package.json`和 `CHANGELOG.md` 的变更
-
-## 版本发布
-
-### Snapshot 版本
-
-提交 MR 后, CI 会自动发布 Snapshot 版本
-
-Snapshot 版本可以用来测试，不建议在生产环境使用.
-
-Snapshot 版本采用了不同的包名，在原包名后加`-canary`后缀, 比如`@lynx-js/lynx-ui-button`的 Snapshot 版本为`@lynx-js/lynx-ui-button-canary`.
-
-合入后，CI 界面会有 Snapshot 版本的报告，Lark 也会收到通知
-![ci_report](https://lf0-fast-deliver-inner.bytedance.net/obj/eden-internal/uhfyeh7nuhfnuhd/tmp/ci_report.jpeg)
-![lark_report](https://lf0-fast-deliver-inner.bytedance.net/obj/eden-internal/uhfyeh7nuhfnuhd/tmp/lark_report.jpeg)
-
-### 正式版本
-
-正式版本需要 Release Owner 进行发布.
-
-需求或者 bugfix 合入 master 后，CI 会将改动同步到`changeset-release/next`分支, 同时生成版本和 changelog
-
-Release Owner 只需要合入`changeset-release/next`分支, 合入后 CI 会自动发布正式版本, 同时 Lark 会收到通知
+正式版本由维护者统一发布。如需测试预发布构建，可使用 CI 产物或 canary 构建（如有提供）。
 
 ## FAQ
 

--- a/docs/zh/lynx-ui/Guides/introduction.mdx
+++ b/docs/zh/lynx-ui/Guides/introduction.mdx
@@ -1,5 +1,4 @@
 import { PackageManagerTabs } from '@theme';
-import { Tab, Tabs } from '@rspress/core/theme';
 import CompareImg from '@assets/lynx-ui-docs/compare.png';
 
 # lynx-ui 是什么
@@ -19,9 +18,29 @@ lynx-ui 将是你接入 Lynx 元件的第一站。我们是 Lynx 团队长期维
 
 lynx-ui 支持按组件引入和整体引入。
 
+### 整体引入（推荐）
+
+建议直接整体引入 `lynx-ui`。lynx-ui 支持 treeshaking，没有使用的组件不会占用体积。
+
+<PackageManagerTabs command="install @lynx-js/lynx-ui" />
+
+在项目中使用
+
+```jsx {1}
+import { Button } from '@lynx-js/lynx-ui';
+
+export default function App() {
+  return (
+    <view>
+      <Button />
+    </view>
+  );
+}
+```
+
 ### 按组件引入
 
-lynx-ui 每个组件都有单独的包，你可以只引入需要使用的组件。所有组件的列表参考：
+lynx-ui 每个组件都有单独的包。如遇到兼容性或特定需求，可以只引入需要使用的组件。
 
 这里以 `<Button>` 组件为例
 
@@ -41,37 +60,15 @@ export default function App() {
 }
 ```
 
-### 整体引入
-
-你也可以整体引入 lynx-ui。 不用担心体积问题，lynx-ui 支持 treeshaking，没有使用的组件不会占用体积。
-
-<PackageManagerTabs command="install @lynx-js/lynx-ui" />
-
-在项目中使用
-
-```jsx {1}
-import { Button } from '@lynx-js/lynx-ui';
-
-export default function App() {
-  return (
-    <view>
-      <Button />
-    </view>
-  );
-}
-```
-
 :::details 我应该选择按组件引入还是整体引入
-我们推荐按组件引入，这样可以带来一些好处
+我们推荐整体引入，这样可以带来一些好处
 
-1. 你可以单独升级具体的组件，而不用担心整体升级 lynx-ui 对其他页面的影响
-2. 只需要满足使用到的组件的配置和版本需求，覆盖范围更大
+1. 安装和使用更简单
+2. treeshaking 会自动优化产物体积
    :::
 
 ## 配置
 
-<Tabs>
-  <Tab value="rspeedy" label="rspeedy">
 ```typescript
 export default defineConfig({
   ...
@@ -84,22 +81,6 @@ export default defineConfig({
   ],
 })
 ```
-  </Tab>
-  <Tab value="speedy" label="speedy">
-```typescript
-module.exports = {
-  ...
-  pageConfig: {
-    enableNewGesture: true,
-  },
-  encode: {
-    useLepusNG: true,
-    targetSdkVersion: '2.14',
-  },
-}
-```
-  </Tab>
-</Tabs>
 
 :::details 担心配置改动影响其他页面？
 这里是整个组件库的配置需求，如果你的担心配置变动的影响，可以看看你使用的具体组件，配置需求会更宽松
@@ -108,7 +89,7 @@ module.exports = {
 
 ## 兼容性
 
-LynxSDK > 2.16，[宿主版本对照](https://lynx.bytedance.net/guide/versioning/2-host-version.html)
+- LynxSDK：>= 3.2
 
 :::details 最低版本不满足需求？
 这里是整个组件库的最低版本需求，如果你的最低版本不能满足需求，可以看看你使用的具体组件，版本需求会更宽松。
@@ -129,7 +110,6 @@ lynx-ui 致力于推动交互设计的前沿，与你一同构思、迭代和落
 🤝 **期待 Lynx 生态繁荣**
 
 拥有丰富 Lynx 开发经验的大家，是推动 Lynx 生态进一步发展的关键。lynx-ui 诚挚地邀请并需要你的输入，期待你的积极参与和无私帮助。
-愿让世界见证字节研发的卓越力量和 Lynx 生态的蓬勃发展。
 
 :::info
 [仓库地址](https://github.com/lynx-family/lynx-ui) && [贡献指南](https://github.com/lynx-family/lynx-ui/blob/main/CONTRIBUTING.md)


### PR DESCRIPTION
- Update Lynx UI intro copy and remove internal-only wording/links (e.g. ByteDance references)
- Prefer full-library installation in the quick(EN/ZH) start to match current recommendations
- Clean up Contributing guides (EN/ZH): switch clone URL to GitHub, drop internal-website/Lark sections, and simplify the submission/release flow for open source contributors

Change-Id: I5b870bb27b11b65d98b93a46c178bb3ac4351ff1