### PR TITLE
ci: block more internal doc URL domains

### DIFF
--- a/scripts/ci/check-asset-urls.mjs
+++ b/scripts/ci/check-asset-urls.mjs
@@ -2,7 +2,13 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
-const blockedDomains = new Set(['tosv-sg.tiktok-row.org', 'tosv.byted.org']);
+const blockedDomains = new Set([
+  'tosv-sg.tiktok-row.org',
+  'tosv.byted.org',
+  'bits.bytedance.net',
+  'code.byted.org',
+  'lynx.bytedance.net',
+]);
 
 const textExts = new Set([
   '.cjs',


### PR DESCRIPTION
- Extend `scripts/ci/check-asset-urls.mjs` blocked domain list
- Prevent accidentally committing internal links like `bits.bytedance.net`, `code.byted.org`, and `lynx.bytedance.net` into OSS docs

## Related

- #958

Change-Id: Ib71313472b2cc614031d3748f378a68808430152