### PR TITLE
docs: add Extracting Translations section to i18n docs

### DIFF
--- a/docs/en/guide/inclusion/internationalization.mdx
+++ b/docs/en/guide/inclusion/internationalization.mdx
@@ -324,3 +324,176 @@ export function App() {
   img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/doc/i18n/switch-language.gif"
   entry="src/index.tsx"
 />
+
+## Extracting Translations
+
+If you downloaded many translations but your project only uses some of them, you may need to extract the translations to reduce the bundle size.
+
+There are two ways to extract the translations used in your source code.
+
+### Plugin (Recommended)
+
+You can use the [`rsbuild-plugin-i18next-extractor`](https://github.com/rstackjs/rsbuild-plugin-i18next-extractor) to extract the translations used in the source code. This plugin is based on [i18next-cli](https://github.com/i18next/i18next-cli), and uses the Rspack module graph to extract i18n messages from modules that are actually imported by the current build. This allows it to extract translations on demand, avoid bundling unused messages, and reduce the risk of missing translations that are used through imported dependencies.
+
+:::tip
+This plugin requires Node.js 22 or above.
+:::
+
+First, install the plugin and its `i18next-cli` peer dependency:
+
+<PackageManagerTabs command="install rsbuild-plugin-i18next-extractor i18next-cli -D" />
+
+Enable the plugin in `lynx.config.ts` and specify the `localesDir` option, which is the directory path of the raw translations:
+
+The examples below assume your raw translations live in `src/locales/`.
+
+```ts title="lynx.config.ts"
+import { defineConfig } from '@lynx-js/rspeedy';
+import { pluginI18nextExtractor } from 'rsbuild-plugin-i18next-extractor';
+
+export default defineConfig({
+  plugins: [
+    pluginI18nextExtractor({
+      localesDir: './src/locales',
+    }),
+  ],
+});
+```
+
+You should import the translations from the `localesDir` which you specify above:
+
+```ts title="src/i18n.ts"
+import i18next from 'i18next';
+import type { i18n } from 'i18next';
+
+import enTranslation from './locales/en.json';
+
+const localI18nInstance: i18n = i18next.createInstance();
+
+localI18nInstance.init({
+  lng: 'en',
+  resources: {
+    en: {
+      translation: enTranslation,
+    },
+  },
+});
+```
+
+:::tip
+After running `DEBUG=rsbuild:i18next rspeedy dev` or `DEBUG=rsbuild:i18next rspeedy build`, you can view the extracted translations in the `node_modules/.rsbuild-plugin-i18next-extractor` directory.
+:::
+
+#### Configuration Options
+
+The plugin scans `node_modules` by default. You can exclude files using the `i18nextToolkitConfig.extract.ignore` option:
+
+```ts title="lynx.config.ts"
+import { defineConfig } from '@lynx-js/rspeedy';
+import { pluginI18nextExtractor } from 'rsbuild-plugin-i18next-extractor';
+
+export default defineConfig({
+  plugins: [
+    pluginI18nextExtractor({
+      localesDir: './src/locales',
+      i18nextToolkitConfig: {
+        extract: {
+          ignore: ['node_modules/**'],
+        },
+      },
+    }),
+  ],
+});
+```
+
+You can also provide a callback for missing translation keys:
+
+```ts title="lynx.config.ts"
+import { defineConfig } from '@lynx-js/rspeedy';
+import { pluginI18nextExtractor } from 'rsbuild-plugin-i18next-extractor';
+
+export default defineConfig({
+  plugins: [
+    pluginI18nextExtractor({
+      localesDir: './src/locales',
+      onKeyNotFound: (key, locale, localeFilePath, entryName) => {
+        console.warn(`Missing translation key: ${key} for locale: ${locale}`);
+      },
+    }),
+  ],
+});
+```
+
+#### Advanced: Dedupe translations in Lynx bundles
+
+For Lynx apps, it is recommended to use [`@lynx-js/i18next-translation-dedupe`](https://github.com/lynx-family/lynx-stack/tree/main/packages/i18n/i18next-translation-dedupe) together with `rsbuild-plugin-i18next-extractor` to avoid bundling the same translations twice.
+
+`@lynx-js/i18next-translation-dedupe` reads the translations extracted by `rsbuild-plugin-i18next-extractor`, skips the extractor's default rendered asset, and writes the translations into the Lynx bundle `customSections` for runtime loading.
+
+First, install the package:
+
+<PackageManagerTabs command="install @lynx-js/i18next-translation-dedupe -D" />
+
+Then add `pluginLynxI18nextTranslationDedupe()`:
+
+```ts title="lynx.config.ts"
+import { defineConfig } from '@lynx-js/rspeedy';
+import { pluginLynxI18nextTranslationDedupe } from '@lynx-js/i18next-translation-dedupe';
+import { pluginI18nextExtractor } from 'rsbuild-plugin-i18next-extractor';
+
+export default defineConfig({
+  plugins: [
+    pluginI18nextExtractor({
+      localesDir: './src/locales',
+    }),
+    pluginLynxI18nextTranslationDedupe(),
+  ],
+});
+```
+
+At runtime, load the extracted translations from the Lynx bundle `customSections`:
+
+```ts title="src/i18n.ts"
+import i18next from 'i18next';
+import type { i18n } from 'i18next';
+import { loadI18nextTranslations } from '@lynx-js/i18next-translation-dedupe';
+
+const localI18nInstance: i18n = i18next.createInstance();
+
+localI18nInstance.init({
+  lng: 'en',
+  resources: loadI18nextTranslations(),
+});
+```
+
+### CLI
+
+You can also use the [i18next-cli](https://github.com/i18next/i18next-cli) to extract translations.
+
+:::tip
+The i18next-cli requires Node.js 22 or above.
+:::
+
+First, install the CLI:
+
+<PackageManagerTabs command="install i18next-cli -D" />
+
+Add an `i18next.config.ts` file at the project root. For example:
+
+```ts title="i18next.config.ts"
+import { defineConfig } from 'i18next-cli';
+
+export default defineConfig({
+  locales: ['en', 'zh'],
+  extract: {
+    input: ['src/**/*.{js,jsx,ts,tsx}'],
+    output: 'src/locales/{{language}}.json',
+  },
+});
+```
+
+You can adjust `locales`, `extract.input`, and `extract.output` to match your project structure. If you use multiple namespaces, include `{{namespace}}` in the output pattern.
+
+Then run the following command to extract translations:
+
+<PackageManagerTabs command="i18next-cli extract" />

--- a/docs/zh/guide/inclusion/internationalization.mdx
+++ b/docs/zh/guide/inclusion/internationalization.mdx
@@ -321,3 +321,176 @@ export function App() {
   img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/doc/i18n/switch-language.gif"
   entry="src/index.tsx"
 />
+
+## 提取翻译
+
+如果你下载了很多翻译资源，但项目中只使用了其中一部分，就可以通过提取来减小产物体积。
+
+提取源码中实际用到的翻译资源有两种方式。
+
+### 插件方式（推荐）
+
+你可以使用 [`rsbuild-plugin-i18next-extractor`](https://github.com/rstackjs/rsbuild-plugin-i18next-extractor) 来提取源码中用到的翻译资源。这个插件基于 [i18next-cli](https://github.com/i18next/i18next-cli)，并利用 Rspack 的模块图提取当前构建中实际导入模块里的 i18n 消息。这样可以按需提取翻译，避免打包未使用的消息，并降低依赖中使用了翻译但遗漏提取的风险。
+
+:::tip
+这个插件要求 Node.js 22 或更高版本。
+:::
+
+首先安装插件以及它的 `i18next-cli` peer dependency：
+
+<PackageManagerTabs command="install rsbuild-plugin-i18next-extractor i18next-cli -D" />
+
+在 `lynx.config.ts` 中启用该插件，并指定 `localesDir` 选项，也就是原始翻译资源所在的目录：
+
+下面的示例统一假设原始翻译资源放在 `src/locales/` 中。
+
+```ts title="lynx.config.ts"
+import { defineConfig } from '@lynx-js/rspeedy';
+import { pluginI18nextExtractor } from 'rsbuild-plugin-i18next-extractor';
+
+export default defineConfig({
+  plugins: [
+    pluginI18nextExtractor({
+      localesDir: './src/locales',
+    }),
+  ],
+});
+```
+
+然后从上一步指定的 `localesDir` 中导入翻译资源：
+
+```ts title="src/i18n.ts"
+import i18next from 'i18next';
+import type { i18n } from 'i18next';
+
+import enTranslation from './locales/en.json';
+
+const localI18nInstance: i18n = i18next.createInstance();
+
+localI18nInstance.init({
+  lng: 'en',
+  resources: {
+    en: {
+      translation: enTranslation,
+    },
+  },
+});
+```
+
+:::tip
+在执行 `DEBUG=rsbuild:i18next rspeedy dev` 或 `DEBUG=rsbuild:i18next rspeedy build` 之后，你可以在 `node_modules/.rsbuild-plugin-i18next-extractor` 目录中查看提取结果。
+:::
+
+#### 配置项
+
+该插件默认会扫描 `node_modules`。你可以使用 `i18nextToolkitConfig.extract.ignore` 选项忽略文件：
+
+```ts title="lynx.config.ts"
+import { defineConfig } from '@lynx-js/rspeedy';
+import { pluginI18nextExtractor } from 'rsbuild-plugin-i18next-extractor';
+
+export default defineConfig({
+  plugins: [
+    pluginI18nextExtractor({
+      localesDir: './src/locales',
+      i18nextToolkitConfig: {
+        extract: {
+          ignore: ['node_modules/**'],
+        },
+      },
+    }),
+  ],
+});
+```
+
+你还可以通过回调处理缺失的翻译键：
+
+```ts title="lynx.config.ts"
+import { defineConfig } from '@lynx-js/rspeedy';
+import { pluginI18nextExtractor } from 'rsbuild-plugin-i18next-extractor';
+
+export default defineConfig({
+  plugins: [
+    pluginI18nextExtractor({
+      localesDir: './src/locales',
+      onKeyNotFound: (key, locale, localeFilePath, entryName) => {
+        console.warn(`Missing translation key: ${key} for locale: ${locale}`);
+      },
+    }),
+  ],
+});
+```
+
+#### 进阶：去重 Lynx 产物中的翻译
+
+对于 Lynx 应用，建议将 [`@lynx-js/i18next-translation-dedupe`](https://github.com/lynx-family/lynx-stack/tree/main/packages/i18n/i18next-translation-dedupe) 与 `rsbuild-plugin-i18next-extractor` 一起使用，以避免重复打包相同的翻译。
+
+`@lynx-js/i18next-translation-dedupe` 会读取 `rsbuild-plugin-i18next-extractor` 提取出的翻译，跳过提取器默认生成的资源文件，并将翻译写入 Lynx 产物的 `customSections` 中，供运行时加载。
+
+首先安装该包：
+
+<PackageManagerTabs command="install @lynx-js/i18next-translation-dedupe -D" />
+
+然后添加 `pluginLynxI18nextTranslationDedupe()`：
+
+```ts title="lynx.config.ts"
+import { defineConfig } from '@lynx-js/rspeedy';
+import { pluginLynxI18nextTranslationDedupe } from '@lynx-js/i18next-translation-dedupe';
+import { pluginI18nextExtractor } from 'rsbuild-plugin-i18next-extractor';
+
+export default defineConfig({
+  plugins: [
+    pluginI18nextExtractor({
+      localesDir: './src/locales',
+    }),
+    pluginLynxI18nextTranslationDedupe(),
+  ],
+});
+```
+
+运行时，从 Lynx 产物的 `customSections` 中加载提取出来的翻译：
+
+```ts title="src/i18n.ts"
+import i18next from 'i18next';
+import type { i18n } from 'i18next';
+import { loadI18nextTranslations } from '@lynx-js/i18next-translation-dedupe';
+
+const localI18nInstance: i18n = i18next.createInstance();
+
+localI18nInstance.init({
+  lng: 'en',
+  resources: loadI18nextTranslations(),
+});
+```
+
+### 命令行方式
+
+你也可以使用 [i18next-cli](https://github.com/i18next/i18next-cli) 来提取翻译。
+
+:::tip
+i18next-cli 要求 Node.js 22 或更高版本。
+:::
+
+首先安装 CLI：
+
+<PackageManagerTabs command="install i18next-cli -D" />
+
+在项目根目录下新增一个 `i18next.config.ts` 文件，例如：
+
+```ts title="i18next.config.ts"
+import { defineConfig } from 'i18next-cli';
+
+export default defineConfig({
+  locales: ['en', 'zh'],
+  extract: {
+    input: ['src/**/*.{js,jsx,ts,tsx}'],
+    output: 'src/locales/{{language}}.json',
+  },
+});
+```
+
+你可以根据项目结构调整 `locales`、`extract.input` 和 `extract.output`。如果你使用多个 namespace，可以把 `{{namespace}}` 加回到输出路径中。
+
+然后运行下面的命令来提取翻译：
+
+<PackageManagerTabs command="i18next-cli extract" />


### PR DESCRIPTION
Change-Id: I82bda2aa682330c0962de7ff9185e1b4833fa2f8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Add Extracting Translations section to i18n docs
- Document plugin-based extraction workflow using rsbuild-plugin-i18next-extractor (Node.js 22+), including lynx.config.ts setup, localesDir usage, importing JSON in src/i18n.ts, ignore options, and onKeyNotFound hook
- Describe CLI extraction workflow using i18next-cli with sample i18next.config.ts and extract command
- Introduce Lynx-specific deduplication flow using @lynx-js/i18next-translation-dedupe and runtime loadI18nextTranslations via customSections
- Provide the new guidance in both English and Chinese docs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->