### PR TITLE
docs: add lynx-ui skills page

### DIFF
--- a/docs/en/ai/_meta.json
+++ b/docs/en/ai/_meta.json
@@ -32,6 +32,10 @@
   },
   {
     "type": "file",
+    "name": "skills/lynx-ui.mdx"
+  },
+  {
+    "type": "file",
     "name": "skills/lynx-typescript.mdx"
   },
   {

--- a/docs/en/ai/skills/lynx-ui.mdx
+++ b/docs/en/ai/skills/lynx-ui.mdx
@@ -1,0 +1,49 @@
+# lynx-ui
+
+Helps coding agents use [`@lynx-js/lynx-ui`](/lynx-ui/Guides/introduction) components with curated references from the lynx-ui repository.
+
+Use it when an agent needs to:
+
+- choose the right lynx-ui component for a feature
+- verify supported props, events, ref methods, exports, or type aliases
+- adapt official examples into project code
+- debug a component usage issue against the documented public API
+- avoid inventing unsupported lynx-ui APIs from model memory
+
+## Installation
+
+```bash
+npx skills add lynx-community/skills -s lynx-ui
+```
+
+This installs the `lynx-ui` skill so compatible coding agents can load its routing guide and bundled references automatically.
+
+## What It Contains
+
+`lynx-ui` is structured for progressive disclosure:
+
+- `SKILL.md`: entrypoint and workflow rules for the agent
+- `reference.md`: component selection and routing guide
+- `references/index.md`: included component coverage
+- `references/components/<component>/guide.md`: usage patterns, composition guidance, and common pitfalls
+- `references/components/<component>/api.md`: public API source of truth
+- `references/components/<component>/examples.md`: concise implementation patterns
+
+## Recommended Workflow
+
+Ask the agent to use `lynx-ui` before implementing lynx-ui code.
+
+1. Identify the concrete component or a small set of candidate components.
+2. Use `reference.md` when component selection is unclear.
+3. Read the component `guide.md` first for usage patterns.
+4. Read `api.md` when exact public surface details matter.
+5. Read `examples.md` only when an implementation pattern is needed.
+
+The agent should prefer imports from `@lynx-js/lynx-ui` by default and treat `api.md` as the source of truth for public props, events, ref methods, and exported types.
+
+## Learn More
+
+- [lynx-ui documentation](/lynx-ui/Guides/introduction)
+- [lynx-family/lynx-ui on GitHub](https://github.com/lynx-family/lynx-ui)
+- [lynx-community/skills on GitHub](https://github.com/lynx-community/skills)
+- [Agent Skills specification](https://github.com/anthropics/skills)

--- a/docs/en/lynx-ui/Guides/_meta.json
+++ b/docs/en/lynx-ui/Guides/_meta.json
@@ -10,6 +10,11 @@
     "label": "Main Thread Script"
   },
   {
+    "type": "custom-link",
+    "link": "/ai/skills/lynx-ui.html",
+    "label": "Skills"
+  },
+  {
     "type": "file",
     "name": "contributing",
     "label": "Contributing"

--- a/docs/zh/ai/_meta.json
+++ b/docs/zh/ai/_meta.json
@@ -32,6 +32,10 @@
   },
   {
     "type": "file",
+    "name": "skills/lynx-ui.mdx"
+  },
+  {
+    "type": "file",
     "name": "skills/lynx-typescript.mdx"
   },
   {

--- a/docs/zh/ai/skills/lynx-ui.mdx
+++ b/docs/zh/ai/skills/lynx-ui.mdx
@@ -1,0 +1,49 @@
+# lynx-ui
+
+帮助 coding agent 基于 lynx-ui 仓库中的精选参考资料使用 [`@lynx-js/lynx-ui`](/zh/lynx-ui/Guides/introduction) 组件。
+
+适合在以下场景使用：
+
+- 为功能选择合适的 lynx-ui 组件
+- 确认组件支持的 props、事件、ref 方法、导出项或类型别名
+- 将官方示例改写为项目代码
+- 对照公开 API 排查组件使用问题
+- 避免 agent 凭模型记忆编造不存在的 lynx-ui API
+
+## 安装
+
+```bash
+npx skills add lynx-community/skills -s lynx-ui
+```
+
+这会安装 `lynx-ui` skill，让兼容的 coding agent 自动加载它的路由指南和参考资料。
+
+## 包含内容
+
+`lynx-ui` 按渐进读取方式组织：
+
+- `SKILL.md`：agent 的入口和工作流规则
+- `reference.md`：组件选择和路由指南
+- `references/index.md`：当前覆盖的组件列表
+- `references/components/<component>/guide.md`：使用模式、组合方式和常见问题
+- `references/components/<component>/api.md`：公开 API 的事实来源
+- `references/components/<component>/examples.md`：精简实现模式
+
+## 推荐工作流
+
+在实现 lynx-ui 代码前，让 agent 优先使用 `lynx-ui`。
+
+1. 确认具体组件，或缩小到少量候选组件。
+2. 组件选择不明确时，先阅读 `reference.md`。
+3. 先阅读组件的 `guide.md`，理解使用模式。
+4. 需要确认公开 API 细节时，再阅读 `api.md`。
+5. 只有需要实现示例模式时，才阅读 `examples.md`。
+
+默认建议 agent 从 `@lynx-js/lynx-ui` 导入组件，并将 `api.md` 作为 props、事件、ref 方法和导出类型的事实来源。
+
+## 了解更多
+
+- [lynx-ui 文档](/zh/lynx-ui/Guides/introduction)
+- [GitHub 上的 lynx-family/lynx-ui](https://github.com/lynx-family/lynx-ui)
+- [GitHub 上的 lynx-community/skills](https://github.com/lynx-community/skills)
+- [Agent Skills 规范](https://github.com/anthropics/skills)

--- a/docs/zh/lynx-ui/Guides/_meta.json
+++ b/docs/zh/lynx-ui/Guides/_meta.json
@@ -10,6 +10,11 @@
     "label": "主线程脚本"
   },
   {
+    "type": "custom-link",
+    "link": "/zh/ai/skills/lynx-ui.html",
+    "label": "Skills"
+  },
+  {
     "type": "file",
     "name": "contributing",
     "label": "贡献指南"


### PR DESCRIPTION
## Summary

Add public English and Chinese Lynx UI skills documentation for coding agents.

Expose the page from the AI skills sidebar and from the Lynx UI Guides sidebar as a `Skills` entry above `Contributing`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Add English and Chinese documentation pages for the lynx-ui skill with installation instructions and recommended agent workflows
- Register lynx-ui skills pages in AI skills navigation metadata for both languages
- Expose lynx-ui skill documentation in Lynx UI Guides navigation for both English and Chinese locales

<!-- end of auto-generated comment: release notes by coderabbit.ai -->