### PR TITLE
fix: correct zh lynx-ui skills link

### DIFF
--- a/docs/zh/lynx-ui/Guides/_meta.json
+++ b/docs/zh/lynx-ui/Guides/_meta.json
@@ -21,7 +21,7 @@
   },
   {
     "type": "custom-link",
-    "link": "/zh/ai/skills/lynx-ui.html",
+    "link": "/ai/skills/lynx-ui.html",
     "label": "Skills"
   },
   {


### PR DESCRIPTION
## Summary

Fix the Chinese Lynx UI sidebar Skills link so it resolves to the localized AI skills page without duplicating the zh path segment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Correct zh lynx-ui Skills link to resolve to localized AI skills page without duplicating the locale path segment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->