### PR TITLE
docs(lynx-ui): add missing Form component to sidebar

### DIFF
--- a/docs/en/lynx-ui/Components/Form.mdx
+++ b/docs/en/lynx-ui/Components/Form.mdx
@@ -1,0 +1,3 @@
+import Form from '@docs/lynx-ui-form/README.mdx';
+
+<Form />

--- a/docs/en/lynx-ui/Components/_meta.json
+++ b/docs/en/lynx-ui/Components/_meta.json
@@ -4,6 +4,7 @@
   "Dialog",
   "Draggable",
   "FeedList",
+  "Form",
   "Input",
   "LazyComponent",
   "List",

--- a/docs/zh/lynx-ui/Components/Form.mdx
+++ b/docs/zh/lynx-ui/Components/Form.mdx
@@ -1,0 +1,3 @@
+import Form from '@docs/lynx-ui-form/README.zh.mdx';
+
+<Form />

--- a/docs/zh/lynx-ui/Components/_meta.json
+++ b/docs/zh/lynx-ui/Components/_meta.json
@@ -4,6 +4,7 @@
   "Dialog",
   "Draggable",
   "FeedList",
+  "Form",
   "Input",
   "LazyComponent",
   "List",


### PR DESCRIPTION
 The Form docs existed but weren’t included in the Components `_meta.json`, so it didn’t appear in the sidebar and was hard to discover.

**Changes**
- Added `Form` to `docs/en/lynx-ui/Components/_meta.json` and `docs/zh/lynx-ui/Components/_meta.json` so it shows up in the sidebar.
- Added `docs/en/lynx-ui/Components/Form.mdx` and `docs/zh/lynx-ui/Components/Form.mdx`, rendering the content by importing `@docs/lynx-ui-form/README.mdx`.

**Verification**
- Confirmed Form is visible in the Components sidebar and the page renders correctly when opened.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Add Form component documentation pages for English and Chinese locales

- Add Form.mdx documentation pages that import from `@docs/lynx-ui-form/README.mdx` for both `docs/en/lynx-ui/Components/` and `docs/zh/lynx-ui/Components/`
- Include Form entry in Components `_meta.json` for both English and Chinese documentation to enable sidebar navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->