### PR TITLE
docs: remove basic usage section from introduction

### DIFF
--- a/sharedDocs/introDocs/lynx-ui-overlay/Introduction.mdx
+++ b/sharedDocs/introDocs/lynx-ui-overlay/Introduction.mdx
@@ -3,5 +3,3 @@ import { Go } from '@lynx-ui/index';
 OverlayView is a drop-in replacement for `x-overlay-ng`. Prefer using it over raw `x-overlay-ng` to reduce setup work and avoid platform quirks and mistakes.
 
 It can render either a plain `view` (when `container` is not provided) or an `x-overlay-ng` (when `container` is provided). Prefer using `OverlayView` over raw `x-overlay-ng`.
-
-## Basic Usage

--- a/sharedDocs/introDocs/lynx-ui-overlay/Introduction.zh.mdx
+++ b/sharedDocs/introDocs/lynx-ui-overlay/Introduction.zh.mdx
@@ -3,5 +3,3 @@ import { Go } from '@lynx-ui/index';
 OverlayView 是 `x-overlay-ng` 的即用替代。推荐使用它来代替原生 `x-overlay-ng`，以准备工作并避免平台差异与错误。
 
 在未提供 `container` 时，它会渲染为普通 `view`；当提供 `container` 时，则渲染为 `x-overlay-ng`。建议优先使用 `OverlayView`，而不是直接使用 `x-overlay-ng`。
-
-## 基础用法


### PR DESCRIPTION
Change-Id: I17e92c42c1bb75665bdcbaaf6e76ffc850e476d3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Remove basic usage section from `lynx-ui-overlay` introduction

- Update Introduction.mdx with focused introductory content explaining `OverlayView` as a drop-in replacement for `x-overlay-ng`
- Update Introduction.zh.mdx with the corresponding Chinese translation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->