### PR TITLE
docs: add Autolink native extension guide

### DIFF
--- a/.cspell/dictionary.txt
+++ b/.cspell/dictionary.txt
@@ -4,6 +4,8 @@ analyzability
 androidx
 ARGB
 asan
+Autolink
+autolink
 bindbgerror
 bindbgload
 bindscrolltolower
@@ -15,6 +17,7 @@ catchtap
 Cheatsheet
 clazz
 Cocoapods
+codegen
 componentized
 Componentizing
 disexposure
@@ -50,6 +53,8 @@ Parames
 perfetto
 pixelization
 Podfile
+podspec
+podspecs
 Pranshu
 primjs
 pycache

--- a/docs/en/guide/_meta.json
+++ b/docs/en/guide/_meta.json
@@ -84,6 +84,11 @@
     "collapsed": true
   },
   {
+    "type": "file",
+    "name": "autolink",
+    "label": "guide.custom.native.autolink"
+  },
+  {
     "type": "dir",
     "name": "embed-lynx-to-native",
     "label": "guide.custom.native.embeded",

--- a/docs/en/guide/autolink.mdx
+++ b/docs/en/guide/autolink.mdx
@@ -50,19 +50,31 @@ plugins {
 }
 ```
 
-After Gradle sync, Autolink generates `com.<app>.generated.extensions.ExtensionRegistry`. Call the generated registry when setting up Lynx:
+After Gradle sync, Autolink generates `com.<app>.generated.extensions.ExtensionRegistry`. Choose one setup path based on where the extension should be available.
+
+For app-wide Autolink, call `setupGlobal(Context)` once during application initialization. This registers extension entries globally and initializes services through the global service center:
 
 ```java
-import android.content.Context;
+import android.app.Application;
+import com.example.app.generated.extensions.ExtensionRegistry;
+
+public final class LynxApp extends Application {
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    ExtensionRegistry.setupGlobal(this);
+  }
+}
+```
+
+For view-specific Autolink, call `setup(LynxViewBuilder)` on the builder that should receive the extension registrations:
+
+```java
 import com.example.app.generated.extensions.ExtensionRegistry;
 import com.lynx.tasm.LynxViewBuilder;
 
-public final class LynxSetup {
-  public static void setupGlobal(Context context) {
-    ExtensionRegistry.setupGlobal(context);
-  }
-
-  public static LynxViewBuilder createBuilder() {
+public final class LynxViewFactory {
+  public LynxViewBuilder createBuilder() {
     LynxViewBuilder builder = new LynxViewBuilder();
     ExtensionRegistry.setup(builder);
     return builder;
@@ -70,7 +82,7 @@ public final class LynxSetup {
 }
 ```
 
-`setupGlobal(Context)` registers global entries and services. `setup(LynxViewBuilder)` applies view-level entries such as Elements and Native Modules to the builder.
+Use the global path when an extension should be visible to every Lynx view in the app. Use the builder path when only selected views should receive the extension registrations.
 
 </PlatformTabs.Tab>
 

--- a/docs/en/guide/autolink.mdx
+++ b/docs/en/guide/autolink.mdx
@@ -1,0 +1,462 @@
+import { PlatformTabs } from '@lynx';
+
+# Autolink Native Extensions
+
+Autolink helps a Lynx app discover native extension packages from `node_modules` and register their Android and iOS capabilities automatically. Extension packages declare their native entry points in `lynx.ext.json`; the host app enables the Autolink build integration once, then uses the generated registry instead of manually wiring each Element, Native Module, or Service.
+
+Autolink currently covers native Android and iOS extensions only. It does not generate Web or HarmonyOS integration code.
+
+:::info Prerequisites
+
+✅ Completed [Integrate with Existing Apps](/guide/start/integrate-with-existing-apps)
+
+✅ Familiar with [Native Modules](/guide/use-native-modules) and [Custom Native Element](/guide/custom-native-component)
+
+:::
+
+:::note Tooling Availability
+
+Use Autolink tooling from the same Lynx release channel as your app. The package and plugin names are:
+
+- npm: `create-lynx-extension` and `@lynx-js/autolink-codegen` (`lynx-autolink-codegen` binary)
+- Android: Gradle plugins `org.lynxsdk.extension-settings` and `org.lynxsdk.extension-build`
+- iOS: Ruby gem `cocoapods-lynx-extension`
+
+If one of these packages cannot be resolved from your configured registries, your current Lynx SDK release does not include Native Autolink in that registry yet. Keep using the existing manual native registration flow until the matching release is available.
+
+:::
+
+## Set Up Autolink in an App
+
+Set up Autolink once in the host app. After that, installed extension packages can be discovered from `node_modules` and registered through the generated registry.
+
+<PlatformTabs queryKey="platform">
+<PlatformTabs.Tab platform="android">
+
+Enable the settings plugin in `settings.gradle` so extension Android projects can be discovered from `lynx.ext.json` and included:
+
+```groovy
+plugins {
+  id 'org.lynxsdk.extension-settings'
+}
+```
+
+Enable the build plugin in the Android application project so the generated registry is added to the app and extension projects are wired as dependencies:
+
+```groovy
+plugins {
+  id 'com.android.application'
+  id 'org.lynxsdk.extension-build'
+}
+```
+
+After Gradle sync, Autolink generates `com.<app>.generated.extensions.ExtensionRegistry`. Call the generated registry when setting up Lynx:
+
+```java
+import android.content.Context;
+import com.example.app.generated.extensions.ExtensionRegistry;
+import com.lynx.tasm.LynxViewBuilder;
+
+public final class LynxSetup {
+  public static void setupGlobal(Context context) {
+    ExtensionRegistry.setupGlobal(context);
+  }
+
+  public static LynxViewBuilder createBuilder() {
+    LynxViewBuilder builder = new LynxViewBuilder();
+    ExtensionRegistry.setup(builder);
+    return builder;
+  }
+}
+```
+
+`setupGlobal(Context)` registers global entries and services. `setup(LynxViewBuilder)` applies view-level entries such as Elements and Native Modules to the builder.
+
+</PlatformTabs.Tab>
+
+<PlatformTabs.Tab platform="ios">
+
+Install the `cocoapods-lynx-extension` gem in your iOS build environment. Then add the CocoaPods plugin to the app's Podfile and call `use_lynx_extension!` so installed extension podspecs and the generated registry pod are added during `pod install`:
+
+```ruby
+plugin 'cocoapods-lynx-extension'
+
+target 'LynxApp' do
+  use_lynx_extension!
+end
+```
+
+Autolink generates `generated/lynx-extension/ExtensionRegistry.h` and `ExtensionRegistry.m`. Import the generated registry and apply it to your `LynxConfig`:
+
+```objc
+#import "ExtensionRegistry.h"
+#import <Lynx/LynxConfig.h>
+
+LynxConfig *config = [[LynxConfig alloc] init];
+ExtensionRegistry *registry = [[ExtensionRegistry alloc] init];
+[registry setup:config];
+```
+
+</PlatformTabs.Tab>
+</PlatformTabs>
+
+## Use an Extension
+
+After the app has set up Autolink, install the extension package in your Lynx app:
+
+```bash
+npm install @example/lynx-button
+```
+
+Each extension package exposes a `lynx.ext.json` manifest at the package root. Autolink scans installed npm packages for this file.
+
+```json
+{
+  "platforms": {
+    "android": {
+      "packageName": "com.example.button",
+      "sourceDir": "android"
+    },
+    "ios": {
+      "sourceDir": "ios",
+      "podspecPath": "ios/build.podspec"
+    }
+  }
+}
+```
+
+For Android, `platforms.android.packageName` is required, and `sourceDir` defaults to `android`. For iOS, `sourceDir` defaults to `ios`, and `podspecPath` defaults to the first `.podspec` found under the iOS source directory.
+
+After installing or updating an extension package, sync/build the Android app and run `pod install` for iOS so the generated registry and native dependencies are refreshed. You do not need to add per-extension manual registration code in the app.
+
+## Extension Package Role and Structure
+
+An Autolink extension package is an npm package that bundles the JavaScript facade, type declarations, native implementation, and Autolink manifest for one reusable capability. App teams install the package as a normal dependency; the Android Gradle plugins and iOS CocoaPods plugin read `lynx.ext.json` and link the native code into the host app.
+
+A typical extension package looks like this:
+
+```text
+lynx-button/
+├── package.json
+├── lynx.ext.json
+├── types/
+│   └── index.d.ts
+├── src/
+│   └── index.ts
+├── generated/
+│   └── ButtonModule.ts
+├── android/
+│   └── src/main/java/com/example/button/
+│       ├── ButtonElement.java
+│       ├── ButtonModule.java
+│       ├── ButtonService.java
+│       └── generated/ButtonModuleSpec.java
+├── ios/
+│   ├── build.podspec
+│   └── src/
+│       ├── ButtonElement.m
+│       ├── ButtonModule.m
+│       ├── ButtonService.m
+│       └── generated/
+│           ├── ButtonModuleSpec.h
+│           └── ButtonModuleSpec.m
+└── example/
+```
+
+- `package.json` makes the package installable from npm and usually provides the `codegen` script.
+- `lynx.ext.json` is the Autolink contract. It tells the host app where Android and iOS source code lives.
+- `types/index.d.ts` describes the Native Module API that codegen uses to create platform specs and the JavaScript facade.
+- `src/index.ts` exports the JavaScript API that app code imports.
+- `android/` and `ios/` contain native implementations and generated native specs.
+- `example/` is a local app used by the extension author to verify the package.
+
+## Create an Extension
+
+Create a new extension package interactively:
+
+```bash
+npm create lynx-extension
+```
+
+For scripts and tests, the same scaffold can run without prompts:
+
+```bash
+npm create lynx-extension -- \
+  --dir ./lynx-button \
+  --types native-module,element,service \
+  --package-name @example/lynx-button \
+  --android-package com.example.button \
+  --module-name ButtonModule \
+  --element-name x-button \
+  --service-name ButtonService
+```
+
+The generated package includes:
+
+- `package.json` with `"codegen": "lynx-autolink-codegen"`
+- `lynx.ext.json` for Android and iOS Autolink discovery
+- `types/index.d.ts` for Native Module type declarations
+- `src/index.ts` for the JavaScript facade
+- `android/` and `ios/` native source folders
+- `example/`, `tsconfig.json`, and `README.md`
+
+Run codegen from the extension root:
+
+```bash
+npm run codegen
+```
+
+`lynx-autolink-codegen` reads `lynx.ext.json` and scans `types/**/*.d.ts` for `@lynxmodule` declarations:
+
+```ts
+/** @lynxmodule */
+export declare class ButtonModule {
+  getLabel(id: string): string;
+  setEnabled(id: string, enabled: boolean): void;
+}
+```
+
+It generates:
+
+- `generated/<ModuleName>.ts` for the JavaScript facade
+- Android `<ModuleName>Spec.java`
+- iOS `<ModuleName>Spec.h` and `<ModuleName>Spec.m`
+
+The first version supports `void`, `string`, `number`, `boolean`, and nullable unions with `null`.
+
+## Write Native APIs
+
+Use the Autolink annotations and markers in extension packages. Native Modules usually extend the spec generated by `lynx-autolink-codegen`; Elements and Services are discovered from their native markers.
+
+<PlatformTabs queryKey="platform">
+<PlatformTabs.Tab platform="android">
+
+Native Module example:
+
+```java
+package com.example.button;
+
+import com.example.button.generated.ButtonModuleSpec;
+import com.lynx.jsbridge.LynxAutolinkNativeModule;
+import com.lynx.jsbridge.LynxMethod;
+import com.lynx.tasm.behavior.LynxContext;
+import java.util.HashMap;
+import java.util.Map;
+
+@LynxAutolinkNativeModule(name = "ButtonModule")
+public final class ButtonModule extends ButtonModuleSpec {
+  private final Map<String, Boolean> enabledState = new HashMap<>();
+
+  public ButtonModule(LynxContext context) {
+    super(context);
+  }
+
+  @Override
+  @LynxMethod
+  public String getLabel(String id) {
+    return "Button " + id;
+  }
+
+  @Override
+  @LynxMethod
+  public void setEnabled(String id, boolean enabled) {
+    enabledState.put(id, enabled);
+  }
+}
+```
+
+Element example:
+
+```java
+package com.example.button;
+
+import android.content.Context;
+import android.view.Gravity;
+import android.widget.TextView;
+import com.lynx.tasm.behavior.LynxAutolinkElement;
+import com.lynx.tasm.behavior.LynxContext;
+import com.lynx.tasm.behavior.LynxProp;
+import com.lynx.tasm.behavior.ui.LynxUI;
+
+@LynxAutolinkElement(name = "x-button")
+public final class ButtonElement extends LynxUI<TextView> {
+  public ButtonElement(LynxContext context) {
+    super(context);
+  }
+
+  @Override
+  protected TextView createView(Context context) {
+    TextView view = new TextView(context);
+    view.setGravity(Gravity.CENTER);
+    view.setText("x-button");
+    return view;
+  }
+
+  @LynxProp(name = "text")
+  public void setText(String text) {
+    mView.setText(text == null ? "" : text);
+  }
+}
+```
+
+Service example:
+
+```java
+package com.example.button;
+
+import android.content.Context;
+import com.lynx.tasm.service.IServiceProvider;
+import com.lynx.tasm.service.LynxAutolinkService;
+
+@LynxAutolinkService
+public final class ButtonService implements IServiceProvider {
+  private Context appContext;
+
+  @Override
+  public Class<? extends IServiceProvider> getServiceClass() {
+    return ButtonService.class;
+  }
+
+  @Override
+  public void onInitialize(Context context) {
+    appContext = context.getApplicationContext();
+  }
+
+  public void recordClick(String id) {
+    // Send analytics or call platform capabilities here.
+  }
+}
+```
+
+</PlatformTabs.Tab>
+
+<PlatformTabs.Tab platform="ios">
+
+Native Module example:
+
+```objc
+// ButtonModule.h
+#import <Foundation/Foundation.h>
+#import <Lynx/LynxModule.h>
+#import "generated/ButtonModuleSpec.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@LynxAutolinkNativeModule("ButtonModule")
+@interface ButtonModule : NSObject <ButtonModuleSpec>
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+// ButtonModule.m
+#import "ButtonModule.h"
+
+@implementation ButtonModule {
+  NSMutableDictionary<NSString *, NSNumber *> *_enabledState;
+}
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _enabledState = [NSMutableDictionary dictionary];
+  }
+  return self;
+}
+
+- (NSString *)getLabel:(NSString *)buttonId {
+  return [NSString stringWithFormat:@"Button %@", buttonId];
+}
+
+- (void)setEnabled:(NSString *)buttonId enabled:(BOOL)enabled {
+  _enabledState[buttonId] = @(enabled);
+}
+
+@end
+```
+
+Element example:
+
+```objc
+// ButtonElement.h
+#import <UIKit/UIKit.h>
+#import <Lynx/LynxUI.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ButtonElement : LynxUI<UILabel *>
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+// ButtonElement.m
+#import "ButtonElement.h"
+#import <Lynx/LynxPropsProcessor.h>
+
+@LynxAutolinkUI("x-button")
+@implementation ButtonElement
+
+LYNX_PROP_SETTER("text", setText, NSString *) {
+  self.view.text = value ?: @"";
+}
+
+- (UILabel *)createView {
+  UILabel *label = [[UILabel alloc] init];
+  label.textAlignment = NSTextAlignmentCenter;
+  label.text = @"x-button";
+  return label;
+}
+
+@end
+```
+
+Service example:
+
+```objc
+// ButtonService.h
+#import <Foundation/Foundation.h>
+#import <LynxServiceAPI/ServiceAPI.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol ButtonServiceProtocol <LynxServiceProtocol>
+
+- (void)recordClick:(NSString *)buttonId;
+
+@end
+
+@interface ButtonService : NSObject <ButtonServiceProtocol>
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+// ButtonService.m
+#import "ButtonService.h"
+
+@LynxAutolinkService(ButtonService, ButtonServiceProtocol)
+@implementation ButtonService
+
++ (instancetype)sharedInstance {
+  static ButtonService *service;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    service = [[ButtonService alloc] init];
+  });
+  return service;
+}
+
+- (void)recordClick:(NSString *)buttonId {
+  // Send analytics or call platform capabilities here.
+}
+
+@end
+```
+
+</PlatformTabs.Tab>
+</PlatformTabs>
+
+Autolink uses the `LynxAutolink` names as its public extension authoring API.
+
+For iOS packages that already use Lynx native registration macros, Autolink also scans existing `LYNX_LAZY_REGISTER_UI`, `LYNX_LAZY_REGISTER_SHADOW_NODE`, and `@LynxServiceRegister(...)` declarations so those packages can be linked without rewriting their native code.

--- a/docs/zh/guide/_meta.json
+++ b/docs/zh/guide/_meta.json
@@ -84,6 +84,11 @@
     "collapsed": true
   },
   {
+    "type": "file",
+    "name": "autolink",
+    "label": "guide.custom.native.autolink"
+  },
+  {
     "type": "dir",
     "name": "embed-lynx-to-native",
     "label": "guide.custom.native.embeded",

--- a/docs/zh/guide/autolink.mdx
+++ b/docs/zh/guide/autolink.mdx
@@ -2,7 +2,7 @@ import { PlatformTabs } from '@lynx';
 
 # Autolink 原生扩展
 
-Autolink 会让 Lynx 应用从 `node_modules` 中发现原生 extension package，并自动注册它们在 Android 和 iOS 上提供的能力。extension package 在包根目录声明 `lynx.ext.json`；宿主应用只需要接入一次 Autolink 构建集成，就可以使用生成的 registry，避免为每个 Element、Native Module 或 Service 手动写注册代码。
+Autolink 会让 Lynx 应用从 `node_modules` 中发现原生扩展包，并自动注册它们在 Android 和 iOS 上提供的能力。扩展包在包根目录声明 `lynx.ext.json`；宿主应用只需要接入一次 Autolink 构建集成，就可以使用生成的 registry，避免为每个元件、原生模块或 Service 手动写注册代码。
 
 Autolink 当前只覆盖 Android 和 iOS 原生扩展，不生成 Web 或 HarmonyOS 的接入代码。
 
@@ -28,12 +28,12 @@ Autolink 当前只覆盖 Android 和 iOS 原生扩展，不生成 Web 或 Harmon
 
 ## 在应用中接入 Autolink
 
-宿主应用只需要接入一次 Autolink。接入完成后，已安装的 extension package 会从 `node_modules` 中被发现，并通过生成的 registry 自动注册。
+宿主应用只需要接入一次 Autolink。接入完成后，已安装的扩展包会从 `node_modules` 中被发现，并通过生成的 registry 自动注册。
 
 <PlatformTabs queryKey="platform">
 <PlatformTabs.Tab platform="android">
 
-在 `settings.gradle` 中启用 settings plugin，让 extension 的 Android 工程可以通过 `lynx.ext.json` 被发现并 include 进来：
+在 `settings.gradle` 中启用 settings plugin，让扩展的 Android 工程可以通过 `lynx.ext.json` 被发现并 include 进来：
 
 ```groovy
 plugins {
@@ -41,7 +41,7 @@ plugins {
 }
 ```
 
-在 Android application 工程中启用 build plugin，让生成的 registry 加入应用源码，并自动把 extension 工程接入为依赖：
+在 Android application 工程中启用 build plugin，让生成的 registry 加入应用源码，并自动把扩展工程接入为依赖：
 
 ```groovy
 plugins {
@@ -70,13 +70,13 @@ public final class LynxSetup {
 }
 ```
 
-`setupGlobal(Context)` 用于注册全局 entries 和 Service。`setup(LynxViewBuilder)` 用于把 Element、Native Module 等视图级能力应用到 builder。
+`setupGlobal(Context)` 用于注册 Service 等全局能力。`setup(LynxViewBuilder)` 用于把元件、原生模块等视图级能力应用到 builder。
 
 </PlatformTabs.Tab>
 
 <PlatformTabs.Tab platform="ios">
 
-在 iOS 构建环境中安装 `cocoapods-lynx-extension` gem。然后在应用的 Podfile 中加入 CocoaPods plugin，并调用 `use_lynx_extension!`。执行 `pod install` 时，插件会加入 extension podspec 和生成的 registry pod：
+在 iOS 构建环境中安装 `cocoapods-lynx-extension` gem。然后在应用的 Podfile 中加入 CocoaPods plugin，并调用 `use_lynx_extension!`。执行 `pod install` 时，插件会加入扩展 podspec 和生成的 registry pod：
 
 ```ruby
 plugin 'cocoapods-lynx-extension'
@@ -100,15 +100,15 @@ ExtensionRegistry *registry = [[ExtensionRegistry alloc] init];
 </PlatformTabs.Tab>
 </PlatformTabs>
 
-## 使用 extension
+## 使用扩展包
 
-应用接入 Autolink 后，在 Lynx 应用中安装 extension package：
+应用接入 Autolink 后，在 Lynx 应用中安装扩展包：
 
 ```bash
 npm install @example/lynx-button
 ```
 
-每个 extension package 都会在包根目录暴露 `lynx.ext.json` manifest。Autolink 会扫描已安装 npm package 中的这个文件。
+每个扩展包都会在包根目录暴露 `lynx.ext.json` manifest。Autolink 会扫描已安装 npm 包中的这个文件。
 
 ```json
 {
@@ -127,13 +127,13 @@ npm install @example/lynx-button
 
 Android 侧必须声明 `platforms.android.packageName`，`sourceDir` 默认是 `android`。iOS 侧 `sourceDir` 默认是 `ios`，`podspecPath` 默认使用 iOS 源码目录下找到的第一个 `.podspec` 文件。
 
-安装或更新 extension package 后，Android 侧重新 sync/build 应用，iOS 侧重新执行 `pod install`，让生成的 registry 和原生依赖刷新。应用中不需要为每个 extension 再写手动注册代码。
+安装或更新扩展包后，Android 侧重新 sync/build 应用，iOS 侧重新执行 `pod install`，让生成的 registry 和原生依赖刷新。应用中不需要为每个扩展再写手动注册代码。
 
-## extension package 的作用和结构
+## 扩展包的作用和结构
 
-Autolink extension package 是一个 npm package，用来把 JavaScript facade、类型声明、原生实现和 Autolink manifest 封装成一个可复用能力。应用侧像安装普通依赖一样安装它；Android Gradle plugin 和 iOS CocoaPods plugin 会读取 `lynx.ext.json`，把原生代码链接进宿主应用。
+Autolink 扩展包是一个 npm 包，用来把 JavaScript facade、类型声明、原生实现和 Autolink 清单封装成一个可复用能力。应用侧像安装普通依赖一样安装它；Android Gradle plugin 和 iOS CocoaPods plugin 会读取 `lynx.ext.json`，把原生代码链接进宿主应用。
 
-一个典型的 extension package 结构如下：
+一个典型的扩展包结构如下：
 
 ```text
 lynx-button/
@@ -163,16 +163,16 @@ lynx-button/
 └── example/
 ```
 
-- `package.json` 让 extension 可以作为 npm package 安装，并通常提供 `codegen` 脚本。
-- `lynx.ext.json` 是 Autolink contract，用来告诉宿主应用 Android 和 iOS 源码在哪里。
-- `types/index.d.ts` 描述 Native Module API，codegen 会基于它生成平台 spec 和 JavaScript facade。
+- `package.json` 让扩展可以通过 npm 安装，并通常提供 `codegen` 脚本。
+- `lynx.ext.json` 是 Autolink 清单文件，用来告诉宿主应用 Android 和 iOS 源码在哪里。
+- `types/index.d.ts` 描述原生模块 API，codegen 会基于它生成平台 spec 和 JavaScript facade。
 - `src/index.ts` 导出应用代码需要 import 的 JavaScript API。
 - `android/` 和 `ios/` 放置原生实现以及生成的原生 spec。
-- `example/` 是 extension 作者用于本地验证 package 的示例应用。
+- `example/` 是扩展作者用于本地验证的示例应用。
 
-## 创建 extension
+## 创建扩展包
 
-使用交互式命令创建 extension package：
+使用交互式命令创建扩展包：
 
 ```bash
 npm create lynx-extension
@@ -191,16 +191,16 @@ npm create lynx-extension -- \
   --service-name ButtonService
 ```
 
-生成的 package 会包含：
+生成的扩展包会包含：
 
 - 带有 `"codegen": "lynx-autolink-codegen"` 的 `package.json`
 - 用于 Android 和 iOS Autolink 发现的 `lynx.ext.json`
-- 用于声明 Native Module 类型的 `types/index.d.ts`
+- 用于原生模块类型声明的 `types/index.d.ts`
 - JavaScript facade 入口 `src/index.ts`
 - 原生源码目录 `android/` 和 `ios/`
 - `example/`、`tsconfig.json` 和 `README.md`
 
-在 extension 根目录运行 codegen：
+在扩展根目录运行 codegen：
 
 ```bash
 npm run codegen
@@ -226,12 +226,12 @@ export declare class ButtonModule {
 
 ## 编写 Native API
 
-extension package 应使用 Autolink 注解和 marker。Native Module 通常继承 `lynx-autolink-codegen` 生成的 spec；Element 和 Service 会通过原生 marker 被发现。
+扩展包应使用 Autolink 注解和标记。原生模块通常继承 `lynx-autolink-codegen` 生成的 spec；元件和 Service 会通过原生标记被发现。
 
 <PlatformTabs queryKey="platform">
 <PlatformTabs.Tab platform="android">
 
-Native Module 示例：
+原生模块示例：
 
 ```java
 package com.example.button;
@@ -265,7 +265,7 @@ public final class ButtonModule extends ButtonModuleSpec {
 }
 ```
 
-Element 示例：
+元件示例：
 
 ```java
 package com.example.button;
@@ -332,7 +332,7 @@ public final class ButtonService implements IServiceProvider {
 
 <PlatformTabs.Tab platform="ios">
 
-Native Module 示例：
+原生模块示例：
 
 ```objc
 // ButtonModule.h
@@ -375,7 +375,7 @@ NS_ASSUME_NONNULL_END
 @end
 ```
 
-Element 示例：
+元件示例：
 
 ```objc
 // ButtonElement.h
@@ -457,6 +457,6 @@ NS_ASSUME_NONNULL_END
 </PlatformTabs.Tab>
 </PlatformTabs>
 
-Autolink 对外使用 `LynxAutolink` 命名作为 extension 作者 API。
+Autolink 对外使用 `LynxAutolink` 命名作为扩展作者 API。
 
-对于已经使用 Lynx 既有原生注册宏的 iOS package，Autolink 也会继续扫描 `LYNX_LAZY_REGISTER_UI`、`LYNX_LAZY_REGISTER_SHADOW_NODE` 和 `@LynxServiceRegister(...)`，让这些 package 无需改写原生代码即可被链接进来。
+对于已经使用 Lynx 既有原生注册宏的 iOS 包，Autolink 也会继续扫描 `LYNX_LAZY_REGISTER_UI`、`LYNX_LAZY_REGISTER_SHADOW_NODE` 和 `@LynxServiceRegister(...)`，让这些包无需改写原生代码即可被链接进来。

--- a/docs/zh/guide/autolink.mdx
+++ b/docs/zh/guide/autolink.mdx
@@ -50,19 +50,31 @@ plugins {
 }
 ```
 
-Gradle sync 后，Autolink 会生成 `com.<app>.generated.extensions.ExtensionRegistry`。初始化 Lynx 时调用生成的 registry：
+Gradle sync 后，Autolink 会生成 `com.<app>.generated.extensions.ExtensionRegistry`。根据扩展生效范围选择一种接入方式。
+
+如果需要应用级全局接入，在应用初始化阶段调用一次 `setupGlobal(Context)`。它会把扩展注册到全局路径，并通过全局 service center 初始化 Service：
 
 ```java
-import android.content.Context;
+import android.app.Application;
+import com.example.app.generated.extensions.ExtensionRegistry;
+
+public final class LynxApp extends Application {
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    ExtensionRegistry.setupGlobal(this);
+  }
+}
+```
+
+如果只希望某个 `LynxViewBuilder` 使用 Autolink 扩展，在创建该 builder 时调用 `setup(LynxViewBuilder)`：
+
+```java
 import com.example.app.generated.extensions.ExtensionRegistry;
 import com.lynx.tasm.LynxViewBuilder;
 
-public final class LynxSetup {
-  public static void setupGlobal(Context context) {
-    ExtensionRegistry.setupGlobal(context);
-  }
-
-  public static LynxViewBuilder createBuilder() {
+public final class LynxViewFactory {
+  public LynxViewBuilder createBuilder() {
     LynxViewBuilder builder = new LynxViewBuilder();
     ExtensionRegistry.setup(builder);
     return builder;
@@ -70,7 +82,7 @@ public final class LynxSetup {
 }
 ```
 
-`setupGlobal(Context)` 用于注册 Service 等全局能力。`setup(LynxViewBuilder)` 用于把元件、原生模块等视图级能力应用到 builder。
+当扩展需要对应用内所有 Lynx view 可见时，使用全局接入；当只想让部分 view 使用这些扩展注册时，使用 builder 接入。
 
 </PlatformTabs.Tab>
 

--- a/docs/zh/guide/autolink.mdx
+++ b/docs/zh/guide/autolink.mdx
@@ -1,0 +1,462 @@
+import { PlatformTabs } from '@lynx';
+
+# Autolink 原生扩展
+
+Autolink 会让 Lynx 应用从 `node_modules` 中发现原生 extension package，并自动注册它们在 Android 和 iOS 上提供的能力。extension package 在包根目录声明 `lynx.ext.json`；宿主应用只需要接入一次 Autolink 构建集成，就可以使用生成的 registry，避免为每个 Element、Native Module 或 Service 手动写注册代码。
+
+Autolink 当前只覆盖 Android 和 iOS 原生扩展，不生成 Web 或 HarmonyOS 的接入代码。
+
+:::info 开始前的准备
+
+✅ 已完成[接入现有应用](/guide/start/integrate-with-existing-apps)
+
+✅ 了解[原生模块](/guide/use-native-modules)和[自定义元件](/guide/custom-native-component)
+
+:::
+
+:::note 工具可用性
+
+请使用与应用 Lynx SDK 同一发布渠道的 Autolink 工具。相关 package 和 plugin 名称如下：
+
+- npm：`create-lynx-extension` 和 `@lynx-js/autolink-codegen`（`lynx-autolink-codegen` binary）
+- Android：Gradle plugin `org.lynxsdk.extension-settings` 和 `org.lynxsdk.extension-build`
+- iOS：Ruby gem `cocoapods-lynx-extension`
+
+如果当前配置的 registry 还无法解析其中某个包，说明你使用的 Lynx SDK 发布版本尚未在该 registry 中包含 Native Autolink。此时请继续使用既有手动原生注册方式，等待匹配版本发布后再接入。
+
+:::
+
+## 在应用中接入 Autolink
+
+宿主应用只需要接入一次 Autolink。接入完成后，已安装的 extension package 会从 `node_modules` 中被发现，并通过生成的 registry 自动注册。
+
+<PlatformTabs queryKey="platform">
+<PlatformTabs.Tab platform="android">
+
+在 `settings.gradle` 中启用 settings plugin，让 extension 的 Android 工程可以通过 `lynx.ext.json` 被发现并 include 进来：
+
+```groovy
+plugins {
+  id 'org.lynxsdk.extension-settings'
+}
+```
+
+在 Android application 工程中启用 build plugin，让生成的 registry 加入应用源码，并自动把 extension 工程接入为依赖：
+
+```groovy
+plugins {
+  id 'com.android.application'
+  id 'org.lynxsdk.extension-build'
+}
+```
+
+Gradle sync 后，Autolink 会生成 `com.<app>.generated.extensions.ExtensionRegistry`。初始化 Lynx 时调用生成的 registry：
+
+```java
+import android.content.Context;
+import com.example.app.generated.extensions.ExtensionRegistry;
+import com.lynx.tasm.LynxViewBuilder;
+
+public final class LynxSetup {
+  public static void setupGlobal(Context context) {
+    ExtensionRegistry.setupGlobal(context);
+  }
+
+  public static LynxViewBuilder createBuilder() {
+    LynxViewBuilder builder = new LynxViewBuilder();
+    ExtensionRegistry.setup(builder);
+    return builder;
+  }
+}
+```
+
+`setupGlobal(Context)` 用于注册全局 entries 和 Service。`setup(LynxViewBuilder)` 用于把 Element、Native Module 等视图级能力应用到 builder。
+
+</PlatformTabs.Tab>
+
+<PlatformTabs.Tab platform="ios">
+
+在 iOS 构建环境中安装 `cocoapods-lynx-extension` gem。然后在应用的 Podfile 中加入 CocoaPods plugin，并调用 `use_lynx_extension!`。执行 `pod install` 时，插件会加入 extension podspec 和生成的 registry pod：
+
+```ruby
+plugin 'cocoapods-lynx-extension'
+
+target 'LynxApp' do
+  use_lynx_extension!
+end
+```
+
+Autolink 会生成 `generated/lynx-extension/ExtensionRegistry.h` 和 `ExtensionRegistry.m`。导入生成的 registry，并把它应用到 `LynxConfig`：
+
+```objc
+#import "ExtensionRegistry.h"
+#import <Lynx/LynxConfig.h>
+
+LynxConfig *config = [[LynxConfig alloc] init];
+ExtensionRegistry *registry = [[ExtensionRegistry alloc] init];
+[registry setup:config];
+```
+
+</PlatformTabs.Tab>
+</PlatformTabs>
+
+## 使用 extension
+
+应用接入 Autolink 后，在 Lynx 应用中安装 extension package：
+
+```bash
+npm install @example/lynx-button
+```
+
+每个 extension package 都会在包根目录暴露 `lynx.ext.json` manifest。Autolink 会扫描已安装 npm package 中的这个文件。
+
+```json
+{
+  "platforms": {
+    "android": {
+      "packageName": "com.example.button",
+      "sourceDir": "android"
+    },
+    "ios": {
+      "sourceDir": "ios",
+      "podspecPath": "ios/build.podspec"
+    }
+  }
+}
+```
+
+Android 侧必须声明 `platforms.android.packageName`，`sourceDir` 默认是 `android`。iOS 侧 `sourceDir` 默认是 `ios`，`podspecPath` 默认使用 iOS 源码目录下找到的第一个 `.podspec` 文件。
+
+安装或更新 extension package 后，Android 侧重新 sync/build 应用，iOS 侧重新执行 `pod install`，让生成的 registry 和原生依赖刷新。应用中不需要为每个 extension 再写手动注册代码。
+
+## extension package 的作用和结构
+
+Autolink extension package 是一个 npm package，用来把 JavaScript facade、类型声明、原生实现和 Autolink manifest 封装成一个可复用能力。应用侧像安装普通依赖一样安装它；Android Gradle plugin 和 iOS CocoaPods plugin 会读取 `lynx.ext.json`，把原生代码链接进宿主应用。
+
+一个典型的 extension package 结构如下：
+
+```text
+lynx-button/
+├── package.json
+├── lynx.ext.json
+├── types/
+│   └── index.d.ts
+├── src/
+│   └── index.ts
+├── generated/
+│   └── ButtonModule.ts
+├── android/
+│   └── src/main/java/com/example/button/
+│       ├── ButtonElement.java
+│       ├── ButtonModule.java
+│       ├── ButtonService.java
+│       └── generated/ButtonModuleSpec.java
+├── ios/
+│   ├── build.podspec
+│   └── src/
+│       ├── ButtonElement.m
+│       ├── ButtonModule.m
+│       ├── ButtonService.m
+│       └── generated/
+│           ├── ButtonModuleSpec.h
+│           └── ButtonModuleSpec.m
+└── example/
+```
+
+- `package.json` 让 extension 可以作为 npm package 安装，并通常提供 `codegen` 脚本。
+- `lynx.ext.json` 是 Autolink contract，用来告诉宿主应用 Android 和 iOS 源码在哪里。
+- `types/index.d.ts` 描述 Native Module API，codegen 会基于它生成平台 spec 和 JavaScript facade。
+- `src/index.ts` 导出应用代码需要 import 的 JavaScript API。
+- `android/` 和 `ios/` 放置原生实现以及生成的原生 spec。
+- `example/` 是 extension 作者用于本地验证 package 的示例应用。
+
+## 创建 extension
+
+使用交互式命令创建 extension package：
+
+```bash
+npm create lynx-extension
+```
+
+在脚本或测试中，也可以用 flags 直接生成：
+
+```bash
+npm create lynx-extension -- \
+  --dir ./lynx-button \
+  --types native-module,element,service \
+  --package-name @example/lynx-button \
+  --android-package com.example.button \
+  --module-name ButtonModule \
+  --element-name x-button \
+  --service-name ButtonService
+```
+
+生成的 package 会包含：
+
+- 带有 `"codegen": "lynx-autolink-codegen"` 的 `package.json`
+- 用于 Android 和 iOS Autolink 发现的 `lynx.ext.json`
+- 用于声明 Native Module 类型的 `types/index.d.ts`
+- JavaScript facade 入口 `src/index.ts`
+- 原生源码目录 `android/` 和 `ios/`
+- `example/`、`tsconfig.json` 和 `README.md`
+
+在 extension 根目录运行 codegen：
+
+```bash
+npm run codegen
+```
+
+`lynx-autolink-codegen` 会读取 `lynx.ext.json`，并扫描 `types/**/*.d.ts` 中带有 `@lynxmodule` 的声明：
+
+```ts
+/** @lynxmodule */
+export declare class ButtonModule {
+  getLabel(id: string): string;
+  setEnabled(id: string, enabled: boolean): void;
+}
+```
+
+它会生成：
+
+- JavaScript facade：`generated/<ModuleName>.ts`
+- Android：`<ModuleName>Spec.java`
+- iOS：`<ModuleName>Spec.h` 和 `<ModuleName>Spec.m`
+
+第一版支持 `void`、`string`、`number`、`boolean`，以及带 `null` 的 nullable union。
+
+## 编写 Native API
+
+extension package 应使用 Autolink 注解和 marker。Native Module 通常继承 `lynx-autolink-codegen` 生成的 spec；Element 和 Service 会通过原生 marker 被发现。
+
+<PlatformTabs queryKey="platform">
+<PlatformTabs.Tab platform="android">
+
+Native Module 示例：
+
+```java
+package com.example.button;
+
+import com.example.button.generated.ButtonModuleSpec;
+import com.lynx.jsbridge.LynxAutolinkNativeModule;
+import com.lynx.jsbridge.LynxMethod;
+import com.lynx.tasm.behavior.LynxContext;
+import java.util.HashMap;
+import java.util.Map;
+
+@LynxAutolinkNativeModule(name = "ButtonModule")
+public final class ButtonModule extends ButtonModuleSpec {
+  private final Map<String, Boolean> enabledState = new HashMap<>();
+
+  public ButtonModule(LynxContext context) {
+    super(context);
+  }
+
+  @Override
+  @LynxMethod
+  public String getLabel(String id) {
+    return "Button " + id;
+  }
+
+  @Override
+  @LynxMethod
+  public void setEnabled(String id, boolean enabled) {
+    enabledState.put(id, enabled);
+  }
+}
+```
+
+Element 示例：
+
+```java
+package com.example.button;
+
+import android.content.Context;
+import android.view.Gravity;
+import android.widget.TextView;
+import com.lynx.tasm.behavior.LynxAutolinkElement;
+import com.lynx.tasm.behavior.LynxContext;
+import com.lynx.tasm.behavior.LynxProp;
+import com.lynx.tasm.behavior.ui.LynxUI;
+
+@LynxAutolinkElement(name = "x-button")
+public final class ButtonElement extends LynxUI<TextView> {
+  public ButtonElement(LynxContext context) {
+    super(context);
+  }
+
+  @Override
+  protected TextView createView(Context context) {
+    TextView view = new TextView(context);
+    view.setGravity(Gravity.CENTER);
+    view.setText("x-button");
+    return view;
+  }
+
+  @LynxProp(name = "text")
+  public void setText(String text) {
+    mView.setText(text == null ? "" : text);
+  }
+}
+```
+
+Service 示例：
+
+```java
+package com.example.button;
+
+import android.content.Context;
+import com.lynx.tasm.service.IServiceProvider;
+import com.lynx.tasm.service.LynxAutolinkService;
+
+@LynxAutolinkService
+public final class ButtonService implements IServiceProvider {
+  private Context appContext;
+
+  @Override
+  public Class<? extends IServiceProvider> getServiceClass() {
+    return ButtonService.class;
+  }
+
+  @Override
+  public void onInitialize(Context context) {
+    appContext = context.getApplicationContext();
+  }
+
+  public void recordClick(String id) {
+    // Send analytics or call platform capabilities here.
+  }
+}
+```
+
+</PlatformTabs.Tab>
+
+<PlatformTabs.Tab platform="ios">
+
+Native Module 示例：
+
+```objc
+// ButtonModule.h
+#import <Foundation/Foundation.h>
+#import <Lynx/LynxModule.h>
+#import "generated/ButtonModuleSpec.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@LynxAutolinkNativeModule("ButtonModule")
+@interface ButtonModule : NSObject <ButtonModuleSpec>
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+// ButtonModule.m
+#import "ButtonModule.h"
+
+@implementation ButtonModule {
+  NSMutableDictionary<NSString *, NSNumber *> *_enabledState;
+}
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _enabledState = [NSMutableDictionary dictionary];
+  }
+  return self;
+}
+
+- (NSString *)getLabel:(NSString *)buttonId {
+  return [NSString stringWithFormat:@"Button %@", buttonId];
+}
+
+- (void)setEnabled:(NSString *)buttonId enabled:(BOOL)enabled {
+  _enabledState[buttonId] = @(enabled);
+}
+
+@end
+```
+
+Element 示例：
+
+```objc
+// ButtonElement.h
+#import <UIKit/UIKit.h>
+#import <Lynx/LynxUI.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ButtonElement : LynxUI<UILabel *>
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+// ButtonElement.m
+#import "ButtonElement.h"
+#import <Lynx/LynxPropsProcessor.h>
+
+@LynxAutolinkUI("x-button")
+@implementation ButtonElement
+
+LYNX_PROP_SETTER("text", setText, NSString *) {
+  self.view.text = value ?: @"";
+}
+
+- (UILabel *)createView {
+  UILabel *label = [[UILabel alloc] init];
+  label.textAlignment = NSTextAlignmentCenter;
+  label.text = @"x-button";
+  return label;
+}
+
+@end
+```
+
+Service 示例：
+
+```objc
+// ButtonService.h
+#import <Foundation/Foundation.h>
+#import <LynxServiceAPI/ServiceAPI.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol ButtonServiceProtocol <LynxServiceProtocol>
+
+- (void)recordClick:(NSString *)buttonId;
+
+@end
+
+@interface ButtonService : NSObject <ButtonServiceProtocol>
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+// ButtonService.m
+#import "ButtonService.h"
+
+@LynxAutolinkService(ButtonService, ButtonServiceProtocol)
+@implementation ButtonService
+
++ (instancetype)sharedInstance {
+  static ButtonService *service;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    service = [[ButtonService alloc] init];
+  });
+  return service;
+}
+
+- (void)recordClick:(NSString *)buttonId {
+  // Send analytics or call platform capabilities here.
+}
+
+@end
+```
+
+</PlatformTabs.Tab>
+</PlatformTabs>
+
+Autolink 对外使用 `LynxAutolink` 命名作为 extension 作者 API。
+
+对于已经使用 Lynx 既有原生注册宏的 iOS package，Autolink 也会继续扫描 `LYNX_LAZY_REGISTER_UI`、`LYNX_LAZY_REGISTER_SHADOW_NODE` 和 `@LynxServiceRegister(...)`，让这些 package 无需改写原生代码即可被链接进来。

--- a/i18n.json
+++ b/i18n.json
@@ -363,6 +363,10 @@
     "en": "Native Modules",
     "zh": "原生模块"
   },
+  "guide.custom.native.autolink": {
+    "en": "Autolink Native Extensions",
+    "zh": "Autolink 原生扩展"
+  },
   "guide.custom.native.component": {
     "en": "Custom Native Element",
     "zh": "自定义元件"


### PR DESCRIPTION
## Summary
- Add English and Chinese guide pages for Autolink native extensions under Native Development.
- Document app-side Autolink setup for Android and iOS, extension package usage/structure, extension creation with `npm create lynx-extension`, and `lynx-autolink-codegen` usage.
- Add the new sidebar/i18n entries and spelling dictionary terms for Autolink docs.

## Impact
- Gives Lynx users a single website entry point for adopting Native-only Autolink extensions.
- Clarifies that the current scope is Android and iOS only, and that extension author APIs use the `LynxAutolink*` names.

## Validation
- `git diff --check`
- `pnpm exec prettier --check docs/en/guide/autolink.mdx docs/zh/guide/autolink.mdx`
- `pnpm exec cspell lint -c cspell.json docs/en/guide/autolink.mdx docs/zh/guide/autolink.mdx`
- `pnpm exec zhlint docs/zh/guide/autolink.mdx`
- `pnpm build`

Note: full `pnpm zhlint` still reports existing issues in unrelated Chinese docs; the new Chinese Autolink page passes zhlint directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Document Autolink native extensions guide

- Add English and Chinese Autolink guide pages under Native Development documenting Android and iOS app setup, extension consumption, and extension package structure
- Document Android setup scenarios and alternatives: use ExtensionRegistry.setupGlobal(Context) for app-wide registration or ExtensionRegistry.setup(LynxViewBuilder) for view-specific registration
- Document iOS setup including cocoapods-lynx-extension, Podfile plugin usage, and importing the generated Objective-C ExtensionRegistry into LynxConfig
- Add instructions to scaffold extensions with npm create lynx-extension and to run lynx-autolink-codegen for generating JS facades, Android/iOS specs, and type-driven artifacts
- Clarify codegen behavior and supported type shapes (including nullable unions with null) and scanning of types/**/*.d.ts for @lynxmodule annotations
- Clarify scope as Android and iOS only and standardize extension author APIs with LynxAutolink*-style names
- Add navigation entries to docs/en/guide/_meta.json and docs/zh/guide/_meta.json for the Autolink guide
- Add translation key guide.custom.native.autolink to i18n.json (en/zh)
- Update .cspell/dictionary.txt with entries: Autolink, codegen, podspec, podspecs

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/983)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->