### PR TITLE
docs: update custom event and touch event docs

### DIFF
--- a/docs/en/api/lynx-api/event/custom-event.mdx
+++ b/docs/en/api/lynx-api/event/custom-event.mdx
@@ -16,6 +16,8 @@ This event object contains some state information of the component customization
 
 :::info
 There are two properties of the custom event object, one is [`params`](#params), the other is [`detail`](#detail). [`params`](#params) will be discarded in the future, and it is recommended to use [`detail`](#detail).
+
+Starting with Lynx version 3.1, custom event objects will always include the [`detail`](#detail) property.
 :::
 
 ### params

--- a/docs/zh/api/lynx-api/event/custom-event.mdx
+++ b/docs/zh/api/lynx-api/event/custom-event.mdx
@@ -16,6 +16,8 @@ import { APISummary, APITable } from '@lynx';
 
 :::info
 自定义事件对象的属性有两种，一种是 [`params`](#params)，一种是 [`detail`](#detail)，后续 [`params`](#params) 会被废弃掉，推荐使用 [`detail`](#detail)。
+
+从 Lynx 3.1 版本开始，自定义事件对象都会有 [`detail`](#detail) 属性。
 :::
 
 ### params

--- a/packages/lynx-compat-data/api-stats.json
+++ b/packages/lynx-compat-data/api-stats.json
@@ -30842,7 +30842,7 @@
             "android": "1.5",
             "ios": "1.5",
             "harmony": "3.4",
-            "web_lynx": true,
+            "web_lynx": false,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -30986,7 +30986,7 @@
             "android": "1.5",
             "ios": "1.5",
             "harmony": "3.6",
-            "web_lynx": true,
+            "web_lynx": false,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -33317,7 +33317,7 @@
               "android": "1.5",
               "ios": "1.5",
               "harmony": "3.4",
-              "web_lynx": true,
+              "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -33461,7 +33461,7 @@
               "android": "1.5",
               "ios": "1.5",
               "harmony": "3.6",
-              "web_lynx": true,
+              "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -34391,7 +34391,7 @@
               "android": "1.5",
               "ios": "1.5",
               "harmony": "3.4",
-              "web_lynx": true,
+              "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -34535,7 +34535,7 @@
               "android": "1.5",
               "ios": "1.5",
               "harmony": "3.6",
-              "web_lynx": true,
+              "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -90083,7 +90083,7 @@
           "version_added": "3.4"
         },
         "web_lynx": {
-          "version_added": true
+          "version_added": false
         },
         "clay_android": {
           "version_added": false
@@ -90407,7 +90407,7 @@
           "version_added": "3.6"
         },
         "web_lynx": {
-          "version_added": true
+          "version_added": false
         },
         "clay_android": {
           "version_added": false

--- a/packages/lynx-compat-data/lynx-api/event/TouchEvent.json
+++ b/packages/lynx-compat-data/lynx-api/event/TouchEvent.json
@@ -45,7 +45,7 @@
                 "version_added": "3.5"
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": false
               }
             }
           }
@@ -270,7 +270,7 @@
                 "version_added": "3.5"
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": false
               }
             }
           }


### PR DESCRIPTION
1. add note about unified detail field for custom events since Lynx 3.1
2. add NoWeb component to touch event api headers to exclude web content

Change-Id: I921c84a2d8b3b6d458878391c3f49c7065c20f15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Update CustomEvent documentation to document the unified `detail` field introduced in Lynx 3.1, noting that `params` is planned for deprecation in favor of `detail`.

Update TouchEvent compatibility data to mark `web_lynx.version_added` as `false` for the `detail` and `click` events, reflecting the exclusion of web content.

Update compatibility metadata in api-stats.json to mark `web_lynx` as `false` across multiple platform and version entries.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/988)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->