### PR TITLE
fix(docs): align lynx.onError JS example with @lynx-js/types definition

### DIFF
--- a/docs/en/api/errors/lynx-error.mdx
+++ b/docs/en/api/errors/lynx-error.mdx
@@ -95,12 +95,13 @@ A JSON-formatted string containing detailed error information, including:
 ### JavaScript
 
 ```js
-lynx.onError((err) => {
-  if (err.getLevel() === 'Fatal') {
+lynx.onError = (error) => {
+  const detail = JSON.parse(error.message);
+  if (detail.level === 'Fatal') {
     // Possibly reload or fallback to home
-    console.error('Critical error occurred:', err.getMsg());
+    console.error('Critical error occurred:', detail.message);
   }
-});
+};
 ```
 
 ### Kotlin

--- a/docs/zh/api/errors/lynx-error.mdx
+++ b/docs/zh/api/errors/lynx-error.mdx
@@ -95,12 +95,13 @@ import { APISummary, APITable } from '@lynx';
 ### JavaScript
 
 ```js
-lynx.onError((err) => {
-  if (err.getLevel() === 'Fatal') {
+lynx.onError = (error) => {
+  const detail = JSON.parse(error.message);
+  if (detail.level === 'Fatal') {
     // Possibly reload or fallback to home
-    console.error('Critical error occurred:', err.getMsg());
+    console.error('Critical error occurred:', detail.message);
   }
-});
+};
 ```
 
 ### Kotlin


### PR DESCRIPTION
## Summary

- Fixes the JavaScript example in `lynx.onError` documentation (en + zh) to match the `@lynx-js/types` definition
- Changes `lynx.onError(callback)` (function call) to `lynx.onError = callback` (property assignment)
- Replaces non-existent `err.getLevel()`/`err.getMsg()` calls with JSON parsing of the standard `Error.message` field

Closes #987

## Context

The [`@lynx-js/types` definition](https://github.com/lynx-family/lynx/blob/develop/js_libraries/types/types/background-thread/lynx.d.ts#L172-L176) declares:

```ts
onError?: (error: Error) => void;
```

This is an assignable property receiving a standard `Error` object. The error's `.message` is a JSON string containing `code`, `subcode`, `level`, `message`, and `suggestion` fields, as described in the LynxError "Message" section of the same doc page.

## Test plan

- [x] Verified `cspell` passes on both modified files
- [x] Confirmed pre-existing `zhlint` issues on unrelated lines (30, 37) are not introduced by this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Align lynx.onError JavaScript example with @lynx-js/types definition

Update the JavaScript `LynxError` example in both English and Chinese documentation to correctly reflect the TypeScript type definition:
- Change from function call form `lynx.onError(callback)` to assignable property form `lynx.onError = (error) => { ... }`
- Replace calls to non-existent platform methods (`err.getLevel()`, `err.getMsg()`) with JSON parsing of the standard Error.message field
- Access error details via `JSON.parse(error.message)` to read properties: `code`, `subcode`, `level`, `message`, and optional `suggestion`

**Files modified:**
- `docs/en/api/errors/lynx-error.mdx`
- `docs/zh/api/errors/lynx-error.mdx`

Resolves issue #987.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/989)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->