### PR TITLE
fix: remove stale catalog block from pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,11 +1,3 @@
 packages:
   - 'packages/*'
   - 'plugins/*'
-
-catalog:
-  '@lynx-js/web-core': '^0.20.3'
-  '@types/react': '^18.3.0'
-  '@types/react-dom': '^18.3.0'
-  motion: '^12.23.0'
-  react: '^18.3.0'
-  react-dom: '^18.3.0'


### PR DESCRIPTION
## Summary

- Follow-up to #992 — removes the now-unused `catalog:` block from `pnpm-workspace.yaml`
- No `package.json` in the workspace references `catalog:` protocol anymore, so the definition is dead config

## Test plan

- [x] Verified no `package.json` uses `catalog:` protocol (`grep` across all workspace packages)
- [x] `pnpm install --frozen-lockfile` succeeds (lockfile unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Remove stale `catalog` block from `pnpm-workspace.yaml`

This follows up on the migration to pnpm 9 in #992. Since no workspace packages reference the `catalog:` protocol anymore, the configuration block is dead code and can be safely removed. The change retains the active workspace glob definitions (`packages/*` and `plugins/*`).

## Changes

- Remove unused `catalog` section from `pnpm-workspace.yaml` (8 lines deleted)

## Testing

- Verified no `package.json` in the workspace uses the `catalog:` protocol
- Confirmed `pnpm install --frozen-lockfile` succeeds with an unchanged lockfile

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/993)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->