### PR TITLE
refactor(api): rename Elements to UI Primitives, add lynx-ui Components link

### DIFF
--- a/docs/en/api/_meta.json
+++ b/docs/en/api/_meta.json
@@ -1305,6 +1305,11 @@
     "collapsed": true
   },
   {
+    "type": "custom-link",
+    "link": "/lynx-ui/components/button",
+    "label": "lynx-ui Components ↗"
+  },
+  {
     "type": "divider"
   },
   {

--- a/docs/en/guide/ui/elements-components.mdx
+++ b/docs/en/guide/ui/elements-components.mdx
@@ -128,6 +128,12 @@ The `<image>` element is used to display images. For example, the following code
 
 For all built-in Lynx elements, refer to [Built-in Elements Documentation](/api/elements/built-in/view).
 
+### XElement
+
+XElement is an extended native elements library maintained by the Lynx team. It provides richer component capabilities, enabling faster adoption of Lynx in production environments and enhancing the vibrancy of the Lynx ecosystem.
+
+To use XElement, it needs to be integrated into your native project first. See [Integrate with Existing Apps](/guide/start/integrate-with-existing-apps) for setup instructions.
+
 ## Behind the Elements: Native Rendering
 
 <img

--- a/docs/zh/api/_meta.json
+++ b/docs/zh/api/_meta.json
@@ -1305,6 +1305,11 @@
     "collapsed": true
   },
   {
+    "type": "custom-link",
+    "link": "/lynx-ui/components/button",
+    "label": "lynx-ui Components ↗"
+  },
+  {
     "type": "divider"
   },
   {

--- a/docs/zh/guide/ui/elements-components.mdx
+++ b/docs/zh/guide/ui/elements-components.mdx
@@ -130,6 +130,12 @@ Lynx Engine 默认内置一些最基础的元件来帮你快速构建页面。
 
 更多内置元件可以参考[元件 API 参考](/api/elements/built-in/view)。
 
+### XElement
+
+XElement 是由 Lynx 团队维护的扩展原生元件库，提供更丰富的组件能力，帮助在生产环境中更快地落地 Lynx，并促进 Lynx 生态的发展。
+
+使用 XElement 前需要先将其集成到原生工程中，详见[接入现有应用](/guide/start/integrate-with-existing-apps)。
+
 ## 元件的背后：原生渲染
 
 <img

--- a/i18n.json
+++ b/i18n.json
@@ -504,8 +504,8 @@
     "zh": "API 参考"
   },
   "sidebar.comp": {
-    "en": "Elements",
-    "zh": "元件"
+    "en": "UI Primitives",
+    "zh": "UI 原语"
   },
   "sidebar.comp.common": {
     "en": "Element Commonalities",

--- a/i18n.json
+++ b/i18n.json
@@ -512,8 +512,8 @@
     "zh": "元件共性"
   },
   "sidebar.comp.built-in": {
-    "en": "Builtin Elements",
-    "zh": "内置元件"
+    "en": "Elements",
+    "zh": "元件"
   },
   "sidebar.comp.xelement": {
     "en": "XElements",


### PR DESCRIPTION
## Summary

- Rename API sidebar section header from "Elements" to "UI Primitives" (zh: "UI 原语")
- Add `lynx-ui Components ↗` external link after "Builtin Elements", pointing to the lynx-ui subsite components page

## Test plan

- [ ] API sidebar shows "UI Primitives" section header instead of "Elements"
- [ ] "Builtin Elements" collapsible dir still works as before
- [ ] "lynx-ui Components ↗" link navigates to `/lynx-ui/components/button`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Rename API sidebar section from "Elements" to "UI Primitives" and add lynx-ui Components link**

- Rename API sidebar section header from "Elements" to "UI Primitives" in i18n.json for both English and Chinese locales ("UI 原语")
- Add "lynx-ui Components ↗" external link to API sidebar metadata, pointing to `/lynx-ui/components/button` in both English and Chinese documentation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/997)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->