### PR TITLE
refactor(api): group @lynx-js/* plugins under collapsible Plugins section

### DIFF
--- a/docs/en/api/_meta.json
+++ b/docs/en/api/_meta.json
@@ -797,7 +797,7 @@
   },
   {
     "type": "custom-link",
-    "label": "Plugins",
+    "label": "Rspeedy Plugins",
     "collapsible": true,
     "collapsed": true,
     "items": [

--- a/docs/en/api/_meta.json
+++ b/docs/en/api/_meta.json
@@ -797,35 +797,107 @@
   },
   {
     "type": "custom-link",
-    "label": "@lynx-js/react-rsbuild-plugin",
+    "label": "Plugins",
     "collapsible": true,
     "collapsed": true,
     "items": [
       {
-        "label": "pluginReactLynx",
         "type": "custom-link",
-        "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynx",
-        "collapsed": true,
+        "label": "@lynx-js/react-rsbuild-plugin",
         "collapsible": true,
+        "collapsed": true,
         "items": [
           {
-            "label": "compat",
+            "label": "pluginReactLynx",
             "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.compat",
+            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynx",
             "collapsed": true,
             "collapsible": true,
             "items": [
               {
-                "label": "addComponentElement",
+                "label": "compat",
                 "type": "custom-link",
-                "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.addcomponentelement",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.compat",
                 "collapsed": true,
                 "collapsible": true,
                 "items": [
                   {
-                    "label": "compilerOnly",
+                    "label": "addComponentElement",
                     "type": "custom-link",
-                    "link": "/api/rspeedy/react-rsbuild-plugin.addcomponentelementconfig.compileronly",
+                    "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.addcomponentelement",
+                    "collapsed": true,
+                    "collapsible": true,
+                    "items": [
+                      {
+                        "label": "compilerOnly",
+                        "type": "custom-link",
+                        "link": "/api/rspeedy/react-rsbuild-plugin.addcomponentelementconfig.compileronly",
+                        "collapsed": true,
+                        "collapsible": false,
+                        "items": []
+                      }
+                    ]
+                  },
+                  {
+                    "label": "additionalComponentAttributes",
+                    "type": "custom-link",
+                    "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.additionalcomponentattributes",
+                    "collapsed": true,
+                    "collapsible": false,
+                    "items": []
+                  },
+                  {
+                    "label": "componentsPkg",
+                    "type": "custom-link",
+                    "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.componentspkg",
+                    "collapsed": true,
+                    "collapsible": false,
+                    "items": []
+                  },
+                  {
+                    "label": "darkMode",
+                    "type": "custom-link",
+                    "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.darkmode",
+                    "collapsed": true,
+                    "collapsible": false,
+                    "items": []
+                  },
+                  {
+                    "label": "disableDeprecatedWarning",
+                    "type": "custom-link",
+                    "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.disabledeprecatedwarning",
+                    "collapsed": true,
+                    "collapsible": false,
+                    "items": []
+                  },
+                  {
+                    "label": "newRuntimePkg",
+                    "type": "custom-link",
+                    "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.newruntimepkg",
+                    "collapsed": true,
+                    "collapsible": false,
+                    "items": []
+                  },
+                  {
+                    "label": "oldRuntimePkg",
+                    "type": "custom-link",
+                    "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.oldruntimepkg",
+                    "collapsed": true,
+                    "collapsible": false,
+                    "items": []
+                  },
+                  {
+                    "label": "removeComponentAttrRegex",
+                    "type": "custom-link",
+                    "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.removecomponentattrregex",
+                    "collapsed": true,
+                    "collapsible": false,
+                    "items": []
+                  },
+                  {
+                    "label": "simplifyCtorLikeReactLynx2",
+                    "type": "custom-link",
+                    "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.simplifyctorlikereactlynx2",
                     "collapsed": true,
                     "collapsible": false,
                     "items": []
@@ -833,459 +905,395 @@
                 ]
               },
               {
-                "label": "additionalComponentAttributes",
+                "label": "customCSSInheritanceList",
                 "type": "custom-link",
-                "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.additionalcomponentattributes",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.customcssinheritancelist",
                 "collapsed": true,
                 "collapsible": false,
                 "items": []
               },
               {
-                "label": "componentsPkg",
+                "label": "debugInfoOutside",
                 "type": "custom-link",
-                "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.componentspkg",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.debuginfooutside",
                 "collapsed": true,
                 "collapsible": false,
                 "items": []
               },
               {
-                "label": "darkMode",
+                "label": "defaultDisplayLinear",
                 "type": "custom-link",
-                "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.darkmode",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.defaultdisplaylinear",
                 "collapsed": true,
                 "collapsible": false,
                 "items": []
               },
               {
-                "label": "disableDeprecatedWarning",
+                "label": "defineDCE",
                 "type": "custom-link",
-                "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.disabledeprecatedwarning",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.definedce",
+                "collapsed": true,
+                "collapsible": true,
+                "items": [
+                  {
+                    "label": "define",
+                    "type": "custom-link",
+                    "link": "/api/rspeedy/react-rsbuild-plugin.definedcevisitorconfig.define",
+                    "collapsed": true,
+                    "collapsible": false,
+                    "items": []
+                  }
+                ]
+              },
+              {
+                "label": "enableAccessibilityElement",
+                "type": "custom-link",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enableaccessibilityelement",
                 "collapsed": true,
                 "collapsible": false,
                 "items": []
               },
               {
-                "label": "newRuntimePkg",
+                "label": "enableCSSInheritance",
                 "type": "custom-link",
-                "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.newruntimepkg",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enablecssinheritance",
                 "collapsed": true,
                 "collapsible": false,
                 "items": []
               },
               {
-                "label": "oldRuntimePkg",
+                "label": "enableCSSInvalidation",
                 "type": "custom-link",
-                "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.oldruntimepkg",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enablecssinvalidation",
                 "collapsed": true,
                 "collapsible": false,
                 "items": []
               },
               {
-                "label": "removeComponentAttrRegex",
+                "label": "enableCSSSelector",
                 "type": "custom-link",
-                "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.removecomponentattrregex",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enablecssselector",
                 "collapsed": true,
                 "collapsible": false,
                 "items": []
               },
               {
-                "label": "simplifyCtorLikeReactLynx2",
+                "label": "enableICU",
                 "type": "custom-link",
-                "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.simplifyctorlikereactlynx2",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enableicu",
+                "collapsed": true,
+                "collapsible": false,
+                "items": []
+              },
+              {
+                "label": "enableNewGesture",
+                "type": "custom-link",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enablenewgesture",
+                "collapsed": true,
+                "collapsible": false,
+                "items": []
+              },
+              {
+                "label": "enableParallelElement",
+                "type": "custom-link",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enableparallelelement",
+                "collapsed": true,
+                "collapsible": false,
+                "items": []
+              },
+              {
+                "label": "enableRemoveCSSScope",
+                "type": "custom-link",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enableremovecssscope",
+                "collapsed": true,
+                "collapsible": false,
+                "items": []
+              },
+              {
+                "label": "enableSSR",
+                "type": "custom-link",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enablessr",
+                "collapsed": true,
+                "collapsible": false,
+                "items": []
+              },
+              {
+                "label": "engineVersion",
+                "type": "custom-link",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.engineversion",
+                "collapsed": true,
+                "collapsible": false,
+                "items": []
+              },
+              {
+                "label": "experimental_isLazyBundle",
+                "type": "custom-link",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.experimental_islazybundle",
+                "collapsed": true,
+                "collapsible": false,
+                "items": []
+              },
+              {
+                "label": "extractStr",
+                "type": "custom-link",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.extractstr",
+                "collapsed": true,
+                "collapsible": true,
+                "items": [
+                  {
+                    "label": "strLength",
+                    "type": "custom-link",
+                    "link": "/api/rspeedy/react-rsbuild-plugin.extractstrconfig.strlength",
+                    "collapsed": true,
+                    "collapsible": false,
+                    "items": []
+                  }
+                ]
+              },
+              {
+                "label": "firstScreenSyncTiming",
+                "type": "custom-link",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.firstscreensynctiming",
+                "collapsed": true,
+                "collapsible": false,
+                "items": []
+              },
+              {
+                "label": "pipelineSchedulerConfig",
+                "type": "custom-link",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.pipelineschedulerconfig",
+                "collapsed": true,
+                "collapsible": false,
+                "items": []
+              },
+              {
+                "label": "removeDescendantSelectorScope",
+                "type": "custom-link",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.removedescendantselectorscope",
+                "collapsed": true,
+                "collapsible": false,
+                "items": []
+              },
+              {
+                "label": "shake",
+                "type": "custom-link",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.shake",
+                "collapsed": true,
+                "collapsible": true,
+                "items": [
+                  {
+                    "label": "pkgName",
+                    "type": "custom-link",
+                    "link": "/api/rspeedy/react-rsbuild-plugin.shakevisitorconfig.pkgname",
+                    "collapsed": true,
+                    "collapsible": false,
+                    "items": []
+                  },
+                  {
+                    "label": "removeCallParams",
+                    "type": "custom-link",
+                    "link": "/api/rspeedy/react-rsbuild-plugin.shakevisitorconfig.removecallparams",
+                    "collapsed": true,
+                    "collapsible": false,
+                    "items": []
+                  },
+                  {
+                    "label": "retainProp",
+                    "type": "custom-link",
+                    "link": "/api/rspeedy/react-rsbuild-plugin.shakevisitorconfig.retainprop",
+                    "collapsed": true,
+                    "collapsible": false,
+                    "items": []
+                  }
+                ]
+              },
+              {
+                "label": "targetSdkVersion",
+                "type": "custom-link",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.targetsdkversion",
                 "collapsed": true,
                 "collapsible": false,
                 "items": []
               }
             ]
-          },
-          {
-            "label": "customCSSInheritanceList",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.customcssinheritancelist",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "debugInfoOutside",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.debuginfooutside",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "defaultDisplayLinear",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.defaultdisplaylinear",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "defineDCE",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.definedce",
-            "collapsed": true,
-            "collapsible": true,
-            "items": [
-              {
-                "label": "define",
-                "type": "custom-link",
-                "link": "/api/rspeedy/react-rsbuild-plugin.definedcevisitorconfig.define",
-                "collapsed": true,
-                "collapsible": false,
-                "items": []
-              }
-            ]
-          },
-          {
-            "label": "enableAccessibilityElement",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enableaccessibilityelement",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "enableCSSInheritance",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enablecssinheritance",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "enableCSSInvalidation",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enablecssinvalidation",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "enableCSSSelector",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enablecssselector",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "enableICU",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enableicu",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "enableNewGesture",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enablenewgesture",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "enableParallelElement",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enableparallelelement",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "enableRemoveCSSScope",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enableremovecssscope",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "enableSSR",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enablessr",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "engineVersion",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.engineversion",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "experimental_isLazyBundle",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.experimental_islazybundle",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "extractStr",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.extractstr",
-            "collapsed": true,
-            "collapsible": true,
-            "items": [
-              {
-                "label": "strLength",
-                "type": "custom-link",
-                "link": "/api/rspeedy/react-rsbuild-plugin.extractstrconfig.strlength",
-                "collapsed": true,
-                "collapsible": false,
-                "items": []
-              }
-            ]
-          },
-          {
-            "label": "firstScreenSyncTiming",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.firstscreensynctiming",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "pipelineSchedulerConfig",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.pipelineschedulerconfig",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "removeDescendantSelectorScope",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.removedescendantselectorscope",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "shake",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.shake",
-            "collapsed": true,
-            "collapsible": true,
-            "items": [
-              {
-                "label": "pkgName",
-                "type": "custom-link",
-                "link": "/api/rspeedy/react-rsbuild-plugin.shakevisitorconfig.pkgname",
-                "collapsed": true,
-                "collapsible": false,
-                "items": []
-              },
-              {
-                "label": "removeCallParams",
-                "type": "custom-link",
-                "link": "/api/rspeedy/react-rsbuild-plugin.shakevisitorconfig.removecallparams",
-                "collapsed": true,
-                "collapsible": false,
-                "items": []
-              },
-              {
-                "label": "retainProp",
-                "type": "custom-link",
-                "link": "/api/rspeedy/react-rsbuild-plugin.shakevisitorconfig.retainprop",
-                "collapsed": true,
-                "collapsible": false,
-                "items": []
-              }
-            ]
-          },
-          {
-            "label": "targetSdkVersion",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.targetsdkversion",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
           }
         ]
-      }
-    ]
-  },
-  {
-    "type": "custom-link",
-    "label": "@lynx-js/qrcode-rsbuild-plugin",
-    "collapsible": true,
-    "collapsed": true,
-    "items": [
-      {
-        "label": "CustomizedSchemaFn",
-        "link": "/api/rspeedy/qrcode-rsbuild-plugin.customizedschemafn",
-        "collapsed": true,
-        "collapsible": false
       },
       {
-        "label": "pluginQRCode",
-        "link": "/api/rspeedy/qrcode-rsbuild-plugin.pluginqrcode",
-        "collapsed": true,
+        "type": "custom-link",
+        "label": "@lynx-js/qrcode-rsbuild-plugin",
         "collapsible": true,
+        "collapsed": true,
         "items": [
           {
-            "label": "schema",
-            "link": "/api/rspeedy/qrcode-rsbuild-plugin.pluginqrcodeoptions.schema",
+            "label": "CustomizedSchemaFn",
+            "link": "/api/rspeedy/qrcode-rsbuild-plugin.customizedschemafn",
             "collapsed": true,
             "collapsible": false
+          },
+          {
+            "label": "pluginQRCode",
+            "link": "/api/rspeedy/qrcode-rsbuild-plugin.pluginqrcode",
+            "collapsed": true,
+            "collapsible": true,
+            "items": [
+              {
+                "label": "schema",
+                "link": "/api/rspeedy/qrcode-rsbuild-plugin.pluginqrcodeoptions.schema",
+                "collapsed": true,
+                "collapsible": false
+              }
+            ]
           }
         ]
-      }
-    ]
-  },
-  {
-    "type": "custom-link",
-    "label": "@lynx-js/external-bundle-rsbuild-plugin",
-    "link": "/api/rspeedy/external-bundle-rsbuild-plugin",
-    "collapsible": true,
-    "collapsed": true,
-    "items": [
-      {
-        "type": "custom-link",
-        "label": "builtInExternalsPresetDefinitions",
-        "link": "/api/rspeedy/external-bundle-rsbuild-plugin.builtinexternalspresetdefinitions"
       },
       {
         "type": "custom-link",
-        "label": "ExternalsPresetContext",
-        "link": "/api/rspeedy/external-bundle-rsbuild-plugin.externalspresetcontext"
+        "label": "@lynx-js/external-bundle-rsbuild-plugin",
+        "link": "/api/rspeedy/external-bundle-rsbuild-plugin",
+        "collapsible": true,
+        "collapsed": true,
+        "items": [
+          {
+            "type": "custom-link",
+            "label": "builtInExternalsPresetDefinitions",
+            "link": "/api/rspeedy/external-bundle-rsbuild-plugin.builtinexternalspresetdefinitions"
+          },
+          {
+            "type": "custom-link",
+            "label": "ExternalsPresetContext",
+            "link": "/api/rspeedy/external-bundle-rsbuild-plugin.externalspresetcontext"
+          },
+          {
+            "type": "custom-link",
+            "label": "ExternalsPresetDefinition",
+            "link": "/api/rspeedy/external-bundle-rsbuild-plugin.externalspresetdefinition"
+          },
+          {
+            "type": "custom-link",
+            "label": "ExternalsPresetDefinitions",
+            "link": "/api/rspeedy/external-bundle-rsbuild-plugin.externalspresetdefinitions"
+          },
+          {
+            "type": "custom-link",
+            "label": "ExternalsPresets",
+            "link": "/api/rspeedy/external-bundle-rsbuild-plugin.externalspresets"
+          },
+          {
+            "type": "custom-link",
+            "label": "normalizeBundlePath",
+            "link": "/api/rspeedy/external-bundle-rsbuild-plugin.normalizebundlepath"
+          },
+          {
+            "type": "custom-link",
+            "label": "pluginExternalBundle",
+            "link": "/api/rspeedy/external-bundle-rsbuild-plugin.pluginexternalbundle"
+          },
+          {
+            "type": "custom-link",
+            "label": "PluginExternalBundleOptions",
+            "link": "/api/rspeedy/external-bundle-rsbuild-plugin.pluginexternalbundleoptions"
+          },
+          {
+            "type": "custom-link",
+            "label": "PluginExternalConfig",
+            "link": "/api/rspeedy/external-bundle-rsbuild-plugin.pluginexternalconfig"
+          },
+          {
+            "type": "custom-link",
+            "label": "PluginExternalValue",
+            "link": "/api/rspeedy/external-bundle-rsbuild-plugin.pluginexternalvalue"
+          },
+          {
+            "type": "custom-link",
+            "label": "ReactLynxExternalsPresetOptions",
+            "link": "/api/rspeedy/external-bundle-rsbuild-plugin.reactlynxexternalspresetoptions"
+          }
+        ]
       },
       {
         "type": "custom-link",
-        "label": "ExternalsPresetDefinition",
-        "link": "/api/rspeedy/external-bundle-rsbuild-plugin.externalspresetdefinition"
-      },
-      {
-        "type": "custom-link",
-        "label": "ExternalsPresetDefinitions",
-        "link": "/api/rspeedy/external-bundle-rsbuild-plugin.externalspresetdefinitions"
-      },
-      {
-        "type": "custom-link",
-        "label": "ExternalsPresets",
-        "link": "/api/rspeedy/external-bundle-rsbuild-plugin.externalspresets"
-      },
-      {
-        "type": "custom-link",
-        "label": "normalizeBundlePath",
-        "link": "/api/rspeedy/external-bundle-rsbuild-plugin.normalizebundlepath"
-      },
-      {
-        "type": "custom-link",
-        "label": "pluginExternalBundle",
-        "link": "/api/rspeedy/external-bundle-rsbuild-plugin.pluginexternalbundle"
-      },
-      {
-        "type": "custom-link",
-        "label": "PluginExternalBundleOptions",
-        "link": "/api/rspeedy/external-bundle-rsbuild-plugin.pluginexternalbundleoptions"
-      },
-      {
-        "type": "custom-link",
-        "label": "PluginExternalConfig",
-        "link": "/api/rspeedy/external-bundle-rsbuild-plugin.pluginexternalconfig"
-      },
-      {
-        "type": "custom-link",
-        "label": "PluginExternalValue",
-        "link": "/api/rspeedy/external-bundle-rsbuild-plugin.pluginexternalvalue"
-      },
-      {
-        "type": "custom-link",
-        "label": "ReactLynxExternalsPresetOptions",
-        "link": "/api/rspeedy/external-bundle-rsbuild-plugin.reactlynxexternalspresetoptions"
-      }
-    ]
-  },
-  {
-    "type": "custom-link",
-    "label": "@lynx-js/lynx-bundle-rslib-config",
-    "link": "/api/rspeedy/lynx-bundle-rslib-config",
-    "collapsible": true,
-    "collapsed": true,
-    "items": [
-      {
-        "type": "custom-link",
-        "label": "builtInExternalsPresetDefinitions",
-        "link": "/api/rspeedy/lynx-bundle-rslib-config.builtinexternalspresetdefinitions"
-      },
-      {
-        "type": "custom-link",
-        "label": "defaultExternalBundleLibConfig",
-        "link": "/api/rspeedy/lynx-bundle-rslib-config.defaultexternalbundlelibconfig"
-      },
-      {
-        "type": "custom-link",
-        "label": "defineExternalBundleRslibConfig",
-        "link": "/api/rspeedy/lynx-bundle-rslib-config.defineexternalbundlerslibconfig"
-      },
-      {
-        "type": "custom-link",
-        "label": "EncodeOptions",
-        "link": "/api/rspeedy/lynx-bundle-rslib-config.encodeoptions"
-      },
-      {
-        "type": "custom-link",
-        "label": "ExternalBundleWebpackPlugin",
-        "link": "/api/rspeedy/lynx-bundle-rslib-config.externalbundlewebpackplugin"
-      },
-      {
-        "type": "custom-link",
-        "label": "ExternalBundleLibConfig",
-        "link": "/api/rspeedy/lynx-bundle-rslib-config.externalbundlelibconfig"
-      },
-      {
-        "type": "custom-link",
-        "label": "ExternalBundleWebpackPluginOptions",
-        "link": "/api/rspeedy/lynx-bundle-rslib-config.externalbundlewebpackpluginoptions"
-      },
-      {
-        "type": "custom-link",
-        "label": "Externals",
-        "link": "/api/rspeedy/lynx-bundle-rslib-config.externals"
-      },
-      {
-        "type": "custom-link",
-        "label": "ExternalsPresetDefinition",
-        "link": "/api/rspeedy/lynx-bundle-rslib-config.externalspresetdefinition"
-      },
-      {
-        "type": "custom-link",
-        "label": "ExternalsPresetDefinitions",
-        "link": "/api/rspeedy/lynx-bundle-rslib-config.externalspresetdefinitions"
-      },
-      {
-        "type": "custom-link",
-        "label": "ExternalsPresets",
-        "link": "/api/rspeedy/lynx-bundle-rslib-config.externalspresets"
-      },
-      {
-        "type": "custom-link",
-        "label": "MainThreadRuntimeWrapperWebpackPlugin",
-        "link": "/api/rspeedy/lynx-bundle-rslib-config.mainthreadruntimewrapperwebpackplugin"
-      },
-      {
-        "type": "custom-link",
-        "label": "MainThreadRuntimeWrapperWebpackPluginOptions",
-        "link": "/api/rspeedy/lynx-bundle-rslib-config.mainthreadruntimewrapperwebpackpluginoptions"
-      },
-      {
-        "type": "custom-link",
-        "label": "OutputConfig",
-        "link": "/api/rspeedy/lynx-bundle-rslib-config.outputconfig"
-      },
-      {
-        "type": "custom-link",
-        "label": "reactLynxExternalsPreset",
-        "link": "/api/rspeedy/lynx-bundle-rslib-config.reactlynxexternalspreset"
+        "label": "@lynx-js/lynx-bundle-rslib-config",
+        "link": "/api/rspeedy/lynx-bundle-rslib-config",
+        "collapsible": true,
+        "collapsed": true,
+        "items": [
+          {
+            "type": "custom-link",
+            "label": "builtInExternalsPresetDefinitions",
+            "link": "/api/rspeedy/lynx-bundle-rslib-config.builtinexternalspresetdefinitions"
+          },
+          {
+            "type": "custom-link",
+            "label": "defaultExternalBundleLibConfig",
+            "link": "/api/rspeedy/lynx-bundle-rslib-config.defaultexternalbundlelibconfig"
+          },
+          {
+            "type": "custom-link",
+            "label": "defineExternalBundleRslibConfig",
+            "link": "/api/rspeedy/lynx-bundle-rslib-config.defineexternalbundlerslibconfig"
+          },
+          {
+            "type": "custom-link",
+            "label": "EncodeOptions",
+            "link": "/api/rspeedy/lynx-bundle-rslib-config.encodeoptions"
+          },
+          {
+            "type": "custom-link",
+            "label": "ExternalBundleWebpackPlugin",
+            "link": "/api/rspeedy/lynx-bundle-rslib-config.externalbundlewebpackplugin"
+          },
+          {
+            "type": "custom-link",
+            "label": "ExternalBundleLibConfig",
+            "link": "/api/rspeedy/lynx-bundle-rslib-config.externalbundlelibconfig"
+          },
+          {
+            "type": "custom-link",
+            "label": "ExternalBundleWebpackPluginOptions",
+            "link": "/api/rspeedy/lynx-bundle-rslib-config.externalbundlewebpackpluginoptions"
+          },
+          {
+            "type": "custom-link",
+            "label": "Externals",
+            "link": "/api/rspeedy/lynx-bundle-rslib-config.externals"
+          },
+          {
+            "type": "custom-link",
+            "label": "ExternalsPresetDefinition",
+            "link": "/api/rspeedy/lynx-bundle-rslib-config.externalspresetdefinition"
+          },
+          {
+            "type": "custom-link",
+            "label": "ExternalsPresetDefinitions",
+            "link": "/api/rspeedy/lynx-bundle-rslib-config.externalspresetdefinitions"
+          },
+          {
+            "type": "custom-link",
+            "label": "ExternalsPresets",
+            "link": "/api/rspeedy/lynx-bundle-rslib-config.externalspresets"
+          },
+          {
+            "type": "custom-link",
+            "label": "MainThreadRuntimeWrapperWebpackPlugin",
+            "link": "/api/rspeedy/lynx-bundle-rslib-config.mainthreadruntimewrapperwebpackplugin"
+          },
+          {
+            "type": "custom-link",
+            "label": "MainThreadRuntimeWrapperWebpackPluginOptions",
+            "link": "/api/rspeedy/lynx-bundle-rslib-config.mainthreadruntimewrapperwebpackpluginoptions"
+          },
+          {
+            "type": "custom-link",
+            "label": "OutputConfig",
+            "link": "/api/rspeedy/lynx-bundle-rslib-config.outputconfig"
+          },
+          {
+            "type": "custom-link",
+            "label": "reactLynxExternalsPreset",
+            "link": "/api/rspeedy/lynx-bundle-rslib-config.reactlynxexternalspreset"
+          }
+        ]
       }
     ]
   },

--- a/docs/zh/api/_meta.json
+++ b/docs/zh/api/_meta.json
@@ -797,7 +797,7 @@
   },
   {
     "type": "custom-link",
-    "label": "Plugins",
+    "label": "Rspeedy Plugins",
     "collapsible": true,
     "collapsed": true,
     "items": [

--- a/docs/zh/api/_meta.json
+++ b/docs/zh/api/_meta.json
@@ -797,35 +797,107 @@
   },
   {
     "type": "custom-link",
-    "label": "@lynx-js/react-rsbuild-plugin",
+    "label": "Plugins",
     "collapsible": true,
     "collapsed": true,
     "items": [
       {
-        "label": "pluginReactLynx",
         "type": "custom-link",
-        "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynx",
-        "collapsed": true,
+        "label": "@lynx-js/react-rsbuild-plugin",
         "collapsible": true,
+        "collapsed": true,
         "items": [
           {
-            "label": "compat",
+            "label": "pluginReactLynx",
             "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.compat",
+            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynx",
             "collapsed": true,
             "collapsible": true,
             "items": [
               {
-                "label": "addComponentElement",
+                "label": "compat",
                 "type": "custom-link",
-                "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.addcomponentelement",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.compat",
                 "collapsed": true,
                 "collapsible": true,
                 "items": [
                   {
-                    "label": "compilerOnly",
+                    "label": "addComponentElement",
                     "type": "custom-link",
-                    "link": "/api/rspeedy/react-rsbuild-plugin.addcomponentelementconfig.compileronly",
+                    "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.addcomponentelement",
+                    "collapsed": true,
+                    "collapsible": true,
+                    "items": [
+                      {
+                        "label": "compilerOnly",
+                        "type": "custom-link",
+                        "link": "/api/rspeedy/react-rsbuild-plugin.addcomponentelementconfig.compileronly",
+                        "collapsed": true,
+                        "collapsible": false,
+                        "items": []
+                      }
+                    ]
+                  },
+                  {
+                    "label": "additionalComponentAttributes",
+                    "type": "custom-link",
+                    "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.additionalcomponentattributes",
+                    "collapsed": true,
+                    "collapsible": false,
+                    "items": []
+                  },
+                  {
+                    "label": "componentsPkg",
+                    "type": "custom-link",
+                    "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.componentspkg",
+                    "collapsed": true,
+                    "collapsible": false,
+                    "items": []
+                  },
+                  {
+                    "label": "darkMode",
+                    "type": "custom-link",
+                    "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.darkmode",
+                    "collapsed": true,
+                    "collapsible": false,
+                    "items": []
+                  },
+                  {
+                    "label": "disableDeprecatedWarning",
+                    "type": "custom-link",
+                    "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.disabledeprecatedwarning",
+                    "collapsed": true,
+                    "collapsible": false,
+                    "items": []
+                  },
+                  {
+                    "label": "newRuntimePkg",
+                    "type": "custom-link",
+                    "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.newruntimepkg",
+                    "collapsed": true,
+                    "collapsible": false,
+                    "items": []
+                  },
+                  {
+                    "label": "oldRuntimePkg",
+                    "type": "custom-link",
+                    "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.oldruntimepkg",
+                    "collapsed": true,
+                    "collapsible": false,
+                    "items": []
+                  },
+                  {
+                    "label": "removeComponentAttrRegex",
+                    "type": "custom-link",
+                    "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.removecomponentattrregex",
+                    "collapsed": true,
+                    "collapsible": false,
+                    "items": []
+                  },
+                  {
+                    "label": "simplifyCtorLikeReactLynx2",
+                    "type": "custom-link",
+                    "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.simplifyctorlikereactlynx2",
                     "collapsed": true,
                     "collapsible": false,
                     "items": []
@@ -833,459 +905,395 @@
                 ]
               },
               {
-                "label": "additionalComponentAttributes",
+                "label": "customCSSInheritanceList",
                 "type": "custom-link",
-                "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.additionalcomponentattributes",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.customcssinheritancelist",
                 "collapsed": true,
                 "collapsible": false,
                 "items": []
               },
               {
-                "label": "componentsPkg",
+                "label": "debugInfoOutside",
                 "type": "custom-link",
-                "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.componentspkg",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.debuginfooutside",
                 "collapsed": true,
                 "collapsible": false,
                 "items": []
               },
               {
-                "label": "darkMode",
+                "label": "defaultDisplayLinear",
                 "type": "custom-link",
-                "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.darkmode",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.defaultdisplaylinear",
                 "collapsed": true,
                 "collapsible": false,
                 "items": []
               },
               {
-                "label": "disableDeprecatedWarning",
+                "label": "defineDCE",
                 "type": "custom-link",
-                "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.disabledeprecatedwarning",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.definedce",
+                "collapsed": true,
+                "collapsible": true,
+                "items": [
+                  {
+                    "label": "define",
+                    "type": "custom-link",
+                    "link": "/api/rspeedy/react-rsbuild-plugin.definedcevisitorconfig.define",
+                    "collapsed": true,
+                    "collapsible": false,
+                    "items": []
+                  }
+                ]
+              },
+              {
+                "label": "enableAccessibilityElement",
+                "type": "custom-link",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enableaccessibilityelement",
                 "collapsed": true,
                 "collapsible": false,
                 "items": []
               },
               {
-                "label": "newRuntimePkg",
+                "label": "enableCSSInheritance",
                 "type": "custom-link",
-                "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.newruntimepkg",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enablecssinheritance",
                 "collapsed": true,
                 "collapsible": false,
                 "items": []
               },
               {
-                "label": "oldRuntimePkg",
+                "label": "enableCSSInvalidation",
                 "type": "custom-link",
-                "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.oldruntimepkg",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enablecssinvalidation",
                 "collapsed": true,
                 "collapsible": false,
                 "items": []
               },
               {
-                "label": "removeComponentAttrRegex",
+                "label": "enableCSSSelector",
                 "type": "custom-link",
-                "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.removecomponentattrregex",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enablecssselector",
                 "collapsed": true,
                 "collapsible": false,
                 "items": []
               },
               {
-                "label": "simplifyCtorLikeReactLynx2",
+                "label": "enableICU",
                 "type": "custom-link",
-                "link": "/api/rspeedy/react-rsbuild-plugin.compatvisitorconfig.simplifyctorlikereactlynx2",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enableicu",
+                "collapsed": true,
+                "collapsible": false,
+                "items": []
+              },
+              {
+                "label": "enableNewGesture",
+                "type": "custom-link",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enablenewgesture",
+                "collapsed": true,
+                "collapsible": false,
+                "items": []
+              },
+              {
+                "label": "enableParallelElement",
+                "type": "custom-link",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enableparallelelement",
+                "collapsed": true,
+                "collapsible": false,
+                "items": []
+              },
+              {
+                "label": "enableRemoveCSSScope",
+                "type": "custom-link",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enableremovecssscope",
+                "collapsed": true,
+                "collapsible": false,
+                "items": []
+              },
+              {
+                "label": "enableSSR",
+                "type": "custom-link",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enablessr",
+                "collapsed": true,
+                "collapsible": false,
+                "items": []
+              },
+              {
+                "label": "engineVersion",
+                "type": "custom-link",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.engineversion",
+                "collapsed": true,
+                "collapsible": false,
+                "items": []
+              },
+              {
+                "label": "experimental_isLazyBundle",
+                "type": "custom-link",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.experimental_islazybundle",
+                "collapsed": true,
+                "collapsible": false,
+                "items": []
+              },
+              {
+                "label": "extractStr",
+                "type": "custom-link",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.extractstr",
+                "collapsed": true,
+                "collapsible": true,
+                "items": [
+                  {
+                    "label": "strLength",
+                    "type": "custom-link",
+                    "link": "/api/rspeedy/react-rsbuild-plugin.extractstrconfig.strlength",
+                    "collapsed": true,
+                    "collapsible": false,
+                    "items": []
+                  }
+                ]
+              },
+              {
+                "label": "firstScreenSyncTiming",
+                "type": "custom-link",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.firstscreensynctiming",
+                "collapsed": true,
+                "collapsible": false,
+                "items": []
+              },
+              {
+                "label": "pipelineSchedulerConfig",
+                "type": "custom-link",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.pipelineschedulerconfig",
+                "collapsed": true,
+                "collapsible": false,
+                "items": []
+              },
+              {
+                "label": "removeDescendantSelectorScope",
+                "type": "custom-link",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.removedescendantselectorscope",
+                "collapsed": true,
+                "collapsible": false,
+                "items": []
+              },
+              {
+                "label": "shake",
+                "type": "custom-link",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.shake",
+                "collapsed": true,
+                "collapsible": true,
+                "items": [
+                  {
+                    "label": "pkgName",
+                    "type": "custom-link",
+                    "link": "/api/rspeedy/react-rsbuild-plugin.shakevisitorconfig.pkgname",
+                    "collapsed": true,
+                    "collapsible": false,
+                    "items": []
+                  },
+                  {
+                    "label": "removeCallParams",
+                    "type": "custom-link",
+                    "link": "/api/rspeedy/react-rsbuild-plugin.shakevisitorconfig.removecallparams",
+                    "collapsed": true,
+                    "collapsible": false,
+                    "items": []
+                  },
+                  {
+                    "label": "retainProp",
+                    "type": "custom-link",
+                    "link": "/api/rspeedy/react-rsbuild-plugin.shakevisitorconfig.retainprop",
+                    "collapsed": true,
+                    "collapsible": false,
+                    "items": []
+                  }
+                ]
+              },
+              {
+                "label": "targetSdkVersion",
+                "type": "custom-link",
+                "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.targetsdkversion",
                 "collapsed": true,
                 "collapsible": false,
                 "items": []
               }
             ]
-          },
-          {
-            "label": "customCSSInheritanceList",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.customcssinheritancelist",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "debugInfoOutside",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.debuginfooutside",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "defaultDisplayLinear",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.defaultdisplaylinear",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "defineDCE",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.definedce",
-            "collapsed": true,
-            "collapsible": true,
-            "items": [
-              {
-                "label": "define",
-                "type": "custom-link",
-                "link": "/api/rspeedy/react-rsbuild-plugin.definedcevisitorconfig.define",
-                "collapsed": true,
-                "collapsible": false,
-                "items": []
-              }
-            ]
-          },
-          {
-            "label": "enableAccessibilityElement",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enableaccessibilityelement",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "enableCSSInheritance",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enablecssinheritance",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "enableCSSInvalidation",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enablecssinvalidation",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "enableCSSSelector",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enablecssselector",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "enableICU",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enableicu",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "enableNewGesture",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enablenewgesture",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "enableParallelElement",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enableparallelelement",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "enableRemoveCSSScope",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enableremovecssscope",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "enableSSR",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enablessr",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "engineVersion",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.engineversion",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "experimental_isLazyBundle",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.experimental_islazybundle",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "extractStr",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.extractstr",
-            "collapsed": true,
-            "collapsible": true,
-            "items": [
-              {
-                "label": "strLength",
-                "type": "custom-link",
-                "link": "/api/rspeedy/react-rsbuild-plugin.extractstrconfig.strlength",
-                "collapsed": true,
-                "collapsible": false,
-                "items": []
-              }
-            ]
-          },
-          {
-            "label": "firstScreenSyncTiming",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.firstscreensynctiming",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "pipelineSchedulerConfig",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.pipelineschedulerconfig",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "removeDescendantSelectorScope",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.removedescendantselectorscope",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
-          },
-          {
-            "label": "shake",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.shake",
-            "collapsed": true,
-            "collapsible": true,
-            "items": [
-              {
-                "label": "pkgName",
-                "type": "custom-link",
-                "link": "/api/rspeedy/react-rsbuild-plugin.shakevisitorconfig.pkgname",
-                "collapsed": true,
-                "collapsible": false,
-                "items": []
-              },
-              {
-                "label": "removeCallParams",
-                "type": "custom-link",
-                "link": "/api/rspeedy/react-rsbuild-plugin.shakevisitorconfig.removecallparams",
-                "collapsed": true,
-                "collapsible": false,
-                "items": []
-              },
-              {
-                "label": "retainProp",
-                "type": "custom-link",
-                "link": "/api/rspeedy/react-rsbuild-plugin.shakevisitorconfig.retainprop",
-                "collapsed": true,
-                "collapsible": false,
-                "items": []
-              }
-            ]
-          },
-          {
-            "label": "targetSdkVersion",
-            "type": "custom-link",
-            "link": "/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.targetsdkversion",
-            "collapsed": true,
-            "collapsible": false,
-            "items": []
           }
         ]
-      }
-    ]
-  },
-  {
-    "type": "custom-link",
-    "label": "@lynx-js/qrcode-rsbuild-plugin",
-    "collapsible": true,
-    "collapsed": true,
-    "items": [
-      {
-        "label": "CustomizedSchemaFn",
-        "link": "/api/rspeedy/qrcode-rsbuild-plugin.customizedschemafn",
-        "collapsed": true,
-        "collapsible": false
       },
       {
-        "label": "pluginQRCode",
-        "link": "/api/rspeedy/qrcode-rsbuild-plugin.pluginqrcode",
-        "collapsed": true,
+        "type": "custom-link",
+        "label": "@lynx-js/qrcode-rsbuild-plugin",
         "collapsible": true,
+        "collapsed": true,
         "items": [
           {
-            "label": "schema",
-            "link": "/api/rspeedy/qrcode-rsbuild-plugin.pluginqrcodeoptions.schema",
+            "label": "CustomizedSchemaFn",
+            "link": "/api/rspeedy/qrcode-rsbuild-plugin.customizedschemafn",
             "collapsed": true,
             "collapsible": false
+          },
+          {
+            "label": "pluginQRCode",
+            "link": "/api/rspeedy/qrcode-rsbuild-plugin.pluginqrcode",
+            "collapsed": true,
+            "collapsible": true,
+            "items": [
+              {
+                "label": "schema",
+                "link": "/api/rspeedy/qrcode-rsbuild-plugin.pluginqrcodeoptions.schema",
+                "collapsed": true,
+                "collapsible": false
+              }
+            ]
           }
         ]
-      }
-    ]
-  },
-  {
-    "type": "custom-link",
-    "label": "@lynx-js/external-bundle-rsbuild-plugin",
-    "link": "/api/rspeedy/external-bundle-rsbuild-plugin",
-    "collapsible": true,
-    "collapsed": true,
-    "items": [
-      {
-        "type": "custom-link",
-        "label": "builtInExternalsPresetDefinitions",
-        "link": "/api/rspeedy/external-bundle-rsbuild-plugin.builtinexternalspresetdefinitions"
       },
       {
         "type": "custom-link",
-        "label": "ExternalsPresetContext",
-        "link": "/api/rspeedy/external-bundle-rsbuild-plugin.externalspresetcontext"
+        "label": "@lynx-js/external-bundle-rsbuild-plugin",
+        "link": "/api/rspeedy/external-bundle-rsbuild-plugin",
+        "collapsible": true,
+        "collapsed": true,
+        "items": [
+          {
+            "type": "custom-link",
+            "label": "builtInExternalsPresetDefinitions",
+            "link": "/api/rspeedy/external-bundle-rsbuild-plugin.builtinexternalspresetdefinitions"
+          },
+          {
+            "type": "custom-link",
+            "label": "ExternalsPresetContext",
+            "link": "/api/rspeedy/external-bundle-rsbuild-plugin.externalspresetcontext"
+          },
+          {
+            "type": "custom-link",
+            "label": "ExternalsPresetDefinition",
+            "link": "/api/rspeedy/external-bundle-rsbuild-plugin.externalspresetdefinition"
+          },
+          {
+            "type": "custom-link",
+            "label": "ExternalsPresetDefinitions",
+            "link": "/api/rspeedy/external-bundle-rsbuild-plugin.externalspresetdefinitions"
+          },
+          {
+            "type": "custom-link",
+            "label": "ExternalsPresets",
+            "link": "/api/rspeedy/external-bundle-rsbuild-plugin.externalspresets"
+          },
+          {
+            "type": "custom-link",
+            "label": "normalizeBundlePath",
+            "link": "/api/rspeedy/external-bundle-rsbuild-plugin.normalizebundlepath"
+          },
+          {
+            "type": "custom-link",
+            "label": "pluginExternalBundle",
+            "link": "/api/rspeedy/external-bundle-rsbuild-plugin.pluginexternalbundle"
+          },
+          {
+            "type": "custom-link",
+            "label": "PluginExternalBundleOptions",
+            "link": "/api/rspeedy/external-bundle-rsbuild-plugin.pluginexternalbundleoptions"
+          },
+          {
+            "type": "custom-link",
+            "label": "PluginExternalConfig",
+            "link": "/api/rspeedy/external-bundle-rsbuild-plugin.pluginexternalconfig"
+          },
+          {
+            "type": "custom-link",
+            "label": "PluginExternalValue",
+            "link": "/api/rspeedy/external-bundle-rsbuild-plugin.pluginexternalvalue"
+          },
+          {
+            "type": "custom-link",
+            "label": "ReactLynxExternalsPresetOptions",
+            "link": "/api/rspeedy/external-bundle-rsbuild-plugin.reactlynxexternalspresetoptions"
+          }
+        ]
       },
       {
         "type": "custom-link",
-        "label": "ExternalsPresetDefinition",
-        "link": "/api/rspeedy/external-bundle-rsbuild-plugin.externalspresetdefinition"
-      },
-      {
-        "type": "custom-link",
-        "label": "ExternalsPresetDefinitions",
-        "link": "/api/rspeedy/external-bundle-rsbuild-plugin.externalspresetdefinitions"
-      },
-      {
-        "type": "custom-link",
-        "label": "ExternalsPresets",
-        "link": "/api/rspeedy/external-bundle-rsbuild-plugin.externalspresets"
-      },
-      {
-        "type": "custom-link",
-        "label": "normalizeBundlePath",
-        "link": "/api/rspeedy/external-bundle-rsbuild-plugin.normalizebundlepath"
-      },
-      {
-        "type": "custom-link",
-        "label": "pluginExternalBundle",
-        "link": "/api/rspeedy/external-bundle-rsbuild-plugin.pluginexternalbundle"
-      },
-      {
-        "type": "custom-link",
-        "label": "PluginExternalBundleOptions",
-        "link": "/api/rspeedy/external-bundle-rsbuild-plugin.pluginexternalbundleoptions"
-      },
-      {
-        "type": "custom-link",
-        "label": "PluginExternalConfig",
-        "link": "/api/rspeedy/external-bundle-rsbuild-plugin.pluginexternalconfig"
-      },
-      {
-        "type": "custom-link",
-        "label": "PluginExternalValue",
-        "link": "/api/rspeedy/external-bundle-rsbuild-plugin.pluginexternalvalue"
-      },
-      {
-        "type": "custom-link",
-        "label": "ReactLynxExternalsPresetOptions",
-        "link": "/api/rspeedy/external-bundle-rsbuild-plugin.reactlynxexternalspresetoptions"
-      }
-    ]
-  },
-  {
-    "type": "custom-link",
-    "label": "@lynx-js/lynx-bundle-rslib-config",
-    "link": "/api/rspeedy/lynx-bundle-rslib-config",
-    "collapsible": true,
-    "collapsed": true,
-    "items": [
-      {
-        "type": "custom-link",
-        "label": "builtInExternalsPresetDefinitions",
-        "link": "/api/rspeedy/lynx-bundle-rslib-config.builtinexternalspresetdefinitions"
-      },
-      {
-        "type": "custom-link",
-        "label": "defaultExternalBundleLibConfig",
-        "link": "/api/rspeedy/lynx-bundle-rslib-config.defaultexternalbundlelibconfig"
-      },
-      {
-        "type": "custom-link",
-        "label": "defineExternalBundleRslibConfig",
-        "link": "/api/rspeedy/lynx-bundle-rslib-config.defineexternalbundlerslibconfig"
-      },
-      {
-        "type": "custom-link",
-        "label": "EncodeOptions",
-        "link": "/api/rspeedy/lynx-bundle-rslib-config.encodeoptions"
-      },
-      {
-        "type": "custom-link",
-        "label": "ExternalBundleWebpackPlugin",
-        "link": "/api/rspeedy/lynx-bundle-rslib-config.externalbundlewebpackplugin"
-      },
-      {
-        "type": "custom-link",
-        "label": "ExternalBundleLibConfig",
-        "link": "/api/rspeedy/lynx-bundle-rslib-config.externalbundlelibconfig"
-      },
-      {
-        "type": "custom-link",
-        "label": "ExternalBundleWebpackPluginOptions",
-        "link": "/api/rspeedy/lynx-bundle-rslib-config.externalbundlewebpackpluginoptions"
-      },
-      {
-        "type": "custom-link",
-        "label": "Externals",
-        "link": "/api/rspeedy/lynx-bundle-rslib-config.externals"
-      },
-      {
-        "type": "custom-link",
-        "label": "ExternalsPresetDefinition",
-        "link": "/api/rspeedy/lynx-bundle-rslib-config.externalspresetdefinition"
-      },
-      {
-        "type": "custom-link",
-        "label": "ExternalsPresetDefinitions",
-        "link": "/api/rspeedy/lynx-bundle-rslib-config.externalspresetdefinitions"
-      },
-      {
-        "type": "custom-link",
-        "label": "ExternalsPresets",
-        "link": "/api/rspeedy/lynx-bundle-rslib-config.externalspresets"
-      },
-      {
-        "type": "custom-link",
-        "label": "MainThreadRuntimeWrapperWebpackPlugin",
-        "link": "/api/rspeedy/lynx-bundle-rslib-config.mainthreadruntimewrapperwebpackplugin"
-      },
-      {
-        "type": "custom-link",
-        "label": "MainThreadRuntimeWrapperWebpackPluginOptions",
-        "link": "/api/rspeedy/lynx-bundle-rslib-config.mainthreadruntimewrapperwebpackpluginoptions"
-      },
-      {
-        "type": "custom-link",
-        "label": "OutputConfig",
-        "link": "/api/rspeedy/lynx-bundle-rslib-config.outputconfig"
-      },
-      {
-        "type": "custom-link",
-        "label": "reactLynxExternalsPreset",
-        "link": "/api/rspeedy/lynx-bundle-rslib-config.reactlynxexternalspreset"
+        "label": "@lynx-js/lynx-bundle-rslib-config",
+        "link": "/api/rspeedy/lynx-bundle-rslib-config",
+        "collapsible": true,
+        "collapsed": true,
+        "items": [
+          {
+            "type": "custom-link",
+            "label": "builtInExternalsPresetDefinitions",
+            "link": "/api/rspeedy/lynx-bundle-rslib-config.builtinexternalspresetdefinitions"
+          },
+          {
+            "type": "custom-link",
+            "label": "defaultExternalBundleLibConfig",
+            "link": "/api/rspeedy/lynx-bundle-rslib-config.defaultexternalbundlelibconfig"
+          },
+          {
+            "type": "custom-link",
+            "label": "defineExternalBundleRslibConfig",
+            "link": "/api/rspeedy/lynx-bundle-rslib-config.defineexternalbundlerslibconfig"
+          },
+          {
+            "type": "custom-link",
+            "label": "EncodeOptions",
+            "link": "/api/rspeedy/lynx-bundle-rslib-config.encodeoptions"
+          },
+          {
+            "type": "custom-link",
+            "label": "ExternalBundleWebpackPlugin",
+            "link": "/api/rspeedy/lynx-bundle-rslib-config.externalbundlewebpackplugin"
+          },
+          {
+            "type": "custom-link",
+            "label": "ExternalBundleLibConfig",
+            "link": "/api/rspeedy/lynx-bundle-rslib-config.externalbundlelibconfig"
+          },
+          {
+            "type": "custom-link",
+            "label": "ExternalBundleWebpackPluginOptions",
+            "link": "/api/rspeedy/lynx-bundle-rslib-config.externalbundlewebpackpluginoptions"
+          },
+          {
+            "type": "custom-link",
+            "label": "Externals",
+            "link": "/api/rspeedy/lynx-bundle-rslib-config.externals"
+          },
+          {
+            "type": "custom-link",
+            "label": "ExternalsPresetDefinition",
+            "link": "/api/rspeedy/lynx-bundle-rslib-config.externalspresetdefinition"
+          },
+          {
+            "type": "custom-link",
+            "label": "ExternalsPresetDefinitions",
+            "link": "/api/rspeedy/lynx-bundle-rslib-config.externalspresetdefinitions"
+          },
+          {
+            "type": "custom-link",
+            "label": "ExternalsPresets",
+            "link": "/api/rspeedy/lynx-bundle-rslib-config.externalspresets"
+          },
+          {
+            "type": "custom-link",
+            "label": "MainThreadRuntimeWrapperWebpackPlugin",
+            "link": "/api/rspeedy/lynx-bundle-rslib-config.mainthreadruntimewrapperwebpackplugin"
+          },
+          {
+            "type": "custom-link",
+            "label": "MainThreadRuntimeWrapperWebpackPluginOptions",
+            "link": "/api/rspeedy/lynx-bundle-rslib-config.mainthreadruntimewrapperwebpackpluginoptions"
+          },
+          {
+            "type": "custom-link",
+            "label": "OutputConfig",
+            "link": "/api/rspeedy/lynx-bundle-rslib-config.outputconfig"
+          },
+          {
+            "type": "custom-link",
+            "label": "reactLynxExternalsPreset",
+            "link": "/api/rspeedy/lynx-bundle-rslib-config.reactlynxexternalspreset"
+          }
+        ]
       }
     ]
   },

--- a/i18n.json
+++ b/i18n.json
@@ -632,8 +632,8 @@
     "zh": "调整样式"
   },
   "sidebar.rspeedy.header": {
-    "en": "Compilation Toolchain",
-    "zh": "编译工具链"
+    "en": "Configuration",
+    "zh": "配置"
   },
   "sidebar.testing": {
     "en": "Testing",


### PR DESCRIPTION
## Summary

- Wrap the four `@lynx-js/*` plugin entries (`react-rsbuild-plugin`, `qrcode-rsbuild-plugin`, `external-bundle-rsbuild-plugin`, `lynx-bundle-rslib-config`) under a collapsible "Plugins" group in the API sidebar

## Test plan

- [ ] "Plugins" appears as a collapsible entry under "Compilation Toolchain"
- [ ] Expanding "Plugins" shows all four `@lynx-js/*` plugin entries
- [ ] `lynx.config.js` remains at the top level, outside "Plugins"
- [ ] Each plugin's nested API entries still expand correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Refactor API sidebar to group Rspeedy plugins under collapsible section

Group the four `@lynx-js/*` plugin documentation entries under a new collapsible "Rspeedy Plugins" section in the API sidebar, while keeping `lynx.config.js` at the top level. Update the section header label from "Compilation Toolchain" to "Configuration" across English and Chinese documentation.

### Changes

- Group `@lynx-js/react-rsbuild-plugin`, `@lynx-js/qrcode-rsbuild-plugin`, `@lynx-js/external-bundle-rsbuild-plugin`, and `@lynx-js/lynx-bundle-rslib-config` under a new "Rspeedy Plugins" collapsible section in both English and Chinese API sidebars
- Update i18n label for section header from "Compilation Toolchain" to "Configuration"
- Preserve `lynx.config.js` as a top-level entry outside the plugins group

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/998)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->