### PR TITLE
fix: reduce Node heap and SSG workers to avoid Netlify OOM kill

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@lynx-js/lynx-doc",
   "version": "1.0.0",
   "scripts": {
-    "build": "NODE_OPTIONS=--max-old-space-size=8192 RSPRESS_SSG_WORKER_THREAD_COUNT=4 rspress build",
+    "build": "NODE_OPTIONS=--max-old-space-size=4096 RSPRESS_SSG_WORKER_THREAD_COUNT=2 rspress build",
     "check-docs": "python3 -m scripts.check_api_doc.index",
     "cspell:check": "cspell lint -c cspell.json \"docs/**/*.md(x)\"",
     "dev": "rspress dev",


### PR DESCRIPTION
## Summary

- Reduce `--max-old-space-size` from 8192 to 4096 MB
- Reduce `RSPRESS_SSG_WORKER_THREAD_COUNT` from 4 to 2

The Netlify deploy was failing with exit code 137 (SIGKILL from OOM killer). The previous 8GB heap + 4 SSG workers config was too aggressive for Netlify's container memory limits -- each Node process inherits the heap ceiling, and concurrent SSG workers multiply peak memory usage.

If this still OOMs, next step is 3072 MB heap + 1 worker.

## Test plan

- [ ] Netlify deploy preview completes without exit 137
- [ ] Cloudflare Pages build also succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Reduce Node heap and SSG workers to avoid Netlify OOM kill

- Reduce Node V8 `max-old-space-size` from 8192 MB to 4096 MB in the `build` script's `NODE_OPTIONS`
- Reduce `RSPRESS_SSG_WORKER_THREAD_COUNT` from 4 to 2 in the `build` script

These changes address Netlify deployment failures caused by the OS OOM killer (exit code 137). The previous configuration resulted in excessive concurrent memory usage because each Node process inherits the heap ceiling and multiple SSG worker processes compound peak memory consumption.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/1000)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->