### PR TITLE
[codex] docs: clarify Autolink host app structure

### DIFF
--- a/docs/en/guide/autolink.mdx
+++ b/docs/en/guide/autolink.mdx
@@ -26,6 +26,28 @@ If one of these packages cannot be resolved from your configured registries, you
 
 :::
 
+## Host App Project Structure
+
+Before enabling Autolink, make sure the host app has a project root that can install npm packages and expose the native app build entry points. A typical host app looks like this:
+
+```text
+lynx-app/
+├── package.json
+├── android/
+│   ├── settings.gradle
+│   └── app/
+│       └── build.gradle
+├── ios/
+│   └── Podfile
+└── src/
+```
+
+- `package.json` is required so the app can declare Autolink extension packages as dependencies.
+- For Android, the project needs a Gradle settings file, such as `settings.gradle` or `settings.gradle.kts`, and an Android application build file, such as `app/build.gradle` or `app/build.gradle.kts`.
+- For iOS, the project needs a CocoaPods entry point, usually `Podfile`. If your team manages Ruby dependencies with Bundler, keep the `cocoapods-lynx-extension` gem in `Gemfile`.
+
+After you install dependencies, Autolink scans the installed npm packages for `lynx.ext.json` files at package roots. A lockfile such as `package-lock.json`, `pnpm-lock.yaml`, or `yarn.lock` is recommended for reproducible installs, but it is not required by Autolink.
+
 ## Set Up Autolink in an App
 
 Set up Autolink once in the host app. After that, installed extension packages can be discovered from `node_modules` and registered through the generated registry.

--- a/docs/zh/guide/autolink.mdx
+++ b/docs/zh/guide/autolink.mdx
@@ -26,6 +26,28 @@ Autolink 当前只覆盖 Android 和 iOS 原生扩展，不生成 Web 或 Harmon
 
 :::
 
+## 宿主应用项目结构
+
+接入 Autolink 前，需要先确保宿主应用有一个可以安装 npm 包的项目根目录，并暴露原生应用的构建入口。典型结构如下：
+
+```text
+lynx-app/
+├── package.json
+├── android/
+│   ├── settings.gradle
+│   └── app/
+│       └── build.gradle
+├── ios/
+│   └── Podfile
+└── src/
+```
+
+- `package.json` 是必需的，用来声明 Autolink 扩展包依赖。
+- Android 接入需要 Gradle settings 文件，例如 `settings.gradle` 或 `settings.gradle.kts`，以及 Android application 的构建文件，例如 `app/build.gradle` 或 `app/build.gradle.kts`。
+- iOS 接入需要 CocoaPods 入口，通常是 `Podfile`。如果团队通过 Bundler 管理 Ruby 依赖，可以在 `Gemfile` 中维护 `cocoapods-lynx-extension` gem。
+
+安装依赖后，Autolink 会从已安装 npm 包的包根目录扫描 `lynx.ext.json`。`package-lock.json`、`pnpm-lock.yaml` 或 `yarn.lock` 等 lockfile 有助于可复现安装，但不是 Autolink 的必需项。
+
 ## 在应用中接入 Autolink
 
 宿主应用只需要接入一次 Autolink。接入完成后，已安装的扩展包会从 `node_modules` 中被发现，并通过生成的 registry 自动注册。


### PR DESCRIPTION
## Summary
- Add a Host App Project Structure section to the Autolink guide.
- Clarify that host apps need a package root with `package.json`, Android Gradle entry points, and an iOS CocoaPods entry point.
- Explain that `node_modules` is part of the install/scanning mechanism and lockfiles are recommended for reproducible installs but not required by Autolink.

## Impact
This helps app integrators understand what project files they must prepare before enabling Autolink, without changing Autolink APIs, schemas, or plugin behavior.

## Validation
- `pnpm exec prettier --check docs/en/guide/autolink.mdx docs/zh/guide/autolink.mdx`
- `pnpm exec cspell lint -c cspell.json docs/en/guide/autolink.mdx docs/zh/guide/autolink.mdx --no-must-find-files`
- `pnpm exec zhlint docs/zh/guide/autolink.mdx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Clarify Autolink host app project structure in documentation

- Add "Host App Project Structure" section to `docs/en/guide/autolink.mdx` documenting required host app elements (package.json, Android Gradle entry points, iOS Podfile)
- Add corresponding "宿主应用项目结构" section to `docs/zh/guide/autolink.mdx` with localized content and typical project layout example
- Document that Autolink scans installed npm packages for `lynx.ext.json` at package roots
- Clarify that lockfiles are recommended for reproducible installs but not required by Autolink
- Note that no Autolink API, schema, or plugin behavior changes are introduced

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/1001)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->