### PR TITLE
refactor(lynx-ui): use dir-section-header for Components and reorganize sidebar

### DIFF
--- a/docs/en/lynx-ui/_meta.json
+++ b/docs/en/lynx-ui/_meta.json
@@ -5,6 +5,11 @@
     "label": "What is lynx-ui"
   },
   {
+    "type": "custom-link",
+    "link": "/ai/skills/lynx-ui.html",
+    "label": "lynx-ui Skills ↗"
+  },
+  {
     "type": "divider"
   },
   {
@@ -25,23 +30,8 @@
     "type": "divider"
   },
   {
-    "type": "file",
-    "name": "contributing",
-    "label": "Contributing"
-  },
-  {
-    "type": "custom-link",
-    "link": "/ai/skills/lynx-ui.html",
-    "label": "Skills ↗"
-  },
-  {
-    "type": "divider"
-  },
-  {
-    "type": "dir",
+    "type": "dir-section-header",
     "name": "components",
-    "label": "Components",
-    "collapsible": true,
-    "collapsed": false
+    "label": "Components"
   }
 ]

--- a/docs/zh/lynx-ui/_meta.json
+++ b/docs/zh/lynx-ui/_meta.json
@@ -5,6 +5,11 @@
     "label": "lynx-ui 是什么"
   },
   {
+    "type": "custom-link",
+    "link": "/ai/skills/lynx-ui.html",
+    "label": "lynx-ui Skills ↗"
+  },
+  {
     "type": "divider"
   },
   {
@@ -25,23 +30,8 @@
     "type": "divider"
   },
   {
-    "type": "file",
-    "name": "contributing",
-    "label": "贡献指南"
-  },
-  {
-    "type": "custom-link",
-    "link": "/ai/skills/lynx-ui.html",
-    "label": "Skills ↗"
-  },
-  {
-    "type": "divider"
-  },
-  {
-    "type": "dir",
+    "type": "dir-section-header",
     "name": "components",
-    "label": "组件",
-    "collapsible": true,
-    "collapsed": false
+    "label": "组件"
   }
 ]


### PR DESCRIPTION
## Summary
- Change Components sidebar entry from collapsible `dir` to `dir-section-header`, so component items render at the same visual tier as the section title
- Move "Skills ↗" link to right after "What is lynx-ui" and rename to "lynx-ui Skills ↗"
- Remove "Contributing" link from sidebar

## Test plan
- [ ] Verify sidebar renders Components as a section header, not a collapsible group
- [ ] Verify "lynx-ui Skills ↗" link appears right after "What is lynx-ui"
- [ ] Verify "Contributing" is no longer in the sidebar
- [ ] Check both EN and ZH locales

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Refactor lynx-ui sidebar layout with dir-section-header and reorganize navigation

- Convert Components sidebar entry from collapsible `dir` to `dir-section-header` in both EN and ZH locales
- Add "lynx-ui Skills ↗" custom link immediately after "What is lynx-ui" section in both locales
- Remove "Contributing" link and replace previous `Skills ↗` link structure with new navigation arrangement

Changes affect:
- `docs/en/lynx-ui/_meta.json`
- `docs/zh/lynx-ui/_meta.json`

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/1002)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->