### PR TITLE
fix(ci): format unformatted files and constrain Netlify build memory

### DIFF
--- a/.github/scripts/cherry-pick-request.mjs
+++ b/.github/scripts/cherry-pick-request.mjs
@@ -530,7 +530,7 @@ function renderValidationFailureComment(errors, workflowUrl, options = {}) {
     ? 'Cherry-pick request is invalid for automatic execution.'
     : options.reopened
       ? 'Cherry-pick request was reopened and revalidated, but it is still invalid.'
-    : 'Cherry-pick request is invalid and will not execute yet.';
+      : 'Cherry-pick request is invalid and will not execute yet.';
   const nextSteps = hasWorkflowFiles
     ? [
         'Handle this backport manually, or use a separately approved process with a token that has workflow permission.',
@@ -805,9 +805,7 @@ async function validateCommand() {
 
   if (event.action === 'unlabeled' && event.label?.name === APPROVED_LABEL) {
     if (isGitHubActionsBot(event.sender)) {
-      console.log(
-        'Approval label was removed by github-actions[bot]; no-op.',
-      );
+      console.log('Approval label was removed by github-actions[bot]; no-op.');
       setOutput('should_execute', 'false');
       return;
     }
@@ -1130,15 +1128,13 @@ function formatConflictList(files) {
 }
 
 function isWorkflowPermissionPushError(error) {
-  const text = [
-    error?.message,
-    error?.git?.stdout,
-    error?.git?.stderr,
-  ]
+  const text = [error?.message, error?.git?.stdout, error?.git?.stderr]
     .filter(Boolean)
     .join('\n');
   return (
-    text.includes('refusing to allow a GitHub App to create or update workflow') ||
+    text.includes(
+      'refusing to allow a GitHub App to create or update workflow',
+    ) ||
     text.includes('without `workflows` permission') ||
     text.includes('without `workflow` permission')
   );
@@ -1244,7 +1240,14 @@ async function findExistingGeneratedPr(
     `&head=${head}&base=${encodeURIComponent(target)}`,
   );
   const open = openPulls.find((pr) =>
-    prHasGeneratedIdentity(pr, repo, sourcePr, target, requestIssue, branchName),
+    prHasGeneratedIdentity(
+      pr,
+      repo,
+      sourcePr,
+      target,
+      requestIssue,
+      branchName,
+    ),
   );
   if (open) return { kind: 'open', pr: open };
 
@@ -1254,7 +1257,14 @@ async function findExistingGeneratedPr(
     `&head=${head}&base=${encodeURIComponent(target)}`,
   );
   const closed = closedPulls.find((pr) =>
-    prHasGeneratedIdentity(pr, repo, sourcePr, target, requestIssue, branchName),
+    prHasGeneratedIdentity(
+      pr,
+      repo,
+      sourcePr,
+      target,
+      requestIssue,
+      branchName,
+    ),
   );
   if (closed)
     return {

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,7 @@
+[build]
+  command = "NODE_OPTIONS=--max-old-space-size=3072 RSPRESS_SSG_WORKER_THREAD_COUNT=1 npx rspress build"
+  publish = "doc_build"
+
 [[headers]]
   for = "/*"
   [headers.values]

--- a/scripts/lynx-example.js
+++ b/scripts/lynx-example.js
@@ -135,9 +135,7 @@ function replaceBufferContent(buffer, from, to) {
   const toBuffer = Buffer.from(to);
 
   if (fromBuffer.length !== toBuffer.length) {
-    throw new Error(
-      `Fixup replacement length mismatch: "${from}" -> "${to}"`,
-    );
+    throw new Error(`Fixup replacement length mismatch: "${from}" -> "${to}"`);
   }
 
   let index = buffer.indexOf(fromBuffer);


### PR DESCRIPTION
## Summary

Fixes two CI failures that have been breaking all PRs since #1001:

- **Prettier**: `cherry-pick-request.mjs` and `lynx-example.js` were merged without formatting, failing the `format:check` step. Fixed by running Prettier on both files.
- **Netlify OOM**: deploy previews have been OOM-killed since new docs were added after #1000. The `[build]` section in `netlify.toml` now overrides the build command with more constrained settings (3072 MB heap, 1 SSG worker) separate from the general `build` script which remains at 4096 MB / 2 workers for other CI environments.

## Test plan
- [ ] Validate CI `format:check` step passes
- [ ] Netlify deploy preview succeeds without OOM kill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Format cherry-pick-request.mjs and lynx-example.js files with Prettier to resolve format:check CI failures.

Constrain Netlify build memory to 3072 MB with a single SSG worker thread for deploy previews, while maintaining 4096 MB and 2 workers for other CI environments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/1004)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->