### PR TITLE
style(prettier): apply formatting

### DIFF
--- a/.github/scripts/cherry-pick-request.mjs
+++ b/.github/scripts/cherry-pick-request.mjs
@@ -530,7 +530,7 @@ function renderValidationFailureComment(errors, workflowUrl, options = {}) {
     ? 'Cherry-pick request is invalid for automatic execution.'
     : options.reopened
       ? 'Cherry-pick request was reopened and revalidated, but it is still invalid.'
-    : 'Cherry-pick request is invalid and will not execute yet.';
+      : 'Cherry-pick request is invalid and will not execute yet.';
   const nextSteps = hasWorkflowFiles
     ? [
         'Handle this backport manually, or use a separately approved process with a token that has workflow permission.',
@@ -805,9 +805,7 @@ async function validateCommand() {
 
   if (event.action === 'unlabeled' && event.label?.name === APPROVED_LABEL) {
     if (isGitHubActionsBot(event.sender)) {
-      console.log(
-        'Approval label was removed by github-actions[bot]; no-op.',
-      );
+      console.log('Approval label was removed by github-actions[bot]; no-op.');
       setOutput('should_execute', 'false');
       return;
     }
@@ -1130,15 +1128,13 @@ function formatConflictList(files) {
 }
 
 function isWorkflowPermissionPushError(error) {
-  const text = [
-    error?.message,
-    error?.git?.stdout,
-    error?.git?.stderr,
-  ]
+  const text = [error?.message, error?.git?.stdout, error?.git?.stderr]
     .filter(Boolean)
     .join('\n');
   return (
-    text.includes('refusing to allow a GitHub App to create or update workflow') ||
+    text.includes(
+      'refusing to allow a GitHub App to create or update workflow',
+    ) ||
     text.includes('without `workflows` permission') ||
     text.includes('without `workflow` permission')
   );
@@ -1244,7 +1240,14 @@ async function findExistingGeneratedPr(
     `&head=${head}&base=${encodeURIComponent(target)}`,
   );
   const open = openPulls.find((pr) =>
-    prHasGeneratedIdentity(pr, repo, sourcePr, target, requestIssue, branchName),
+    prHasGeneratedIdentity(
+      pr,
+      repo,
+      sourcePr,
+      target,
+      requestIssue,
+      branchName,
+    ),
   );
   if (open) return { kind: 'open', pr: open };
 
@@ -1254,7 +1257,14 @@ async function findExistingGeneratedPr(
     `&head=${head}&base=${encodeURIComponent(target)}`,
   );
   const closed = closedPulls.find((pr) =>
-    prHasGeneratedIdentity(pr, repo, sourcePr, target, requestIssue, branchName),
+    prHasGeneratedIdentity(
+      pr,
+      repo,
+      sourcePr,
+      target,
+      requestIssue,
+      branchName,
+    ),
   );
   if (closed)
     return {

--- a/packages/lynx-compat-data/api-stats.json
+++ b/packages/lynx-compat-data/api-stats.json
@@ -189,7 +189,7 @@
           "android": 39,
           "ios": 39,
           "harmony": 39,
-          "web_lynx": 64,
+          "web_lynx": 62,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 66,
@@ -200,7 +200,7 @@
           "android": 58,
           "ios": 58,
           "harmony": 58,
-          "web_lynx": 96,
+          "web_lynx": 93,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 99,
@@ -633,8 +633,8 @@
         "exclusive_count": 7
       },
       "web_lynx": {
-        "supported_count": 712,
-        "coverage_percent": 70,
+        "supported_count": 710,
+        "coverage_percent": 69,
         "exclusive_count": 30
       },
       "clay_android": {
@@ -31543,7 +31543,7 @@
           "android": 39,
           "ios": 39,
           "harmony": 39,
-          "web_lynx": 64,
+          "web_lynx": 62,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 66,
@@ -31554,7 +31554,7 @@
           "android": 58,
           "ios": 58,
           "harmony": 58,
-          "web_lynx": 96,
+          "web_lynx": 93,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 99,
@@ -34101,6 +34101,22 @@
             }
           },
           {
+            "path": "lynx-api/event/TouchEvent.detail",
+            "name": "detail",
+            "doc_url": "api/lynx-api/event/touch-event",
+            "support": {
+              "android": "1.5",
+              "ios": "1.5",
+              "harmony": "3.4",
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "3.5",
+              "clay_windows": "3.5",
+              "clay": "3.5"
+            }
+          },
+          {
             "path": "lynx-api/event/TouchEvent.longpress",
             "name": "longpress",
             "doc_url": "api/lynx-api/event/touch-event",
@@ -34108,6 +34124,22 @@
               "android": "1.5",
               "ios": "1.5",
               "harmony": "3.4",
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "3.5",
+              "clay_windows": "3.5",
+              "clay": "3.5"
+            }
+          },
+          {
+            "path": "lynx-api/event/TouchEvent.click",
+            "name": "click",
+            "doc_url": "api/lynx-api/event/touch-event",
+            "support": {
+              "android": "1.5",
+              "ios": "1.5",
+              "harmony": "3.6",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -107150,8 +107182,8 @@
           "coverage": 3
         },
         "web_lynx": {
-          "supported": 703,
-          "coverage": 69
+          "supported": 701,
+          "coverage": 68
         },
         "clay_android": {
           "supported": 464,
@@ -107192,8 +107224,8 @@
           "coverage": 3
         },
         "web_lynx": {
-          "supported": 703,
-          "coverage": 69
+          "supported": 701,
+          "coverage": 68
         },
         "clay_android": {
           "supported": 464,
@@ -107234,8 +107266,8 @@
           "coverage": 3
         },
         "web_lynx": {
-          "supported": 703,
-          "coverage": 69
+          "supported": 701,
+          "coverage": 68
         },
         "clay_android": {
           "supported": 470,
@@ -107276,8 +107308,8 @@
           "coverage": 3
         },
         "web_lynx": {
-          "supported": 703,
-          "coverage": 69
+          "supported": 701,
+          "coverage": 68
         },
         "clay_android": {
           "supported": 473,
@@ -107318,8 +107350,8 @@
           "coverage": 3
         },
         "web_lynx": {
-          "supported": 703,
-          "coverage": 69
+          "supported": 701,
+          "coverage": 68
         },
         "clay_android": {
           "supported": 484,
@@ -107360,8 +107392,8 @@
           "coverage": 3
         },
         "web_lynx": {
-          "supported": 703,
-          "coverage": 69
+          "supported": 701,
+          "coverage": 68
         },
         "clay_android": {
           "supported": 488,
@@ -107402,8 +107434,8 @@
           "coverage": 3
         },
         "web_lynx": {
-          "supported": 703,
-          "coverage": 69
+          "supported": 701,
+          "coverage": 68
         },
         "clay_android": {
           "supported": 488,
@@ -107444,8 +107476,8 @@
           "coverage": 3
         },
         "web_lynx": {
-          "supported": 703,
-          "coverage": 69
+          "supported": 701,
+          "coverage": 68
         },
         "clay_android": {
           "supported": 493,
@@ -107486,8 +107518,8 @@
           "coverage": 3
         },
         "web_lynx": {
-          "supported": 703,
-          "coverage": 69
+          "supported": 701,
+          "coverage": 68
         },
         "clay_android": {
           "supported": 493,
@@ -107528,8 +107560,8 @@
           "coverage": 69
         },
         "web_lynx": {
-          "supported": 703,
-          "coverage": 69
+          "supported": 701,
+          "coverage": 68
         },
         "clay_android": {
           "supported": 522,

--- a/scripts/lynx-example.js
+++ b/scripts/lynx-example.js
@@ -135,9 +135,7 @@ function replaceBufferContent(buffer, from, to) {
   const toBuffer = Buffer.from(to);
 
   if (fromBuffer.length !== toBuffer.length) {
-    throw new Error(
-      `Fixup replacement length mismatch: "${from}" -> "${to}"`,
-    );
+    throw new Error(`Fixup replacement length mismatch: "${from}" -> "${to}"`);
   }
 
   let index = buffer.indexOf(fromBuffer);


### PR DESCRIPTION
This commit only applies Prettier formatting; no functional changes intended.

Formatting drift was introduced by earlier PRs:
- #921
- #956

Verification:
- pnpm format:check

Change-Id: Ideb2bf4b8e60eb21c094e4463bbc03688c8f6900

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/1005)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->