### PR TITLE
refactor: make afterNavTitle a pluggable prop in Layout

### DIFF
--- a/theme/index.tsx
+++ b/theme/index.tsx
@@ -55,7 +55,10 @@ declare global {
   }
 }
 
-function Layout(props: Parameters<typeof BaseLayout>[0]) {
+function Layout({
+  afterNavTitle = <AfterNavTitle />,
+  ...props
+}: Parameters<typeof BaseLayout>[0]) {
   const { pathname } = useLocation();
   const subsite = findSubsite(pathname);
   const normalizedPath = removeBase(pathname);
@@ -72,7 +75,7 @@ function Layout(props: Parameters<typeof BaseLayout>[0]) {
       </Head>
       <BaseLayout
         {...props}
-        afterNavTitle={<AfterNavTitle />}
+        afterNavTitle={afterNavTitle}
         beforeSidebar={<BeforeSidebar />}
         bottom={<Footer />}
       />


### PR DESCRIPTION
## Summary

- Allow downstream consumers (e.g. inhouse theme) to override the `AfterNavTitle` component by passing it as a prop to `Layout`
- Defaults to the built-in `AfterNavTitle` when not specified — zero behavior change for existing usage

## Motivation

The inhouse site needs a customized header dropdown (3-column layout with additional subsites). Currently `AfterNavTitle` is hardcoded in `Layout`, forcing inhouse to either modify the symlinked OSS theme files or use complex overlay mechanisms. Making it a prop allows clean override via:

```tsx
<Layout afterNavTitle={<InhouseAfterNavTitle />} />
```

## Test plan

- [x] No behavior change when prop is not passed (default `<AfterNavTitle />`)
- [ ] Verify build passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Make `afterNavTitle` a pluggable prop in Layout

- Accept `afterNavTitle` prop in the `Layout` component with a default value of `<AfterNavTitle />`
- Pass the `afterNavTitle` prop through to `BaseLayout` instead of hardcoding it
- Enable downstream consumers to override the header component by providing a custom implementation (e.g., `<Layout afterNavTitle={<CustomAfterNavTitle />} />`)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/1006)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->