### PR TITLE
fix(docs): add missing APISummary to element API pages

### DIFF
--- a/docs/en/api/elements/built-in/blur-view.mdx
+++ b/docs/en/api/elements/built-in/blur-view.mdx
@@ -10,9 +10,12 @@ import {
   IOSOnly,
   Required,
   APITable,
+  APISummary,
 } from '@lynx';
 
 # `<blur-view>`
+
+<APISummary />
 
 `<blur-view>` is an element that provides a backdrop blur effect, similar to `backdrop-filter: blur`.
 

--- a/docs/en/api/elements/built-in/refresh.mdx
+++ b/docs/en/api/elements/built-in/refresh.mdx
@@ -10,9 +10,12 @@ import {
   IOSOnly,
   Required,
   APITable,
+  APISummary,
 } from '@lynx';
 
 # `<refresh>`
+
+<APISummary />
 
 `<refresh>` element provides a pull-to-refresh gesture that reveals a customizable header view while new data is being fetched.
 

--- a/docs/en/api/elements/built-in/scroll-coordinator.mdx
+++ b/docs/en/api/elements/built-in/scroll-coordinator.mdx
@@ -10,9 +10,12 @@ import {
   IOSOnly,
   Required,
   APITable,
+  APISummary,
 } from '@lynx';
 
 # `<scroll-coordinator>`
+
+<APISummary />
 
 `<scroll-coordinator>` is a nested scroll coordination component for implementing coordinated scrolling between multiple scrollable containers. It is commonly used in sticky-header page layouts found in mainstream apps, and is typically combined with `<viewpager>` and `<list>` to build composite scenarios involving nested scrolling and tabbed paging.
 

--- a/docs/en/api/elements/built-in/svg.mdx
+++ b/docs/en/api/elements/built-in/svg.mdx
@@ -1,8 +1,7 @@
 ---
 tag: 'XElement'
+api: elements/svg
 ---
-
-# `<svg>`
 
 import {
   Required,
@@ -11,9 +10,14 @@ import {
   IOSOnly,
   Go,
   APITable,
+  APISummary,
 } from '@lynx';
 import { PropsTable, EventsTable, MethodsTable } from '@theme/reference';
 import svgExampleImg from '@assets/blog/lynx-3-7/svg-example.png?url';
+
+# `<svg>`
+
+<APISummary />
 
 `<svg>` is the cornerstone element for embedding Scalable Vector Graphics (SVG) directly within your markup. It lets you create crisp, resolution-independent graphics, from simple icons to complex data visualizations, that scale flawlessly across every screen size and pixel density.
 

--- a/docs/en/api/elements/built-in/viewpager.mdx
+++ b/docs/en/api/elements/built-in/viewpager.mdx
@@ -10,9 +10,12 @@ import {
   IOSOnly,
   Required,
   APITable,
+  APISummary,
 } from '@lynx';
 
 # `<viewpager>`
+
+<APISummary />
 
 `<viewpager>` is a horizontally swipeable paging component. It is commonly used to build tabbed paging experiences.
 

--- a/docs/en/api/elements/built-in/webview.mdx
+++ b/docs/en/api/elements/built-in/webview.mdx
@@ -10,9 +10,12 @@ import {
   IOSOnly,
   Required,
   APITable,
+  APISummary,
 } from '@lynx';
 
 # `<webview>`
+
+<APISummary />
 
 Used to embed web pages in Lynx, providing a flexible way to integrate existing web resources and accelerate development.
 

--- a/docs/zh/api/elements/built-in/blur-view.mdx
+++ b/docs/zh/api/elements/built-in/blur-view.mdx
@@ -10,9 +10,12 @@ import {
   IOSOnly,
   Required,
   APITable,
+  APISummary,
 } from '@lynx';
 
 # `<blur-view>`
+
+<APISummary />
 
 `<blur-view>` 用于为背景内容提供高斯模糊效果，类似于 CSS 中的 `backdrop-filter: blur`。
 

--- a/docs/zh/api/elements/built-in/refresh.mdx
+++ b/docs/zh/api/elements/built-in/refresh.mdx
@@ -10,9 +10,12 @@ import {
   IOSOnly,
   Required,
   APITable,
+  APISummary,
 } from '@lynx';
 
 # `<refresh>`
+
+<APISummary />
 
 `<refresh>` 元素提供下拉刷新手势，在拉动过程中展示可自定义的头部视图，用于指示正在获取新数据。
 

--- a/docs/zh/api/elements/built-in/scroll-coordinator.mdx
+++ b/docs/zh/api/elements/built-in/scroll-coordinator.mdx
@@ -10,9 +10,12 @@ import {
   IOSOnly,
   Required,
   APITable,
+  APISummary,
 } from '@lynx';
 
 # `<scroll-coordinator>`
+
+<APISummary />
 
 `<scroll-coordinator>` 是一个嵌套滚动协调组件，用于实现多层可滚动容器之间的联动滚动，常见于滚动吸顶等主流 APP 页面结构中，一般搭配 `<viewpager>` 和 `<list>` 等组件一起构建嵌套滚动 + 分页切换的复合场景。
 

--- a/docs/zh/api/elements/built-in/svg.mdx
+++ b/docs/zh/api/elements/built-in/svg.mdx
@@ -1,8 +1,7 @@
 ---
 tag: 'XElement'
+api: elements/svg
 ---
-
-# `<svg>`
 
 import {
   Required,
@@ -11,9 +10,14 @@ import {
   IOSOnly,
   Go,
   APITable,
+  APISummary,
 } from '@lynx';
 import { PropsTable, EventsTable, MethodsTable } from '@theme/reference';
 import svgExampleImg from '@assets/blog/lynx-3-7/svg-example.png?url';
+
+# `<svg>`
+
+<APISummary />
 
 `<svg>` 是在标记中直接嵌入可缩放矢量图形（SVG）的基础元素。它可以帮助你创建清晰、与分辨率无关的图形，从简单图标到复杂的数据可视化，在不同屏幕尺寸与像素密度下都能无损缩放。
 

--- a/docs/zh/api/elements/built-in/viewpager.mdx
+++ b/docs/zh/api/elements/built-in/viewpager.mdx
@@ -10,9 +10,12 @@ import {
   IOSOnly,
   Required,
   APITable,
+  APISummary,
 } from '@lynx';
 
 # `<viewpager>`
+
+<APISummary />
 
 `<viewpager>` 是一个横滑翻页组件，常用于构建带多标签的分页场景。
 

--- a/docs/zh/api/elements/built-in/webview.mdx
+++ b/docs/zh/api/elements/built-in/webview.mdx
@@ -10,9 +10,12 @@ import {
   IOSOnly,
   Required,
   APITable,
+  APISummary,
 } from '@lynx';
 
 # `<webview>`
+
+<APISummary />
 
 用于在 Lynx 中嵌入网页，提供灵活的方式集成现有 Web 资源并加速开发。
 


### PR DESCRIPTION
## Summary
- Add missing `<APISummary />` component to 5 element pages that had `-API.mdx` data files but weren't rendering the API summary: `blur-view`, `refresh`, `scroll-coordinator`, `svg`, `viewpager`
- Add missing `api: elements/svg` frontmatter to `svg.mdx` (both en and zh)
- All changes applied to both English and Chinese docs (10 files total)

## Test plan
- [ ] Verify `<APISummary />` renders correctly on each affected page
- [ ] Check that no existing content is broken

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Add `APISummary` component to element API documentation pages

- Import and render `APISummary` from `@lynx` in blur-view, refresh, scroll-coordinator, svg, viewpager, and webview element API pages
- Display auto-generated API summaries beneath element headings across both English and Chinese documentation
- Add missing `api: elements/svg` frontmatter to svg.mdx in both language versions

**Files changed:** 10 documentation pages (5 English + 5 Chinese)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/1007)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->