### PR TITLE
fix(ci): add pre-commit lint to enforce APISummary when APITable is used

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,10 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,md,mdx,json,yml,yaml,css,scss}": "prettier --write",
-    "*.{md,mdx}": "cspell lint -c cspell.json --no-must-find-files",
+    "*.{md,mdx}": [
+      "cspell lint -c cspell.json --no-must-find-files",
+      "node scripts/ci/check-api-summary.mjs"
+    ],
     "*.{js,jsx,ts,tsx,md,mdx,json,yml,yaml,html,svg,css,scss,less}": "node scripts/ci/check-asset-urls.mjs"
   },
   "dependencies": {

--- a/scripts/ci/check-api-summary.mjs
+++ b/scripts/ci/check-api-summary.mjs
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+
+const args = process.argv.slice(2);
+if (args.length === 0) {
+  process.exit(0);
+}
+
+const violations = [];
+
+for (const file of args) {
+  if (!file.endsWith('.mdx')) continue;
+  // Only check API reference pages, not guides that use APITable inline
+  if (!file.includes('/api/')) continue;
+  // Skip the API-only reference partials (e.g. image-API.mdx)
+  if (file.endsWith('-API.mdx')) continue;
+
+  let content;
+  try {
+    content = readFileSync(file, 'utf8');
+  } catch {
+    continue;
+  }
+
+  const hasAPITable = content.includes('<APITable');
+  const hasAPISummary = content.includes('<APISummary');
+
+  if (hasAPITable && !hasAPISummary) {
+    violations.push(file);
+  }
+}
+
+if (violations.length > 0) {
+  console.error(
+    'Files using <APITable> must also include <APISummary /> after the heading:',
+  );
+  for (const file of violations) {
+    console.error(`  - ${file}`);
+  }
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- Add `scripts/ci/check-api-summary.mjs` that flags any `.mdx` file using `<APITable>` without also including `<APISummary />`
- Wire it into lint-staged so it runs on pre-commit alongside cspell and check-asset-urls
- Prevents the issue fixed in #1007 from recurring

## Test plan
- [x] Passes on files with both components (e.g. `image.mdx`)
- [x] Passes on files with neither (e.g. `page.mdx`)
- [x] Fails on files with `APITable` but missing `APISummary`
- [x] Pre-commit hook runs successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/1008)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->