### PR TITLE
docs: update Autolink setup guide

### DIFF
--- a/docs/en/guide/autolink.mdx
+++ b/docs/en/guide/autolink.mdx
@@ -2,7 +2,7 @@ import { PlatformTabs } from '@lynx';
 
 # Autolink Native Extensions
 
-Autolink helps a Lynx app discover native extension packages from `node_modules` and register their Android and iOS capabilities automatically. Extension packages declare their native entry points in `lynx.ext.json`; the host app enables the Autolink build integration once, then uses the generated registry instead of manually wiring each Element, Native Module, or Service.
+Autolink helps a Lynx app discover native extension packages from `node_modules` and register their Android and iOS capabilities automatically. Extension packages declare their native entry points in `lynx.ext.json`; the host app enables the Autolink build integration once, then the generated registry takes effect during Lynx initialization instead of requiring manual wiring for each Element, Native Module, or Service.
 
 Autolink currently covers native Android and iOS extensions only. It does not generate Web or HarmonyOS integration code.
 
@@ -50,7 +50,7 @@ After you install dependencies, Autolink scans the installed npm packages for `l
 
 ## Set Up Autolink in an App
 
-Set up Autolink once in the host app. After that, installed extension packages can be discovered from `node_modules` and registered through the generated registry.
+Set up Autolink once in the host app. After that, installed extension packages can be discovered from `node_modules` and registered through the generated registry during Lynx initialization.
 
 <PlatformTabs queryKey="platform">
 <PlatformTabs.Tab platform="android">
@@ -72,39 +72,7 @@ plugins {
 }
 ```
 
-After Gradle sync, Autolink generates `com.<app>.generated.extensions.ExtensionRegistry`. Choose one setup path based on where the extension should be available.
-
-For app-wide Autolink, call `setupGlobal(Context)` once during application initialization. This registers extension entries globally and initializes services through the global service center:
-
-```java
-import android.app.Application;
-import com.example.app.generated.extensions.ExtensionRegistry;
-
-public final class LynxApp extends Application {
-  @Override
-  public void onCreate() {
-    super.onCreate();
-    ExtensionRegistry.setupGlobal(this);
-  }
-}
-```
-
-For view-specific Autolink, call `setup(LynxViewBuilder)` on the builder that should receive the extension registrations:
-
-```java
-import com.example.app.generated.extensions.ExtensionRegistry;
-import com.lynx.tasm.LynxViewBuilder;
-
-public final class LynxViewFactory {
-  public LynxViewBuilder createBuilder() {
-    LynxViewBuilder builder = new LynxViewBuilder();
-    ExtensionRegistry.setup(builder);
-    return builder;
-  }
-}
-```
-
-Use the global path when an extension should be visible to every Lynx view in the app. Use the builder path when only selected views should receive the extension registrations.
+After Gradle sync/build, Autolink generates a fixed Android registry entry and adds it to the app sources. When the app initializes `LynxEnv`, that entry is loaded automatically, and extension Elements, Native Modules, and Services are registered app-wide. App code does not need any additional native initialization.
 
 </PlatformTabs.Tab>
 
@@ -120,16 +88,7 @@ target 'LynxApp' do
 end
 ```
 
-Autolink generates `generated/lynx-extension/ExtensionRegistry.h` and `ExtensionRegistry.m`. Import the generated registry and apply it to your `LynxConfig`:
-
-```objc
-#import "ExtensionRegistry.h"
-#import <Lynx/LynxConfig.h>
-
-LynxConfig *config = [[LynxConfig alloc] init];
-ExtensionRegistry *registry = [[ExtensionRegistry alloc] init];
-[registry setup:config];
-```
+After `pod install`, Autolink generates the registry pod and hooks it into the Lynx initialization flow. When the app creates `LynxConfig` or initializes `LynxEnv`, extension Elements, Native Modules, and Services are registered automatically. App code does not need to import generated files or add extra native initialization.
 
 </PlatformTabs.Tab>
 </PlatformTabs>

--- a/docs/zh/guide/autolink.mdx
+++ b/docs/zh/guide/autolink.mdx
@@ -2,7 +2,7 @@ import { PlatformTabs } from '@lynx';
 
 # Autolink 原生扩展
 
-Autolink 会让 Lynx 应用从 `node_modules` 中发现原生扩展包，并自动注册它们在 Android 和 iOS 上提供的能力。扩展包在包根目录声明 `lynx.ext.json`；宿主应用只需要接入一次 Autolink 构建集成，就可以使用生成的 registry，避免为每个元件、原生模块或 Service 手动写注册代码。
+Autolink 会让 Lynx 应用从 `node_modules` 中发现原生扩展包，并自动注册它们在 Android 和 iOS 上提供的能力。扩展包在包根目录声明 `lynx.ext.json`；宿主应用只需要接入一次 Autolink 构建集成，生成的 registry 就会随 Lynx 初始化自动生效，避免为每个元件、原生模块或 Service 手动写注册代码。
 
 Autolink 当前只覆盖 Android 和 iOS 原生扩展，不生成 Web 或 HarmonyOS 的接入代码。
 
@@ -50,7 +50,7 @@ lynx-app/
 
 ## 在应用中接入 Autolink
 
-宿主应用只需要接入一次 Autolink。接入完成后，已安装的扩展包会从 `node_modules` 中被发现，并通过生成的 registry 自动注册。
+宿主应用只需要接入一次 Autolink。接入完成后，已安装的扩展包会从 `node_modules` 中被发现，并在 Lynx 初始化时通过生成的 registry 自动注册。
 
 <PlatformTabs queryKey="platform">
 <PlatformTabs.Tab platform="android">
@@ -72,39 +72,7 @@ plugins {
 }
 ```
 
-Gradle sync 后，Autolink 会生成 `com.<app>.generated.extensions.ExtensionRegistry`。根据扩展生效范围选择一种接入方式。
-
-如果需要应用级全局接入，在应用初始化阶段调用一次 `setupGlobal(Context)`。它会把扩展注册到全局路径，并通过全局 service center 初始化 Service：
-
-```java
-import android.app.Application;
-import com.example.app.generated.extensions.ExtensionRegistry;
-
-public final class LynxApp extends Application {
-  @Override
-  public void onCreate() {
-    super.onCreate();
-    ExtensionRegistry.setupGlobal(this);
-  }
-}
-```
-
-如果只希望某个 `LynxViewBuilder` 使用 Autolink 扩展，在创建该 builder 时调用 `setup(LynxViewBuilder)`：
-
-```java
-import com.example.app.generated.extensions.ExtensionRegistry;
-import com.lynx.tasm.LynxViewBuilder;
-
-public final class LynxViewFactory {
-  public LynxViewBuilder createBuilder() {
-    LynxViewBuilder builder = new LynxViewBuilder();
-    ExtensionRegistry.setup(builder);
-    return builder;
-  }
-}
-```
-
-当扩展需要对应用内所有 Lynx view 可见时，使用全局接入；当只想让部分 view 使用这些扩展注册时，使用 builder 接入。
+Gradle sync/build 后，Autolink 会生成固定的 Android registry 入口并加入应用源码。应用初始化 `LynxEnv` 时会自动加载该入口，扩展提供的元件、原生模块和 Service 会按应用全局注册生效；业务侧无需额外编写原生初始化代码。
 
 </PlatformTabs.Tab>
 
@@ -120,16 +88,7 @@ target 'LynxApp' do
 end
 ```
 
-Autolink 会生成 `generated/lynx-extension/ExtensionRegistry.h` 和 `ExtensionRegistry.m`。导入生成的 registry，并把它应用到 `LynxConfig`：
-
-```objc
-#import "ExtensionRegistry.h"
-#import <Lynx/LynxConfig.h>
-
-LynxConfig *config = [[LynxConfig alloc] init];
-ExtensionRegistry *registry = [[ExtensionRegistry alloc] init];
-[registry setup:config];
-```
+执行 `pod install` 后，Autolink 会生成 registry pod，并把它接入 Lynx 的初始化流程。应用创建 `LynxConfig` 或初始化 `LynxEnv` 时，扩展提供的元件、原生模块和 Service 会自动注册生效；业务侧无需导入生成文件或编写额外初始化代码。
 
 </PlatformTabs.Tab>
 </PlatformTabs>


### PR DESCRIPTION
## Summary

- Update the Autolink guide to state that generated registries are loaded during Lynx initialization after the build integration is configured.
- Remove Android manual `setupGlobal` initialization guidance.
- Remove Android view/builder-level setup guidance because view-level Autolink setup is no longer supported.
- Update the iOS section to describe automatic initialization through the generated registry pod.

## Validation

- `git diff --check`
- `pnpm exec prettier --check docs/zh/guide/autolink.mdx docs/en/guide/autolink.mdx`
- `pnpm exec cspell lint -c cspell.json --no-must-find-files docs/zh/guide/autolink.mdx docs/en/guide/autolink.mdx`
- `pnpm exec zhlint docs/zh/guide/autolink.mdx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Clarify Autolink setup to emphasize automatic registry loading during Lynx initialization

- Add Host App Project Structure section describing required project layout and build entry points
- Replace Android manual setup instructions with automatic registry generation and loading behavior
- Replace iOS manual import/wiring instructions with automatic pod initialization through generated registry
- Remove Android view-builder-level setup guidance (no longer supported)
- Simplify initialization messaging to highlight one-time build integration and automatic registry-based registration across Android and iOS

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/1010)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->