### PR TITLE
fix(luna-studio): simplify chip controls + align dark mode styling

### DIFF
--- a/packages/lynx-compat-data/api-stats.json
+++ b/packages/lynx-compat-data/api-stats.json
@@ -189,7 +189,7 @@
           "android": 39,
           "ios": 39,
           "harmony": 39,
-          "web_lynx": 64,
+          "web_lynx": 62,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 66,
@@ -200,7 +200,7 @@
           "android": 58,
           "ios": 58,
           "harmony": 58,
-          "web_lynx": 96,
+          "web_lynx": 93,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 99,
@@ -633,8 +633,8 @@
         "exclusive_count": 7
       },
       "web_lynx": {
-        "supported_count": 712,
-        "coverage_percent": 70,
+        "supported_count": 710,
+        "coverage_percent": 69,
         "exclusive_count": 30
       },
       "clay_android": {
@@ -31543,7 +31543,7 @@
           "android": 39,
           "ios": 39,
           "harmony": 39,
-          "web_lynx": 64,
+          "web_lynx": 62,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 66,
@@ -31554,7 +31554,7 @@
           "android": 58,
           "ios": 58,
           "harmony": 58,
-          "web_lynx": 96,
+          "web_lynx": 93,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 99,
@@ -34101,6 +34101,22 @@
             }
           },
           {
+            "path": "lynx-api/event/TouchEvent.detail",
+            "name": "detail",
+            "doc_url": "api/lynx-api/event/touch-event",
+            "support": {
+              "android": "1.5",
+              "ios": "1.5",
+              "harmony": "3.4",
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "3.5",
+              "clay_windows": "3.5",
+              "clay": "3.5"
+            }
+          },
+          {
             "path": "lynx-api/event/TouchEvent.longpress",
             "name": "longpress",
             "doc_url": "api/lynx-api/event/touch-event",
@@ -34108,6 +34124,22 @@
               "android": "1.5",
               "ios": "1.5",
               "harmony": "3.4",
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "3.5",
+              "clay_windows": "3.5",
+              "clay": "3.5"
+            }
+          },
+          {
+            "path": "lynx-api/event/TouchEvent.click",
+            "name": "click",
+            "doc_url": "api/lynx-api/event/touch-event",
+            "support": {
+              "android": "1.5",
+              "ios": "1.5",
+              "harmony": "3.6",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -107150,8 +107182,8 @@
           "coverage": 3
         },
         "web_lynx": {
-          "supported": 703,
-          "coverage": 69
+          "supported": 701,
+          "coverage": 68
         },
         "clay_android": {
           "supported": 464,
@@ -107192,8 +107224,8 @@
           "coverage": 3
         },
         "web_lynx": {
-          "supported": 703,
-          "coverage": 69
+          "supported": 701,
+          "coverage": 68
         },
         "clay_android": {
           "supported": 464,
@@ -107234,8 +107266,8 @@
           "coverage": 3
         },
         "web_lynx": {
-          "supported": 703,
-          "coverage": 69
+          "supported": 701,
+          "coverage": 68
         },
         "clay_android": {
           "supported": 470,
@@ -107276,8 +107308,8 @@
           "coverage": 3
         },
         "web_lynx": {
-          "supported": 703,
-          "coverage": 69
+          "supported": 701,
+          "coverage": 68
         },
         "clay_android": {
           "supported": 473,
@@ -107318,8 +107350,8 @@
           "coverage": 3
         },
         "web_lynx": {
-          "supported": 703,
-          "coverage": 69
+          "supported": 701,
+          "coverage": 68
         },
         "clay_android": {
           "supported": 484,
@@ -107360,8 +107392,8 @@
           "coverage": 3
         },
         "web_lynx": {
-          "supported": 703,
-          "coverage": 69
+          "supported": 701,
+          "coverage": 68
         },
         "clay_android": {
           "supported": 488,
@@ -107402,8 +107434,8 @@
           "coverage": 3
         },
         "web_lynx": {
-          "supported": 703,
-          "coverage": 69
+          "supported": 701,
+          "coverage": 68
         },
         "clay_android": {
           "supported": 488,
@@ -107444,8 +107476,8 @@
           "coverage": 3
         },
         "web_lynx": {
-          "supported": 703,
-          "coverage": 69
+          "supported": 701,
+          "coverage": 68
         },
         "clay_android": {
           "supported": 493,
@@ -107486,8 +107518,8 @@
           "coverage": 3
         },
         "web_lynx": {
-          "supported": 703,
-          "coverage": 69
+          "supported": 701,
+          "coverage": 68
         },
         "clay_android": {
           "supported": 493,
@@ -107528,8 +107560,8 @@
           "coverage": 69
         },
         "web_lynx": {
-          "supported": 703,
-          "coverage": 69
+          "supported": 701,
+          "coverage": 68
         },
         "clay_android": {
           "supported": 522,

--- a/src/luna/luna-studio.tsx
+++ b/src/luna/luna-studio.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useRef, useState, type ReactNode } from 'react';
 import { withBase } from '@rspress/core/runtime';
 import { useContainerResize } from '@dugyu/luna-stage';
 import { Choreography } from '@dugyu/luna-studio';
@@ -8,6 +8,9 @@ import type {
   LunaThemeVariant,
   StudioViewMode,
 } from '@dugyu/luna-studio';
+
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 
 import {
   createDemoInteractionHandler,
@@ -21,6 +24,26 @@ const VIEW_MODES: StudioViewMode[] = ['compare', 'focus', 'lineup'];
 const resolveFocusKey = createDemoResolveFocusKey(lunaStudioDemoLayout);
 
 const BUNDLE_ROOT = withBase('/lynx-examples/luna-demo-bundles/dist/');
+
+function ChipButton(props: {
+  active: boolean;
+  onClick: () => void;
+  className: string;
+  children: ReactNode;
+}) {
+  return (
+    <Button
+      className={props.className}
+      onClick={props.onClick}
+      size="sm"
+      type="button"
+      variant="ghost"
+      aria-pressed={props.active}
+    >
+      {props.children}
+    </Button>
+  );
+}
 
 function LunaStudio() {
   const [viewMode, setViewMode] = useState<StudioViewMode>('compare');
@@ -78,25 +101,22 @@ function LunaStudio() {
   const dividerClassName =
     themeMode === 'light' ? 'bg-black/10' : 'bg-white/10';
 
-  const chipBaseClassName =
-    'rounded-full border px-4 py-2 text-sm transition-colors';
-
   const chipClassName = (active: boolean) => {
     if (themeMode === 'light') {
-      return [
-        chipBaseClassName,
+      return cn(
+        'h-auto rounded-full border px-4 py-2 text-sm font-normal transition-colors',
         active
-          ? 'border-black bg-black text-white'
-          : 'border-black/20 bg-transparent text-black',
-      ].join(' ');
+          ? 'border-black bg-black !text-white hover:bg-black/90 hover:!text-white'
+          : 'border-black/20 bg-transparent !text-black hover:bg-black/5 hover:!text-black',
+      );
     }
 
-    return [
-      chipBaseClassName,
+    return cn(
+      'h-auto rounded-full border px-4 py-2 text-sm font-normal transition-colors',
       active
-        ? 'border-white bg-white text-black'
-        : 'border-white/20 bg-transparent text-white',
-    ].join(' ');
+        ? 'border-white/60 bg-white/10 !text-white hover:bg-white/15 hover:!text-white'
+        : 'border-white/20 bg-transparent !text-white/80 hover:bg-white/10 hover:!text-white',
+    );
   };
 
   return (
@@ -130,51 +150,46 @@ function LunaStudio() {
         {VIEW_MODES.map((mode) => {
           const active = mode === viewMode;
           return (
-            <button
+            <ChipButton
               key={mode}
+              active={active}
               className={chipClassName(active)}
               onClick={() => setViewMode(mode)}
-              type="button"
-              {...{ 'aria-pressed': active }}
             >
               {mode}
-            </button>
+            </ChipButton>
           );
         })}
         <div className={['mx-2 h-6 w-px', dividerClassName].join(' ')} />
-        <button
+        <ChipButton
+          active={themeVariant === 'luna'}
           className={chipClassName(themeVariant === 'luna')}
           onClick={() => setStudioThemeVariant('luna')}
-          type="button"
-          {...{ 'aria-pressed': themeVariant === 'luna' }}
         >
           luna
-        </button>
-        <button
+        </ChipButton>
+        <ChipButton
+          active={themeVariant === 'lunaris'}
           className={chipClassName(themeVariant === 'lunaris')}
           onClick={() => setStudioThemeVariant('lunaris')}
-          type="button"
-          {...{ 'aria-pressed': themeVariant === 'lunaris' }}
         >
           lunaris
-        </button>
+        </ChipButton>
         <div className={['mx-2 h-6 w-px', dividerClassName].join(' ')} />
-        <button
+        <ChipButton
+          active={themeMode === 'light'}
           className={chipClassName(themeMode === 'light')}
           onClick={() => setStudioThemeMode('light')}
-          type="button"
-          {...{ 'aria-pressed': themeMode === 'light' }}
         >
           light
-        </button>
-        <button
+        </ChipButton>
+        <ChipButton
+          active={themeMode === 'dark'}
           className={chipClassName(themeMode === 'dark')}
           onClick={() => setStudioThemeMode('dark')}
-          type="button"
-          {...{ 'aria-pressed': themeMode === 'dark' }}
         >
           dark
-        </button>
+        </ChipButton>
       </div>
     </div>
   );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,13 +12,14 @@ export default {
     './theme/**/*.{js,ts,jsx,tsx}',
     './src/luna/**/*.{js,ts,jsx,tsx}',
   ],
-  // Use class-based dark mode to sync with Rspress's toggle (adds .dark to <html>)
-  darkMode: 'class',
+  // Use class-based dark mode to sync with Rspress's toggle
+  // Rspress may use either `.dark` or `.rp-dark` on <html> depending on theme pipeline
+  darkMode: ['class', ':is(.dark, .rp-dark)'],
   // When there is no explicit usage of the `.dark` class in project files,
   // tailwind will not include dark mode styles in the final bundle.
   // Adding 'dark' to safelist ensures the dark mode classes are preserved.
   // See: https://github.com/shadcn-ui/ui/issues/313#issuecomment-1927525155
-  safelist: ['dark'],
+  safelist: ['dark', 'rp-dark'],
   theme: {
     container: {
       center: true,


### PR DESCRIPTION
- Refactor top controls to reuse shadcn/ui Button via ChipButton
- Fix selected-state text color issues under Rspress dark mode
- Make Tailwind dark variant match both .dark and .rp-dark; safelist rp-dark
- Update compat-data api-stats snapshot (changed after installation)

Change-Id: I7ad6eec7116488d1da84595a5c6f07255f2de32a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Simplify chip controls and align dark mode styling across the Luna Studio guide.

## Changes

- Refactor chip controls in Luna Studio to use the shared `Button` component via `ChipButton` helper
- Support both `.dark` and `.rp-dark` selectors in Tailwind dark mode configuration
- Add `rp-dark` to Tailwind safelist to preserve dark mode class variants
- Update api-stats snapshot in `packages/lynx-compat-data/api-stats.json`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/1011)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->