### PR TITLE
chore(deps): bump @lynx-js/go-web to 0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@dugyu/luna-demo-bundles": "0.1.0",
     "@dugyu/luna-stage": "0.2.1",
     "@dugyu/luna-studio": "0.1.3",
-    "@lynx-js/go-web": "^0.5.0",
+    "@lynx-js/go-web": "^0.5.1",
     "@lynx-js/lynx-core": "^0.1.3",
     "@lynx-js/web-core": "^0.20.3",
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: 0.1.3
         version: 0.1.3(@lynx-js/web-core@0.20.3(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(motion@12.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@lynx-js/go-web':
-        specifier: ^0.5.0
-        version: 0.5.0(@douyinfe/semi-icons@2.95.1(react@18.3.1))(@douyinfe/semi-ui@2.95.1(@floating-ui/dom@1.7.6)(@tiptap/suggestion@3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core@0.20.3(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.6(@types/mdast@4.0.4)(@types/react@18.3.28)(micromark-util-types@2.0.2)(micromark@4.0.2))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)
+        specifier: ^0.5.1
+        version: 0.5.1(@douyinfe/semi-icons@2.95.1(react@18.3.1))(@douyinfe/semi-ui@2.95.1(@floating-ui/dom@1.7.6)(@tiptap/suggestion@3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core@0.20.3(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.6(@types/mdast@4.0.4)(@types/react@18.3.28)(micromark-util-types@2.0.2)(micromark@4.0.2))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)
       '@lynx-js/lynx-core':
         specifier: ^0.1.3
         version: 0.1.3
@@ -1560,8 +1560,8 @@ packages:
       '@lynx-js/react': '*'
       '@lynx-js/types': '*'
 
-  '@lynx-js/go-web@0.5.0':
-    resolution: {integrity: sha512-JU1PA6GPBtmBpScWt3veO8nHMlYORzPOdt6c4OHnDqlAFQAlNMzPxRRWnzmGfUqrxE+UnfheTuwboAg1T+vrew==}
+  '@lynx-js/go-web@0.5.1':
+    resolution: {integrity: sha512-HQO72C1ALInCzjDVEzCYJ7aGh/jQHTKc3fG8MNUs6TLy2lXl8ut/dKsztEw3OzD6NlCcQpoRdSsbmuI8ETDo7w==}
     engines: {node: ^22 || ^24}
     peerDependencies:
       '@douyinfe/semi-icons': '>=2.74.0'
@@ -7700,7 +7700,7 @@ snapshots:
       '@lynx-js/react': 0.114.0(@lynx-js/types@3.7.0)(@types/react@18.3.28)
       '@lynx-js/types': 3.7.0
 
-  '@lynx-js/go-web@0.5.0(@douyinfe/semi-icons@2.95.1(react@18.3.1))(@douyinfe/semi-ui@2.95.1(@floating-ui/dom@1.7.6)(@tiptap/suggestion@3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core@0.20.3(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.6(@types/mdast@4.0.4)(@types/react@18.3.28)(micromark-util-types@2.0.2)(micromark@4.0.2))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)':
+  '@lynx-js/go-web@0.5.1(@douyinfe/semi-icons@2.95.1(react@18.3.1))(@douyinfe/semi-ui@2.95.1(@floating-ui/dom@1.7.6)(@tiptap/suggestion@3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core@0.20.3(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.6(@types/mdast@4.0.4)(@types/react@18.3.28)(micromark-util-types@2.0.2)(micromark@4.0.2))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)':
     dependencies:
       '@douyinfe/semi-icons': 2.95.1(react@18.3.1)
       '@douyinfe/semi-ui': 2.95.1(@floating-ui/dom@1.7.6)(@tiptap/suggestion@3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)


### PR DESCRIPTION
### What

Upgrade `@lynx-js/go-web` dependency `0.5.0` → `0.5.1`.

### Why

Picks up the `<lynx-view>` initial load race fix (ensure `url` is present during element upgrade/handshake), which reduces intermittent first-load blank / refresh-needed behavior (more visible on mobile or slower devices but not Safari-only).

### Related: 
- lynx-community/go-web#57

Change-Id: I87e805109dc4709098662c7024608e0ffc4d80d1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Bump `@lynx-js/go-web` to 0.5.1

This dependency update includes a fix for an initial-load race condition in <lynx-view> that ensures the url is present during element upgrade/handshake. This reduces intermittent first-load blank and refresh-needed behavior, particularly noticeable on mobile and slower devices. The update also improves error surfacing from lynx-view.

Related: lynx-community/go-web#57

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/1015?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->