### PR TITLE
feat(luna): add LunaStudioShowcase to lynx-ui home

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
   "dependencies": {
     "@douyinfe/semi-icons": "^2.74.0",
     "@douyinfe/semi-ui": "^2.75.0",
-    "@dugyu/luna-demo-bundles": "0.1.0",
-    "@dugyu/luna-stage": "0.2.1",
-    "@dugyu/luna-studio": "0.1.3",
+    "@dugyu/luna-demo-bundles": "0.2.0",
+    "@dugyu/luna-stage": "0.2.2",
+    "@dugyu/luna-studio": "0.2.0",
     "@lynx-js/go-web": "^0.5.1",
     "@lynx-js/lynx-core": "^0.1.3",
     "@lynx-js/web-core": "^0.20.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,14 +15,14 @@ importers:
         specifier: ^2.75.0
         version: 2.95.1(@floating-ui/dom@1.7.6)(@tiptap/suggestion@3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@dugyu/luna-demo-bundles':
-        specifier: 0.1.0
-        version: 0.1.0
+        specifier: 0.2.0
+        version: 0.2.0
       '@dugyu/luna-stage':
-        specifier: 0.2.1
-        version: 0.2.1(@lynx-js/web-core@0.20.3(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(motion@12.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        specifier: 0.2.2
+        version: 0.2.2(@lynx-js/web-core@0.20.3(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(motion@12.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@dugyu/luna-studio':
-        specifier: 0.1.3
-        version: 0.1.3(@lynx-js/web-core@0.20.3(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(motion@12.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        specifier: 0.2.0
+        version: 0.2.0(@lynx-js/web-core@0.20.3(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(motion@12.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@lynx-js/go-web':
         specifier: ^0.5.1
         version: 0.5.1(@douyinfe/semi-icons@2.95.1(react@18.3.1))(@douyinfe/semi-ui@2.95.1(@floating-ui/dom@1.7.6)(@tiptap/suggestion@3.22.4(@tiptap/core@3.22.4(@tiptap/pm@3.22.4))(@tiptap/pm@3.22.4))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core@0.20.3(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.6(@types/mdast@4.0.4)(@types/react@18.3.28)(micromark-util-types@2.0.2)(micromark@4.0.2))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)
@@ -959,14 +959,14 @@ packages:
       react: '>=16.0.0'
       react-dom: '>=16.0.0'
 
-  '@dugyu/luna-core@0.4.0':
-    resolution: {integrity: sha512-OqSxI2tViGDB0tLJY2K+bi510XN/lD+idGYkT4ztcrHZdzNp8hxE4+TLbkA5gPAGzV8WZ1yzSwbap5mCT5vZCA==}
+  '@dugyu/luna-core@0.5.0':
+    resolution: {integrity: sha512-2i/I9YedSrt8U9zMxB3JB2JEsh7/deS4zF7NTtQyinumOqPc9io1xSWzCAkOZEHIElfbqst2BwGKIyEDKx22mg==}
 
-  '@dugyu/luna-demo-bundles@0.1.0':
-    resolution: {integrity: sha512-Ipz/mXPRap1IwwknFOMMWblWmuC5YcDE5pTxoRajSaiNnyeaKXBB+vpQdQwk6Vu4uQPUZnF4wzc3ziyojgsexw==}
+  '@dugyu/luna-demo-bundles@0.2.0':
+    resolution: {integrity: sha512-zoT/nueb3wpiGzCMZ9BnCiEGbsJJc4GjbhxHgA0PCMa9tI8rPCo+kBdy9vNZaMXqqNS16FVY0z1M4gtPWP/igg==}
 
-  '@dugyu/luna-stage@0.2.1':
-    resolution: {integrity: sha512-jby48lAQauneiDqTAkI6a9W/qTtb1/3HvJgMsHxbcl8Az2dAbomeVRx87TAmhpkQrcr4c2HOarBnj1gwFQT6cA==}
+  '@dugyu/luna-stage@0.2.2':
+    resolution: {integrity: sha512-WiNWCzUzYI+m60Q9ESRbHaBItYdmziPde8P1QGGTu9I4B8CNatyKwGDVozIVVE9vO+AttITT9x6RsE6dbZF3yQ==}
     peerDependencies:
       '@lynx-js/web-core': '>=0.20.0'
       motion: '>=12.23.16'
@@ -977,8 +977,8 @@ packages:
       motion:
         optional: true
 
-  '@dugyu/luna-studio@0.1.3':
-    resolution: {integrity: sha512-iUBNeGk4DRPaoBSQrPSTnuIch1/MkR5Fx/WBXwd/wVybgkudzSAmgZ9XjcJYqwUhgRNwIurQqM/ErlTTfqAGoQ==}
+  '@dugyu/luna-studio@0.2.0':
+    resolution: {integrity: sha512-yEtmy7WGiTC3lqR1YDESyWFhC5dMi4nLcKbYegnvEw5e7RRdkaU4tcD6tB5NAKw867E1RBd6Diqv7Ib20U/xxA==}
     peerDependencies:
       '@lynx-js/web-core': '>=0.20.0'
       motion: '>=12.23.16'
@@ -6901,22 +6901,22 @@ snapshots:
       - '@types/react-dom'
       - supports-color
 
-  '@dugyu/luna-core@0.4.0': {}
+  '@dugyu/luna-core@0.5.0': {}
 
-  '@dugyu/luna-demo-bundles@0.1.0': {}
+  '@dugyu/luna-demo-bundles@0.2.0': {}
 
-  '@dugyu/luna-stage@0.2.1(@lynx-js/web-core@0.20.3(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(motion@12.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+  '@dugyu/luna-stage@0.2.2(@lynx-js/web-core@0.20.3(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(motion@12.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@dugyu/luna-core': 0.4.0
+      '@dugyu/luna-core': 0.5.0
       react: 18.3.1
     optionalDependencies:
       '@lynx-js/web-core': 0.20.3(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)
       motion: 12.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@dugyu/luna-studio@0.1.3(@lynx-js/web-core@0.20.3(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(motion@12.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+  '@dugyu/luna-studio@0.2.0(@lynx-js/web-core@0.20.3(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(motion@12.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@dugyu/luna-core': 0.4.0
-      '@dugyu/luna-stage': 0.2.1(@lynx-js/web-core@0.20.3(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(motion@12.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      '@dugyu/luna-core': 0.5.0
+      '@dugyu/luna-stage': 0.2.2(@lynx-js/web-core@0.20.3(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(motion@12.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@lynx-js/web-core': 0.20.3(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)
       motion: 12.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1

--- a/src/luna/index.ts
+++ b/src/luna/index.ts
@@ -1,1 +1,1 @@
-export { LunaStudio } from './luna-studio';
+export { LunaStudio, LunaStudioShowcase } from './luna-studio';

--- a/src/luna/layout.ts
+++ b/src/luna/layout.ts
@@ -22,7 +22,7 @@ const stagePool: Record<string, StudioStage> = {
   },
   Dialog: {
     id: 'Dialog',
-    entry: 'OffstageActDialog',
+    entry: 'ActDialog',
     theme: 'luna-dark',
     focusKey: 'dialog',
   },
@@ -45,7 +45,7 @@ const stagePool: Record<string, StudioStage> = {
   },
   Popover: {
     id: 'Popover',
-    entry: 'OffstageActPopover',
+    entry: 'ActPopover',
     theme: 'luna-light',
     focusKey: 'popover',
   },
@@ -63,7 +63,7 @@ const stagePool: Record<string, StudioStage> = {
   },
   Sheet: {
     id: 'Sheet',
-    entry: 'ActOneDark',
+    entry: 'ActOne',
     theme: 'lunaris-dark',
     focusKey: 'sheet',
   },
@@ -98,7 +98,13 @@ const layoutSpec: StudioLayout = {
     { id: 'Swiper', style: { gridColumn: '2 / 4', gridRow: '1 / 2' } },
     { id: 'Dialog', style: { gridColumn: '2 / 4', gridRow: '1 / 2' } },
     { id: 'Popover', style: { gridColumn: '2 / 4', gridRow: '1 / 2' } },
-    { id: 'MoonRise', style: { gridColumn: '2 / 4', gridRow: '1 / 2' } },
+    {
+      id: 'MoonRise',
+      style: {
+        gridColumn: '2 / 4',
+        gridRow: '1 / 2',
+      },
+    },
     { id: 'Bloom', style: { gridColumn: '1 / 2', gridRow: '1 / 2' } },
   ],
   lineup: [
@@ -114,9 +120,32 @@ const layoutSpec: StudioLayout = {
     { id: 'MoonRise', style: { gridColumn: '2 / 3', gridRow: '2 / 3' } },
   ],
 };
+
+const layoutSpecShowcase: StudioLayout = {
+  ...layoutSpec,
+  focus: layoutSpec.focus.map((item) => {
+    if (item.id !== 'MoonRise') return item;
+    return {
+      ...item,
+      style: {
+        ...item.style,
+        backdropFilter: 'blur(2px)',
+      },
+    };
+  }),
+};
+
 const lunaStudioDemoLayout: StudioResolvedLayout = resolveStudioLayout({
   stagePool,
   layoutSpec,
 });
+const lunaStudioShowcaseLayout: StudioResolvedLayout = resolveStudioLayout({
+  stagePool,
+  layoutSpec: layoutSpecShowcase,
+});
 
-export { lunaStudioDemoLayout, lunaStudioDemoModeGrid };
+export {
+  lunaStudioDemoLayout,
+  lunaStudioDemoModeGrid,
+  lunaStudioShowcaseLayout,
+};

--- a/src/luna/luna-studio.tsx
+++ b/src/luna/luna-studio.tsx
@@ -8,6 +8,16 @@ import type {
   LunaThemeVariant,
   StudioViewMode,
 } from '@dugyu/luna-studio';
+import {
+  Columns2,
+  GalleryHorizontalEnd,
+  Moon,
+  Sparkle,
+  Grid2x2,
+  Sparkles,
+  Sun,
+} from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
@@ -17,7 +27,11 @@ import {
   createDemoResolveFocusKey,
   createDemoStageGlobalPropsBuilder,
 } from './interaction';
-import { lunaStudioDemoLayout, lunaStudioDemoModeGrid } from './layout';
+import {
+  lunaStudioDemoLayout,
+  lunaStudioDemoModeGrid,
+  lunaStudioShowcaseLayout,
+} from './layout';
 
 const VIEW_MODES: StudioViewMode[] = ['compare', 'focus', 'lineup'];
 
@@ -41,6 +55,70 @@ function ChipButton(props: {
       aria-pressed={props.active}
     >
       {props.children}
+    </Button>
+  );
+}
+
+const VIEW_MODE_ITEMS: Array<{
+  value: StudioViewMode;
+  label: string;
+  icon: LucideIcon;
+}> = [
+  { value: 'compare', label: 'Compare', icon: Columns2 },
+  { value: 'focus', label: 'Focus', icon: GalleryHorizontalEnd },
+  { value: 'lineup', label: 'Lineup', icon: Grid2x2 },
+];
+
+const THEME_VARIANT_ITEMS: Array<{
+  value: LunaThemeVariant;
+  label: string;
+  icon: LucideIcon;
+}> = [
+  { value: 'luna', label: 'Luna', icon: Sparkle },
+  { value: 'lunaris', label: 'Lunaris', icon: Sparkles },
+];
+
+const THEME_MODE_ITEMS: Array<{
+  value: LunaThemeMode;
+  label: string;
+  icon: LucideIcon;
+}> = [
+  { value: 'light', label: 'Light', icon: Sun },
+  { value: 'dark', label: 'Dark', icon: Moon },
+];
+
+function IconToggleButton(props: {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+  icon: LucideIcon;
+  themeMode: LunaThemeMode;
+  className?: string;
+}) {
+  const isLight = props.themeMode === 'light';
+  const activeClassName = isLight
+    ? 'bg-black text-white ring-1 ring-black/20 shadow-sm'
+    : 'bg-white/20 text-white ring-1 ring-white/20 shadow-sm';
+  const inactiveClassName = isLight
+    ? 'bg-transparent text-black/60 opacity-70 hover:bg-black/5 hover:text-black hover:opacity-100'
+    : 'bg-transparent text-white/60 opacity-70 hover:bg-white/10 hover:text-white hover:opacity-100';
+
+  return (
+    <Button
+      type="button"
+      size="icon"
+      variant="ghost"
+      aria-pressed={props.active}
+      onClick={props.onClick}
+      title={props.label}
+      className={cn(
+        'h-9 w-9 rounded-full border transition-all hover:scale-110 focus-visible:ring-0 focus-visible:ring-offset-0',
+        isLight ? 'border-black/10' : 'border-white/10',
+        props.active ? activeClassName : inactiveClassName,
+        props.className,
+      )}
+    >
+      <props.icon className="h-4 w-4 md:h-5 md:w-5" />
     </Button>
   );
 }
@@ -80,9 +158,13 @@ function LunaStudio() {
         return params.suggestedViewMode;
       }
 
-      const index = VIEW_MODES.indexOf(prevMode);
-      if (index < 0) return VIEW_MODES[0];
-      return VIEW_MODES[(index + 1) % VIEW_MODES.length];
+      const nextViewMode: Record<StudioViewMode, StudioViewMode> = {
+        compare: 'focus',
+        focus: 'lineup',
+        lineup: 'compare',
+      };
+
+      return nextViewMode[prevMode] ?? 'compare';
     });
   };
 
@@ -96,7 +178,7 @@ function LunaStudio() {
   const containerClassName =
     themeMode === 'light'
       ? 'bg-[#f5f5f5] text-black'
-      : 'bg-[#0d0d0d] text-white';
+      : 'bg-[#000000] text-white';
 
   const dividerClassName =
     themeMode === 'light' ? 'bg-black/10' : 'bg-white/10';
@@ -107,7 +189,7 @@ function LunaStudio() {
         'h-auto rounded-full border px-4 py-2 text-sm font-normal transition-colors',
         active
           ? 'border-black bg-black !text-white hover:bg-black/90 hover:!text-white'
-          : 'border-black/20 bg-transparent !text-black hover:bg-black/5 hover:!text-black',
+          : 'border-black/20 dark:border-white/20 bg-transparent !text-black hover:bg-black/5 hover:!text-black',
       );
     }
 
@@ -123,7 +205,7 @@ function LunaStudio() {
     <div
       ref={containerRef}
       className={[
-        'relative h-[360px] w-full overflow-hidden',
+        'relative h-[360px] w-full overflow-hidden transition-all',
         containerClassName,
       ].join(' ')}
       style={{ height: containerHeight }}
@@ -195,4 +277,145 @@ function LunaStudio() {
   );
 }
 
-export { LunaStudio };
+function LunaStudioShowcase({
+  className,
+  defaultViewMode = 'lineup',
+  defaultThemeMode,
+}: {
+  className?: string;
+  defaultViewMode?: StudioViewMode;
+  defaultThemeMode?: LunaThemeMode;
+}) {
+  const [viewMode, setViewMode] = useState<StudioViewMode>(defaultViewMode);
+  const [themeVariant, setThemeVariant] = useState<LunaThemeVariant>('lunaris');
+  const [themeMode, setThemeMode] = useState<LunaThemeMode>(
+    defaultThemeMode ?? 'dark',
+  );
+  const [studioAutoplay, setStudioAutoplay] = useState(false);
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const { width: containerWidth } = useContainerResize({ ref: containerRef });
+  const containerHeight =
+    containerWidth === undefined
+      ? 420
+      : containerWidth < 640
+        ? 520
+        : containerWidth < 800
+          ? 580
+          : 640;
+
+  const studioThemeKey: LunaThemeKey = `${themeVariant}-${themeMode}`;
+
+  const handleRequestViewModeChange = (params: {
+    suggestedViewMode?: StudioViewMode;
+  }) => {
+    if (params.suggestedViewMode !== undefined) {
+      setViewMode(params.suggestedViewMode);
+      return;
+    }
+
+    setViewMode(defaultViewMode);
+  };
+
+  const handleInteraction = createDemoInteractionHandler({
+    onThemeModeChange: setThemeMode,
+    onThemeVariantChange: setThemeVariant,
+    onAutoplayChange: setStudioAutoplay,
+    onRequestViewModeChange: handleRequestViewModeChange,
+  });
+
+  const isLight = themeMode === 'light';
+  const containerClassName = isLight
+    ? 'bg-[#f5f5f5] text-black'
+    : 'bg-[#000000] text-white';
+  const controlsBgClassName = isLight ? 'bg-[#ffffffbb]' : 'bg-[#0000001a]';
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn(
+        'relative w-full overflow-hidden rounded-[24px]',
+        containerClassName,
+        className,
+      )}
+      style={{ height: containerHeight }}
+    >
+      <div className="relative h-full w-full p-6 px-4">
+        <Choreography
+          bundleRoot={BUNDLE_ROOT}
+          className="gap-4"
+          layout={lunaStudioShowcaseLayout}
+          modeGrid={lunaStudioDemoModeGrid}
+          viewMode={viewMode}
+          defaultFocusKey="button"
+          resolveFocusKey={resolveFocusKey}
+          buildStageGlobalProps={createDemoStageGlobalPropsBuilder({
+            studioThemeKey,
+            studioAutoplay,
+          })}
+          interactionTarget="content"
+          onInteraction={handleInteraction}
+          themeKey={studioThemeKey}
+        />
+      </div>
+
+      <div
+        className={cn(
+          'absolute bottom-4 right-4 z-10 rounded-full shadow-sm backdrop-blur',
+          controlsBgClassName,
+        )}
+      >
+        <div className="flex items-center gap-1 px-2 py-2 md:flex-col md:justify-between md:gap-2 md:px-2 md:py-3">
+          {VIEW_MODE_ITEMS.map((item) => (
+            <IconToggleButton
+              key={item.value}
+              active={viewMode === item.value}
+              icon={item.icon}
+              label={item.label}
+              themeMode={themeMode}
+              onClick={() => setViewMode(item.value)}
+            />
+          ))}
+
+          <div
+            className={cn(
+              'mx-2 h-px w-6 md:mx-0 md:h-6 md:w-px',
+              isLight ? 'bg-black/10' : 'bg-white/10',
+            )}
+          />
+
+          {THEME_VARIANT_ITEMS.map((item) => (
+            <IconToggleButton
+              key={item.value}
+              active={themeVariant === item.value}
+              icon={item.icon}
+              label={item.label}
+              themeMode={themeMode}
+              onClick={() => setThemeVariant(item.value)}
+            />
+          ))}
+
+          <div
+            className={cn(
+              'mx-2 h-px w-6 md:mx-0 md:h-6 md:w-px',
+              isLight ? 'bg-black/10' : 'bg-white/10',
+            )}
+          />
+
+          {THEME_MODE_ITEMS.map((item) => (
+            <IconToggleButton
+              key={item.value}
+              active={themeMode === item.value}
+              icon={item.icon}
+              label={item.label}
+              themeMode={themeMode}
+              onClick={() => setThemeMode(item.value)}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export { LunaStudio, LunaStudioShowcase };

--- a/src/luna/luna-studio.tsx
+++ b/src/luna/luna-studio.tsx
@@ -35,6 +35,12 @@ import {
 
 const VIEW_MODES: StudioViewMode[] = ['compare', 'focus', 'lineup'];
 
+const NEXT_VIEW_MODE: Record<StudioViewMode, StudioViewMode> = {
+  compare: 'focus',
+  focus: 'lineup',
+  lineup: 'compare',
+};
+
 const resolveFocusKey = createDemoResolveFocusKey(lunaStudioDemoLayout);
 
 const BUNDLE_ROOT = withBase('/lynx-examples/luna-demo-bundles/dist/');
@@ -109,11 +115,14 @@ function IconToggleButton(props: {
       size="icon"
       variant="ghost"
       aria-pressed={props.active}
+      aria-label={props.label}
       onClick={props.onClick}
       title={props.label}
       className={cn(
-        'h-9 w-9 rounded-full border transition-all hover:scale-110 focus-visible:ring-0 focus-visible:ring-offset-0',
-        isLight ? 'border-black/10' : 'border-white/10',
+        'h-9 w-9 rounded-full border transition-all hover:scale-110 focus-visible:ring-2 focus-visible:ring-offset-2',
+        isLight
+          ? 'border-black/10 focus-visible:ring-black/30 focus-visible:ring-offset-white'
+          : 'border-white/10 focus-visible:ring-white/40 focus-visible:ring-offset-black',
         props.active ? activeClassName : inactiveClassName,
         props.className,
       )}
@@ -157,14 +166,7 @@ function LunaStudio() {
       if (params.suggestedViewMode !== undefined) {
         return params.suggestedViewMode;
       }
-
-      const nextViewMode: Record<StudioViewMode, StudioViewMode> = {
-        compare: 'focus',
-        focus: 'lineup',
-        lineup: 'compare',
-      };
-
-      return nextViewMode[prevMode] ?? 'compare';
+      return NEXT_VIEW_MODE[prevMode] ?? 'compare';
     });
   };
 
@@ -189,7 +191,7 @@ function LunaStudio() {
         'h-auto rounded-full border px-4 py-2 text-sm font-normal transition-colors',
         active
           ? 'border-black bg-black !text-white hover:bg-black/90 hover:!text-white'
-          : 'border-black/20 dark:border-white/20 bg-transparent !text-black hover:bg-black/5 hover:!text-black',
+          : 'border-black/20 bg-transparent !text-black hover:bg-black/5 hover:!text-black',
       );
     }
 
@@ -309,12 +311,12 @@ function LunaStudioShowcase({
   const handleRequestViewModeChange = (params: {
     suggestedViewMode?: StudioViewMode;
   }) => {
-    if (params.suggestedViewMode !== undefined) {
-      setViewMode(params.suggestedViewMode);
-      return;
-    }
-
-    setViewMode(defaultViewMode);
+    setViewMode((prevMode) => {
+      if (params.suggestedViewMode !== undefined) {
+        return params.suggestedViewMode;
+      }
+      return NEXT_VIEW_MODE[prevMode] ?? defaultViewMode;
+    });
   };
 
   const handleInteraction = createDemoInteractionHandler({
@@ -334,13 +336,13 @@ function LunaStudioShowcase({
     <div
       ref={containerRef}
       className={cn(
-        'relative w-full overflow-hidden rounded-[24px]',
+        'relative isolate w-full overflow-hidden rounded-[24px]',
         containerClassName,
         className,
       )}
       style={{ height: containerHeight }}
     >
-      <div className="relative h-full w-full p-6 px-4">
+      <div className="relative z-0 h-full w-full p-6 px-4">
         <Choreography
           bundleRoot={BUNDLE_ROOT}
           className="gap-4"
@@ -361,7 +363,7 @@ function LunaStudioShowcase({
 
       <div
         className={cn(
-          'absolute bottom-4 right-4 z-10 rounded-full shadow-sm backdrop-blur',
+          'absolute bottom-4 right-4 z-50 rounded-full shadow-sm backdrop-blur transform-gpu',
           controlsBgClassName,
         )}
       >

--- a/theme/lynx-ui-home/index.tsx
+++ b/theme/lynx-ui-home/index.tsx
@@ -73,7 +73,7 @@ export const HomeLayout = () => {
       />
       <div className="home-layout-container relative z-10">
         <BaseHomeLayout afterHeroActions={afterHeroActions} />
-        <div className="w-full md:px-4 lg:px-8">
+        <div className="luna-studio-showcase-home w-full md:px-4 lg:px-8">
           <LunaStudioShowcase
             className="px-4 md:px-6 lg:px-8 py-8 md:py-4"
             defaultViewMode="lineup"

--- a/theme/lynx-ui-home/index.tsx
+++ b/theme/lynx-ui-home/index.tsx
@@ -9,11 +9,14 @@ import {
   getCustomMDXComponent as basicGetCustomMDXComponent,
 } from '@rspress/core/theme-original';
 import { useRef } from 'react';
+import { useDark } from '@rspress/core/runtime';
 import { ClearAPI } from './ClearApi';
 import { ConsistencyAndPerformance } from './CombinedConsistencyAndPerformance';
 import { StartBuilding } from './StartBuildingBottom';
+import { LunaStudioShowcase } from '@site/src/luna';
 
 export const HomeLayout = () => {
+  const dark = useDark();
   const { pre: PreWithCodeButtonGroup, code: Code } =
     basicGetCustomMDXComponent();
   const copyElementRef = useRef<HTMLElement | null>(null);
@@ -70,6 +73,13 @@ export const HomeLayout = () => {
       />
       <div className="home-layout-container relative z-10">
         <BaseHomeLayout afterHeroActions={afterHeroActions} />
+        <div className="w-full md:px-4 lg:px-8">
+          <LunaStudioShowcase
+            className="px-4 md:px-6 lg:px-8 py-8 md:py-4"
+            defaultViewMode="lineup"
+            defaultThemeMode={dark ? 'dark' : 'light'}
+          />
+        </div>
         <div className="flex flex-col">
           <ClearAPI />
           <ConsistencyAndPerformance />


### PR DESCRIPTION
### Changes
- Add `LunaStudioShowcase` as a homepage-friendly Luna demo with overlay icon controls (view mode / theme variant / light-dark).
- Support uncontrolled init props: `defaultViewMode` and `defaultThemeMode`; `defaultThemeMode` falls back to Rspress color mode when omitted.
- Keep `backdropFilter` blur scoped to the showcase by introducing a dedicated resolved layout (`lunaStudioShowcaseLayout`), leaving the original demo layout untouched.
- Export showcase from `@site/src/luna` and wire it into `theme/lynx-ui-home`.
- Bump Luna demo deps for polished demos: `@dugyu/luna-demo-bundles@0.2.0`, `@dugyu/luna-stage@0.2.2`, `@dugyu/luna-studio@0.2.0`.


### Interaction
- **Quick Scene Switch (Demo Interaction)**
   Click “Let it bloom” in the `MoonRise` scene to cycle through view modes and preview different layouts.
   
[LunaStudioShowcase_interaction.webm](https://github.com/user-attachments/assets/6f9c7328-2d01-4140-81a6-d9e8759e7a32)

- **Theme Mode**
  `LunaStudioShowcase` is initialized with Rspress current theme mode, but will not sync to it afterwards. This is intentional.

Change-Id: I7097da58bcbe598d1c96ee71bedcd4b214f771de

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Introduce LunaStudioShowcase component with icon-based controls for the lynx-ui homepage.

- Add `LunaStudioShowcase` component with overlay icon controls for view mode, theme variant, and light/dark themes
- Support uncontrolled initialization via `defaultViewMode` and `defaultThemeMode` props, with automatic fallback to Rspress color mode
- Restrict `backdropFilter` blur to the showcase by introducing a new resolved layout `lunaStudioShowcaseLayout`
- Export `LunaStudioShowcase` from `@site/src/luna`
- Integrate `LunaStudioShowcase` into `theme/lynx-ui-home` with dynamic theme detection
- Bump Luna demo dependencies: `@dugyu/luna-demo-bundles@0.2.0`, `@dugyu/luna-stage@0.2.2`, `@dugyu/luna-studio@0.2.0`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/1016?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->