### PR TITLE
style(lynx-ui): tweak home hero styling, particles, and theme lock controls

### DIFF
--- a/docs/en/lynx-ui/index.md
+++ b/docs/en/lynx-ui/index.md
@@ -2,7 +2,7 @@
 pageType: home
 
 hero:
-  badge: 'lynx-ui v3 is officially released'
+  badge: 'lynx-ui is officially released'
   tagline: Pack the best Lynx for you, one component at a time
   text: <span class="hero-title">
     <span class="normal">UI Components for</span>

--- a/docs/zh/lynx-ui/index.md
+++ b/docs/zh/lynx-ui/index.md
@@ -2,7 +2,7 @@
 pageType: home
 
 hero:
-  badge: 'lynx-ui v3 版本正式发布'
+  badge: 'lynx-ui 正式发布'
   tagline: 为你打包最好的 Lynx 组件，一次一个
   text: <span class="hero-title">
     <span class="normal">开箱即用的 </span>

--- a/src/luna/luna-studio.tsx
+++ b/src/luna/luna-studio.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState, type ReactNode } from 'react';
-import { withBase } from '@rspress/core/runtime';
+import { useDark, withBase } from '@rspress/core/runtime';
 import { useContainerResize } from '@dugyu/luna-stage';
 import { Choreography } from '@dugyu/luna-studio';
 import type {
@@ -11,6 +11,8 @@ import type {
 import {
   Columns2,
   GalleryHorizontalEnd,
+  Lock,
+  LockOpen,
   Moon,
   Sparkle,
   Grid2x2,
@@ -100,6 +102,7 @@ function IconToggleButton(props: {
   icon: LucideIcon;
   themeMode: LunaThemeMode;
   className?: string;
+  disabled?: boolean;
 }) {
   const isLight = props.themeMode === 'light';
   const activeClassName = isLight
@@ -116,6 +119,7 @@ function IconToggleButton(props: {
       variant="ghost"
       aria-pressed={props.active}
       aria-label={props.label}
+      disabled={props.disabled}
       onClick={props.onClick}
       title={props.label}
       className={cn(
@@ -283,15 +287,23 @@ function LunaStudioShowcase({
   className,
   defaultViewMode = 'lineup',
   defaultThemeMode,
+  defaultThemeModeLocked = true,
 }: {
   className?: string;
   defaultViewMode?: StudioViewMode;
   defaultThemeMode?: LunaThemeMode;
+  defaultThemeModeLocked?: boolean;
 }) {
+  const pageIsDark = useDark();
+  const pageThemeMode: LunaThemeMode = pageIsDark ? 'dark' : 'light';
+
   const [viewMode, setViewMode] = useState<StudioViewMode>(defaultViewMode);
   const [themeVariant, setThemeVariant] = useState<LunaThemeVariant>('lunaris');
-  const [themeMode, setThemeMode] = useState<LunaThemeMode>(
-    defaultThemeMode ?? 'dark',
+  const [themeModeLocked, setThemeModeLocked] = useState<boolean>(
+    defaultThemeModeLocked,
+  );
+  const [localThemeMode, setLocalThemeMode] = useState<LunaThemeMode>(
+    defaultThemeMode ?? pageThemeMode,
   );
   const [studioAutoplay, setStudioAutoplay] = useState(false);
 
@@ -306,6 +318,7 @@ function LunaStudioShowcase({
           ? 580
           : 640;
 
+  const themeMode = themeModeLocked ? pageThemeMode : localThemeMode;
   const studioThemeKey: LunaThemeKey = `${themeVariant}-${themeMode}`;
 
   const handleRequestViewModeChange = (params: {
@@ -320,7 +333,9 @@ function LunaStudioShowcase({
   };
 
   const handleInteraction = createDemoInteractionHandler({
-    onThemeModeChange: setThemeMode,
+    onThemeModeChange: (mode) => {
+      if (!themeModeLocked) setLocalThemeMode(mode);
+    },
     onThemeVariantChange: setThemeVariant,
     onAutoplayChange: setStudioAutoplay,
     onRequestViewModeChange: handleRequestViewModeChange,
@@ -363,7 +378,7 @@ function LunaStudioShowcase({
 
       <div
         className={cn(
-          'absolute bottom-4 right-4 z-50 rounded-full shadow-sm backdrop-blur transform-gpu',
+          'absolute bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-full shadow-sm backdrop-blur transform-gpu md:left-auto md:right-4 md:translate-x-0',
           controlsBgClassName,
         )}
       >
@@ -381,7 +396,7 @@ function LunaStudioShowcase({
 
           <div
             className={cn(
-              'mx-2 h-px w-6 md:mx-0 md:h-6 md:w-px',
+              'mx-1 h-px w-2 md:mx-0 md:h-6 md:w-px',
               isLight ? 'bg-black/10' : 'bg-white/10',
             )}
           />
@@ -399,7 +414,7 @@ function LunaStudioShowcase({
 
           <div
             className={cn(
-              'mx-2 h-px w-6 md:mx-0 md:h-6 md:w-px',
+              'mx-1 h-px w-2 md:mx-0 md:h-6 md:w-px',
               isLight ? 'bg-black/10' : 'bg-white/10',
             )}
           />
@@ -411,9 +426,31 @@ function LunaStudioShowcase({
               icon={item.icon}
               label={item.label}
               themeMode={themeMode}
-              onClick={() => setThemeMode(item.value)}
+              disabled={themeModeLocked}
+              onClick={() => setLocalThemeMode(item.value)}
             />
           ))}
+
+          <div
+            className={cn(
+              'mx-1 h-px w-1 md:mx-0 md:h-6 md:w-px',
+              isLight ? 'bg-black/10' : 'bg-white/10',
+            )}
+          />
+
+          <IconToggleButton
+            active={themeModeLocked}
+            icon={themeModeLocked ? Lock : LockOpen}
+            label={themeModeLocked ? 'Theme synced' : 'Theme local'}
+            themeMode={themeMode}
+            onClick={() => {
+              setThemeModeLocked((prev) => {
+                const next = !prev;
+                if (prev) setLocalThemeMode(pageThemeMode);
+                return next;
+              });
+            }}
+          />
         </div>
       </div>
     </div>

--- a/theme/hooks/use-blog-btn-dom.ts
+++ b/theme/hooks/use-blog-btn-dom.ts
@@ -95,7 +95,9 @@ const useBlogBtnDom = (src: string) => {
   useEffect(() => {
     if (page.pageType !== 'home') return;
 
-    const badgeElement = document.querySelector('.rp-home-hero__badge');
+    const badgeElement = document.querySelector<HTMLElement>(
+      '.rp-home-hero__badge',
+    );
 
     const h1 = document.querySelector('.rp-home-hero__title');
     if (!h1) return;
@@ -109,7 +111,7 @@ const useBlogBtnDom = (src: string) => {
         ? `rp-home-hero__badge active-hover`
         : `rp-home-hero__badge`;
     badgeElement.textContent = displayText;
-    badgeElement.setAttribute('style', 'opacity: 1;');
+    badgeElement.style.opacity = '1';
 
     if (configKey === '/') {
       badgeElement.addEventListener('click', handleInteraction);

--- a/theme/index.scss
+++ b/theme/index.scss
@@ -112,10 +112,16 @@ $link-color-dark: rgba(84, 169, 255, 1);
 
 .dark[data-subsite='lynx-ui'] {
   @include subsite-theme(#ff8ab5);
-  --rp-c-bg: #0d0d0d;
+  --rp-c-bg: #0a0a0a;
+  --rp-c-bg-mute: rgba(255, 255, 255, 0.06);
+  --rp-c-bg-soft: rgba(255, 255, 255, 0.04);
   .lynx-ui-home-warp {
     --background: 0 0% 0%;
     --foreground: 213 31% 91%;
+  }
+
+  .rp-home-hero .rp-button--brand {
+    color: rgba(0, 0, 0, 0.85);
   }
 }
 

--- a/theme/lynx-ui-home/WarpBackground.tsx
+++ b/theme/lynx-ui-home/WarpBackground.tsx
@@ -3,7 +3,13 @@
 // LICENSE file in the root directory of this source tree.
 
 import { motion } from 'motion/react';
-import React, { HTMLAttributes, useCallback, useMemo } from 'react';
+import React, {
+  HTMLAttributes,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 
 interface WarpBackgroundProps extends HTMLAttributes<HTMLDivElement> {
   children?: React.ReactNode;
@@ -14,25 +20,102 @@ interface WarpBackgroundProps extends HTMLAttributes<HTMLDivElement> {
   beamDelayMax?: number;
   beamDelayMin?: number;
   beamDuration?: number;
+  beamOpacity?: number;
+  beamColorVars?: readonly string[];
   gridColor?: string;
+  gridOpacity?: number;
   gridSize?: number;
   gridLineWidth?: number;
 }
+
+type Rgb = { r: number; g: number; b: number };
+
+const DEFAULT_BEAM_COLOR_VARS = [
+  '--major-brand-color',
+  '--gradient-brand-color',
+  '--second-brand-color',
+] as const;
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(max, Math.max(min, value));
+
+const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
+
+const parseHexColor = (value: string): Rgb | null => {
+  const raw = value.trim();
+  if (!raw.startsWith('#')) return null;
+  const hex = raw.slice(1);
+  if (hex.length === 3) {
+    const r = parseInt(hex[0] + hex[0], 16);
+    const g = parseInt(hex[1] + hex[1], 16);
+    const b = parseInt(hex[2] + hex[2], 16);
+    if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) return null;
+    return { r, g, b };
+  }
+  if (hex.length === 6) {
+    const r = parseInt(hex.slice(0, 2), 16);
+    const g = parseInt(hex.slice(2, 4), 16);
+    const b = parseInt(hex.slice(4, 6), 16);
+    if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) return null;
+    return { r, g, b };
+  }
+  return null;
+};
+
+const mixRgb = (a: Rgb, b: Rgb, t: number): Rgb => {
+  const tt = clamp(t, 0, 1);
+  return {
+    r: Math.round(lerp(a.r, b.r, tt)),
+    g: Math.round(lerp(a.g, b.g, tt)),
+    b: Math.round(lerp(a.b, b.b, tt)),
+  };
+};
+
+const readCssVar = (varName: string) => {
+  if (typeof window === 'undefined') return '';
+  return getComputedStyle(document.documentElement)
+    .getPropertyValue(varName)
+    .trim();
+};
+
+const pickThemeRgbPalette = (varNames: string[]): Rgb[] => {
+  const rgbs = varNames
+    .map((name) => parseHexColor(readCssVar(name)))
+    .filter((v): v is Rgb => v != null);
+
+  if (rgbs.length > 0) return rgbs;
+
+  return [
+    { r: 255, g: 61, b: 99 },
+    { r: 255, g: 93, b: 153 },
+    { r: 61, g: 213, b: 233 },
+  ];
+};
+
+const randomLerpedColor = (palette: Rgb[]) => {
+  const a = palette[Math.floor(Math.random() * palette.length)];
+  const b = palette[Math.floor(Math.random() * palette.length)];
+  const t = Math.random();
+  return mixRgb(a, b, t);
+};
 
 const Beam = ({
   width,
   x,
   delay,
   duration,
+  color,
+  opacity,
+  aspectRatio,
 }: {
   width: string | number;
   x: string | number;
   delay: number;
   duration: number;
+  color: string;
+  opacity: number;
+  aspectRatio: string;
 }) => {
-  const hue = Math.floor(Math.random() * 360);
-  const ar = Math.floor(Math.random() * 10) + 1;
-
   return (
     <motion.div
       style={{
@@ -40,9 +123,10 @@ const Beam = ({
         left: `${x}`,
         top: 0,
         width: `${width}`,
-        aspectRatio: `1/${ar}`,
-        background: `linear-gradient(hsl(${hue} 80% 60%), transparent)`,
+        aspectRatio,
+        background: `linear-gradient(${color}, transparent)`,
         transform: 'translateX(-50%)',
+        opacity,
       }}
       initial={{ y: '100cqmax', x: '-50%' }}
       animate={{ y: '-100%', x: '-50%' }}
@@ -66,13 +150,52 @@ export const WarpBackground: React.FC<WarpBackgroundProps> = ({
   beamDelayMax = 3,
   beamDelayMin = 0,
   beamDuration = 3,
-  gridColor = 'hsl(var(--border))',
+  beamOpacity = 0.6,
+  beamColorVars = DEFAULT_BEAM_COLOR_VARS,
+  gridColor,
+  gridOpacity = 1,
   gridSize = beamSize,
   gridLineWidth = 1,
   ...props
 }) => {
   const { style, ...restProps } = props;
   const resolvedHeight = warpHeight ?? style?.height ?? '80vh';
+
+  const [beamPalette, setBeamPalette] = useState<Rgb[]>(() =>
+    pickThemeRgbPalette([...beamColorVars]),
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const update = () =>
+      setBeamPalette(pickThemeRgbPalette([...beamColorVars]));
+    update();
+    const observer = new MutationObserver(update);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class', 'data-subsite'],
+    });
+    return () => observer.disconnect();
+  }, [beamColorVars]);
+
+  const resolvedGridColor =
+    gridColor ?? `hsl(var(--border) / ${clamp(gridOpacity, 0, 1)})`;
+
+  const buildBeamSpec = useCallback(
+    (x: number) => {
+      const delay =
+        Math.random() * (beamDelayMax - beamDelayMin) + beamDelayMin;
+      const ar = Math.floor(Math.random() * 10) + 1;
+      const rgb = randomLerpedColor(beamPalette);
+      return {
+        x,
+        delay,
+        aspectRatio: `1/${ar}`,
+        color: `rgb(${rgb.r} ${rgb.g} ${rgb.b})`,
+      };
+    },
+    [beamDelayMax, beamDelayMin, beamPalette],
+  );
 
   const generateBeams = useCallback(() => {
     const beams = [];
@@ -81,29 +204,32 @@ export const WarpBackground: React.FC<WarpBackgroundProps> = ({
 
     for (let i = 0; i < beamsPerSide; i++) {
       const x = Math.floor(i * step);
-      const delay =
-        Math.random() * (beamDelayMax - beamDelayMin) + beamDelayMin;
-      beams.push({ x, delay });
+      beams.push(buildBeamSpec(x));
     }
     return beams;
-  }, [beamsPerSide, beamSize, beamDelayMax, beamDelayMin]);
+  }, [beamsPerSide, beamSize, buildBeamSpec]);
 
   const generateBeamsHorizontal = useCallback(() => {
     const beams = [];
-    const beamX = [0, 22, 46, 70, 100];
+    const cellsPerSide = Math.floor(100 / beamSize);
+    const step = beamsPerSide > 1 ? cellsPerSide / (beamsPerSide - 1) : 0;
     for (let i = 0; i < beamsPerSide; i++) {
-      const x = beamX[i];
-      const delay =
-        Math.random() * (beamDelayMax - beamDelayMin) + beamDelayMin;
-      beams.push({ x, delay });
+      const x = Math.floor(i * step);
+      beams.push(buildBeamSpec(x));
     }
     return beams;
-  }, [beamsPerSide, beamSize, beamDelayMax, beamDelayMin]);
+  }, [beamsPerSide, beamSize, buildBeamSpec]);
 
   const topBeams = useMemo(() => generateBeams(), [generateBeams]);
-  const rightBeams = useMemo(() => generateBeamsHorizontal(), [generateBeams]);
+  const rightBeams = useMemo(
+    () => generateBeamsHorizontal(),
+    [generateBeamsHorizontal],
+  );
   const bottomBeams = useMemo(() => generateBeams(), [generateBeams]);
-  const leftBeams = useMemo(() => generateBeamsHorizontal(), [generateBeams]);
+  const leftBeams = useMemo(
+    () => generateBeamsHorizontal(),
+    [generateBeamsHorizontal],
+  );
 
   const containerStyles: React.CSSProperties = {
     position: 'relative',
@@ -123,7 +249,7 @@ export const WarpBackground: React.FC<WarpBackgroundProps> = ({
     transformStyle: 'preserve-3d' as const,
     height: resolvedHeight,
     ['--perspective' as string]: `${perspective}px`,
-    ['--grid-color' as string]: gridColor,
+    ['--grid-color' as string]: resolvedGridColor,
     ['--grid-size' as string]: `${gridSize}%`,
     ['--2-grid-size' as string]: `${2 * gridSize}%`,
     ['--grid-line-width' as string]: `${gridLineWidth}px`,
@@ -187,6 +313,9 @@ export const WarpBackground: React.FC<WarpBackgroundProps> = ({
               x={`${beam.x * beamSize}%`}
               delay={beam.delay}
               duration={beamDuration}
+              color={beam.color}
+              opacity={beamOpacity}
+              aspectRatio={beam.aspectRatio}
             />
           ))}
         </div>
@@ -199,6 +328,9 @@ export const WarpBackground: React.FC<WarpBackgroundProps> = ({
               x={`${beam.x * beamSize}%`}
               delay={beam.delay}
               duration={beamDuration}
+              color={beam.color}
+              opacity={beamOpacity}
+              aspectRatio={beam.aspectRatio}
             />
           ))}
         </div>
@@ -211,6 +343,9 @@ export const WarpBackground: React.FC<WarpBackgroundProps> = ({
               x={`${beam.x * beamSize}%`}
               delay={beam.delay}
               duration={beamDuration}
+              color={beam.color}
+              opacity={beamOpacity}
+              aspectRatio={beam.aspectRatio}
             />
           ))}
         </div>
@@ -223,6 +358,9 @@ export const WarpBackground: React.FC<WarpBackgroundProps> = ({
               x={`${beam.x * beamSize}%`}
               delay={beam.delay}
               duration={beamDuration}
+              color={beam.color}
+              opacity={beamOpacity}
+              aspectRatio={beam.aspectRatio}
             />
           ))}
         </div>

--- a/theme/lynx-ui-home/home-layout-var.scss
+++ b/theme/lynx-ui-home/home-layout-var.scss
@@ -9,7 +9,8 @@
   --luna-line: rgba(0, 0, 0, 0.17);
   --luna-neutral-ambient: #eeeeee;
   --home-blog-bg-img: url('@assets/lynx-ui-icon-dark.svg');
-  --home-features-list-frame-bg: url('https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/home/f-lynx-ui-light.svg');
+  --home-features-list-frame-bg: url('https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/home/f-lynx-ui-light.svg')
+    no-repeat center center;
 
   --home-highlight-title-color: var(--luna-primary);
 
@@ -34,7 +35,8 @@
 
   --luna-line: rgba(248, 248, 248, 0.32);
   --home-blog-bg-img: url('@assets/lynx-ui-icon-light.svg');
-  --home-features-list-frame-bg: url('https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/home/f-lynx-ui-dark.svg');
+  --home-features-list-frame-bg: url('https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/home/f-lynx-ui-dark.svg')
+    no-repeat center center;
 
   --luna-primary: #ff8ab5;
   --luna-paper: #1a1a1a;

--- a/theme/lynx-ui-home/index.scss
+++ b/theme/lynx-ui-home/index.scss
@@ -5,6 +5,10 @@
 @use './sidebar-badge';
 
 :root[data-subsite='lynx-ui'] {
+  .rp-home-hero__badge {
+    opacity: 1;
+  }
+
   .rp-home-feature {
     display: none;
   }

--- a/theme/lynx-ui-home/index.tsx
+++ b/theme/lynx-ui-home/index.tsx
@@ -9,14 +9,12 @@ import {
   getCustomMDXComponent as basicGetCustomMDXComponent,
 } from '@rspress/core/theme-original';
 import { useRef } from 'react';
-import { useDark } from '@rspress/core/runtime';
 import { ClearAPI } from './ClearApi';
 import { ConsistencyAndPerformance } from './CombinedConsistencyAndPerformance';
 import { StartBuilding } from './StartBuildingBottom';
 import { LunaStudioShowcase } from '@site/src/luna';
 
 export const HomeLayout = () => {
-  const dark = useDark();
   const { pre: PreWithCodeButtonGroup, code: Code } =
     basicGetCustomMDXComponent();
   const copyElementRef = useRef<HTMLElement | null>(null);
@@ -66,7 +64,7 @@ export const HomeLayout = () => {
           zIndex: 0,
         }}
         beamSize={0.5}
-        beamsPerSide={5}
+        beamsPerSide={7}
         perspective={500}
         gridSize={3}
         gridLineWidth={0.5}
@@ -77,7 +75,6 @@ export const HomeLayout = () => {
           <LunaStudioShowcase
             className="px-4 md:px-6 lg:px-8 py-8 md:py-4"
             defaultViewMode="lineup"
-            defaultThemeMode={dark ? 'dark' : 'light'}
           />
         </div>
         <div className="flex flex-col">


### PR DESCRIPTION
- Restore the home hero badge (it was inadvertently hidden by the `useBlogBtnDom` related logic and styles, which should only affect the main site)
- Fix home hero primary button text color
- Soften dark mode secondary button styling
- Prevent home feature frame background image from repeating
- Increase particle density and derive particle colors from theme palette
- Add a Theme Lock toggle (Lock/LockOpen) to switch between syncing with the site theme and using a local demo theme; disable the Light/Dark buttons while locked, and refine mobile controls layout (center the floating panel and tighten divider spacing) to avoid clipping on small screens

Change-Id: I9604f8888993720c0cf35923cd4ec1c55a55d45a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## style(lynx-ui): tweak home hero styling, particles, and theme lock controls

- Restore home hero badge visibility with explicit opacity styling
- Fix home hero primary button text color in dark mode
- Soften dark mode secondary button styling with adjusted color variables
- Prevent home feature frame background image from repeating
- Increase particle density (beams per side from 5 to 7)
- Derive particle colors from theme palette using CSS color variables with dynamic palette updates
- Add Theme Lock toggle (Lock/LockOpen icons) to switch between site theme sync and local demo theme
- Disable Light/Dark theme buttons when theme mode is locked
- Support disabled state in IconToggleButton component
- Refine mobile controls layout and divider spacing

Updates documentation badge text and improves theme synchronization control for the Lynx UI showcase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/1018?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->