### PR TITLE
fix(lynx-ui-home): reduce LunaStudioShowcase theme flash by relying on CSS tokens

### DIFF
--- a/src/luna/luna-studio.tsx
+++ b/src/luna/luna-studio.tsx
@@ -125,8 +125,8 @@ function IconToggleButton(props: {
       className={cn(
         'h-9 w-9 rounded-full border transition-all hover:scale-110 focus-visible:ring-2 focus-visible:ring-offset-2',
         isLight
-          ? 'border-black/10 focus-visible:ring-black/30 focus-visible:ring-offset-white'
-          : 'border-white/10 focus-visible:ring-white/40 focus-visible:ring-offset-black',
+          ? 'border-black/10 focus-visible:ring-black/30 focus-visible:ring-offset-background'
+          : 'border-white/10 focus-visible:ring-white/40 focus-visible:ring-offset-background',
         props.active ? activeClassName : inactiveClassName,
         props.className,
       )}
@@ -342,16 +342,27 @@ function LunaStudioShowcase({
   });
 
   const isLight = themeMode === 'light';
-  const containerClassName = isLight
-    ? 'bg-[#f5f5f5] text-black'
-    : 'bg-[#000000] text-white';
-  const controlsBgClassName = isLight ? 'bg-[#ffffffbb]' : 'bg-[#0000001a]';
+  const containerClassName = themeModeLocked
+    ? 'bg-canvas-ambient text-foreground'
+    : isLight
+      ? 'bg-[#f5f5f5] text-black'
+      : 'bg-[#000000] text-white';
+  const dividerClassName = themeModeLocked
+    ? 'bg-rule'
+    : isLight
+      ? 'bg-black/10'
+      : 'bg-white/10';
+  const controlsBgClassName = themeModeLocked
+    ? 'bg-soft'
+    : isLight
+      ? 'bg-[#ffffffbb]'
+      : 'bg-[#0000001a]';
 
   return (
     <div
       ref={containerRef}
       className={cn(
-        'relative isolate w-full overflow-hidden rounded-[24px]',
+        'relative isolate w-full overflow-hidden rounded-[24px] transition-all duration-300',
         containerClassName,
         className,
       )}
@@ -397,7 +408,7 @@ function LunaStudioShowcase({
           <div
             className={cn(
               'mx-1 h-px w-2 md:mx-0 md:h-6 md:w-px',
-              isLight ? 'bg-black/10' : 'bg-white/10',
+              dividerClassName,
             )}
           />
 
@@ -415,7 +426,7 @@ function LunaStudioShowcase({
           <div
             className={cn(
               'mx-1 h-px w-2 md:mx-0 md:h-6 md:w-px',
-              isLight ? 'bg-black/10' : 'bg-white/10',
+              dividerClassName,
             )}
           />
 
@@ -434,7 +445,7 @@ function LunaStudioShowcase({
           <div
             className={cn(
               'mx-1 h-px w-1 md:mx-0 md:h-6 md:w-px',
-              isLight ? 'bg-black/10' : 'bg-white/10',
+              dividerClassName,
             )}
           />
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -41,6 +41,11 @@ export default {
         ring: 'var(--rp-c-brand)',
         background: 'var(--rp-c-bg)',
         foreground: 'var(--rp-c-text-1)',
+        canvas: {
+          DEFAULT: 'var(--rp-c-bg)',
+          ambient: 'var(--rp-c-bg-alt)',
+        },
+        rule: 'var(--rp-c-divider-secondary)',
         primary: {
           DEFAULT: 'var(--rp-c-brand)',
           foreground: 'var(--rp-c-text-1)',

--- a/theme/index.scss
+++ b/theme/index.scss
@@ -100,6 +100,15 @@ $link-color-dark: rgba(84, 169, 255, 1);
 :root[data-subsite='lynx-ui'] {
   @include subsite-theme(#ff1a6e);
   --rp-c-bg: #ffffff;
+  --rp-c-bg-alt: #f5f5f5;
+  --rp-c-text-1: #010101;
+  --rp-c-divider-secondary: rgba(0, 0, 0, 0.1);
+  &,
+  & *,
+  & *::before,
+  & *::after {
+    --tw-ring-color: #0101013a;
+  }
   .lynx-ui-home-warp {
     --background: 0 0% 100%;
     --foreground: 222.2 47.4% 11.2%;
@@ -113,6 +122,16 @@ $link-color-dark: rgba(84, 169, 255, 1);
 .dark[data-subsite='lynx-ui'] {
   @include subsite-theme(#ff8ab5);
   --rp-c-bg: #0a0a0a;
+  --rp-c-bg-alt: #000000;
+  --rp-c-text-1: #f8f8f8;
+  --rp-c-divider-secondary: rgba(255, 255, 255, 0.1);
+  --tw-ring-color: #f8f8f8;
+  &,
+  & *,
+  & *::before,
+  & *::after {
+    --tw-ring-color: #f8f8f84d;
+  }
   --rp-c-bg-mute: rgba(255, 255, 255, 0.06);
   --rp-c-bg-soft: rgba(255, 255, 255, 0.04);
   .lynx-ui-home-warp {


### PR DESCRIPTION
- Avoid initial light→dark flash on direct `/lynx-ui` entry by styling `LunaStudioShowcase` (locked mode) with Rspress CSS variables instead of `useDark()`-driven hardcoded colors.
- Introduce `canvas` (`bg-canvas-ambient`) and `rule` (`bg-rule`) utilities mapped to `--rp-c-bg-alt` / `--rp-c-divider-secondary` for stable, theme-aware surfaces and dividers.
- Define lynx-ui subsite token overrides for `--rp-c-bg-alt` and `--rp-c-divider-secondary` and scope `--tw-ring-color` to prevent Tailwind preflight from overriding focus ring color.

Change-Id: I508de2070cd1af9824ef36030fc72bdc660048f8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Reduce theme flash by relying on CSS tokens in lynx-ui

- Update `LunaStudioShowcase` to style locked mode with Rspress CSS variables instead of useDark()-driven hardcoded colors, preventing initial light→dark flash on `/lynx-ui`
- Add `canvas` and `rule` Tailwind utility classes mapped to `--rp-c-bg-alt` and `--rp-c-divider-secondary` CSS variables for consistent, theme-aware surfaces and dividers
- Centralize divider styling in controls panel to use `bg-rule` utility instead of inline conditional theme colors
- Update `IconToggleButton` focus ring styling to use `focus-visible:ring-offset-background` token for both light and dark cases
- Provide `lynx-ui` subsite CSS variable overrides for `--rp-c-bg-alt`, `--rp-c-text-1`, and `--rp-c-divider-secondary` in both light and dark modes
- Scope `--tw-ring-color` in `lynx-ui` theme to prevent Tailwind preflight from overriding focus ring color styling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/1019?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->