### PR TITLE
fix(lynx-ui-home): improve Luna Studio showcase sizing on large screens

### DIFF
--- a/src/luna/luna-studio.tsx
+++ b/src/luna/luna-studio.tsx
@@ -307,17 +307,6 @@ function LunaStudioShowcase({
   );
   const [studioAutoplay, setStudioAutoplay] = useState(false);
 
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const { width: containerWidth } = useContainerResize({ ref: containerRef });
-  const containerHeight =
-    containerWidth === undefined
-      ? 420
-      : containerWidth < 640
-        ? 520
-        : containerWidth < 800
-          ? 580
-          : 640;
-
   const themeMode = themeModeLocked ? pageThemeMode : localThemeMode;
   const studioThemeKey: LunaThemeKey = `${themeVariant}-${themeMode}`;
 
@@ -360,13 +349,11 @@ function LunaStudioShowcase({
 
   return (
     <div
-      ref={containerRef}
       className={cn(
-        'relative isolate w-full overflow-hidden rounded-[24px] transition-all duration-300',
+        'relative isolate w-full overflow-hidden rounded-[24px] transition-all duration-300 h-[420px] sm:h-[520px] md:h-[580px] lg:h-[640px] xl:h-[700px] 2xl:h-[760px]',
         containerClassName,
         className,
       )}
-      style={{ height: containerHeight }}
     >
       <div className="relative z-0 h-full w-full p-6 px-4">
         <Choreography

--- a/theme/lynx-ui-home/index.tsx
+++ b/theme/lynx-ui-home/index.tsx
@@ -71,7 +71,7 @@ export const HomeLayout = () => {
       />
       <div className="home-layout-container relative z-10">
         <BaseHomeLayout afterHeroActions={afterHeroActions} />
-        <div className="luna-studio-showcase-home w-full md:px-4 lg:px-8">
+        <div className="luna-studio-showcase-home mx-auto w-full max-w-screen-2xl md:px-4 lg:px-8">
           <LunaStudioShowcase
             className="px-4 md:px-6 lg:px-8 py-8 md:py-4"
             defaultViewMode="lineup"


### PR DESCRIPTION
Constrain the showcase section width on ultra-wide screens to avoid a flattened look.

- Center the Luna Studio showcase container and cap it at 2xl width
- Tune LunaStudioShowcase height across lg/xl/2xl breakpoints for better aspect ratio
- Prefer CSS breakpoint-driven sizing over JS resize logic for the homepage layout (no sidebar involved)

Change-Id: If0924cfeeaff3c881c532fa31a62a4a79daa84d2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Replace JavaScript resize-based height logic with responsive Tailwind height utilities in `LunaStudioShowcase` (h-[420px] through 2xl:h-[760px])
- Center Luna Studio showcase container and constrain maximum width to `max-w-screen-2xl` breakpoint

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/1020?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->