### PR TITLE
docs: update lynx-ui blog post with proper casing and content fixes

### DIFF
--- a/docs/en/blog/lynx-ui.mdx
+++ b/docs/en/blog/lynx-ui.mdx
@@ -1,10 +1,10 @@
 ---
-title: 'Introducing Lynx UI'
+title: 'Introducing lynx-ui'
 date: 2026-05-22
 sidebar: false
 authors: ['lynx']
-badge_text: 'Lynx UI is here!'
-description: 'Introducing Lynx UI, a set of ready-to-use components that preserve native user experience while delivering the velocity of the web. With LUNA, Motion.js, and support for iOS, Android, and HarmonyOS.'
+badge_text: 'lynx-ui is here!'
+description: 'Introducing lynx-ui, a set of ready-to-use components that preserve native user experience while delivering the velocity of the web. With LUNA, Motion.js, and support for iOS, Android, and HarmonyOS.'
 ---
 
 import { BlogHeader, Go } from '@lynx';
@@ -15,13 +15,17 @@ import { BlogHeader, Go } from '@lynx';
 
 Lynx's native elements are powerful, but they cannot solve every product problem on their own.
 
-[Built-in elements](/guide/ui/elements-components.html#built-in-elements) and [XElement](/guide/ui/elements-components.html#xelement) provide the atomic capabilities that make an interface feel truly native: fast scrolling, precise gestures, [platform-level rendering](/guide/ui/elements-components.html#behind-the-elements-native-rendering), and predictable behavior across iOS, Android, and HarmonyOS. But real products need more than atoms. They need components that can adapt to different scenarios, absorb platform differences, encode interaction patterns, and leave enough room for each team to express its own design system.
+[Built-in elements](/guide/ui/elements-components.html#built-in-elements) and [XElement](/guide/ui/elements-components.html#xelement) provide the atomic capabilities that make an interface feel truly native: fast scrolling, precise gestures, [platform-level rendering](/guide/ui/elements-components.html#behind-the-elements-native-rendering), and predictable behavior across iOS, Android, and HarmonyOS.
 
-That is where the [frontend component layer](/guide/ui/elements-components.html#components-composition-of-elements) belongs. Native provides the performance-critical foundation; [JavaScript](/guide/scripting-runtime/index.html) provides the extension layer for composition, state, styling, and product-specific behavior. Lynx UI is built around this boundary, so teams can keep the performance of native primitives while gaining the flexibility and iteration speed of frontend development.
+But real products need more than atoms. They need components that can adapt to different scenarios, absorb platform differences, encode interaction patterns, and leave enough room for each team to express its own design system.
+
+That is where the [frontend component layer](/guide/ui/elements-components.html#components-composition-of-elements) belongs. Native provides the performance-critical foundation; [JavaScript](/guide/scripting-runtime/index.html) provides the extension layer for composition, state, styling, and product-specific behavior.
+
+What teams need here is a frontend component library: a layer that handles product-level patterns while preserving the performance of native primitives and the flexibility of frontend development.
 
 ## Built on Native Ground
 
-That boundary only works if the native side is strong. Lynx UI is not merely a simple wrapper around existing Web components, but the result of our deep exploration into bridging the mental model gap between Web and Native.
+That boundary only works if the native side is strong. Frontend components in Lynx need to map familiar Web-like patterns onto native primitives, bridging the mental model gap between Web and Native instead of simply wrapping existing Web components.
 
 - Lynx provides high-performance element primitives: [`scroll-view`](/api/elements/built-in/scroll-view), [`list`](/api/elements/built-in/list), [`overlay`](/api/elements/built-in/overlay).
 - These render to actual native views or native rendering layers, enabling behaviors that are structurally difficult on the mobile web.
@@ -39,13 +43,13 @@ The hardest part of native-quality interaction is timing.
 - Swiper as example: `delta in, transform out`, per frame, synchronously on the main thread.
 - This enables fully programmable per-frame callbacks for properties such as rotation, scale, opacity, or any other adjustable property.
 
-## Meet Lynx UI
+## Meet lynx-ui
 
-[Lynx UI](/lynx-ui/) is the official headless UI library for ReactLynx: native underneath, composable on top, and style-free by default. It provides behavior, state management, native-layer integration, and interaction primitives that teams can shape with their own design systems.
+[lynx-ui](/lynx-ui/) is the official headless UI library for ReactLynx: native underneath, composable on top, and style-free by default. It provides behavior, state management, native-layer integration, and interaction primitives that teams can shape with their own design systems.
 
 We have re-examined every high-frequency interaction scenario from both Web and Native perspectives, distilling them into a series of components that embody best practices:
 
-- **Composability First**: Drawing inspiration from libraries like Radix UI, we rejected the "black-box" component model. Instead of adding endless props to a monolithic component, Lynx UI exposes underlying primitives (e.g., `DialogRoot`, `DialogTrigger`, `DialogContent`). This structural design gives you complete control over layout and styling while we handle the complex native states.
+- **Composability First**: Drawing inspiration from libraries like Radix UI, we rejected the "black-box" component model. Instead of adding endless props to a monolithic component, lynx-ui exposes underlying primitives (e.g., `DialogRoot`, `DialogTrigger`, `DialogContent`). This structural design gives you complete control over layout and styling while we handle the complex native states.
 - **ScrollView & List**: Provide true native scrolling and a 120fps fluid experience, along with high-performance virtualization capabilities designed for long lists.
 - **Swiper**: Provides precise scroll snap behavior, ensuring smooth transitions for carousels and other swipeable views.
 - **SwipeAction**: Implements side-swipe operations for list items, providing delicate damping and rebound effects.
@@ -292,29 +296,19 @@ The difference between good and great is in the curve.
 - **Same code. Same API. Web and native.**
 - We're now sponsoring the Motion.js project
 
-## LUNA: A Design Language for Lynx UI
+## LUNA: A Design Language for lynx-ui
 
 We are obsessed with design. LUNA is the proof.
 
-- Lynx UI components are headless: no opinions on visual style, fully open to your design system
-- LUNA (Lynx UI Neo-Aesthetics) is a reference design system built on top of Lynx UI, used across all examples and demos
+- lynx-ui components are headless: no opinions on visual style, fully open to your design system
+- LUNA (lynx-ui Neo-Aesthetics) is a reference design system built on top of lynx-ui, used across all examples and demos
 - Design token system: dark/light mode, color, spacing, motion timing, all codified
 - Extensible: LUNA is the default; your design system is the override
 
-## Availability
+## Try it today
 
-This is the beginning.
+lynx-ui is available on iOS, Android, and HarmonyOS today, with partial web support and Lynx Desktop support on the horizon. The packages are published under [`@lynx-js/lynx-ui-*`](https://www.npmjs.com/package/@lynx-js/lynx-ui).
 
-- iOS, Android, HarmonyOS on release
-- Partial web support (platform ceiling caveat)
-- Lynx Desktop support on the horizon
-- All packages under `@lynx-js/lynx-ui-*`
-- Try it today: download Lynx Go, scan the QR code
+To get a feel for lynx-ui, try the components in action. Grab [Lynx Explorer](/guide/start/quick-start.html#prepare-lynx-explorer), scan the QR codes in the [demo](/lynx-ui/components/button), and you can see them running right away. Or bring it into your own Lynx app and try it in a real product flow.
 
-## Shape Lynx UI Together
-
-Lynx UI is still early, and we know the best component APIs are refined through real product feedback. If you try it in your own Lynx app, we would love to hear what feels natural, what feels missing, and where the primitives should give you more control.
-
-More components are also on their way to open source, and we hope to shape them with the community from the start.
-
-You can share feedback, open issues, or contribute directly in the [lynx-family/lynx-ui repository](https://github.com/lynx-family/lynx-ui). Even small examples, bug reports, and design-system use cases help us make Lynx UI better for everyone.
+We want lynx-ui to grow from the way real apps are built. If it feels great, gets in your way, or leaves something missing, let us know in the [lynx-family/lynx-ui repository](https://github.com/lynx-family/lynx-ui) and help shape what comes next.


### PR DESCRIPTION
Adjust all references of Lynx UI to lowercase lynx-ui where appropriate, restructure awkward paragraph breaks, update the availability and getting started sections to be more clear and concise, and fix inconsistent naming throughout the blog post.

Change-Id: I5eca6b2afe6908e0d4db2f798be0286d10eda7bd