### PR TITLE
docs(css): add -x-auto-font-size-line-ranges docs

### DIFF
--- a/docs/en/api/css/properties/-x-auto-font-size-line-ranges.mdx
+++ b/docs/en/api/css/properties/-x-auto-font-size-line-ranges.mdx
@@ -1,0 +1,74 @@
+---
+api: css/properties/-x-auto-font-size-line-ranges
+---
+
+import { APISummary, APITable, Go } from '@lynx';
+
+# -x-auto-font-size-line-ranges
+
+<APISummary />
+
+## Introduction
+
+The `-x-auto-font-size-line-ranges` property defines line-count-based font size ranges for text auto sizing. Use it together with `-x-auto-font-size: true` to provide different font size search ranges for different rendered line counts.
+
+## Examples
+
+<Go
+  example="css-api"
+  defaultFile="src/-x-auto-font-size-line-ranges/App.tsx"
+  img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/doc/auto-font-size-line-ranges.jpeg"
+  defaultEntryFile="dist/-x-auto-font-size-line-ranges.lynx.bundle"
+  entry="src/-x-auto-font-size-line-ranges"
+/>
+
+## Syntax
+
+```css
+-x-auto-font-size: true;
+-x-auto-font-size-line-ranges:
+  line-range(1, 18px, 22px), line-range(2, 16px, 18px),
+  line-range(3 to infinity, 14px);
+```
+
+### Values
+
+- `line-range(<line-count>, <min-size>[, <max-size>])`
+  - Defines one line-count rule.
+  - `<line-count>` can be an exact positive integer such as `1` or an open-ended range such as `3 to infinity`.
+  - `<min-size>` is required and must be a [`<length>`](/api/css/data-type/length.mdx).
+  - `<max-size>` is optional and must be a [`<length>`](/api/css/data-type/length.mdx). If omitted, the value defaults to `<min-size>`, meaning a fixed font size is used for the matched rule.
+
+## Formal definition
+
+import { PropertyDefinition } from '@/components/PropertyDefinition';
+
+<PropertyDefinition
+  initialValue={<>[]</>}
+  appliesTo={<>text</>}
+  inherited="no"
+  animatable="no"
+/>
+
+## Formal syntax
+
+```
+-x-auto-font-size-line-ranges = <line-range-function>#
+
+<line-range-function> = line-range( <line-count> , <length> [, <length>]? )
+<line-count> = <integer> | <integer> to infinity
+```
+
+## Differences from Web
+
+- This is a Lynx-specific property.
+
+## Notes
+
+- This property is only effective when `-x-auto-font-size` is enabled.
+- This property overrides the minimum and maximum font size settings in `-x-auto-font-size`.
+- When this property is set, `-x-auto-font-size-preset-sizes` does not take effect.
+
+## Compatibility
+
+<APITable />

--- a/docs/zh/api/css/properties/-x-auto-font-size-line-ranges.mdx
+++ b/docs/zh/api/css/properties/-x-auto-font-size-line-ranges.mdx
@@ -1,0 +1,74 @@
+---
+api: css/properties/-x-auto-font-size-line-ranges
+---
+
+import { APISummary, APITable, Go } from '@lynx';
+
+# -x-auto-font-size-line-ranges
+
+<APISummary />
+
+## 介绍
+
+`-x-auto-font-size-line-ranges` 属性为文本字号自适应定义基于行数的字号范围规则。它需要与 `-x-auto-font-size: true` 配合使用，用于为不同的实际渲染行数指定不同的字号搜索区间。
+
+## 使用示例
+
+<Go
+  example="css-api"
+  defaultFile="src/-x-auto-font-size-line-ranges/App.tsx"
+  img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/doc/auto-font-size-line-ranges.jpeg"
+  defaultEntryFile="dist/-x-auto-font-size-line-ranges.lynx.bundle"
+  entry="src/-x-auto-font-size-line-ranges"
+/>
+
+## 语法
+
+```css
+-x-auto-font-size: true;
+-x-auto-font-size-line-ranges:
+  line-range(1, 18px, 22px), line-range(2, 16px, 18px),
+  line-range(3 to infinity, 14px);
+```
+
+### 取值
+
+- `line-range(<line-count>, <min-size>[, <max-size>])`
+  - 定义一条行数规则。
+  - `<line-count>` 可以是精确的正整数，例如 `1`，也可以是开放区间，例如 `3 to infinity`。
+  - `<min-size>` 为必填项，类型是 [`<length>`](/api/css/data-type/length.mdx)。
+  - `<max-size>` 为可选项，类型是 [`<length>`](/api/css/data-type/length.mdx)。如果省略，则默认等于 `<min-size>`，表示命中该规则时使用固定字号。
+
+## 形式定义
+
+import { PropertyDefinition } from '@/components/PropertyDefinition';
+
+<PropertyDefinition
+  initialValue={<>[]</>}
+  appliesTo={<>text</>}
+  inherited="no"
+  animatable="no"
+/>
+
+## 形式语法
+
+```
+-x-auto-font-size-line-ranges = <line-range-function>#
+
+<line-range-function> = line-range( <line-count> , <length> [, <length>]? )
+<line-count> = <integer> | <integer> to infinity
+```
+
+## 与 Web 的区别
+
+- Lynx 特有的属性。
+
+## 注意事项
+
+- 此属性仅在 `-x-auto-font-size` 开启时生效。
+- 此属性会覆盖 `-x-auto-font-size` 中的最小字号和最大字号设置。
+- 当此属性被设置后，`-x-auto-font-size-preset-sizes` 不生效。
+
+## 兼容性
+
+<APITable />

--- a/packages/lynx-compat-data/api-stats.json
+++ b/packages/lynx-compat-data/api-stats.json
@@ -1,7 +1,7 @@
 {
   "summary": {
-    "total_apis": 1118,
-    "platform_api_total": 1024,
+    "total_apis": 1119,
+    "platform_api_total": 1025,
     "by_category": {
       "elements": {
         "total": 305,
@@ -40,10 +40,10 @@
         }
       },
       "css/properties": {
-        "total": 351,
+        "total": 352,
         "supported": {
-          "android": 319,
-          "ios": 319,
+          "android": 320,
+          "ios": 320,
           "harmony": 309,
           "web_lynx": 326,
           "clay_android": 311,
@@ -57,11 +57,11 @@
           "ios": 91,
           "harmony": 88,
           "web_lynx": 93,
-          "clay_android": 89,
-          "clay_ios": 87,
+          "clay_android": 88,
+          "clay_ios": 86,
           "clay_macos": 95,
           "clay_windows": 96,
-          "clay": 98
+          "clay": 97
         },
         "exclusive": {
           "android": 0,
@@ -618,12 +618,12 @@
     },
     "by_platform": {
       "android": {
-        "supported_count": 907,
+        "supported_count": 908,
         "coverage_percent": 89,
         "exclusive_count": 18
       },
       "ios": {
-        "supported_count": 909,
+        "supported_count": 910,
         "coverage_percent": 89,
         "exclusive_count": 12
       },
@@ -17423,10 +17423,10 @@
     "css/properties": {
       "display_name": "CSS Properties",
       "stats": {
-        "total": 351,
+        "total": 352,
         "supported": {
-          "android": 319,
-          "ios": 319,
+          "android": 320,
+          "ios": 320,
           "harmony": 309,
           "web_lynx": 326,
           "clay_android": 311,
@@ -17440,11 +17440,11 @@
           "ios": 91,
           "harmony": 88,
           "web_lynx": 93,
-          "clay_android": 89,
-          "clay_ios": 87,
+          "clay_android": 88,
+          "clay_ios": 86,
           "clay_macos": 95,
           "clay_windows": 96,
-          "clay": 98
+          "clay": 97
         },
         "exclusive": {
           "android": 0,
@@ -17460,6 +17460,7 @@
       },
       "apis": [
         "css/properties/-x-animation-color-interpolation",
+        "css/properties/-x-auto-font-size-line-ranges",
         "css/properties/-x-auto-font-size-preset-sizes",
         "css/properties/-x-auto-font-size",
         "css/properties/-x-handle-color",
@@ -17859,6 +17860,22 @@
             "clay_macos": "3.4",
             "clay_windows": "3.4",
             "clay": "3.4"
+          }
+        },
+        {
+          "path": "css/properties/-x-auto-font-size-line-ranges",
+          "name": "-x-auto-font-size-line-ranges",
+          "doc_url": "api/css/properties/-x-auto-font-size-line-ranges",
+          "support": {
+            "android": "3.8",
+            "ios": "3.8",
+            "harmony": false,
+            "web_lynx": false,
+            "clay_android": false,
+            "clay_ios": false,
+            "clay_macos": false,
+            "clay_windows": false,
+            "clay": false
           }
         },
         {
@@ -25021,6 +25038,22 @@
         ],
         "harmony": [
           {
+            "path": "css/properties/-x-auto-font-size-line-ranges",
+            "name": "-x-auto-font-size-line-ranges",
+            "doc_url": "api/css/properties/-x-auto-font-size-line-ranges",
+            "support": {
+              "android": "3.8",
+              "ios": "3.8",
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
             "path": "css/properties/-x-auto-font-size-preset-sizes",
             "name": "-x-auto-font-size-preset-sizes",
             "doc_url": "api/css/properties/-x-auto-font-size-preset-sizes",
@@ -25711,6 +25744,22 @@
             }
           },
           {
+            "path": "css/properties/-x-auto-font-size-line-ranges",
+            "name": "-x-auto-font-size-line-ranges",
+            "doc_url": "api/css/properties/-x-auto-font-size-line-ranges",
+            "support": {
+              "android": "3.8",
+              "ios": "3.8",
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
             "path": "css/properties/-x-auto-font-size-preset-sizes",
             "name": "-x-auto-font-size-preset-sizes",
             "doc_url": "api/css/properties/-x-auto-font-size-preset-sizes",
@@ -26096,6 +26145,22 @@
           }
         ],
         "clay_android": [
+          {
+            "path": "css/properties/-x-auto-font-size-line-ranges",
+            "name": "-x-auto-font-size-line-ranges",
+            "doc_url": "api/css/properties/-x-auto-font-size-line-ranges",
+            "support": {
+              "android": "3.8",
+              "ios": "3.8",
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
           {
             "path": "css/properties/-x-handle-color",
             "name": "-x-handle-color",
@@ -26738,6 +26803,22 @@
           }
         ],
         "clay_ios": [
+          {
+            "path": "css/properties/-x-auto-font-size-line-ranges",
+            "name": "-x-auto-font-size-line-ranges",
+            "doc_url": "api/css/properties/-x-auto-font-size-line-ranges",
+            "support": {
+              "android": "3.8",
+              "ios": "3.8",
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
           {
             "path": "css/properties/-x-handle-color",
             "name": "-x-handle-color",
@@ -27493,6 +27574,22 @@
         ],
         "clay_macos": [
           {
+            "path": "css/properties/-x-auto-font-size-line-ranges",
+            "name": "-x-auto-font-size-line-ranges",
+            "doc_url": "api/css/properties/-x-auto-font-size-line-ranges",
+            "support": {
+              "android": "3.8",
+              "ios": "3.8",
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
             "path": "css/properties/-x-handle-color",
             "name": "-x-handle-color",
             "doc_url": "api/css/properties/-x-handle-color",
@@ -27783,6 +27880,22 @@
         ],
         "clay_windows": [
           {
+            "path": "css/properties/-x-auto-font-size-line-ranges",
+            "name": "-x-auto-font-size-line-ranges",
+            "doc_url": "api/css/properties/-x-auto-font-size-line-ranges",
+            "support": {
+              "android": "3.8",
+              "ios": "3.8",
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
             "path": "css/properties/-x-handle-color",
             "name": "-x-handle-color",
             "doc_url": "api/css/properties/-x-handle-color",
@@ -28008,6 +28121,22 @@
           }
         ],
         "clay": [
+          {
+            "path": "css/properties/-x-auto-font-size-line-ranges",
+            "name": "-x-auto-font-size-line-ranges",
+            "doc_url": "api/css/properties/-x-auto-font-size-line-ranges",
+            "support": {
+              "android": "3.8",
+              "ios": "3.8",
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
           {
             "path": "css/properties/-x-handle-color",
             "name": "-x-handle-color",
@@ -74873,6 +75002,42 @@
     },
     {
       "id": "feature-339",
+      "query": "css/properties/-x-auto-font-size-line-ranges",
+      "name": "-x-auto-font-size-line-ranges",
+      "category": "css/properties",
+      "source_file": "css/properties/-x-auto-font-size-line-ranges.json",
+      "support": {
+        "android": {
+          "version_added": "3.8"
+        },
+        "ios": {
+          "version_added": "3.8"
+        },
+        "harmony": {
+          "version_added": false
+        },
+        "web_lynx": {
+          "version_added": false
+        },
+        "clay_android": {
+          "version_added": false
+        },
+        "clay_ios": {
+          "version_added": false
+        },
+        "clay_macos": {
+          "version_added": false
+        },
+        "clay_windows": {
+          "version_added": false
+        },
+        "clay": {
+          "version_added": false
+        }
+      }
+    },
+    {
+      "id": "feature-340",
       "query": "css/properties/-x-auto-font-size-preset-sizes",
       "name": "-x-auto-font-size-preset-sizes",
       "category": "css/properties",
@@ -74908,7 +75073,7 @@
       }
     },
     {
-      "id": "feature-340",
+      "id": "feature-341",
       "query": "css/properties/-x-auto-font-size",
       "name": "-x-auto-font-size",
       "category": "css/properties",
@@ -74944,7 +75109,7 @@
       }
     },
     {
-      "id": "feature-341",
+      "id": "feature-342",
       "query": "css/properties/-x-handle-color",
       "name": "-x-handle-color",
       "category": "css/properties",
@@ -74980,7 +75145,7 @@
       }
     },
     {
-      "id": "feature-342",
+      "id": "feature-343",
       "query": "css/properties/-x-handle-size",
       "name": "-x-handle-size",
       "category": "css/properties",
@@ -75016,7 +75181,7 @@
       }
     },
     {
-      "id": "feature-343",
+      "id": "feature-344",
       "query": "css/properties/align-content",
       "name": "align-content",
       "category": "css/properties",
@@ -75052,7 +75217,7 @@
       }
     },
     {
-      "id": "feature-344",
+      "id": "feature-345",
       "query": "css/properties/align-content.unsupported_value_",
       "name": "<code>normal</code>, <code>space-evenly</code>",
       "category": "css/properties",
@@ -75088,7 +75253,7 @@
       }
     },
     {
-      "id": "feature-345",
+      "id": "feature-346",
       "query": "css/properties/align-content.supported_in_flex_layout",
       "name": "Supported in Flexible Box Layout",
       "category": "css/properties",
@@ -75124,7 +75289,7 @@
       }
     },
     {
-      "id": "feature-346",
+      "id": "feature-347",
       "query": "css/properties/align-content.supported_in_flex_layout.nested_value_1",
       "name": "<code>stretch</code>, <code>flex-start</code>, <code>flex-end</code>, <code>center</code>, <code>space-between</code> and <code>space-around</code>",
       "category": "css/properties",
@@ -75160,7 +75325,7 @@
       }
     },
     {
-      "id": "feature-347",
+      "id": "feature-348",
       "query": "css/properties/align-content.supported_in_flex_layout.nested_value_2",
       "name": "<code>start</code> and <code>end</code>",
       "category": "css/properties",
@@ -75196,7 +75361,7 @@
       }
     },
     {
-      "id": "feature-348",
+      "id": "feature-349",
       "query": "css/properties/align-content.supported_in_grid_layout",
       "name": "Supported in Grid Layout",
       "category": "css/properties",
@@ -75232,7 +75397,7 @@
       }
     },
     {
-      "id": "feature-349",
+      "id": "feature-350",
       "query": "css/properties/align-content.supported_in_grid_layout.nested_value_1",
       "name": "<code>stretch</code>, <code>flex-start</code>, <code>flex-end</code>, <code>center</code>, <code>space-between</code> and <code>space-around</code>",
       "category": "css/properties",
@@ -75268,7 +75433,7 @@
       }
     },
     {
-      "id": "feature-350",
+      "id": "feature-351",
       "query": "css/properties/align-content.supported_in_grid_layout.nested_value_2",
       "name": "<code>start</code> and <code>end</code>",
       "category": "css/properties",
@@ -75304,7 +75469,7 @@
       }
     },
     {
-      "id": "feature-351",
+      "id": "feature-352",
       "query": "css/properties/align-items",
       "name": "align-items",
       "category": "css/properties",
@@ -75340,7 +75505,7 @@
       }
     },
     {
-      "id": "feature-352",
+      "id": "feature-353",
       "query": "css/properties/align-items.supported_in_flex_layout",
       "name": "Supported in Flexible Box Layout",
       "category": "css/properties",
@@ -75376,7 +75541,7 @@
       }
     },
     {
-      "id": "feature-353",
+      "id": "feature-354",
       "query": "css/properties/align-items.supported_in_flex_layout.stretch-flex-start-flex-end-center",
       "name": "<code>stretch</code>, <code>flex-start</code>, <code>flex-end</code>, <code>center</code>",
       "category": "css/properties",
@@ -75412,7 +75577,7 @@
       }
     },
     {
-      "id": "feature-354",
+      "id": "feature-355",
       "query": "css/properties/align-items.supported_in_flex_layout.start-and-end",
       "name": "<code>start</code> and <code>end</code>",
       "category": "css/properties",
@@ -75448,7 +75613,7 @@
       }
     },
     {
-      "id": "feature-355",
+      "id": "feature-356",
       "query": "css/properties/align-items.supported_in_flex_layout.baseline",
       "name": "baseline",
       "category": "css/properties",
@@ -75484,7 +75649,7 @@
       }
     },
     {
-      "id": "feature-356",
+      "id": "feature-357",
       "query": "css/properties/align-items.supported_in_linear_layout",
       "name": "Supported in Linear Layout",
       "category": "css/properties",
@@ -75520,7 +75685,7 @@
       }
     },
     {
-      "id": "feature-357",
+      "id": "feature-358",
       "query": "css/properties/align-items.supported_in_linear_layout.flex-start-flex-end-center",
       "name": "<code>flex-start</code>, <code>flex-end</code>, <code>center</code>",
       "category": "css/properties",
@@ -75556,7 +75721,7 @@
       }
     },
     {
-      "id": "feature-358",
+      "id": "feature-359",
       "query": "css/properties/align-items.supported_in_linear_layout.start-and-end",
       "name": "<code>start</code> and <code>end</code>",
       "category": "css/properties",
@@ -75592,7 +75757,7 @@
       }
     },
     {
-      "id": "feature-359",
+      "id": "feature-360",
       "query": "css/properties/align-items.supported_in_linear_layout.baseline-and-stretch",
       "name": "<code>baseline</code> and <code>stretch</code>",
       "category": "css/properties",
@@ -75628,7 +75793,7 @@
       }
     },
     {
-      "id": "feature-360",
+      "id": "feature-361",
       "query": "css/properties/align-items.supported_in_grid_layout",
       "name": "Supported in Grid Layout",
       "category": "css/properties",
@@ -75664,7 +75829,7 @@
       }
     },
     {
-      "id": "feature-361",
+      "id": "feature-362",
       "query": "css/properties/align-items.supported_in_grid_layout.stretch-flex-start-flex-end-center",
       "name": "<code>stretch</code>, <code>flex-start</code>, <code>flex-end</code>, <code>center</code>",
       "category": "css/properties",
@@ -75700,7 +75865,7 @@
       }
     },
     {
-      "id": "feature-362",
+      "id": "feature-363",
       "query": "css/properties/align-items.supported_in_grid_layout.start-and-end",
       "name": "<code>start</code> and <code>end</code>",
       "category": "css/properties",
@@ -75736,7 +75901,7 @@
       }
     },
     {
-      "id": "feature-363",
+      "id": "feature-364",
       "query": "css/properties/align-items.supported_in_grid_layout.baseline",
       "name": "baseline",
       "category": "css/properties",
@@ -75772,7 +75937,7 @@
       }
     },
     {
-      "id": "feature-364",
+      "id": "feature-365",
       "query": "css/properties/align-items.normal",
       "name": "normal",
       "category": "css/properties",
@@ -75808,7 +75973,7 @@
       }
     },
     {
-      "id": "feature-365",
+      "id": "feature-366",
       "query": "css/properties/align-self",
       "name": "align-self",
       "category": "css/properties",
@@ -75844,7 +76009,7 @@
       }
     },
     {
-      "id": "feature-366",
+      "id": "feature-367",
       "query": "css/properties/align-self.supported_in_flex_layout",
       "name": "Supported in Flexible Box Layout",
       "category": "css/properties",
@@ -75880,7 +76045,7 @@
       }
     },
     {
-      "id": "feature-367",
+      "id": "feature-368",
       "query": "css/properties/align-self.supported_in_flex_layout.nested_value_1",
       "name": "<code>auto</code>, <code>stretch</code>, <code>flex-start</code>, <code>flex-end</code>, <code>center</code>",
       "category": "css/properties",
@@ -75916,7 +76081,7 @@
       }
     },
     {
-      "id": "feature-368",
+      "id": "feature-369",
       "query": "css/properties/align-self.supported_in_flex_layout.nested_value_3",
       "name": "<code>start</code> and <code>end</code>",
       "category": "css/properties",
@@ -75952,7 +76117,7 @@
       }
     },
     {
-      "id": "feature-369",
+      "id": "feature-370",
       "query": "css/properties/align-self.supported_in_flex_layout.baseline",
       "name": "<code>baseline</code>",
       "category": "css/properties",
@@ -75988,7 +76153,7 @@
       }
     },
     {
-      "id": "feature-370",
+      "id": "feature-371",
       "query": "css/properties/align-self.supported_in_linear_layout",
       "name": "Supported in Linear Layout",
       "category": "css/properties",
@@ -76024,7 +76189,7 @@
       }
     },
     {
-      "id": "feature-371",
+      "id": "feature-372",
       "query": "css/properties/align-self.supported_in_linear_layout.nested_value_1",
       "name": "<code>auto</code>, <code>flex-start</code>, <code>flex-end</code>, <code>center</code>",
       "category": "css/properties",
@@ -76060,7 +76225,7 @@
       }
     },
     {
-      "id": "feature-372",
+      "id": "feature-373",
       "query": "css/properties/align-self.supported_in_linear_layout.nested_value_2",
       "name": "<code>start</code> and <code>end</code>",
       "category": "css/properties",
@@ -76096,7 +76261,7 @@
       }
     },
     {
-      "id": "feature-373",
+      "id": "feature-374",
       "query": "css/properties/align-self.supported_in_linear_layout.nested_value_3",
       "name": "<code>baseline</code> and <code>stretch</code>",
       "category": "css/properties",
@@ -76132,7 +76297,7 @@
       }
     },
     {
-      "id": "feature-374",
+      "id": "feature-375",
       "query": "css/properties/align-self.supported_in_grid_layout",
       "name": "Supported in Grid Layout",
       "category": "css/properties",
@@ -76168,7 +76333,7 @@
       }
     },
     {
-      "id": "feature-375",
+      "id": "feature-376",
       "query": "css/properties/align-self.supported_in_grid_layout.nested_value_1",
       "name": "<code>auto</code>, <code>stretch</code>, <code>flex-start</code>, <code>flex-end</code>, <code>center</code>",
       "category": "css/properties",
@@ -76204,7 +76369,7 @@
       }
     },
     {
-      "id": "feature-376",
+      "id": "feature-377",
       "query": "css/properties/align-self.supported_in_grid_layout.nested_value_2",
       "name": "<code>start</code> and <code>end</code>",
       "category": "css/properties",
@@ -76240,7 +76405,7 @@
       }
     },
     {
-      "id": "feature-377",
+      "id": "feature-378",
       "query": "css/properties/align-self.supported_in_grid_layout.baseline",
       "name": "<code>baseline</code>",
       "category": "css/properties",
@@ -76276,7 +76441,7 @@
       }
     },
     {
-      "id": "feature-378",
+      "id": "feature-379",
       "query": "css/properties/align-self.normal",
       "name": "<code>normal</code>",
       "category": "css/properties",
@@ -76312,7 +76477,7 @@
       }
     },
     {
-      "id": "feature-379",
+      "id": "feature-380",
       "query": "css/properties/animation-delay",
       "name": "animation-delay",
       "category": "css/properties",
@@ -76348,7 +76513,7 @@
       }
     },
     {
-      "id": "feature-380",
+      "id": "feature-381",
       "query": "css/properties/animation-direction",
       "name": "animation-direction",
       "category": "css/properties",
@@ -76384,7 +76549,7 @@
       }
     },
     {
-      "id": "feature-381",
+      "id": "feature-382",
       "query": "css/properties/animation-duration",
       "name": "animation-duration",
       "category": "css/properties",
@@ -76420,7 +76585,7 @@
       }
     },
     {
-      "id": "feature-382",
+      "id": "feature-383",
       "query": "css/properties/animation-fill-mode",
       "name": "animation-fill-mode",
       "category": "css/properties",
@@ -76456,7 +76621,7 @@
       }
     },
     {
-      "id": "feature-383",
+      "id": "feature-384",
       "query": "css/properties/animation-iteration-count",
       "name": "animation-iteration-count",
       "category": "css/properties",
@@ -76492,7 +76657,7 @@
       }
     },
     {
-      "id": "feature-384",
+      "id": "feature-385",
       "query": "css/properties/animation-name",
       "name": "animation-name",
       "category": "css/properties",
@@ -76528,7 +76693,7 @@
       }
     },
     {
-      "id": "feature-385",
+      "id": "feature-386",
       "query": "css/properties/animation-play-state",
       "name": "animation-play-state",
       "category": "css/properties",
@@ -76564,7 +76729,7 @@
       }
     },
     {
-      "id": "feature-386",
+      "id": "feature-387",
       "query": "css/properties/animation-timing-function",
       "name": "animation-timing-function",
       "category": "css/properties",
@@ -76600,7 +76765,7 @@
       }
     },
     {
-      "id": "feature-387",
+      "id": "feature-388",
       "query": "css/properties/animation",
       "name": "animation",
       "category": "css/properties",
@@ -76636,7 +76801,7 @@
       }
     },
     {
-      "id": "feature-388",
+      "id": "feature-389",
       "query": "css/properties/aspect-ratio",
       "name": "aspect-ratio",
       "category": "css/properties",
@@ -76672,7 +76837,7 @@
       }
     },
     {
-      "id": "feature-389",
+      "id": "feature-390",
       "query": "css/properties/aspect-ratio.auto",
       "name": "auto",
       "category": "css/properties",
@@ -76708,7 +76873,7 @@
       }
     },
     {
-      "id": "feature-390",
+      "id": "feature-391",
       "query": "css/properties/background-clip",
       "name": "background-clip",
       "category": "css/properties",
@@ -76744,7 +76909,7 @@
       }
     },
     {
-      "id": "feature-391",
+      "id": "feature-392",
       "query": "css/properties/background-clip.box",
       "name": "<code>&lt;box&gt;</code>",
       "category": "css/properties",
@@ -76780,7 +76945,7 @@
       }
     },
     {
-      "id": "feature-392",
+      "id": "feature-393",
       "query": "css/properties/background-clip.border-area",
       "name": "<code>border-area</code>",
       "category": "css/properties",
@@ -76816,7 +76981,7 @@
       }
     },
     {
-      "id": "feature-393",
+      "id": "feature-394",
       "query": "css/properties/background-color",
       "name": "background-color",
       "category": "css/properties",
@@ -76852,7 +77017,7 @@
       }
     },
     {
-      "id": "feature-394",
+      "id": "feature-395",
       "query": "css/properties/background-image",
       "name": "background-image",
       "category": "css/properties",
@@ -76888,7 +77053,7 @@
       }
     },
     {
-      "id": "feature-395",
+      "id": "feature-396",
       "query": "css/properties/background-image.conic-gradient",
       "name": "conic-gradient",
       "category": "css/properties",
@@ -76924,7 +77089,7 @@
       }
     },
     {
-      "id": "feature-396",
+      "id": "feature-397",
       "query": "css/properties/background-origin",
       "name": "background-origin",
       "category": "css/properties",
@@ -76960,7 +77125,7 @@
       }
     },
     {
-      "id": "feature-397",
+      "id": "feature-398",
       "query": "css/properties/background-position",
       "name": "background-position",
       "category": "css/properties",
@@ -76996,7 +77161,7 @@
       }
     },
     {
-      "id": "feature-398",
+      "id": "feature-399",
       "query": "css/properties/background-repeat",
       "name": "background-repeat",
       "category": "css/properties",
@@ -77032,7 +77197,7 @@
       }
     },
     {
-      "id": "feature-399",
+      "id": "feature-400",
       "query": "css/properties/background-size",
       "name": "background-size",
       "category": "css/properties",
@@ -77068,7 +77233,7 @@
       }
     },
     {
-      "id": "feature-400",
+      "id": "feature-401",
       "query": "css/properties/background",
       "name": "background",
       "category": "css/properties",
@@ -77104,7 +77269,7 @@
       }
     },
     {
-      "id": "feature-401",
+      "id": "feature-402",
       "query": "css/properties/border-bottom-color",
       "name": "border-bottom-color",
       "category": "css/properties",
@@ -77140,7 +77305,7 @@
       }
     },
     {
-      "id": "feature-402",
+      "id": "feature-403",
       "query": "css/properties/border-bottom-left-radius",
       "name": "border-bottom-left-radius",
       "category": "css/properties",
@@ -77176,7 +77341,7 @@
       }
     },
     {
-      "id": "feature-403",
+      "id": "feature-404",
       "query": "css/properties/border-bottom-right-radius",
       "name": "border-bottom-right-radius",
       "category": "css/properties",
@@ -77212,7 +77377,7 @@
       }
     },
     {
-      "id": "feature-404",
+      "id": "feature-405",
       "query": "css/properties/border-bottom-style",
       "name": "border-bottom-style",
       "category": "css/properties",
@@ -77248,7 +77413,7 @@
       }
     },
     {
-      "id": "feature-405",
+      "id": "feature-406",
       "query": "css/properties/border-bottom-width",
       "name": "border-bottom-width",
       "category": "css/properties",
@@ -77284,7 +77449,7 @@
       }
     },
     {
-      "id": "feature-406",
+      "id": "feature-407",
       "query": "css/properties/border-bottom",
       "name": "border-bottom",
       "category": "css/properties",
@@ -77320,7 +77485,7 @@
       }
     },
     {
-      "id": "feature-407",
+      "id": "feature-408",
       "query": "css/properties/border-color",
       "name": "border-color",
       "category": "css/properties",
@@ -77356,7 +77521,7 @@
       }
     },
     {
-      "id": "feature-408",
+      "id": "feature-409",
       "query": "css/properties/border-end-end-radius",
       "name": "border-end-end-radius",
       "category": "css/properties",
@@ -77392,7 +77557,7 @@
       }
     },
     {
-      "id": "feature-409",
+      "id": "feature-410",
       "query": "css/properties/border-end-start-radius",
       "name": "border-end-start-radius",
       "category": "css/properties",
@@ -77428,7 +77593,7 @@
       }
     },
     {
-      "id": "feature-410",
+      "id": "feature-411",
       "query": "css/properties/border-inline-end-color",
       "name": "border-inline-end-color",
       "category": "css/properties",
@@ -77464,7 +77629,7 @@
       }
     },
     {
-      "id": "feature-411",
+      "id": "feature-412",
       "query": "css/properties/border-inline-end-style",
       "name": "border-inline-end-style",
       "category": "css/properties",
@@ -77500,7 +77665,7 @@
       }
     },
     {
-      "id": "feature-412",
+      "id": "feature-413",
       "query": "css/properties/border-inline-end-width",
       "name": "border-inline-end-width",
       "category": "css/properties",
@@ -77536,7 +77701,7 @@
       }
     },
     {
-      "id": "feature-413",
+      "id": "feature-414",
       "query": "css/properties/border-inline-start-color",
       "name": "border-inline-start-color",
       "category": "css/properties",
@@ -77572,7 +77737,7 @@
       }
     },
     {
-      "id": "feature-414",
+      "id": "feature-415",
       "query": "css/properties/border-inline-start-style",
       "name": "border-inline-start-style",
       "category": "css/properties",
@@ -77608,7 +77773,7 @@
       }
     },
     {
-      "id": "feature-415",
+      "id": "feature-416",
       "query": "css/properties/border-inline-start-width",
       "name": "border-inline-start-width",
       "category": "css/properties",
@@ -77644,7 +77809,7 @@
       }
     },
     {
-      "id": "feature-416",
+      "id": "feature-417",
       "query": "css/properties/border-left-color",
       "name": "border-left-color",
       "category": "css/properties",
@@ -77680,7 +77845,7 @@
       }
     },
     {
-      "id": "feature-417",
+      "id": "feature-418",
       "query": "css/properties/border-left-style",
       "name": "border-left-style",
       "category": "css/properties",
@@ -77716,7 +77881,7 @@
       }
     },
     {
-      "id": "feature-418",
+      "id": "feature-419",
       "query": "css/properties/border-left-width",
       "name": "border-left-width",
       "category": "css/properties",
@@ -77752,7 +77917,7 @@
       }
     },
     {
-      "id": "feature-419",
+      "id": "feature-420",
       "query": "css/properties/border-left",
       "name": "border-left",
       "category": "css/properties",
@@ -77788,7 +77953,7 @@
       }
     },
     {
-      "id": "feature-420",
+      "id": "feature-421",
       "query": "css/properties/border-radius",
       "name": "border-radius",
       "category": "css/properties",
@@ -77824,7 +77989,7 @@
       }
     },
     {
-      "id": "feature-421",
+      "id": "feature-422",
       "query": "css/properties/border-right-color",
       "name": "border-right-color",
       "category": "css/properties",
@@ -77860,7 +78025,7 @@
       }
     },
     {
-      "id": "feature-422",
+      "id": "feature-423",
       "query": "css/properties/border-right-style",
       "name": "border-right-style",
       "category": "css/properties",
@@ -77896,7 +78061,7 @@
       }
     },
     {
-      "id": "feature-423",
+      "id": "feature-424",
       "query": "css/properties/border-right-width",
       "name": "border-right-width",
       "category": "css/properties",
@@ -77932,7 +78097,7 @@
       }
     },
     {
-      "id": "feature-424",
+      "id": "feature-425",
       "query": "css/properties/border-right",
       "name": "border-right",
       "category": "css/properties",
@@ -77968,7 +78133,7 @@
       }
     },
     {
-      "id": "feature-425",
+      "id": "feature-426",
       "query": "css/properties/border-start-end-radius",
       "name": "border-start-end-radius",
       "category": "css/properties",
@@ -78004,7 +78169,7 @@
       }
     },
     {
-      "id": "feature-426",
+      "id": "feature-427",
       "query": "css/properties/border-start-start-radius",
       "name": "border-start-start-radius",
       "category": "css/properties",
@@ -78040,7 +78205,7 @@
       }
     },
     {
-      "id": "feature-427",
+      "id": "feature-428",
       "query": "css/properties/border-style",
       "name": "border-style",
       "category": "css/properties",
@@ -78076,7 +78241,7 @@
       }
     },
     {
-      "id": "feature-428",
+      "id": "feature-429",
       "query": "css/properties/border-top-color",
       "name": "border-top-color",
       "category": "css/properties",
@@ -78112,7 +78277,7 @@
       }
     },
     {
-      "id": "feature-429",
+      "id": "feature-430",
       "query": "css/properties/border-top-left-radius",
       "name": "border-top-left-radius",
       "category": "css/properties",
@@ -78148,7 +78313,7 @@
       }
     },
     {
-      "id": "feature-430",
+      "id": "feature-431",
       "query": "css/properties/border-top-right-radius",
       "name": "border-top-right-radius",
       "category": "css/properties",
@@ -78184,7 +78349,7 @@
       }
     },
     {
-      "id": "feature-431",
+      "id": "feature-432",
       "query": "css/properties/border-top-style",
       "name": "border-top-style",
       "category": "css/properties",
@@ -78220,7 +78385,7 @@
       }
     },
     {
-      "id": "feature-432",
+      "id": "feature-433",
       "query": "css/properties/border-top-width",
       "name": "border-top-width",
       "category": "css/properties",
@@ -78256,7 +78421,7 @@
       }
     },
     {
-      "id": "feature-433",
+      "id": "feature-434",
       "query": "css/properties/border-top",
       "name": "border-top",
       "category": "css/properties",
@@ -78292,7 +78457,7 @@
       }
     },
     {
-      "id": "feature-434",
+      "id": "feature-435",
       "query": "css/properties/border-width",
       "name": "border-width",
       "category": "css/properties",
@@ -78328,7 +78493,7 @@
       }
     },
     {
-      "id": "feature-435",
+      "id": "feature-436",
       "query": "css/properties/border",
       "name": "border",
       "category": "css/properties",
@@ -78364,7 +78529,7 @@
       }
     },
     {
-      "id": "feature-436",
+      "id": "feature-437",
       "query": "css/properties/bottom",
       "name": "bottom",
       "category": "css/properties",
@@ -78400,7 +78565,7 @@
       }
     },
     {
-      "id": "feature-437",
+      "id": "feature-438",
       "query": "css/properties/box-shadow",
       "name": "box-shadow",
       "category": "css/properties",
@@ -78436,7 +78601,7 @@
       }
     },
     {
-      "id": "feature-438",
+      "id": "feature-439",
       "query": "css/properties/box-sizing",
       "name": "box-sizing",
       "category": "css/properties",
@@ -78472,7 +78637,7 @@
       }
     },
     {
-      "id": "feature-439",
+      "id": "feature-440",
       "query": "css/properties/clip-path",
       "name": "clip-path",
       "category": "css/properties",
@@ -78508,7 +78673,7 @@
       }
     },
     {
-      "id": "feature-440",
+      "id": "feature-441",
       "query": "css/properties/clip-path.circle()",
       "name": "circle()",
       "category": "css/properties",
@@ -78544,7 +78709,7 @@
       }
     },
     {
-      "id": "feature-441",
+      "id": "feature-442",
       "query": "css/properties/clip-path.inset()",
       "name": "inset()",
       "category": "css/properties",
@@ -78580,7 +78745,7 @@
       }
     },
     {
-      "id": "feature-442",
+      "id": "feature-443",
       "query": "css/properties/clip-path.ellipse()",
       "name": "ellipse()",
       "category": "css/properties",
@@ -78616,7 +78781,7 @@
       }
     },
     {
-      "id": "feature-443",
+      "id": "feature-444",
       "query": "css/properties/clip-path.path()",
       "name": "path()",
       "category": "css/properties",
@@ -78652,7 +78817,7 @@
       }
     },
     {
-      "id": "feature-444",
+      "id": "feature-445",
       "query": "css/properties/clip-path.polygon()",
       "name": "polygon()",
       "category": "css/properties",
@@ -78688,7 +78853,7 @@
       }
     },
     {
-      "id": "feature-445",
+      "id": "feature-446",
       "query": "css/properties/color",
       "name": "color",
       "category": "css/properties",
@@ -78724,7 +78889,7 @@
       }
     },
     {
-      "id": "feature-446",
+      "id": "feature-447",
       "query": "css/properties/column-gap",
       "name": "<code>column-gap</code>",
       "category": "css/properties",
@@ -78760,7 +78925,7 @@
       }
     },
     {
-      "id": "feature-447",
+      "id": "feature-448",
       "query": "css/properties/column-gap.grid-column-gap",
       "name": "<code>grid-column-gap</code>",
       "category": "css/properties",
@@ -78796,7 +78961,7 @@
       }
     },
     {
-      "id": "feature-448",
+      "id": "feature-449",
       "query": "css/properties/column-gap.supported_in_flex_layout",
       "name": "Supported in Flexible Box Layout",
       "category": "css/properties",
@@ -78832,7 +78997,7 @@
       }
     },
     {
-      "id": "feature-449",
+      "id": "feature-450",
       "query": "css/properties/column-gap.supported_in_flex_layout.nested_value_1",
       "name": "<code>column-gap</code> and <code>grid-column-gap</code>",
       "category": "css/properties",
@@ -78868,7 +79033,7 @@
       }
     },
     {
-      "id": "feature-450",
+      "id": "feature-451",
       "query": "css/properties/column-gap.supported_in_grid_layout",
       "name": "Supported in Grid Layout",
       "category": "css/properties",
@@ -78904,7 +79069,7 @@
       }
     },
     {
-      "id": "feature-451",
+      "id": "feature-452",
       "query": "css/properties/column-gap.supported_in_grid_layout.grid-column-gap",
       "name": "<code>grid-column-gap</code>",
       "category": "css/properties",
@@ -78940,7 +79105,7 @@
       }
     },
     {
-      "id": "feature-452",
+      "id": "feature-453",
       "query": "css/properties/column-gap.supported_in_grid_layout",
       "name": "<code>column-gap</code>",
       "category": "css/properties",
@@ -78976,7 +79141,7 @@
       }
     },
     {
-      "id": "feature-453",
+      "id": "feature-454",
       "query": "css/properties/css-variable",
       "name": "css-variable",
       "category": "css/properties",
@@ -79012,7 +79177,7 @@
       }
     },
     {
-      "id": "feature-454",
+      "id": "feature-455",
       "query": "css/properties/cursor",
       "name": "The cursor CSS property controls the mouse pointer displayed when the pointer hovers over an element.",
       "category": "css/properties",
@@ -79048,7 +79213,7 @@
       }
     },
     {
-      "id": "feature-455",
+      "id": "feature-456",
       "query": "css/properties/cursor.default",
       "name": "default",
       "category": "css/properties",
@@ -79084,7 +79249,7 @@
       }
     },
     {
-      "id": "feature-456",
+      "id": "feature-457",
       "query": "css/properties/cursor.none",
       "name": "none",
       "category": "css/properties",
@@ -79120,7 +79285,7 @@
       }
     },
     {
-      "id": "feature-457",
+      "id": "feature-458",
       "query": "css/properties/cursor.context-menu",
       "name": "context-menu",
       "category": "css/properties",
@@ -79156,7 +79321,7 @@
       }
     },
     {
-      "id": "feature-458",
+      "id": "feature-459",
       "query": "css/properties/cursor.help",
       "name": "help",
       "category": "css/properties",
@@ -79192,7 +79357,7 @@
       }
     },
     {
-      "id": "feature-459",
+      "id": "feature-460",
       "query": "css/properties/cursor.pointer",
       "name": "pointer",
       "category": "css/properties",
@@ -79228,7 +79393,7 @@
       }
     },
     {
-      "id": "feature-460",
+      "id": "feature-461",
       "query": "css/properties/cursor.progress",
       "name": "progress",
       "category": "css/properties",
@@ -79264,7 +79429,7 @@
       }
     },
     {
-      "id": "feature-461",
+      "id": "feature-462",
       "query": "css/properties/cursor.wait",
       "name": "wait",
       "category": "css/properties",
@@ -79300,7 +79465,7 @@
       }
     },
     {
-      "id": "feature-462",
+      "id": "feature-463",
       "query": "css/properties/cursor.crosshair",
       "name": "crosshair",
       "category": "css/properties",
@@ -79336,7 +79501,7 @@
       }
     },
     {
-      "id": "feature-463",
+      "id": "feature-464",
       "query": "css/properties/cursor.text",
       "name": "text",
       "category": "css/properties",
@@ -79372,7 +79537,7 @@
       }
     },
     {
-      "id": "feature-464",
+      "id": "feature-465",
       "query": "css/properties/cursor.vertical-text",
       "name": "vertical-text",
       "category": "css/properties",
@@ -79408,7 +79573,7 @@
       }
     },
     {
-      "id": "feature-465",
+      "id": "feature-466",
       "query": "css/properties/cursor.alias",
       "name": "alias",
       "category": "css/properties",
@@ -79444,7 +79609,7 @@
       }
     },
     {
-      "id": "feature-466",
+      "id": "feature-467",
       "query": "css/properties/cursor.copy",
       "name": "copy",
       "category": "css/properties",
@@ -79480,7 +79645,7 @@
       }
     },
     {
-      "id": "feature-467",
+      "id": "feature-468",
       "query": "css/properties/cursor.move",
       "name": "move",
       "category": "css/properties",
@@ -79516,7 +79681,7 @@
       }
     },
     {
-      "id": "feature-468",
+      "id": "feature-469",
       "query": "css/properties/cursor.no-drop",
       "name": "no-drop",
       "category": "css/properties",
@@ -79552,7 +79717,7 @@
       }
     },
     {
-      "id": "feature-469",
+      "id": "feature-470",
       "query": "css/properties/cursor.not-allowed",
       "name": "not-allowed",
       "category": "css/properties",
@@ -79588,7 +79753,7 @@
       }
     },
     {
-      "id": "feature-470",
+      "id": "feature-471",
       "query": "css/properties/cursor.grab",
       "name": "grab",
       "category": "css/properties",
@@ -79624,7 +79789,7 @@
       }
     },
     {
-      "id": "feature-471",
+      "id": "feature-472",
       "query": "css/properties/cursor.grabbing",
       "name": "grabbing",
       "category": "css/properties",
@@ -79660,7 +79825,7 @@
       }
     },
     {
-      "id": "feature-472",
+      "id": "feature-473",
       "query": "css/properties/cursor.col-resize",
       "name": "col-resize",
       "category": "css/properties",
@@ -79696,7 +79861,7 @@
       }
     },
     {
-      "id": "feature-473",
+      "id": "feature-474",
       "query": "css/properties/cursor.row-resize",
       "name": "row-resize",
       "category": "css/properties",
@@ -79732,7 +79897,7 @@
       }
     },
     {
-      "id": "feature-474",
+      "id": "feature-475",
       "query": "css/properties/cursor.n-resize",
       "name": "n-resize",
       "category": "css/properties",
@@ -79768,7 +79933,7 @@
       }
     },
     {
-      "id": "feature-475",
+      "id": "feature-476",
       "query": "css/properties/cursor.e-resize",
       "name": "e-resize",
       "category": "css/properties",
@@ -79804,7 +79969,7 @@
       }
     },
     {
-      "id": "feature-476",
+      "id": "feature-477",
       "query": "css/properties/cursor.s-resize",
       "name": "s-resize",
       "category": "css/properties",
@@ -79840,7 +80005,7 @@
       }
     },
     {
-      "id": "feature-477",
+      "id": "feature-478",
       "query": "css/properties/cursor.w-resize",
       "name": "w-resize",
       "category": "css/properties",
@@ -79876,7 +80041,7 @@
       }
     },
     {
-      "id": "feature-478",
+      "id": "feature-479",
       "query": "css/properties/cursor.ne-resize",
       "name": "ne-resize",
       "category": "css/properties",
@@ -79912,7 +80077,7 @@
       }
     },
     {
-      "id": "feature-479",
+      "id": "feature-480",
       "query": "css/properties/cursor.nw-resize",
       "name": "nw-resize",
       "category": "css/properties",
@@ -79948,7 +80113,7 @@
       }
     },
     {
-      "id": "feature-480",
+      "id": "feature-481",
       "query": "css/properties/cursor.se-resize",
       "name": "se-resize",
       "category": "css/properties",
@@ -79984,7 +80149,7 @@
       }
     },
     {
-      "id": "feature-481",
+      "id": "feature-482",
       "query": "css/properties/cursor.sw-resize",
       "name": "sw-resize",
       "category": "css/properties",
@@ -80020,7 +80185,7 @@
       }
     },
     {
-      "id": "feature-482",
+      "id": "feature-483",
       "query": "css/properties/cursor.ew-resize",
       "name": "ew-resize",
       "category": "css/properties",
@@ -80056,7 +80221,7 @@
       }
     },
     {
-      "id": "feature-483",
+      "id": "feature-484",
       "query": "css/properties/cursor.ns-resize",
       "name": "ns-resize",
       "category": "css/properties",
@@ -80092,7 +80257,7 @@
       }
     },
     {
-      "id": "feature-484",
+      "id": "feature-485",
       "query": "css/properties/cursor.nesw-resize",
       "name": "nesw-resize",
       "category": "css/properties",
@@ -80128,7 +80293,7 @@
       }
     },
     {
-      "id": "feature-485",
+      "id": "feature-486",
       "query": "css/properties/cursor.nwse-resize",
       "name": "nwse-resize",
       "category": "css/properties",
@@ -80164,7 +80329,7 @@
       }
     },
     {
-      "id": "feature-486",
+      "id": "feature-487",
       "query": "css/properties/custom-property",
       "name": "custom-property",
       "category": "css/properties",
@@ -80200,7 +80365,7 @@
       }
     },
     {
-      "id": "feature-487",
+      "id": "feature-488",
       "query": "css/properties/custom-property.In StyleSheet",
       "name": "Declare and reference variables in css files",
       "category": "css/properties",
@@ -80236,7 +80401,7 @@
       }
     },
     {
-      "id": "feature-488",
+      "id": "feature-489",
       "query": "css/properties/custom-property.In `style` attributes",
       "name": "Declare and reference variables in <code>style</code> attribute",
       "category": "css/properties",
@@ -80272,7 +80437,7 @@
       }
     },
     {
-      "id": "feature-489",
+      "id": "feature-490",
       "query": "css/properties/custom-property.Nested references",
       "name": "Nested references",
       "category": "css/properties",
@@ -80308,7 +80473,7 @@
       }
     },
     {
-      "id": "feature-490",
+      "id": "feature-491",
       "query": "css/properties/custom-property.At property rule",
       "name": "Use <code>@property</code> rule to declare custom property",
       "category": "css/properties",
@@ -80344,7 +80509,7 @@
       }
     },
     {
-      "id": "feature-491",
+      "id": "feature-492",
       "query": "css/properties/direction",
       "name": "direction",
       "category": "css/properties",
@@ -80380,7 +80545,7 @@
       }
     },
     {
-      "id": "feature-492",
+      "id": "feature-493",
       "query": "css/properties/direction.lynx-rtl",
       "name": "<code>lynx-rtl</code>",
       "category": "css/properties",
@@ -80416,7 +80581,7 @@
       }
     },
     {
-      "id": "feature-493",
+      "id": "feature-494",
       "query": "css/properties/display",
       "name": "display",
       "category": "css/properties",
@@ -80452,7 +80617,7 @@
       }
     },
     {
-      "id": "feature-494",
+      "id": "feature-495",
       "query": "css/properties/display.api1",
       "name": "<code>none</code>, <code>flex</code>, <code>linear</code>",
       "category": "css/properties",
@@ -80488,7 +80653,7 @@
       }
     },
     {
-      "id": "feature-495",
+      "id": "feature-496",
       "query": "css/properties/display.relative",
       "name": "<code>relative</code>",
       "category": "css/properties",
@@ -80524,7 +80689,7 @@
       }
     },
     {
-      "id": "feature-496",
+      "id": "feature-497",
       "query": "css/properties/display.grid",
       "name": "<code>grid</code>",
       "category": "css/properties",
@@ -80560,7 +80725,7 @@
       }
     },
     {
-      "id": "feature-497",
+      "id": "feature-498",
       "query": "css/properties/display.unsupported_value",
       "name": "<code>inline</code> and <code>block</code>",
       "category": "css/properties",
@@ -80596,7 +80761,7 @@
       }
     },
     {
-      "id": "feature-498",
+      "id": "feature-499",
       "query": "css/properties/filter-properties.blur",
       "name": "blur",
       "category": "css/properties",
@@ -80632,7 +80797,7 @@
       }
     },
     {
-      "id": "feature-499",
+      "id": "feature-500",
       "query": "css/properties/filter-properties.grayscale",
       "name": "grayscale",
       "category": "css/properties",
@@ -80668,7 +80833,7 @@
       }
     },
     {
-      "id": "feature-500",
+      "id": "feature-501",
       "query": "css/properties/filter-properties.brightness",
       "name": "brightness",
       "category": "css/properties",
@@ -80704,7 +80869,7 @@
       }
     },
     {
-      "id": "feature-501",
+      "id": "feature-502",
       "query": "css/properties/filter-properties.contrast",
       "name": "contrast",
       "category": "css/properties",
@@ -80740,7 +80905,7 @@
       }
     },
     {
-      "id": "feature-502",
+      "id": "feature-503",
       "query": "css/properties/filter-properties.saturate",
       "name": "saturate",
       "category": "css/properties",
@@ -80776,7 +80941,7 @@
       }
     },
     {
-      "id": "feature-503",
+      "id": "feature-504",
       "query": "css/properties/filter",
       "name": "filter",
       "category": "css/properties",
@@ -80812,7 +80977,7 @@
       }
     },
     {
-      "id": "feature-504",
+      "id": "feature-505",
       "query": "css/properties/flex-basis",
       "name": "<code>flex-basis</code>",
       "category": "css/properties",
@@ -80848,7 +81013,7 @@
       }
     },
     {
-      "id": "feature-505",
+      "id": "feature-506",
       "query": "css/properties/flex-basis.unsupported_value_",
       "name": "<code>max-content</code>, <code>min-content</code>, <code>fit-content</code>",
       "category": "css/properties",
@@ -80884,7 +81049,7 @@
       }
     },
     {
-      "id": "feature-506",
+      "id": "feature-507",
       "query": "css/properties/flex-direction",
       "name": "flex-direction",
       "category": "css/properties",
@@ -80920,7 +81085,7 @@
       }
     },
     {
-      "id": "feature-507",
+      "id": "feature-508",
       "query": "css/properties/flex-flow",
       "name": "flex-flow",
       "category": "css/properties",
@@ -80956,7 +81121,7 @@
       }
     },
     {
-      "id": "feature-508",
+      "id": "feature-509",
       "query": "css/properties/flex-grow",
       "name": "flex-grow",
       "category": "css/properties",
@@ -80992,7 +81157,7 @@
       }
     },
     {
-      "id": "feature-509",
+      "id": "feature-510",
       "query": "css/properties/flex-shrink",
       "name": "flex-shrink",
       "category": "css/properties",
@@ -81028,7 +81193,7 @@
       }
     },
     {
-      "id": "feature-510",
+      "id": "feature-511",
       "query": "css/properties/flex-wrap",
       "name": "flex-wrap",
       "category": "css/properties",
@@ -81064,7 +81229,7 @@
       }
     },
     {
-      "id": "feature-511",
+      "id": "feature-512",
       "query": "css/properties/flex-wrap.nowrap",
       "name": "nowrap",
       "category": "css/properties",
@@ -81100,7 +81265,7 @@
       }
     },
     {
-      "id": "feature-512",
+      "id": "feature-513",
       "query": "css/properties/flex-wrap.wrap",
       "name": "wrap",
       "category": "css/properties",
@@ -81136,7 +81301,7 @@
       }
     },
     {
-      "id": "feature-513",
+      "id": "feature-514",
       "query": "css/properties/flex-wrap.wrap-reverse",
       "name": "wrap-reverse",
       "category": "css/properties",
@@ -81172,7 +81337,7 @@
       }
     },
     {
-      "id": "feature-514",
+      "id": "feature-515",
       "query": "css/properties/flex",
       "name": "flex",
       "category": "css/properties",
@@ -81208,7 +81373,7 @@
       }
     },
     {
-      "id": "feature-515",
+      "id": "feature-516",
       "query": "css/properties/flex.none",
       "name": "none",
       "category": "css/properties",
@@ -81244,7 +81409,7 @@
       }
     },
     {
-      "id": "feature-516",
+      "id": "feature-517",
       "query": "css/properties/font-family",
       "name": "font-family",
       "category": "css/properties",
@@ -81280,7 +81445,7 @@
       }
     },
     {
-      "id": "feature-517",
+      "id": "feature-518",
       "query": "css/properties/font-feature-settings",
       "name": "font-feature-settings",
       "category": "css/properties",
@@ -81316,7 +81481,7 @@
       }
     },
     {
-      "id": "feature-518",
+      "id": "feature-519",
       "query": "css/properties/font-optical-sizing",
       "name": "font-optical-sizing",
       "category": "css/properties",
@@ -81352,7 +81517,7 @@
       }
     },
     {
-      "id": "feature-519",
+      "id": "feature-520",
       "query": "css/properties/font-size",
       "name": "font-size",
       "category": "css/properties",
@@ -81388,7 +81553,7 @@
       }
     },
     {
-      "id": "feature-520",
+      "id": "feature-521",
       "query": "css/properties/font-style",
       "name": "font-style",
       "category": "css/properties",
@@ -81424,7 +81589,7 @@
       }
     },
     {
-      "id": "feature-521",
+      "id": "feature-522",
       "query": "css/properties/font-variation-settings",
       "name": "font-variation-settings",
       "category": "css/properties",
@@ -81460,7 +81625,7 @@
       }
     },
     {
-      "id": "feature-522",
+      "id": "feature-523",
       "query": "css/properties/font-weight",
       "name": "font-weight",
       "category": "css/properties",
@@ -81496,7 +81661,7 @@
       }
     },
     {
-      "id": "feature-523",
+      "id": "feature-524",
       "query": "css/properties/gap",
       "name": "gap",
       "category": "css/properties",
@@ -81532,7 +81697,7 @@
       }
     },
     {
-      "id": "feature-524",
+      "id": "feature-525",
       "query": "css/properties/gap.Flex",
       "name": "Supported in Flexible Box Layout",
       "category": "css/properties",
@@ -81568,7 +81733,7 @@
       }
     },
     {
-      "id": "feature-525",
+      "id": "feature-526",
       "query": "css/properties/gap.Grid",
       "name": "Supported in Grid Layout",
       "category": "css/properties",
@@ -81604,7 +81769,7 @@
       }
     },
     {
-      "id": "feature-526",
+      "id": "feature-527",
       "query": "css/properties/grid-auto-columns",
       "name": "grid-auto-columns",
       "category": "css/properties",
@@ -81640,7 +81805,7 @@
       }
     },
     {
-      "id": "feature-527",
+      "id": "feature-528",
       "query": "css/properties/grid-auto-columns.calc",
       "name": "<code>calc()</code>",
       "category": "css/properties",
@@ -81676,7 +81841,7 @@
       }
     },
     {
-      "id": "feature-528",
+      "id": "feature-529",
       "query": "css/properties/grid-auto-columns.fr",
       "name": "<code>fr</code>",
       "category": "css/properties",
@@ -81712,7 +81877,7 @@
       }
     },
     {
-      "id": "feature-529",
+      "id": "feature-530",
       "query": "css/properties/grid-auto-columns.max-content",
       "name": "<code>max-content</code>, <code>fit-content</code> and <code>minmax()</code>",
       "category": "css/properties",
@@ -81748,7 +81913,7 @@
       }
     },
     {
-      "id": "feature-530",
+      "id": "feature-531",
       "query": "css/properties/grid-auto-columns.unsupported_value1",
       "name": "<code>none</code> and <code>[linename]</code>",
       "category": "css/properties",
@@ -81784,7 +81949,7 @@
       }
     },
     {
-      "id": "feature-531",
+      "id": "feature-532",
       "query": "css/properties/grid-auto-columns.unsupported_value2",
       "name": "<code>min-content</code></code>",
       "category": "css/properties",
@@ -81820,7 +81985,7 @@
       }
     },
     {
-      "id": "feature-532",
+      "id": "feature-533",
       "query": "css/properties/grid-auto-flow",
       "name": "grid-auto-flow",
       "category": "css/properties",
@@ -81856,7 +82021,7 @@
       }
     },
     {
-      "id": "feature-533",
+      "id": "feature-534",
       "query": "css/properties/grid-auto-rows",
       "name": "grid-auto-rows",
       "category": "css/properties",
@@ -81892,7 +82057,7 @@
       }
     },
     {
-      "id": "feature-534",
+      "id": "feature-535",
       "query": "css/properties/grid-auto-rows.calc",
       "name": "<code>calc()</code>",
       "category": "css/properties",
@@ -81928,7 +82093,7 @@
       }
     },
     {
-      "id": "feature-535",
+      "id": "feature-536",
       "query": "css/properties/grid-auto-rows.fr",
       "name": "<code>fr</code>",
       "category": "css/properties",
@@ -81964,7 +82129,7 @@
       }
     },
     {
-      "id": "feature-536",
+      "id": "feature-537",
       "query": "css/properties/grid-auto-rows.max-content",
       "name": "<code>max-content</code>, <code>fit-content</code> and <code>minmax()</code>",
       "category": "css/properties",
@@ -82000,7 +82165,7 @@
       }
     },
     {
-      "id": "feature-537",
+      "id": "feature-538",
       "query": "css/properties/grid-auto-rows.unsupported_value1",
       "name": "<code>none</code> and <code>[linename]</code>",
       "category": "css/properties",
@@ -82036,7 +82201,7 @@
       }
     },
     {
-      "id": "feature-538",
+      "id": "feature-539",
       "query": "css/properties/grid-auto-rows.unsupported_value2",
       "name": "<code>min-content</code>",
       "category": "css/properties",
@@ -82072,7 +82237,7 @@
       }
     },
     {
-      "id": "feature-539",
+      "id": "feature-540",
       "query": "css/properties/grid-column-end",
       "name": "grid-column-end",
       "category": "css/properties",
@@ -82108,7 +82273,7 @@
       }
     },
     {
-      "id": "feature-540",
+      "id": "feature-541",
       "query": "css/properties/grid-column-span",
       "name": "grid-column-span",
       "category": "css/properties",
@@ -82144,7 +82309,7 @@
       }
     },
     {
-      "id": "feature-541",
+      "id": "feature-542",
       "query": "css/properties/grid-column-start",
       "name": "grid-column-start",
       "category": "css/properties",
@@ -82180,7 +82345,7 @@
       }
     },
     {
-      "id": "feature-542",
+      "id": "feature-543",
       "query": "css/properties/grid-row-end",
       "name": "grid-row-end",
       "category": "css/properties",
@@ -82216,7 +82381,7 @@
       }
     },
     {
-      "id": "feature-543",
+      "id": "feature-544",
       "query": "css/properties/grid-row-span",
       "name": "grid-row-span",
       "category": "css/properties",
@@ -82252,7 +82417,7 @@
       }
     },
     {
-      "id": "feature-544",
+      "id": "feature-545",
       "query": "css/properties/grid-row-start",
       "name": "grid-row-start",
       "category": "css/properties",
@@ -82288,7 +82453,7 @@
       }
     },
     {
-      "id": "feature-545",
+      "id": "feature-546",
       "query": "css/properties/grid-template-columns",
       "name": "grid-template-columns",
       "category": "css/properties",
@@ -82324,7 +82489,7 @@
       }
     },
     {
-      "id": "feature-546",
+      "id": "feature-547",
       "query": "css/properties/grid-template-columns.calc",
       "name": "<code>calc()</code>",
       "category": "css/properties",
@@ -82360,7 +82525,7 @@
       }
     },
     {
-      "id": "feature-547",
+      "id": "feature-548",
       "query": "css/properties/grid-template-columns.fr",
       "name": "<code>fr</code>",
       "category": "css/properties",
@@ -82396,7 +82561,7 @@
       }
     },
     {
-      "id": "feature-548",
+      "id": "feature-549",
       "query": "css/properties/grid-template-columns.max-content",
       "name": "<code>max-content</code>, <code>fit-content</code> and <code>minmax()</code>",
       "category": "css/properties",
@@ -82432,7 +82597,7 @@
       }
     },
     {
-      "id": "feature-549",
+      "id": "feature-550",
       "query": "css/properties/grid-template-columns.unsupported_value1",
       "name": "<code>min-content</code>",
       "category": "css/properties",
@@ -82468,7 +82633,7 @@
       }
     },
     {
-      "id": "feature-550",
+      "id": "feature-551",
       "query": "css/properties/grid-template-columns.unsupported_value2",
       "name": "<code>none</code> and <code>[linename]</code>",
       "category": "css/properties",
@@ -82504,7 +82669,7 @@
       }
     },
     {
-      "id": "feature-551",
+      "id": "feature-552",
       "query": "css/properties/grid-template-rows",
       "name": "grid-template-rows",
       "category": "css/properties",
@@ -82540,7 +82705,7 @@
       }
     },
     {
-      "id": "feature-552",
+      "id": "feature-553",
       "query": "css/properties/grid-template-rows.calc",
       "name": "<code>calc()</code>",
       "category": "css/properties",
@@ -82576,7 +82741,7 @@
       }
     },
     {
-      "id": "feature-553",
+      "id": "feature-554",
       "query": "css/properties/grid-template-rows.fr",
       "name": "<code>fr</code>",
       "category": "css/properties",
@@ -82612,7 +82777,7 @@
       }
     },
     {
-      "id": "feature-554",
+      "id": "feature-555",
       "query": "css/properties/grid-template-rows.max-content",
       "name": "<code>max-content</code>, <code>fit-content</code> and <code>minmax()</code>",
       "category": "css/properties",
@@ -82648,7 +82813,7 @@
       }
     },
     {
-      "id": "feature-555",
+      "id": "feature-556",
       "query": "css/properties/grid-template-rows.unsupported_value1",
       "name": "<code>none</code> and <code>[linename]</code>",
       "category": "css/properties",
@@ -82684,7 +82849,7 @@
       }
     },
     {
-      "id": "feature-556",
+      "id": "feature-557",
       "query": "css/properties/grid-template-rows.unsupported_value2",
       "name": "<code>min-content</code>",
       "category": "css/properties",
@@ -82720,7 +82885,7 @@
       }
     },
     {
-      "id": "feature-557",
+      "id": "feature-558",
       "query": "css/properties/height",
       "name": "height",
       "category": "css/properties",
@@ -82756,7 +82921,7 @@
       }
     },
     {
-      "id": "feature-558",
+      "id": "feature-559",
       "query": "css/properties/height.max-content",
       "name": "max-content",
       "category": "css/properties",
@@ -82792,7 +82957,7 @@
       }
     },
     {
-      "id": "feature-559",
+      "id": "feature-560",
       "query": "css/properties/height.fit-content",
       "name": "fit-content",
       "category": "css/properties",
@@ -82828,7 +82993,7 @@
       }
     },
     {
-      "id": "feature-560",
+      "id": "feature-561",
       "query": "css/properties/height.min-content",
       "name": "min-content",
       "category": "css/properties",
@@ -82864,7 +83029,7 @@
       }
     },
     {
-      "id": "feature-561",
+      "id": "feature-562",
       "query": "css/properties/image-rendering",
       "name": "The image-rendering CSS property sets an image scaling algorithm. The property applies to an element itself.",
       "category": "css/properties",
@@ -82900,7 +83065,7 @@
       }
     },
     {
-      "id": "feature-562",
+      "id": "feature-563",
       "query": "css/properties/inset-inline-end",
       "name": "The inset-inline-end CSS property defines the logical inline end inset of an element, which maps to a physical offset depending on the element's directionality.",
       "category": "css/properties",
@@ -82936,7 +83101,7 @@
       }
     },
     {
-      "id": "feature-563",
+      "id": "feature-564",
       "query": "css/properties/inset-inline-start",
       "name": "The inset-inline-start CSS property defines the logical inline start inset of an element, which maps to a physical offset depending on the element's directionality.",
       "category": "css/properties",
@@ -82972,7 +83137,7 @@
       }
     },
     {
-      "id": "feature-564",
+      "id": "feature-565",
       "query": "css/properties/justify-content",
       "name": "justify-content",
       "category": "css/properties",
@@ -83008,7 +83173,7 @@
       }
     },
     {
-      "id": "feature-565",
+      "id": "feature-566",
       "query": "css/properties/justify-content.supported_in_flex_layout",
       "name": "Supported in Flexible Box Layout",
       "category": "css/properties",
@@ -83044,7 +83209,7 @@
       }
     },
     {
-      "id": "feature-566",
+      "id": "feature-567",
       "query": "css/properties/justify-content.supported_in_flex_layout.nested_value_1",
       "name": "<code>flex-start</code>, <code>flex-end</code>, <code>center</code>, <code>space-between</code>, <code>space-around</code>, <code>space-evenly</code>",
       "category": "css/properties",
@@ -83080,7 +83245,7 @@
       }
     },
     {
-      "id": "feature-567",
+      "id": "feature-568",
       "query": "css/properties/justify-content.supported_in_flex_layout.nested_value_2",
       "name": "<code>start</code> and <code>end</code>",
       "category": "css/properties",
@@ -83116,7 +83281,7 @@
       }
     },
     {
-      "id": "feature-568",
+      "id": "feature-569",
       "query": "css/properties/justify-content.supported_in_linear_layout",
       "name": "Supported in Linear Layout",
       "category": "css/properties",
@@ -83152,7 +83317,7 @@
       }
     },
     {
-      "id": "feature-569",
+      "id": "feature-570",
       "query": "css/properties/justify-content.supported_in_linear_layout.nested_value_1",
       "name": "<code>flex-start</code>, <code>flex-end</code>, <code>center</code>, <code>space-between</code>, <code>start</code>, <code>end</code>",
       "category": "css/properties",
@@ -83188,7 +83353,7 @@
       }
     },
     {
-      "id": "feature-570",
+      "id": "feature-571",
       "query": "css/properties/justify-content.supported_in_grid_layout",
       "name": "Supported in Grid Layout",
       "category": "css/properties",
@@ -83224,7 +83389,7 @@
       }
     },
     {
-      "id": "feature-571",
+      "id": "feature-572",
       "query": "css/properties/justify-content.supported_in_grid_layout.nested_value_1",
       "name": "<code>flex-start</code>, <code>flex-end</code>, <code>center</code>, <code>space-between</code>, <code>space-around</code>, <code>space-evenly</code>, <code>start</code>, <code>end</code>, <code>stretch</code>",
       "category": "css/properties",
@@ -83260,7 +83425,7 @@
       }
     },
     {
-      "id": "feature-572",
+      "id": "feature-573",
       "query": "css/properties/justify-content.unsupported_value_2",
       "name": "<code>left</code> and <code>right</code>",
       "category": "css/properties",
@@ -83296,7 +83461,7 @@
       }
     },
     {
-      "id": "feature-573",
+      "id": "feature-574",
       "query": "css/properties/justify-content.normal",
       "name": "<code>normal</code>",
       "category": "css/properties",
@@ -83332,7 +83497,7 @@
       }
     },
     {
-      "id": "feature-574",
+      "id": "feature-575",
       "query": "css/properties/justify-content.baseline",
       "name": "<code>baseline</code>",
       "category": "css/properties",
@@ -83368,7 +83533,7 @@
       }
     },
     {
-      "id": "feature-575",
+      "id": "feature-576",
       "query": "css/properties/justify-items",
       "name": "defines the default justify-self for all items of the box, giving them all a default way of justifying each box along the appropriate axis.",
       "category": "css/properties",
@@ -83404,7 +83569,7 @@
       }
     },
     {
-      "id": "feature-576",
+      "id": "feature-577",
       "query": "css/properties/justify-self",
       "name": "The CSS justify-self property sets the way a box is justified inside its alignment container along the appropriate axis.",
       "category": "css/properties",
@@ -83440,7 +83605,7 @@
       }
     },
     {
-      "id": "feature-577",
+      "id": "feature-578",
       "query": "css/properties/left",
       "name": "participates in setting the horizontal position of a positioned element. It has no effect on non-positioned elements.",
       "category": "css/properties",
@@ -83476,7 +83641,7 @@
       }
     },
     {
-      "id": "feature-578",
+      "id": "feature-579",
       "query": "css/properties/letter-spacing",
       "name": "letter-spacing",
       "category": "css/properties",
@@ -83512,7 +83677,7 @@
       }
     },
     {
-      "id": "feature-579",
+      "id": "feature-580",
       "query": "css/properties/line-height",
       "name": "line-height",
       "category": "css/properties",
@@ -83548,7 +83713,7 @@
       }
     },
     {
-      "id": "feature-580",
+      "id": "feature-581",
       "query": "css/properties/linear-cross-gravity",
       "name": "Set the position of the child element on the cross axis of the parent container in linear layout.",
       "category": "css/properties",
@@ -83584,7 +83749,7 @@
       }
     },
     {
-      "id": "feature-581",
+      "id": "feature-582",
       "query": "css/properties/linear-direction",
       "name": "sets how linear items are placed in the linear container defining the main axis and the direction.",
       "category": "css/properties",
@@ -83620,7 +83785,7 @@
       }
     },
     {
-      "id": "feature-582",
+      "id": "feature-583",
       "query": "css/properties/linear-direction.support_linear_direction",
       "name": "Support <code>linear-direction</code>",
       "category": "css/properties",
@@ -83656,7 +83821,7 @@
       }
     },
     {
-      "id": "feature-583",
+      "id": "feature-584",
       "query": "css/properties/linear-direction.support_linear_direction.nested_value_1",
       "name": "<code>row</code>, <code>row-reverse</code>, <code>column</code>, <code>column-reverse</code>",
       "category": "css/properties",
@@ -83692,7 +83857,7 @@
       }
     },
     {
-      "id": "feature-584",
+      "id": "feature-585",
       "query": "css/properties/linear-direction.support_linear_direction.nested_value_2",
       "name": "<code>vertical</code>, <code>horizontal</code>, <code>vertical-reverse</code>, <code>horizontal-reverse</code>",
       "category": "css/properties",
@@ -83728,7 +83893,7 @@
       }
     },
     {
-      "id": "feature-585",
+      "id": "feature-586",
       "query": "css/properties/linear-direction.support_linear_orientation",
       "name": "Supported <code>linear-orientation</code>",
       "category": "css/properties",
@@ -83764,7 +83929,7 @@
       }
     },
     {
-      "id": "feature-586",
+      "id": "feature-587",
       "query": "css/properties/linear-gravity",
       "name": "defines how distributes space between and around content items along the main-axis of a linear container.",
       "category": "css/properties",
@@ -83800,7 +83965,7 @@
       }
     },
     {
-      "id": "feature-587",
+      "id": "feature-588",
       "query": "css/properties/linear-gravity.value1",
       "name": "<code>start</code>, <code>end</code>, <code>center</code>",
       "category": "css/properties",
@@ -83836,7 +84001,7 @@
       }
     },
     {
-      "id": "feature-588",
+      "id": "feature-589",
       "query": "css/properties/linear-layout-gravity",
       "name": "The position of the child element in the linear container, perpendicular to the layout direction.",
       "category": "css/properties",
@@ -83872,7 +84037,7 @@
       }
     },
     {
-      "id": "feature-589",
+      "id": "feature-590",
       "query": "css/properties/linear-layout-gravity.value1",
       "name": "<code>stretch</code>, <code>start</code>, <code>end</code>, <code>center</code>",
       "category": "css/properties",
@@ -83908,7 +84073,7 @@
       }
     },
     {
-      "id": "feature-590",
+      "id": "feature-591",
       "query": "css/properties/linear-weight-sum",
       "name": "Child element's weight sum in linear layout.",
       "category": "css/properties",
@@ -83944,7 +84109,7 @@
       }
     },
     {
-      "id": "feature-591",
+      "id": "feature-592",
       "query": "css/properties/linear-weight",
       "name": "Child element's weight in linear layout.",
       "category": "css/properties",
@@ -83980,7 +84145,7 @@
       }
     },
     {
-      "id": "feature-592",
+      "id": "feature-593",
       "query": "css/properties/margin-bottom",
       "name": "margin-bottom",
       "category": "css/properties",
@@ -84016,7 +84181,7 @@
       }
     },
     {
-      "id": "feature-593",
+      "id": "feature-594",
       "query": "css/properties/margin-bottom.supported_in_flex_layout",
       "name": "Supported in Flexible Box Layout",
       "category": "css/properties",
@@ -84052,7 +84217,7 @@
       }
     },
     {
-      "id": "feature-594",
+      "id": "feature-595",
       "query": "css/properties/margin-bottom.supported_in_flex_layout.auto",
       "name": "<code>auto</code>",
       "category": "css/properties",
@@ -84088,7 +84253,7 @@
       }
     },
     {
-      "id": "feature-595",
+      "id": "feature-596",
       "query": "css/properties/margin-bottom.supported_in_linear_layout",
       "name": "Supported in Linear Layout",
       "category": "css/properties",
@@ -84124,7 +84289,7 @@
       }
     },
     {
-      "id": "feature-596",
+      "id": "feature-597",
       "query": "css/properties/margin-bottom.supported_in_linear_layout.nested_value_1",
       "name": "<code>auto</code> in cross-axis",
       "category": "css/properties",
@@ -84160,7 +84325,7 @@
       }
     },
     {
-      "id": "feature-597",
+      "id": "feature-598",
       "query": "css/properties/margin-bottom.supported_in_linear_layout.nested_value_2",
       "name": "<code>auto</code> in main-axis",
       "category": "css/properties",
@@ -84196,7 +84361,7 @@
       }
     },
     {
-      "id": "feature-598",
+      "id": "feature-599",
       "query": "css/properties/margin-bottom.supported_in_grid_layout",
       "name": "Supported in Grid Layout",
       "category": "css/properties",
@@ -84232,7 +84397,7 @@
       }
     },
     {
-      "id": "feature-599",
+      "id": "feature-600",
       "query": "css/properties/margin-bottom.supported_in_grid_layout.auto",
       "name": "<code>auto</code>",
       "category": "css/properties",
@@ -84268,7 +84433,7 @@
       }
     },
     {
-      "id": "feature-600",
+      "id": "feature-601",
       "query": "css/properties/margin-inline-end",
       "name": "margin-inline-end",
       "category": "css/properties",
@@ -84304,7 +84469,7 @@
       }
     },
     {
-      "id": "feature-601",
+      "id": "feature-602",
       "query": "css/properties/margin-inline-end.supported_in_flex_layout",
       "name": "Supported in Flexible Box Layout",
       "category": "css/properties",
@@ -84340,7 +84505,7 @@
       }
     },
     {
-      "id": "feature-602",
+      "id": "feature-603",
       "query": "css/properties/margin-inline-end.supported_in_flex_layout.auto",
       "name": "<code>auto</code>",
       "category": "css/properties",
@@ -84376,7 +84541,7 @@
       }
     },
     {
-      "id": "feature-603",
+      "id": "feature-604",
       "query": "css/properties/margin-inline-end.supported_in_linear_layout",
       "name": "Supported in Linear Layout",
       "category": "css/properties",
@@ -84412,7 +84577,7 @@
       }
     },
     {
-      "id": "feature-604",
+      "id": "feature-605",
       "query": "css/properties/margin-inline-end.supported_in_linear_layout.nested_value_1",
       "name": "<code>auto</code> in cross-axis",
       "category": "css/properties",
@@ -84448,7 +84613,7 @@
       }
     },
     {
-      "id": "feature-605",
+      "id": "feature-606",
       "query": "css/properties/margin-inline-end.supported_in_linear_layout.nested_value_2",
       "name": "<code>auto</code> in main-axis",
       "category": "css/properties",
@@ -84484,7 +84649,7 @@
       }
     },
     {
-      "id": "feature-606",
+      "id": "feature-607",
       "query": "css/properties/margin-inline-end.supported_in_grid_layout",
       "name": "Supported in Grid Layout",
       "category": "css/properties",
@@ -84520,7 +84685,7 @@
       }
     },
     {
-      "id": "feature-607",
+      "id": "feature-608",
       "query": "css/properties/margin-inline-end.supported_in_grid_layout.auto",
       "name": "<code>auto</code>",
       "category": "css/properties",
@@ -84556,7 +84721,7 @@
       }
     },
     {
-      "id": "feature-608",
+      "id": "feature-609",
       "query": "css/properties/margin-inline-start",
       "name": "margin-inline-start",
       "category": "css/properties",
@@ -84592,7 +84757,7 @@
       }
     },
     {
-      "id": "feature-609",
+      "id": "feature-610",
       "query": "css/properties/margin-inline-start.supported_in_flex_layout",
       "name": "Supported in Flexible Box Layout",
       "category": "css/properties",
@@ -84628,7 +84793,7 @@
       }
     },
     {
-      "id": "feature-610",
+      "id": "feature-611",
       "query": "css/properties/margin-inline-start.supported_in_flex_layout.auto",
       "name": "<code>auto</code>",
       "category": "css/properties",
@@ -84664,7 +84829,7 @@
       }
     },
     {
-      "id": "feature-611",
+      "id": "feature-612",
       "query": "css/properties/margin-inline-start.supported_in_linear_layout",
       "name": "Supported in Linear Layout",
       "category": "css/properties",
@@ -84700,7 +84865,7 @@
       }
     },
     {
-      "id": "feature-612",
+      "id": "feature-613",
       "query": "css/properties/margin-inline-start.supported_in_linear_layout.nested_value_1",
       "name": "<code>auto</code> in cross-axis",
       "category": "css/properties",
@@ -84736,7 +84901,7 @@
       }
     },
     {
-      "id": "feature-613",
+      "id": "feature-614",
       "query": "css/properties/margin-inline-start.supported_in_linear_layout.nested_value_2",
       "name": "<code>auto</code> in main-axis",
       "category": "css/properties",
@@ -84772,7 +84937,7 @@
       }
     },
     {
-      "id": "feature-614",
+      "id": "feature-615",
       "query": "css/properties/margin-inline-start.supported_in_grid_layout",
       "name": "Supported in Grid Layout",
       "category": "css/properties",
@@ -84808,7 +84973,7 @@
       }
     },
     {
-      "id": "feature-615",
+      "id": "feature-616",
       "query": "css/properties/margin-inline-start.supported_in_grid_layout.auto",
       "name": "<code>auto</code>",
       "category": "css/properties",
@@ -84844,7 +85009,7 @@
       }
     },
     {
-      "id": "feature-616",
+      "id": "feature-617",
       "query": "css/properties/margin-left",
       "name": "margin-left",
       "category": "css/properties",
@@ -84880,7 +85045,7 @@
       }
     },
     {
-      "id": "feature-617",
+      "id": "feature-618",
       "query": "css/properties/margin-left.supported_in_flex_layout",
       "name": "Supported in Flexible Box Layout",
       "category": "css/properties",
@@ -84916,7 +85081,7 @@
       }
     },
     {
-      "id": "feature-618",
+      "id": "feature-619",
       "query": "css/properties/margin-left.supported_in_flex_layout.auto",
       "name": "<code>auto</code>",
       "category": "css/properties",
@@ -84952,7 +85117,7 @@
       }
     },
     {
-      "id": "feature-619",
+      "id": "feature-620",
       "query": "css/properties/margin-left.supported_in_linear_layout",
       "name": "Supported in Linear Layout",
       "category": "css/properties",
@@ -84988,7 +85153,7 @@
       }
     },
     {
-      "id": "feature-620",
+      "id": "feature-621",
       "query": "css/properties/margin-left.supported_in_linear_layout.nested_value_1",
       "name": "<code>auto</code> in cross-axis",
       "category": "css/properties",
@@ -85024,7 +85189,7 @@
       }
     },
     {
-      "id": "feature-621",
+      "id": "feature-622",
       "query": "css/properties/margin-left.supported_in_linear_layout.nested_value_2",
       "name": "<code>auto</code> in main-axis",
       "category": "css/properties",
@@ -85060,7 +85225,7 @@
       }
     },
     {
-      "id": "feature-622",
+      "id": "feature-623",
       "query": "css/properties/margin-left.supported_in_grid_layout",
       "name": "Supported in Grid Layout",
       "category": "css/properties",
@@ -85096,7 +85261,7 @@
       }
     },
     {
-      "id": "feature-623",
+      "id": "feature-624",
       "query": "css/properties/margin-left.supported_in_grid_layout.auto",
       "name": "<code>auto</code>",
       "category": "css/properties",
@@ -85132,7 +85297,7 @@
       }
     },
     {
-      "id": "feature-624",
+      "id": "feature-625",
       "query": "css/properties/margin-right",
       "name": "margin-right",
       "category": "css/properties",
@@ -85168,7 +85333,7 @@
       }
     },
     {
-      "id": "feature-625",
+      "id": "feature-626",
       "query": "css/properties/margin-right.supported_in_flex_layout",
       "name": "Supported in Flexible Box Layout",
       "category": "css/properties",
@@ -85204,7 +85369,7 @@
       }
     },
     {
-      "id": "feature-626",
+      "id": "feature-627",
       "query": "css/properties/margin-right.supported_in_flex_layout.auto",
       "name": "<code>auto</code>",
       "category": "css/properties",
@@ -85240,7 +85405,7 @@
       }
     },
     {
-      "id": "feature-627",
+      "id": "feature-628",
       "query": "css/properties/margin-right.supported_in_linear_layout",
       "name": "Supported in Linear Layout",
       "category": "css/properties",
@@ -85276,7 +85441,7 @@
       }
     },
     {
-      "id": "feature-628",
+      "id": "feature-629",
       "query": "css/properties/margin-right.supported_in_linear_layout.nested_value_1",
       "name": "<code>auto</code> in cross-axis",
       "category": "css/properties",
@@ -85312,7 +85477,7 @@
       }
     },
     {
-      "id": "feature-629",
+      "id": "feature-630",
       "query": "css/properties/margin-right.supported_in_linear_layout.nested_value_2",
       "name": "<code>auto</code> in main-axis",
       "category": "css/properties",
@@ -85348,7 +85513,7 @@
       }
     },
     {
-      "id": "feature-630",
+      "id": "feature-631",
       "query": "css/properties/margin-right.supported_in_grid_layout",
       "name": "Supported in Grid Layout",
       "category": "css/properties",
@@ -85384,7 +85549,7 @@
       }
     },
     {
-      "id": "feature-631",
+      "id": "feature-632",
       "query": "css/properties/margin-right.supported_in_grid_layout.auto",
       "name": "<code>auto</code>",
       "category": "css/properties",
@@ -85420,7 +85585,7 @@
       }
     },
     {
-      "id": "feature-632",
+      "id": "feature-633",
       "query": "css/properties/margin-top",
       "name": "margin-top",
       "category": "css/properties",
@@ -85456,7 +85621,7 @@
       }
     },
     {
-      "id": "feature-633",
+      "id": "feature-634",
       "query": "css/properties/margin-top.supported_in_flex_layout",
       "name": "Supported in Flexible Box Layout",
       "category": "css/properties",
@@ -85492,7 +85657,7 @@
       }
     },
     {
-      "id": "feature-634",
+      "id": "feature-635",
       "query": "css/properties/margin-top.supported_in_flex_layout.auto",
       "name": "<code>auto</code>",
       "category": "css/properties",
@@ -85528,7 +85693,7 @@
       }
     },
     {
-      "id": "feature-635",
+      "id": "feature-636",
       "query": "css/properties/margin-top.supported_in_linear_layout",
       "name": "Supported in Linear Layout",
       "category": "css/properties",
@@ -85564,7 +85729,7 @@
       }
     },
     {
-      "id": "feature-636",
+      "id": "feature-637",
       "query": "css/properties/margin-top.supported_in_linear_layout.nested_value_1",
       "name": "<code>auto</code> in cross-axis",
       "category": "css/properties",
@@ -85600,7 +85765,7 @@
       }
     },
     {
-      "id": "feature-637",
+      "id": "feature-638",
       "query": "css/properties/margin-top.supported_in_linear_layout.nested_value_2",
       "name": "<code>auto</code> in main-axis",
       "category": "css/properties",
@@ -85636,7 +85801,7 @@
       }
     },
     {
-      "id": "feature-638",
+      "id": "feature-639",
       "query": "css/properties/margin-top.supported_in_grid_layout",
       "name": "Supported in Grid Layout",
       "category": "css/properties",
@@ -85672,7 +85837,7 @@
       }
     },
     {
-      "id": "feature-639",
+      "id": "feature-640",
       "query": "css/properties/margin-top.supported_in_grid_layout.auto",
       "name": "<code>auto</code>",
       "category": "css/properties",
@@ -85708,7 +85873,7 @@
       }
     },
     {
-      "id": "feature-640",
+      "id": "feature-641",
       "query": "css/properties/margin",
       "name": "margin",
       "category": "css/properties",
@@ -85744,7 +85909,7 @@
       }
     },
     {
-      "id": "feature-641",
+      "id": "feature-642",
       "query": "css/properties/margin.supported_in_flex_layout",
       "name": "Supported in Flexible Box Layout",
       "category": "css/properties",
@@ -85780,7 +85945,7 @@
       }
     },
     {
-      "id": "feature-642",
+      "id": "feature-643",
       "query": "css/properties/margin.supported_in_flex_layout.auto",
       "name": "<code>auto</code>",
       "category": "css/properties",
@@ -85816,7 +85981,7 @@
       }
     },
     {
-      "id": "feature-643",
+      "id": "feature-644",
       "query": "css/properties/margin.supported_in_linear_layout",
       "name": "Supported in Linear Layout",
       "category": "css/properties",
@@ -85852,7 +86017,7 @@
       }
     },
     {
-      "id": "feature-644",
+      "id": "feature-645",
       "query": "css/properties/margin.supported_in_linear_layout.nested_value_1",
       "name": "<code>auto</code> in cross-axis",
       "category": "css/properties",
@@ -85888,7 +86053,7 @@
       }
     },
     {
-      "id": "feature-645",
+      "id": "feature-646",
       "query": "css/properties/margin.supported_in_linear_layout.nested_value_2",
       "name": "<code>auto</code> in main-axis",
       "category": "css/properties",
@@ -85924,7 +86089,7 @@
       }
     },
     {
-      "id": "feature-646",
+      "id": "feature-647",
       "query": "css/properties/margin.supported_in_grid_layout",
       "name": "Supported in Grid Layout",
       "category": "css/properties",
@@ -85960,7 +86125,7 @@
       }
     },
     {
-      "id": "feature-647",
+      "id": "feature-648",
       "query": "css/properties/margin.supported_in_grid_layout.auto",
       "name": "<code>auto</code>",
       "category": "css/properties",
@@ -85996,7 +86161,7 @@
       }
     },
     {
-      "id": "feature-648",
+      "id": "feature-649",
       "query": "css/properties/mask-image",
       "name": "The mask-image CSS property sets the image that is used as mask layer for an element. By default this means the alpha channel of the mask image will be multiplied with the alpha channel of the element. This can be controlled with the mask-mode property.",
       "category": "css/properties",
@@ -86032,7 +86197,7 @@
       }
     },
     {
-      "id": "feature-649",
+      "id": "feature-650",
       "query": "css/properties/mask",
       "name": "The mask CSS shorthand property hides an element (partially or fully) by masking or clipping the image at specific points.",
       "category": "css/properties",
@@ -86068,7 +86233,7 @@
       }
     },
     {
-      "id": "feature-650",
+      "id": "feature-651",
       "query": "css/properties/max-height",
       "name": "sets the maximum height of an element.",
       "category": "css/properties",
@@ -86104,7 +86269,7 @@
       }
     },
     {
-      "id": "feature-651",
+      "id": "feature-652",
       "query": "css/properties/max-width",
       "name": "sets the maximum width of an element.",
       "category": "css/properties",
@@ -86140,7 +86305,7 @@
       }
     },
     {
-      "id": "feature-652",
+      "id": "feature-653",
       "query": "css/properties/min-height",
       "name": "sets the minimum height of an element.",
       "category": "css/properties",
@@ -86176,7 +86341,7 @@
       }
     },
     {
-      "id": "feature-653",
+      "id": "feature-654",
       "query": "css/properties/min-width",
       "name": "sets the minimum width of an element.",
       "category": "css/properties",
@@ -86212,7 +86377,7 @@
       }
     },
     {
-      "id": "feature-654",
+      "id": "feature-655",
       "query": "css/properties/opacity",
       "name": "opacity",
       "category": "css/properties",
@@ -86248,7 +86413,7 @@
       }
     },
     {
-      "id": "feature-655",
+      "id": "feature-656",
       "query": "css/properties/order",
       "name": "The order CSS property sets the order to lay out an item.",
       "category": "css/properties",
@@ -86284,7 +86449,7 @@
       }
     },
     {
-      "id": "feature-656",
+      "id": "feature-657",
       "query": "css/properties/overflow-x",
       "name": "overflow-x",
       "category": "css/properties",
@@ -86320,7 +86485,7 @@
       }
     },
     {
-      "id": "feature-657",
+      "id": "feature-658",
       "query": "css/properties/overflow-y",
       "name": "overflow-y",
       "category": "css/properties",
@@ -86356,7 +86521,7 @@
       }
     },
     {
-      "id": "feature-658",
+      "id": "feature-659",
       "query": "css/properties/overflow",
       "name": "overflow",
       "category": "css/properties",
@@ -86392,7 +86557,7 @@
       }
     },
     {
-      "id": "feature-659",
+      "id": "feature-660",
       "query": "css/properties/padding-bottom",
       "name": "padding-bottom",
       "category": "css/properties",
@@ -86428,7 +86593,7 @@
       }
     },
     {
-      "id": "feature-660",
+      "id": "feature-661",
       "query": "css/properties/padding-inline-end",
       "name": "padding-inline-end",
       "category": "css/properties",
@@ -86464,7 +86629,7 @@
       }
     },
     {
-      "id": "feature-661",
+      "id": "feature-662",
       "query": "css/properties/padding-inline-start",
       "name": "padding-inline-start",
       "category": "css/properties",
@@ -86500,7 +86665,7 @@
       }
     },
     {
-      "id": "feature-662",
+      "id": "feature-663",
       "query": "css/properties/padding-left",
       "name": "padding-left",
       "category": "css/properties",
@@ -86536,7 +86701,7 @@
       }
     },
     {
-      "id": "feature-663",
+      "id": "feature-664",
       "query": "css/properties/padding-right",
       "name": "padding-right",
       "category": "css/properties",
@@ -86572,7 +86737,7 @@
       }
     },
     {
-      "id": "feature-664",
+      "id": "feature-665",
       "query": "css/properties/padding-top",
       "name": "padding-top",
       "category": "css/properties",
@@ -86608,7 +86773,7 @@
       }
     },
     {
-      "id": "feature-665",
+      "id": "feature-666",
       "query": "css/properties/padding",
       "name": "padding",
       "category": "css/properties",
@@ -86644,7 +86809,7 @@
       }
     },
     {
-      "id": "feature-666",
+      "id": "feature-667",
       "query": "css/properties/perspective",
       "name": "perspective",
       "category": "css/properties",
@@ -86680,7 +86845,7 @@
       }
     },
     {
-      "id": "feature-667",
+      "id": "feature-668",
       "query": "css/properties/pointer-events",
       "name": "pointer-events",
       "category": "css/properties",
@@ -86716,7 +86881,7 @@
       }
     },
     {
-      "id": "feature-668",
+      "id": "feature-669",
       "query": "css/properties/position",
       "name": "position",
       "category": "css/properties",
@@ -86752,7 +86917,7 @@
       }
     },
     {
-      "id": "feature-669",
+      "id": "feature-670",
       "query": "css/properties/position.relative",
       "name": "relative",
       "category": "css/properties",
@@ -86788,7 +86953,7 @@
       }
     },
     {
-      "id": "feature-670",
+      "id": "feature-671",
       "query": "css/properties/position.absolute",
       "name": "absolute",
       "category": "css/properties",
@@ -86824,7 +86989,7 @@
       }
     },
     {
-      "id": "feature-671",
+      "id": "feature-672",
       "query": "css/properties/position.fixed",
       "name": "fixed",
       "category": "css/properties",
@@ -86860,7 +87025,7 @@
       }
     },
     {
-      "id": "feature-672",
+      "id": "feature-673",
       "query": "css/properties/position.sticky",
       "name": "sticky",
       "category": "css/properties",
@@ -86896,7 +87061,7 @@
       }
     },
     {
-      "id": "feature-673",
+      "id": "feature-674",
       "query": "css/properties/position.static",
       "name": "static",
       "category": "css/properties",
@@ -86932,7 +87097,7 @@
       }
     },
     {
-      "id": "feature-674",
+      "id": "feature-675",
       "query": "css/properties/relative-align-bottom",
       "name": "Specifies that the current element is aligned with the bottom edge of the parent or sibling element corresponding to id.",
       "category": "css/properties",
@@ -86968,7 +87133,7 @@
       }
     },
     {
-      "id": "feature-675",
+      "id": "feature-676",
       "query": "css/properties/relative-align-inline-end",
       "name": "Specifies that the current element is aligned with the left/right edges of the parent or sibling element corresponding to id.",
       "category": "css/properties",
@@ -87004,7 +87169,7 @@
       }
     },
     {
-      "id": "feature-676",
+      "id": "feature-677",
       "query": "css/properties/relative-align-inline-start",
       "name": "Specifies that the current element is aligned with the left/right edges of the parent or sibling element corresponding to id.",
       "category": "css/properties",
@@ -87040,7 +87205,7 @@
       }
     },
     {
-      "id": "feature-677",
+      "id": "feature-678",
       "query": "css/properties/relative-align-left",
       "name": "Specifies that the current element is aligned with the left edge of the parent or sibling element corresponding to id.",
       "category": "css/properties",
@@ -87076,7 +87241,7 @@
       }
     },
     {
-      "id": "feature-678",
+      "id": "feature-679",
       "query": "css/properties/relative-align-right",
       "name": "Specifies that the current element is aligned with the right edge of the parent or sibling element corresponding to id.",
       "category": "css/properties",
@@ -87112,7 +87277,7 @@
       }
     },
     {
-      "id": "feature-679",
+      "id": "feature-680",
       "query": "css/properties/relative-align-top",
       "name": "Specifies that the current element is aligned with the top edge of the parent or sibling element corresponding to id.",
       "category": "css/properties",
@@ -87148,7 +87313,7 @@
       }
     },
     {
-      "id": "feature-680",
+      "id": "feature-681",
       "query": "css/properties/relative-bottom-of",
       "name": "The current element is to the bottom of the sibling element specified corresponding to id.",
       "category": "css/properties",
@@ -87184,7 +87349,7 @@
       }
     },
     {
-      "id": "feature-681",
+      "id": "feature-682",
       "query": "css/properties/relative-center",
       "name": "Specifies that the current element is aligned with the bottom edge of the parent or sibling element corresponding to id.",
       "category": "css/properties",
@@ -87220,7 +87385,7 @@
       }
     },
     {
-      "id": "feature-682",
+      "id": "feature-683",
       "query": "css/properties/relative-id",
       "name": "Used to set the number of sibling elements in the relative layout.",
       "category": "css/properties",
@@ -87256,7 +87421,7 @@
       }
     },
     {
-      "id": "feature-683",
+      "id": "feature-684",
       "query": "css/properties/relative-inline-end-of",
       "name": "The current element is to the left/right of the sibling element corresponding to the specified id.",
       "category": "css/properties",
@@ -87292,7 +87457,7 @@
       }
     },
     {
-      "id": "feature-684",
+      "id": "feature-685",
       "query": "css/properties/relative-inline-start-of",
       "name": "The current element is to the left/right of the sibling element corresponding to the specified id.",
       "category": "css/properties",
@@ -87328,7 +87493,7 @@
       }
     },
     {
-      "id": "feature-685",
+      "id": "feature-686",
       "query": "css/properties/relative-layout-once",
       "name": "Used to set typesetting acceleration. When using positioning between elements at the same level, it is recommended to enable this property, and elements at the same level will only depend upwards.",
       "category": "css/properties",
@@ -87364,7 +87529,7 @@
       }
     },
     {
-      "id": "feature-686",
+      "id": "feature-687",
       "query": "css/properties/relative-left-of",
       "name": "The current element is to the left of the sibling element specified corresponding to id.",
       "category": "css/properties",
@@ -87400,7 +87565,7 @@
       }
     },
     {
-      "id": "feature-687",
+      "id": "feature-688",
       "query": "css/properties/relative-right-of",
       "name": "The current element is to the right of the sibling element specified corresponding to id.",
       "category": "css/properties",
@@ -87436,7 +87601,7 @@
       }
     },
     {
-      "id": "feature-688",
+      "id": "feature-689",
       "query": "css/properties/relative-top-of",
       "name": "The current element is to the top of the sibling element specified corresponding to id.",
       "category": "css/properties",
@@ -87472,7 +87637,7 @@
       }
     },
     {
-      "id": "feature-689",
+      "id": "feature-690",
       "query": "css/properties/right",
       "name": "participates in setting the horizontal position of a positioned element. It has no effect on non-positioned elements.",
       "category": "css/properties",
@@ -87508,7 +87673,7 @@
       }
     },
     {
-      "id": "feature-690",
+      "id": "feature-691",
       "query": "css/properties/row-gap",
       "name": "<code>row-gap</code>",
       "category": "css/properties",
@@ -87544,7 +87709,7 @@
       }
     },
     {
-      "id": "feature-691",
+      "id": "feature-692",
       "query": "css/properties/row-gap.grid-row-gap",
       "name": "<code>grid-row-gap</code>",
       "category": "css/properties",
@@ -87580,7 +87745,7 @@
       }
     },
     {
-      "id": "feature-692",
+      "id": "feature-693",
       "query": "css/properties/row-gap.supported_in_flex_layout",
       "name": "Supported in Flexible Box Layout",
       "category": "css/properties",
@@ -87616,7 +87781,7 @@
       }
     },
     {
-      "id": "feature-693",
+      "id": "feature-694",
       "query": "css/properties/row-gap.supported_in_flex_layout.nested_value_1",
       "name": "<code>row-gap</code> and <code>grid-row-gap</code>",
       "category": "css/properties",
@@ -87652,7 +87817,7 @@
       }
     },
     {
-      "id": "feature-694",
+      "id": "feature-695",
       "query": "css/properties/row-gap.supported_in_grid_layout",
       "name": "Supported in Grid Layout",
       "category": "css/properties",
@@ -87688,7 +87853,7 @@
       }
     },
     {
-      "id": "feature-695",
+      "id": "feature-696",
       "query": "css/properties/row-gap.supported_in_grid_layout.grid-row-gap",
       "name": "<code>grid-row-gap</code>",
       "category": "css/properties",
@@ -87724,7 +87889,7 @@
       }
     },
     {
-      "id": "feature-696",
+      "id": "feature-697",
       "query": "css/properties/row-gap.supported_in_grid_layout",
       "name": "<code>row-gap</code>",
       "category": "css/properties",
@@ -87760,7 +87925,7 @@
       }
     },
     {
-      "id": "feature-697",
+      "id": "feature-698",
       "query": "css/properties/text-align",
       "name": "text-align",
       "category": "css/properties",
@@ -87796,7 +87961,7 @@
       }
     },
     {
-      "id": "feature-698",
+      "id": "feature-699",
       "query": "css/properties/text-decoration",
       "name": "text-decoration",
       "category": "css/properties",
@@ -87832,7 +87997,7 @@
       }
     },
     {
-      "id": "feature-699",
+      "id": "feature-700",
       "query": "css/properties/text-indent",
       "name": "text-indent",
       "category": "css/properties",
@@ -87868,7 +88033,7 @@
       }
     },
     {
-      "id": "feature-700",
+      "id": "feature-701",
       "query": "css/properties/text-overflow",
       "name": "text-overflow",
       "category": "css/properties",
@@ -87904,7 +88069,7 @@
       }
     },
     {
-      "id": "feature-701",
+      "id": "feature-702",
       "query": "css/properties/text-shadow",
       "name": "text-shadow",
       "category": "css/properties",
@@ -87940,7 +88105,7 @@
       }
     },
     {
-      "id": "feature-702",
+      "id": "feature-703",
       "query": "css/properties/text-stroke-color",
       "name": "text-stroke-color",
       "category": "css/properties",
@@ -87976,7 +88141,7 @@
       }
     },
     {
-      "id": "feature-703",
+      "id": "feature-704",
       "query": "css/properties/text-stroke-width",
       "name": "text-stroke-width",
       "category": "css/properties",
@@ -88012,7 +88177,7 @@
       }
     },
     {
-      "id": "feature-704",
+      "id": "feature-705",
       "query": "css/properties/text-stroke",
       "name": "text-stroke",
       "category": "css/properties",
@@ -88048,7 +88213,7 @@
       }
     },
     {
-      "id": "feature-705",
+      "id": "feature-706",
       "query": "css/properties/top",
       "name": "participates in setting the vertical position of a positioned element. It has no effect on non-positioned elements.",
       "category": "css/properties",
@@ -88084,7 +88249,7 @@
       }
     },
     {
-      "id": "feature-706",
+      "id": "feature-707",
       "query": "css/properties/transform-origin",
       "name": "transform-origin",
       "category": "css/properties",
@@ -88120,7 +88285,7 @@
       }
     },
     {
-      "id": "feature-707",
+      "id": "feature-708",
       "query": "css/properties/transform",
       "name": "transform",
       "category": "css/properties",
@@ -88156,7 +88321,7 @@
       }
     },
     {
-      "id": "feature-708",
+      "id": "feature-709",
       "query": "css/properties/transition-delay",
       "name": "transition-delay",
       "category": "css/properties",
@@ -88192,7 +88357,7 @@
       }
     },
     {
-      "id": "feature-709",
+      "id": "feature-710",
       "query": "css/properties/transition-duration",
       "name": "transition-duration",
       "category": "css/properties",
@@ -88228,7 +88393,7 @@
       }
     },
     {
-      "id": "feature-710",
+      "id": "feature-711",
       "query": "css/properties/transition-property",
       "name": "transition-property",
       "category": "css/properties",
@@ -88264,7 +88429,7 @@
       }
     },
     {
-      "id": "feature-711",
+      "id": "feature-712",
       "query": "css/properties/transition-timing-function",
       "name": "transition-timing-function",
       "category": "css/properties",
@@ -88300,7 +88465,7 @@
       }
     },
     {
-      "id": "feature-712",
+      "id": "feature-713",
       "query": "css/properties/transition",
       "name": "transition",
       "category": "css/properties",
@@ -88336,7 +88501,7 @@
       }
     },
     {
-      "id": "feature-713",
+      "id": "feature-714",
       "query": "css/properties/vertical-align",
       "name": "vertical-align",
       "category": "css/properties",
@@ -88372,7 +88537,7 @@
       }
     },
     {
-      "id": "feature-714",
+      "id": "feature-715",
       "query": "css/properties/visibility",
       "name": "visibility",
       "category": "css/properties",
@@ -88408,7 +88573,7 @@
       }
     },
     {
-      "id": "feature-715",
+      "id": "feature-716",
       "query": "css/properties/white-space",
       "name": "white-space",
       "category": "css/properties",
@@ -88444,7 +88609,7 @@
       }
     },
     {
-      "id": "feature-716",
+      "id": "feature-717",
       "query": "css/properties/width",
       "name": "width",
       "category": "css/properties",
@@ -88480,7 +88645,7 @@
       }
     },
     {
-      "id": "feature-717",
+      "id": "feature-718",
       "query": "css/properties/width.max-content",
       "name": "max-content",
       "category": "css/properties",
@@ -88516,7 +88681,7 @@
       }
     },
     {
-      "id": "feature-718",
+      "id": "feature-719",
       "query": "css/properties/width.fit-content",
       "name": "fit-content",
       "category": "css/properties",
@@ -88552,7 +88717,7 @@
       }
     },
     {
-      "id": "feature-719",
+      "id": "feature-720",
       "query": "css/properties/width.min-content",
       "name": "min-content",
       "category": "css/properties",
@@ -88588,7 +88753,7 @@
       }
     },
     {
-      "id": "feature-720",
+      "id": "feature-721",
       "query": "css/properties/word-break",
       "name": "word-break",
       "category": "css/properties",
@@ -88624,7 +88789,7 @@
       }
     },
     {
-      "id": "feature-721",
+      "id": "feature-722",
       "query": "css/properties/z-index",
       "name": "z-index",
       "category": "css/properties",
@@ -88660,7 +88825,7 @@
       }
     },
     {
-      "id": "feature-722",
+      "id": "feature-723",
       "query": "css/at-rule/font-face",
       "name": "font-face",
       "category": "css/at-rule",
@@ -88696,7 +88861,7 @@
       }
     },
     {
-      "id": "feature-723",
+      "id": "feature-724",
       "query": "css/data-type/angle",
       "name": "<code>&lt;angle&gt;</code>",
       "category": "css/data-type",
@@ -88732,7 +88897,7 @@
       }
     },
     {
-      "id": "feature-724",
+      "id": "feature-725",
       "query": "css/data-type/angle.deg",
       "name": "deg",
       "category": "css/data-type",
@@ -88768,7 +88933,7 @@
       }
     },
     {
-      "id": "feature-725",
+      "id": "feature-726",
       "query": "css/data-type/angle.grad",
       "name": "grad",
       "category": "css/data-type",
@@ -88804,7 +88969,7 @@
       }
     },
     {
-      "id": "feature-726",
+      "id": "feature-727",
       "query": "css/data-type/angle.rad",
       "name": "rad",
       "category": "css/data-type",
@@ -88840,7 +89005,7 @@
       }
     },
     {
-      "id": "feature-727",
+      "id": "feature-728",
       "query": "css/data-type/angle.turn",
       "name": "turn",
       "category": "css/data-type",
@@ -88876,7 +89041,7 @@
       }
     },
     {
-      "id": "feature-728",
+      "id": "feature-729",
       "query": "css/data-type/color",
       "name": "<code>&lt;color&gt;</code>",
       "category": "css/data-type",
@@ -88912,7 +89077,7 @@
       }
     },
     {
-      "id": "feature-729",
+      "id": "feature-730",
       "query": "css/data-type/color.rgb()",
       "name": "<code>rgb()</code> (RGB color model)",
       "category": "css/data-type",
@@ -88948,7 +89113,7 @@
       }
     },
     {
-      "id": "feature-730",
+      "id": "feature-731",
       "query": "css/data-type/color.rgb().legacy-rgb-syntax",
       "name": "<a href='https://drafts.csswg.org/css-color/#typedef-legacy-rgb-syntax'><code>&lt;legacy-rgb-syntax&gt;</code></a>",
       "category": "css/data-type",
@@ -88984,7 +89149,7 @@
       }
     },
     {
-      "id": "feature-731",
+      "id": "feature-732",
       "query": "css/data-type/color.rgb().modern-rgb-syntax",
       "name": "<a href='https://drafts.csswg.org/css-color/#typedef-modern-rgb-syntax'><code>&lt;modern-rgb-syntax&gt;</code></a>",
       "category": "css/data-type",
@@ -89020,7 +89185,7 @@
       }
     },
     {
-      "id": "feature-732",
+      "id": "feature-733",
       "query": "css/data-type/color.rgb().legacy-rgba-syntax",
       "name": "<a href='https://drafts.csswg.org/css-color/#typedef-legacy-rgba-syntax'><code>&lt;legacy-rgba-syntax&gt;</code></a>",
       "category": "css/data-type",
@@ -89056,7 +89221,7 @@
       }
     },
     {
-      "id": "feature-733",
+      "id": "feature-734",
       "query": "css/data-type/color.rgb().modern-rgba-syntax",
       "name": "<a href='https://drafts.csswg.org/css-color/#typedef-modern-rgba-syntax'><code>&lt;modern-rgba-syntax&gt;</code></a>",
       "category": "css/data-type",
@@ -89092,7 +89257,7 @@
       }
     },
     {
-      "id": "feature-734",
+      "id": "feature-735",
       "query": "css/data-type/color.hsl",
       "name": "<code>hsl()</code> (HSL color model)",
       "category": "css/data-type",
@@ -89128,7 +89293,7 @@
       }
     },
     {
-      "id": "feature-735",
+      "id": "feature-736",
       "query": "css/data-type/fit-content",
       "name": "fit-content",
       "category": "css/data-type",
@@ -89164,7 +89329,7 @@
       }
     },
     {
-      "id": "feature-736",
+      "id": "feature-737",
       "query": "css/data-type/gradient",
       "name": "<code>&lt;gradient&gt;</code>",
       "category": "css/data-type",
@@ -89200,7 +89365,7 @@
       }
     },
     {
-      "id": "feature-737",
+      "id": "feature-738",
       "query": "css/data-type/gradient.linear-gradient()",
       "name": "linear-gradient()",
       "category": "css/data-type",
@@ -89236,7 +89401,7 @@
       }
     },
     {
-      "id": "feature-738",
+      "id": "feature-739",
       "query": "css/data-type/gradient.radial-gradient()",
       "name": "radial-gradient()",
       "category": "css/data-type",
@@ -89272,7 +89437,7 @@
       }
     },
     {
-      "id": "feature-739",
+      "id": "feature-740",
       "query": "css/data-type/gradient.conic-gradient()",
       "name": "conic-gradient()",
       "category": "css/data-type",
@@ -89308,7 +89473,7 @@
       }
     },
     {
-      "id": "feature-740",
+      "id": "feature-741",
       "query": "css/data-type/length-percentage",
       "name": "<code>&lt;length-percentage&gt;</code>",
       "category": "css/data-type",
@@ -89344,7 +89509,7 @@
       }
     },
     {
-      "id": "feature-741",
+      "id": "feature-742",
       "query": "css/data-type/length",
       "name": "<code>&lt;length&gt;</code>",
       "category": "css/data-type",
@@ -89380,7 +89545,7 @@
       }
     },
     {
-      "id": "feature-742",
+      "id": "feature-743",
       "query": "css/data-type/length.absolute",
       "name": "Absolute length units",
       "category": "css/data-type",
@@ -89416,7 +89581,7 @@
       }
     },
     {
-      "id": "feature-743",
+      "id": "feature-744",
       "query": "css/data-type/length.absolute.value_px",
       "name": "<code>px</code> unit",
       "category": "css/data-type",
@@ -89452,7 +89617,7 @@
       }
     },
     {
-      "id": "feature-744",
+      "id": "feature-745",
       "query": "css/data-type/length.absolute.value_ppx",
       "name": "<code>ppx</code> unit",
       "category": "css/data-type",
@@ -89488,7 +89653,7 @@
       }
     },
     {
-      "id": "feature-745",
+      "id": "feature-746",
       "query": "css/data-type/length.relative",
       "name": "Relative length units",
       "category": "css/data-type",
@@ -89524,7 +89689,7 @@
       }
     },
     {
-      "id": "feature-746",
+      "id": "feature-747",
       "query": "css/data-type/length.relative.value_rpx",
       "name": "<code>rpx</code> unit",
       "category": "css/data-type",
@@ -89560,7 +89725,7 @@
       }
     },
     {
-      "id": "feature-747",
+      "id": "feature-748",
       "query": "css/data-type/length.relative.value_rem",
       "name": "<code>rem</code> unit",
       "category": "css/data-type",
@@ -89596,7 +89761,7 @@
       }
     },
     {
-      "id": "feature-748",
+      "id": "feature-749",
       "query": "css/data-type/length.relative.value_em",
       "name": "<code>em</code> unit",
       "category": "css/data-type",
@@ -89632,7 +89797,7 @@
       }
     },
     {
-      "id": "feature-749",
+      "id": "feature-750",
       "query": "css/data-type/length.relative.value_vh",
       "name": "<code>vh</code> unit",
       "category": "css/data-type",
@@ -89668,7 +89833,7 @@
       }
     },
     {
-      "id": "feature-750",
+      "id": "feature-751",
       "query": "css/data-type/length.relative.value_vw",
       "name": "<code>vw</code> unit",
       "category": "css/data-type",
@@ -89704,7 +89869,7 @@
       }
     },
     {
-      "id": "feature-751",
+      "id": "feature-752",
       "query": "css/data-type/max-content",
       "name": "max-content",
       "category": "css/data-type",
@@ -89740,7 +89905,7 @@
       }
     },
     {
-      "id": "feature-752",
+      "id": "feature-753",
       "query": "css/data-type/number",
       "name": "<code>&lt;number&gt;</code>",
       "category": "css/data-type",
@@ -89776,7 +89941,7 @@
       }
     },
     {
-      "id": "feature-753",
+      "id": "feature-754",
       "query": "css/data-type/percentage",
       "name": "<code>&lt;percentage&gt;</code>",
       "category": "css/data-type",
@@ -89812,7 +89977,7 @@
       }
     },
     {
-      "id": "feature-754",
+      "id": "feature-755",
       "query": "css/data-type/string",
       "name": "<code>&lt;string&gt;</code>",
       "category": "css/data-type",
@@ -89848,7 +90013,7 @@
       }
     },
     {
-      "id": "feature-755",
+      "id": "feature-756",
       "query": "css/data-type/time",
       "name": "<code>&lt;time&gt;</code>",
       "category": "css/data-type",
@@ -89884,7 +90049,7 @@
       }
     },
     {
-      "id": "feature-756",
+      "id": "feature-757",
       "query": "lynx-api/global/SystemInfo",
       "name": "Information of the current system",
       "category": "lynx-api/global",
@@ -89920,7 +90085,7 @@
       }
     },
     {
-      "id": "feature-757",
+      "id": "feature-758",
       "query": "lynx-api/global/SystemInfo.SystemInfo.engineVersion",
       "name": "engineVersion",
       "category": "lynx-api/global",
@@ -89956,7 +90121,7 @@
       }
     },
     {
-      "id": "feature-758",
+      "id": "feature-759",
       "query": "lynx-api/global/SystemInfo.SystemInfo.lynxSdkVersion",
       "name": "lynxSdkVersion",
       "category": "lynx-api/global",
@@ -89992,7 +90157,7 @@
       }
     },
     {
-      "id": "feature-759",
+      "id": "feature-760",
       "query": "lynx-api/global/clearInterval",
       "name": "Cancels the timer set by `setInterval`.",
       "category": "lynx-api/global",
@@ -90028,7 +90193,7 @@
       }
     },
     {
-      "id": "feature-760",
+      "id": "feature-761",
       "query": "lynx-api/global/clearTimeout",
       "name": "Cancel the timer set by `setTimeout`.",
       "category": "lynx-api/global",
@@ -90064,7 +90229,7 @@
       }
     },
     {
-      "id": "feature-761",
+      "id": "feature-762",
       "query": "lynx-api/global/console/assert",
       "name": "assert failed and output error level message",
       "category": "lynx-api/global",
@@ -90100,7 +90265,7 @@
       }
     },
     {
-      "id": "feature-762",
+      "id": "feature-763",
       "query": "lynx-api/global/console/count",
       "name": "start count",
       "category": "lynx-api/global",
@@ -90136,7 +90301,7 @@
       }
     },
     {
-      "id": "feature-763",
+      "id": "feature-764",
       "query": "lynx-api/global/console/countReset",
       "name": "reset count",
       "category": "lynx-api/global",
@@ -90172,7 +90337,7 @@
       }
     },
     {
-      "id": "feature-764",
+      "id": "feature-765",
       "query": "lynx-api/global/console/debug",
       "name": "output a debug level message",
       "category": "lynx-api/global",
@@ -90208,7 +90373,7 @@
       }
     },
     {
-      "id": "feature-765",
+      "id": "feature-766",
       "query": "lynx-api/global/console/error",
       "name": "output a error level message",
       "category": "lynx-api/global",
@@ -90244,7 +90409,7 @@
       }
     },
     {
-      "id": "feature-766",
+      "id": "feature-767",
       "query": "lynx-api/global/console/group",
       "name": "start a console group",
       "category": "lynx-api/global",
@@ -90280,7 +90445,7 @@
       }
     },
     {
-      "id": "feature-767",
+      "id": "feature-768",
       "query": "lynx-api/global/console/groupCollapsed",
       "name": "start a collapsed console group",
       "category": "lynx-api/global",
@@ -90316,7 +90481,7 @@
       }
     },
     {
-      "id": "feature-768",
+      "id": "feature-769",
       "query": "lynx-api/global/console/groupEnd",
       "name": "end a console group",
       "category": "lynx-api/global",
@@ -90352,7 +90517,7 @@
       }
     },
     {
-      "id": "feature-769",
+      "id": "feature-770",
       "query": "lynx-api/global/console/info",
       "name": "output a info level message",
       "category": "lynx-api/global",
@@ -90388,7 +90553,7 @@
       }
     },
     {
-      "id": "feature-770",
+      "id": "feature-771",
       "query": "lynx-api/global/console/log",
       "name": "output a log level message",
       "category": "lynx-api/global",
@@ -90424,7 +90589,7 @@
       }
     },
     {
-      "id": "feature-771",
+      "id": "feature-772",
       "query": "lynx-api/global/console/profile",
       "name": "output a message",
       "category": "lynx-api/global",
@@ -90460,7 +90625,7 @@
       }
     },
     {
-      "id": "feature-772",
+      "id": "feature-773",
       "query": "lynx-api/global/console/profileEnd",
       "name": "end profile",
       "category": "lynx-api/global",
@@ -90496,7 +90661,7 @@
       }
     },
     {
-      "id": "feature-773",
+      "id": "feature-774",
       "query": "lynx-api/global/console/table",
       "name": "print message by table",
       "category": "lynx-api/global",
@@ -90532,7 +90697,7 @@
       }
     },
     {
-      "id": "feature-774",
+      "id": "feature-775",
       "query": "lynx-api/global/console/time",
       "name": "start a timer",
       "category": "lynx-api/global",
@@ -90568,7 +90733,7 @@
       }
     },
     {
-      "id": "feature-775",
+      "id": "feature-776",
       "query": "lynx-api/global/console/timeEnd",
       "name": "end a timer",
       "category": "lynx-api/global",
@@ -90604,7 +90769,7 @@
       }
     },
     {
-      "id": "feature-776",
+      "id": "feature-777",
       "query": "lynx-api/global/console/timeLog",
       "name": "print timer",
       "category": "lynx-api/global",
@@ -90640,7 +90805,7 @@
       }
     },
     {
-      "id": "feature-777",
+      "id": "feature-778",
       "query": "lynx-api/global/console/warn",
       "name": "output a warn level message",
       "category": "lynx-api/global",
@@ -90676,7 +90841,7 @@
       }
     },
     {
-      "id": "feature-778",
+      "id": "feature-779",
       "query": "lynx-api/global/setInterval",
       "name": "Repeatedly calls a function or executes a code fragment with a fixed time interval between each call.",
       "category": "lynx-api/global",
@@ -90712,7 +90877,7 @@
       }
     },
     {
-      "id": "feature-779",
+      "id": "feature-780",
       "query": "lynx-api/global/setTimeout",
       "name": "setTimeout",
       "category": "lynx-api/global",
@@ -90748,7 +90913,7 @@
       }
     },
     {
-      "id": "feature-780",
+      "id": "feature-781",
       "query": "lynx-api/event/AnimationEvent",
       "name": "AnimationEvent",
       "category": "lynx-api/event",
@@ -90784,7 +90949,7 @@
       }
     },
     {
-      "id": "feature-781",
+      "id": "feature-782",
       "query": "lynx-api/event/AnimationEvent.detail",
       "name": "detail",
       "category": "lynx-api/event",
@@ -90820,7 +90985,7 @@
       }
     },
     {
-      "id": "feature-782",
+      "id": "feature-783",
       "query": "lynx-api/event/AnimationEvent.animationstart",
       "name": "animationstart",
       "category": "lynx-api/event",
@@ -90856,7 +91021,7 @@
       }
     },
     {
-      "id": "feature-783",
+      "id": "feature-784",
       "query": "lynx-api/event/AnimationEvent.animationend",
       "name": "animationend",
       "category": "lynx-api/event",
@@ -90892,7 +91057,7 @@
       }
     },
     {
-      "id": "feature-784",
+      "id": "feature-785",
       "query": "lynx-api/event/AnimationEvent.animationiteration",
       "name": "animationiteration",
       "category": "lynx-api/event",
@@ -90928,7 +91093,7 @@
       }
     },
     {
-      "id": "feature-785",
+      "id": "feature-786",
       "query": "lynx-api/event/AnimationEvent.animationcancel",
       "name": "animationcancel",
       "category": "lynx-api/event",
@@ -90964,7 +91129,7 @@
       }
     },
     {
-      "id": "feature-786",
+      "id": "feature-787",
       "query": "lynx-api/event/AnimationEvent.transitionstart",
       "name": "transitionstart",
       "category": "lynx-api/event",
@@ -91000,7 +91165,7 @@
       }
     },
     {
-      "id": "feature-787",
+      "id": "feature-788",
       "query": "lynx-api/event/AnimationEvent.transitionend",
       "name": "transitionend",
       "category": "lynx-api/event",
@@ -91036,7 +91201,7 @@
       }
     },
     {
-      "id": "feature-788",
+      "id": "feature-789",
       "query": "lynx-api/event/AnimationEvent.transitioncancel",
       "name": "transitioncancel",
       "category": "lynx-api/event",
@@ -91072,7 +91237,7 @@
       }
     },
     {
-      "id": "feature-789",
+      "id": "feature-790",
       "query": "lynx-api/event/CustomEvent",
       "name": "CustomEvent",
       "category": "lynx-api/event",
@@ -91108,7 +91273,7 @@
       }
     },
     {
-      "id": "feature-790",
+      "id": "feature-791",
       "query": "lynx-api/event/CustomEvent.params",
       "name": "params",
       "category": "lynx-api/event",
@@ -91144,7 +91309,7 @@
       }
     },
     {
-      "id": "feature-791",
+      "id": "feature-792",
       "query": "lynx-api/event/CustomEvent.detail",
       "name": "detail",
       "category": "lynx-api/event",
@@ -91180,7 +91345,7 @@
       }
     },
     {
-      "id": "feature-792",
+      "id": "feature-793",
       "query": "lynx-api/event/Event",
       "name": "Event",
       "category": "lynx-api/event",
@@ -91216,7 +91381,7 @@
       }
     },
     {
-      "id": "feature-793",
+      "id": "feature-794",
       "query": "lynx-api/event/Event.TouchEvent",
       "name": "TouchEvent",
       "category": "lynx-api/event",
@@ -91252,7 +91417,7 @@
       }
     },
     {
-      "id": "feature-794",
+      "id": "feature-795",
       "query": "lynx-api/event/Event.CustomEvent",
       "name": "CustomEvent",
       "category": "lynx-api/event",
@@ -91288,7 +91453,7 @@
       }
     },
     {
-      "id": "feature-795",
+      "id": "feature-796",
       "query": "lynx-api/event/Event.AnimationEvent",
       "name": "AnimationEvent",
       "category": "lynx-api/event",
@@ -91324,7 +91489,7 @@
       }
     },
     {
-      "id": "feature-796",
+      "id": "feature-797",
       "query": "lynx-api/event/Event.type",
       "name": "type",
       "category": "lynx-api/event",
@@ -91360,7 +91525,7 @@
       }
     },
     {
-      "id": "feature-797",
+      "id": "feature-798",
       "query": "lynx-api/event/Event.timestamp",
       "name": "timestamp",
       "category": "lynx-api/event",
@@ -91396,7 +91561,7 @@
       }
     },
     {
-      "id": "feature-798",
+      "id": "feature-799",
       "query": "lynx-api/event/Event.target",
       "name": "target",
       "category": "lynx-api/event",
@@ -91432,7 +91597,7 @@
       }
     },
     {
-      "id": "feature-799",
+      "id": "feature-800",
       "query": "lynx-api/event/Event.currentTarget",
       "name": "currentTarget",
       "category": "lynx-api/event",
@@ -91468,7 +91633,7 @@
       }
     },
     {
-      "id": "feature-800",
+      "id": "feature-801",
       "query": "lynx-api/event/Event.stopPropagation",
       "name": "stopPropagation",
       "category": "lynx-api/event",
@@ -91504,7 +91669,7 @@
       }
     },
     {
-      "id": "feature-801",
+      "id": "feature-802",
       "query": "lynx-api/event/Event.stopImmediatePropagation",
       "name": "stopImmediatePropagation",
       "category": "lynx-api/event",
@@ -91540,7 +91705,7 @@
       }
     },
     {
-      "id": "feature-802",
+      "id": "feature-803",
       "query": "lynx-api/event/GlobalEvent",
       "name": "GlobalEvent",
       "category": "lynx-api/event",
@@ -91576,7 +91741,7 @@
       }
     },
     {
-      "id": "feature-803",
+      "id": "feature-804",
       "query": "lynx-api/event/GlobalEvent.keyboardstatuschanged",
       "name": "keyboardstatuschanged",
       "category": "lynx-api/event",
@@ -91612,7 +91777,7 @@
       }
     },
     {
-      "id": "feature-804",
+      "id": "feature-805",
       "query": "lynx-api/event/GlobalEvent.onWindowResize",
       "name": "onWindowResize",
       "category": "lynx-api/event",
@@ -91648,7 +91813,7 @@
       }
     },
     {
-      "id": "feature-805",
+      "id": "feature-806",
       "query": "lynx-api/event/GlobalEvent.exposure",
       "name": "exposure",
       "category": "lynx-api/event",
@@ -91684,7 +91849,7 @@
       }
     },
     {
-      "id": "feature-806",
+      "id": "feature-807",
       "query": "lynx-api/event/GlobalEvent.disexposure",
       "name": "disexposure",
       "category": "lynx-api/event",
@@ -91720,7 +91885,7 @@
       }
     },
     {
-      "id": "feature-807",
+      "id": "feature-808",
       "query": "lynx-api/event/KeyEvent",
       "name": "KeyEvent",
       "category": "lynx-api/event",
@@ -91756,7 +91921,7 @@
       }
     },
     {
-      "id": "feature-808",
+      "id": "feature-809",
       "query": "lynx-api/event/KeyEvent.key",
       "name": "key",
       "category": "lynx-api/event",
@@ -91792,7 +91957,7 @@
       }
     },
     {
-      "id": "feature-809",
+      "id": "feature-810",
       "query": "lynx-api/event/KeyEvent.repeat",
       "name": "repeat",
       "category": "lynx-api/event",
@@ -91828,7 +91993,7 @@
       }
     },
     {
-      "id": "feature-810",
+      "id": "feature-811",
       "query": "lynx-api/event/KeyEvent.altKey",
       "name": "altKey",
       "category": "lynx-api/event",
@@ -91864,7 +92029,7 @@
       }
     },
     {
-      "id": "feature-811",
+      "id": "feature-812",
       "query": "lynx-api/event/KeyEvent.ctrlKey",
       "name": "ctrlKey",
       "category": "lynx-api/event",
@@ -91900,7 +92065,7 @@
       }
     },
     {
-      "id": "feature-812",
+      "id": "feature-813",
       "query": "lynx-api/event/KeyEvent.metaKey",
       "name": "metaKey",
       "category": "lynx-api/event",
@@ -91936,7 +92101,7 @@
       }
     },
     {
-      "id": "feature-813",
+      "id": "feature-814",
       "query": "lynx-api/event/KeyEvent.shiftKey",
       "name": "shiftKey",
       "category": "lynx-api/event",
@@ -91972,7 +92137,7 @@
       }
     },
     {
-      "id": "feature-814",
+      "id": "feature-815",
       "query": "lynx-api/event/KeyEvent.keydown",
       "name": "keydown",
       "category": "lynx-api/event",
@@ -92008,7 +92173,7 @@
       }
     },
     {
-      "id": "feature-815",
+      "id": "feature-816",
       "query": "lynx-api/event/KeyEvent.keyup",
       "name": "keyup",
       "category": "lynx-api/event",
@@ -92044,7 +92209,7 @@
       }
     },
     {
-      "id": "feature-816",
+      "id": "feature-817",
       "query": "lynx-api/event/MemoryEvent",
       "name": "MemoryEvent",
       "category": "lynx-api/event",
@@ -92080,7 +92245,7 @@
       }
     },
     {
-      "id": "feature-817",
+      "id": "feature-818",
       "query": "lynx-api/event/MouseEvent",
       "name": "MouseEvent",
       "category": "lynx-api/event",
@@ -92116,7 +92281,7 @@
       }
     },
     {
-      "id": "feature-818",
+      "id": "feature-819",
       "query": "lynx-api/event/MouseEvent.button",
       "name": "button",
       "category": "lynx-api/event",
@@ -92152,7 +92317,7 @@
       }
     },
     {
-      "id": "feature-819",
+      "id": "feature-820",
       "query": "lynx-api/event/MouseEvent.buttons",
       "name": "buttons",
       "category": "lynx-api/event",
@@ -92188,7 +92353,7 @@
       }
     },
     {
-      "id": "feature-820",
+      "id": "feature-821",
       "query": "lynx-api/event/MouseEvent.x",
       "name": "x",
       "category": "lynx-api/event",
@@ -92224,7 +92389,7 @@
       }
     },
     {
-      "id": "feature-821",
+      "id": "feature-822",
       "query": "lynx-api/event/MouseEvent.y  ",
       "name": "y  ",
       "category": "lynx-api/event",
@@ -92260,7 +92425,7 @@
       }
     },
     {
-      "id": "feature-822",
+      "id": "feature-823",
       "query": "lynx-api/event/MouseEvent.pageX",
       "name": "pageX",
       "category": "lynx-api/event",
@@ -92296,7 +92461,7 @@
       }
     },
     {
-      "id": "feature-823",
+      "id": "feature-824",
       "query": "lynx-api/event/MouseEvent.pageY",
       "name": "pageY",
       "category": "lynx-api/event",
@@ -92332,7 +92497,7 @@
       }
     },
     {
-      "id": "feature-824",
+      "id": "feature-825",
       "query": "lynx-api/event/MouseEvent.clientX",
       "name": "clientX",
       "category": "lynx-api/event",
@@ -92368,7 +92533,7 @@
       }
     },
     {
-      "id": "feature-825",
+      "id": "feature-826",
       "query": "lynx-api/event/MouseEvent.clientY",
       "name": "clientY",
       "category": "lynx-api/event",
@@ -92404,7 +92569,7 @@
       }
     },
     {
-      "id": "feature-826",
+      "id": "feature-827",
       "query": "lynx-api/event/MouseEvent.mousedown",
       "name": "mousedown",
       "category": "lynx-api/event",
@@ -92440,7 +92605,7 @@
       }
     },
     {
-      "id": "feature-827",
+      "id": "feature-828",
       "query": "lynx-api/event/MouseEvent.mousemove",
       "name": "mousemove",
       "category": "lynx-api/event",
@@ -92476,7 +92641,7 @@
       }
     },
     {
-      "id": "feature-828",
+      "id": "feature-829",
       "query": "lynx-api/event/MouseEvent.mouseup",
       "name": "mouseup",
       "category": "lynx-api/event",
@@ -92512,7 +92677,7 @@
       }
     },
     {
-      "id": "feature-829",
+      "id": "feature-830",
       "query": "lynx-api/event/MouseEvent.mouseenter",
       "name": "mouseenter",
       "category": "lynx-api/event",
@@ -92548,7 +92713,7 @@
       }
     },
     {
-      "id": "feature-830",
+      "id": "feature-831",
       "query": "lynx-api/event/MouseEvent.mouseover",
       "name": "mouseover",
       "category": "lynx-api/event",
@@ -92584,7 +92749,7 @@
       }
     },
     {
-      "id": "feature-831",
+      "id": "feature-832",
       "query": "lynx-api/event/MouseEvent.mouseleave",
       "name": "mouseleave",
       "category": "lynx-api/event",
@@ -92620,7 +92785,7 @@
       }
     },
     {
-      "id": "feature-832",
+      "id": "feature-833",
       "query": "lynx-api/event/TouchEvent",
       "name": "TouchEvent",
       "category": "lynx-api/event",
@@ -92656,7 +92821,7 @@
       }
     },
     {
-      "id": "feature-833",
+      "id": "feature-834",
       "query": "lynx-api/event/TouchEvent.detail",
       "name": "detail",
       "category": "lynx-api/event",
@@ -92692,7 +92857,7 @@
       }
     },
     {
-      "id": "feature-834",
+      "id": "feature-835",
       "query": "lynx-api/event/TouchEvent.touches",
       "name": "touches",
       "category": "lynx-api/event",
@@ -92728,7 +92893,7 @@
       }
     },
     {
-      "id": "feature-835",
+      "id": "feature-836",
       "query": "lynx-api/event/TouchEvent.changedTouches",
       "name": "changedTouches",
       "category": "lynx-api/event",
@@ -92764,7 +92929,7 @@
       }
     },
     {
-      "id": "feature-836",
+      "id": "feature-837",
       "query": "lynx-api/event/TouchEvent.touchstart",
       "name": "touchstart",
       "category": "lynx-api/event",
@@ -92800,7 +92965,7 @@
       }
     },
     {
-      "id": "feature-837",
+      "id": "feature-838",
       "query": "lynx-api/event/TouchEvent.touchmove",
       "name": "touchmove",
       "category": "lynx-api/event",
@@ -92836,7 +93001,7 @@
       }
     },
     {
-      "id": "feature-838",
+      "id": "feature-839",
       "query": "lynx-api/event/TouchEvent.touchend",
       "name": "touchend",
       "category": "lynx-api/event",
@@ -92872,7 +93037,7 @@
       }
     },
     {
-      "id": "feature-839",
+      "id": "feature-840",
       "query": "lynx-api/event/TouchEvent.touchcancel",
       "name": "touchcancel",
       "category": "lynx-api/event",
@@ -92908,7 +93073,7 @@
       }
     },
     {
-      "id": "feature-840",
+      "id": "feature-841",
       "query": "lynx-api/event/TouchEvent.tap",
       "name": "tap",
       "category": "lynx-api/event",
@@ -92944,7 +93109,7 @@
       }
     },
     {
-      "id": "feature-841",
+      "id": "feature-842",
       "query": "lynx-api/event/TouchEvent.longpress",
       "name": "longpress",
       "category": "lynx-api/event",
@@ -92980,7 +93145,7 @@
       }
     },
     {
-      "id": "feature-842",
+      "id": "feature-843",
       "query": "lynx-api/event/TouchEvent.click",
       "name": "click",
       "category": "lynx-api/event",
@@ -93016,7 +93181,7 @@
       }
     },
     {
-      "id": "feature-843",
+      "id": "feature-844",
       "query": "lynx-api/event/WheelEvent",
       "name": "WheelEvent",
       "category": "lynx-api/event",
@@ -93052,7 +93217,7 @@
       }
     },
     {
-      "id": "feature-844",
+      "id": "feature-845",
       "query": "lynx-api/event/WheelEvent.deltaX",
       "name": "deltaX",
       "category": "lynx-api/event",
@@ -93088,7 +93253,7 @@
       }
     },
     {
-      "id": "feature-845",
+      "id": "feature-846",
       "query": "lynx-api/event/WheelEvent.deltaY",
       "name": "deltaY",
       "category": "lynx-api/event",
@@ -93124,7 +93289,7 @@
       }
     },
     {
-      "id": "feature-846",
+      "id": "feature-847",
       "query": "lynx-api/event/WheelEvent.wheel",
       "name": "wheel",
       "category": "lynx-api/event",
@@ -93160,7 +93325,7 @@
       }
     },
     {
-      "id": "feature-847",
+      "id": "feature-848",
       "query": "lynx-api/fetch/Headers",
       "name": "Headers",
       "category": "lynx-api/fetch",
@@ -93196,7 +93361,7 @@
       }
     },
     {
-      "id": "feature-848",
+      "id": "feature-849",
       "query": "lynx-api/fetch/Headers",
       "name": "<code>Headers()</code> constructor",
       "category": "lynx-api/fetch",
@@ -93232,7 +93397,7 @@
       }
     },
     {
-      "id": "feature-849",
+      "id": "feature-850",
       "query": "lynx-api/fetch/Headers.append",
       "name": "append",
       "category": "lynx-api/fetch",
@@ -93268,7 +93433,7 @@
       }
     },
     {
-      "id": "feature-850",
+      "id": "feature-851",
       "query": "lynx-api/fetch/Headers.delete",
       "name": "delete",
       "category": "lynx-api/fetch",
@@ -93304,7 +93469,7 @@
       }
     },
     {
-      "id": "feature-851",
+      "id": "feature-852",
       "query": "lynx-api/fetch/Headers.entries",
       "name": "entries",
       "category": "lynx-api/fetch",
@@ -93340,7 +93505,7 @@
       }
     },
     {
-      "id": "feature-852",
+      "id": "feature-853",
       "query": "lynx-api/fetch/Headers.forEach",
       "name": "forEach",
       "category": "lynx-api/fetch",
@@ -93376,7 +93541,7 @@
       }
     },
     {
-      "id": "feature-853",
+      "id": "feature-854",
       "query": "lynx-api/fetch/Headers.get",
       "name": "get",
       "category": "lynx-api/fetch",
@@ -93412,7 +93577,7 @@
       }
     },
     {
-      "id": "feature-854",
+      "id": "feature-855",
       "query": "lynx-api/fetch/Headers.getSetCookie",
       "name": "getSetCookie",
       "category": "lynx-api/fetch",
@@ -93448,7 +93613,7 @@
       }
     },
     {
-      "id": "feature-855",
+      "id": "feature-856",
       "query": "lynx-api/fetch/Headers.has",
       "name": "has",
       "category": "lynx-api/fetch",
@@ -93484,7 +93649,7 @@
       }
     },
     {
-      "id": "feature-856",
+      "id": "feature-857",
       "query": "lynx-api/fetch/Headers.keys",
       "name": "keys",
       "category": "lynx-api/fetch",
@@ -93520,7 +93685,7 @@
       }
     },
     {
-      "id": "feature-857",
+      "id": "feature-858",
       "query": "lynx-api/fetch/Headers.set",
       "name": "set",
       "category": "lynx-api/fetch",
@@ -93556,7 +93721,7 @@
       }
     },
     {
-      "id": "feature-858",
+      "id": "feature-859",
       "query": "lynx-api/fetch/Headers.values",
       "name": "values",
       "category": "lynx-api/fetch",
@@ -93592,7 +93757,7 @@
       }
     },
     {
-      "id": "feature-859",
+      "id": "feature-860",
       "query": "lynx-api/fetch/Headers.@@iterator",
       "name": "<code>[Symbol.iterator]</code>",
       "category": "lynx-api/fetch",
@@ -93628,7 +93793,7 @@
       }
     },
     {
-      "id": "feature-860",
+      "id": "feature-861",
       "query": "lynx-api/fetch/Request",
       "name": "Request",
       "category": "lynx-api/fetch",
@@ -93664,7 +93829,7 @@
       }
     },
     {
-      "id": "feature-861",
+      "id": "feature-862",
       "query": "lynx-api/fetch/Request",
       "name": "`Request()` constructor",
       "category": "lynx-api/fetch",
@@ -93700,7 +93865,7 @@
       }
     },
     {
-      "id": "feature-862",
+      "id": "feature-863",
       "query": "lynx-api/fetch/Request.cors",
       "name": "cors",
       "category": "lynx-api/fetch",
@@ -93736,7 +93901,7 @@
       }
     },
     {
-      "id": "feature-863",
+      "id": "feature-864",
       "query": "lynx-api/fetch/Request.init_attributionReporting_parameter",
       "name": "`init.attributionReporting` parameter",
       "category": "lynx-api/fetch",
@@ -93772,7 +93937,7 @@
       }
     },
     {
-      "id": "feature-864",
+      "id": "feature-865",
       "query": "lynx-api/fetch/Request.init_browsingTopics_parameter",
       "name": "`init.browsingTopics` parameter",
       "category": "lynx-api/fetch",
@@ -93808,7 +93973,7 @@
       }
     },
     {
-      "id": "feature-865",
+      "id": "feature-866",
       "query": "lynx-api/fetch/Request.init_keepalive_parameter",
       "name": "`init.keepalive` parameter",
       "category": "lynx-api/fetch",
@@ -93844,7 +94009,7 @@
       }
     },
     {
-      "id": "feature-866",
+      "id": "feature-867",
       "query": "lynx-api/fetch/Request.init_priority_parameter",
       "name": "`init.priority` parameter",
       "category": "lynx-api/fetch",
@@ -93880,7 +94045,7 @@
       }
     },
     {
-      "id": "feature-867",
+      "id": "feature-868",
       "query": "lynx-api/fetch/Request.init_referrer_parameter",
       "name": "`init.referrer` parameter",
       "category": "lynx-api/fetch",
@@ -93916,7 +94081,7 @@
       }
     },
     {
-      "id": "feature-868",
+      "id": "feature-869",
       "query": "lynx-api/fetch/Request.request_body_readablestream",
       "name": "Send `ReadableStream` in request body",
       "category": "lynx-api/fetch",
@@ -93952,7 +94117,7 @@
       }
     },
     {
-      "id": "feature-869",
+      "id": "feature-870",
       "query": "lynx-api/fetch/Request.response_body_readablestream",
       "name": "Consume `ReadableStream` as a response body",
       "category": "lynx-api/fetch",
@@ -93988,7 +94153,7 @@
       }
     },
     {
-      "id": "feature-870",
+      "id": "feature-871",
       "query": "lynx-api/fetch/Request.arrayBuffer",
       "name": "arrayBuffer",
       "category": "lynx-api/fetch",
@@ -94024,7 +94189,7 @@
       }
     },
     {
-      "id": "feature-871",
+      "id": "feature-872",
       "query": "lynx-api/fetch/Request.blob",
       "name": "blob",
       "category": "lynx-api/fetch",
@@ -94060,7 +94225,7 @@
       }
     },
     {
-      "id": "feature-872",
+      "id": "feature-873",
       "query": "lynx-api/fetch/Request.body",
       "name": "body",
       "category": "lynx-api/fetch",
@@ -94096,7 +94261,7 @@
       }
     },
     {
-      "id": "feature-873",
+      "id": "feature-874",
       "query": "lynx-api/fetch/Request.bodyUsed",
       "name": "bodyUsed",
       "category": "lynx-api/fetch",
@@ -94132,7 +94297,7 @@
       }
     },
     {
-      "id": "feature-874",
+      "id": "feature-875",
       "query": "lynx-api/fetch/Request.bytes",
       "name": "bytes",
       "category": "lynx-api/fetch",
@@ -94168,7 +94333,7 @@
       }
     },
     {
-      "id": "feature-875",
+      "id": "feature-876",
       "query": "lynx-api/fetch/Request.cache",
       "name": "cache",
       "category": "lynx-api/fetch",
@@ -94204,7 +94369,7 @@
       }
     },
     {
-      "id": "feature-876",
+      "id": "feature-877",
       "query": "lynx-api/fetch/Request.cache.only-if-cached",
       "name": "only-if-cached",
       "category": "lynx-api/fetch",
@@ -94240,7 +94405,7 @@
       }
     },
     {
-      "id": "feature-877",
+      "id": "feature-878",
       "query": "lynx-api/fetch/Request.clone",
       "name": "clone",
       "category": "lynx-api/fetch",
@@ -94276,7 +94441,7 @@
       }
     },
     {
-      "id": "feature-878",
+      "id": "feature-879",
       "query": "lynx-api/fetch/Request.credentials",
       "name": "credentials",
       "category": "lynx-api/fetch",
@@ -94312,7 +94477,7 @@
       }
     },
     {
-      "id": "feature-879",
+      "id": "feature-880",
       "query": "lynx-api/fetch/Request.destination",
       "name": "destination",
       "category": "lynx-api/fetch",
@@ -94348,7 +94513,7 @@
       }
     },
     {
-      "id": "feature-880",
+      "id": "feature-881",
       "query": "lynx-api/fetch/Request.duplex",
       "name": "duplex",
       "category": "lynx-api/fetch",
@@ -94384,7 +94549,7 @@
       }
     },
     {
-      "id": "feature-881",
+      "id": "feature-882",
       "query": "lynx-api/fetch/Request.formData",
       "name": "formData",
       "category": "lynx-api/fetch",
@@ -94420,7 +94585,7 @@
       }
     },
     {
-      "id": "feature-882",
+      "id": "feature-883",
       "query": "lynx-api/fetch/Request.headers",
       "name": "headers",
       "category": "lynx-api/fetch",
@@ -94456,7 +94621,7 @@
       }
     },
     {
-      "id": "feature-883",
+      "id": "feature-884",
       "query": "lynx-api/fetch/Request.integrity",
       "name": "integrity",
       "category": "lynx-api/fetch",
@@ -94492,7 +94657,7 @@
       }
     },
     {
-      "id": "feature-884",
+      "id": "feature-885",
       "query": "lynx-api/fetch/Request.isHistoryNavigation",
       "name": "isHistoryNavigation",
       "category": "lynx-api/fetch",
@@ -94528,7 +94693,7 @@
       }
     },
     {
-      "id": "feature-885",
+      "id": "feature-886",
       "query": "lynx-api/fetch/Request.json",
       "name": "json",
       "category": "lynx-api/fetch",
@@ -94564,7 +94729,7 @@
       }
     },
     {
-      "id": "feature-886",
+      "id": "feature-887",
       "query": "lynx-api/fetch/Request.keepalive",
       "name": "keepalive",
       "category": "lynx-api/fetch",
@@ -94600,7 +94765,7 @@
       }
     },
     {
-      "id": "feature-887",
+      "id": "feature-888",
       "query": "lynx-api/fetch/Request.method",
       "name": "method",
       "category": "lynx-api/fetch",
@@ -94636,7 +94801,7 @@
       }
     },
     {
-      "id": "feature-888",
+      "id": "feature-889",
       "query": "lynx-api/fetch/Request.mode",
       "name": "mode",
       "category": "lynx-api/fetch",
@@ -94672,7 +94837,7 @@
       }
     },
     {
-      "id": "feature-889",
+      "id": "feature-890",
       "query": "lynx-api/fetch/Request.mode.navigate_mode",
       "name": "`navigate` mode",
       "category": "lynx-api/fetch",
@@ -94708,7 +94873,7 @@
       }
     },
     {
-      "id": "feature-890",
+      "id": "feature-891",
       "query": "lynx-api/fetch/Request.redirect",
       "name": "redirect",
       "category": "lynx-api/fetch",
@@ -94744,7 +94909,7 @@
       }
     },
     {
-      "id": "feature-891",
+      "id": "feature-892",
       "query": "lynx-api/fetch/Request.referrer",
       "name": "referrer",
       "category": "lynx-api/fetch",
@@ -94780,7 +94945,7 @@
       }
     },
     {
-      "id": "feature-892",
+      "id": "feature-893",
       "query": "lynx-api/fetch/Request.referrerPolicy",
       "name": "referrerPolicy",
       "category": "lynx-api/fetch",
@@ -94816,7 +94981,7 @@
       }
     },
     {
-      "id": "feature-893",
+      "id": "feature-894",
       "query": "lynx-api/fetch/Request.signal",
       "name": "signal",
       "category": "lynx-api/fetch",
@@ -94852,7 +95017,7 @@
       }
     },
     {
-      "id": "feature-894",
+      "id": "feature-895",
       "query": "lynx-api/fetch/Request.targetAddressSpace",
       "name": "targetAddressSpace",
       "category": "lynx-api/fetch",
@@ -94888,7 +95053,7 @@
       }
     },
     {
-      "id": "feature-895",
+      "id": "feature-896",
       "query": "lynx-api/fetch/Request.text",
       "name": "text",
       "category": "lynx-api/fetch",
@@ -94924,7 +95089,7 @@
       }
     },
     {
-      "id": "feature-896",
+      "id": "feature-897",
       "query": "lynx-api/fetch/Request.url",
       "name": "url",
       "category": "lynx-api/fetch",
@@ -94960,7 +95125,7 @@
       }
     },
     {
-      "id": "feature-897",
+      "id": "feature-898",
       "query": "lynx-api/fetch/Response",
       "name": "Response",
       "category": "lynx-api/fetch",
@@ -94996,7 +95161,7 @@
       }
     },
     {
-      "id": "feature-898",
+      "id": "feature-899",
       "query": "lynx-api/fetch/Response",
       "name": "`Response()` constructor",
       "category": "lynx-api/fetch",
@@ -95032,7 +95197,7 @@
       }
     },
     {
-      "id": "feature-899",
+      "id": "feature-900",
       "query": "lynx-api/fetch/Response.accept_readablestream",
       "name": "body parameter accepts ReadableByteStream",
       "category": "lynx-api/fetch",
@@ -95068,7 +95233,7 @@
       }
     },
     {
-      "id": "feature-900",
+      "id": "feature-901",
       "query": "lynx-api/fetch/Response.body_parameter_optional",
       "name": "`body` parameter is optional",
       "category": "lynx-api/fetch",
@@ -95104,7 +95269,7 @@
       }
     },
     {
-      "id": "feature-901",
+      "id": "feature-902",
       "query": "lynx-api/fetch/Response.arrayBuffer",
       "name": "arrayBuffer",
       "category": "lynx-api/fetch",
@@ -95140,7 +95305,7 @@
       }
     },
     {
-      "id": "feature-902",
+      "id": "feature-903",
       "query": "lynx-api/fetch/Response.blob",
       "name": "blob",
       "category": "lynx-api/fetch",
@@ -95176,7 +95341,7 @@
       }
     },
     {
-      "id": "feature-903",
+      "id": "feature-904",
       "query": "lynx-api/fetch/Response.body",
       "name": "body",
       "category": "lynx-api/fetch",
@@ -95212,7 +95377,7 @@
       }
     },
     {
-      "id": "feature-904",
+      "id": "feature-905",
       "query": "lynx-api/fetch/Response.body.readable_byte_stream",
       "name": "`body` is a readable byte stream",
       "category": "lynx-api/fetch",
@@ -95248,7 +95413,7 @@
       }
     },
     {
-      "id": "feature-905",
+      "id": "feature-906",
       "query": "lynx-api/fetch/Response.bodyUsed",
       "name": "bodyUsed",
       "category": "lynx-api/fetch",
@@ -95284,7 +95449,7 @@
       }
     },
     {
-      "id": "feature-906",
+      "id": "feature-907",
       "query": "lynx-api/fetch/Response.bytes",
       "name": "bytes",
       "category": "lynx-api/fetch",
@@ -95320,7 +95485,7 @@
       }
     },
     {
-      "id": "feature-907",
+      "id": "feature-908",
       "query": "lynx-api/fetch/Response.clone",
       "name": "clone",
       "category": "lynx-api/fetch",
@@ -95356,7 +95521,7 @@
       }
     },
     {
-      "id": "feature-908",
+      "id": "feature-909",
       "query": "lynx-api/fetch/Response.error_static",
       "name": "`error()` static method",
       "category": "lynx-api/fetch",
@@ -95392,7 +95557,7 @@
       }
     },
     {
-      "id": "feature-909",
+      "id": "feature-910",
       "query": "lynx-api/fetch/Response.formData",
       "name": "formData",
       "category": "lynx-api/fetch",
@@ -95428,7 +95593,7 @@
       }
     },
     {
-      "id": "feature-910",
+      "id": "feature-911",
       "query": "lynx-api/fetch/Response.headers",
       "name": "headers",
       "category": "lynx-api/fetch",
@@ -95464,7 +95629,7 @@
       }
     },
     {
-      "id": "feature-911",
+      "id": "feature-912",
       "query": "lynx-api/fetch/Response.json",
       "name": "json",
       "category": "lynx-api/fetch",
@@ -95500,7 +95665,7 @@
       }
     },
     {
-      "id": "feature-912",
+      "id": "feature-913",
       "query": "lynx-api/fetch/Response.json_static",
       "name": "json_static",
       "category": "lynx-api/fetch",
@@ -95536,7 +95701,7 @@
       }
     },
     {
-      "id": "feature-913",
+      "id": "feature-914",
       "query": "lynx-api/fetch/Response.ok",
       "name": "ok",
       "category": "lynx-api/fetch",
@@ -95572,7 +95737,7 @@
       }
     },
     {
-      "id": "feature-914",
+      "id": "feature-915",
       "query": "lynx-api/fetch/Response.redirect_static",
       "name": "`redirect()` static method",
       "category": "lynx-api/fetch",
@@ -95608,7 +95773,7 @@
       }
     },
     {
-      "id": "feature-915",
+      "id": "feature-916",
       "query": "lynx-api/fetch/Response.redirected",
       "name": "redirected",
       "category": "lynx-api/fetch",
@@ -95644,7 +95809,7 @@
       }
     },
     {
-      "id": "feature-916",
+      "id": "feature-917",
       "query": "lynx-api/fetch/Response.status",
       "name": "status",
       "category": "lynx-api/fetch",
@@ -95680,7 +95845,7 @@
       }
     },
     {
-      "id": "feature-917",
+      "id": "feature-918",
       "query": "lynx-api/fetch/Response.statusText",
       "name": "statusText",
       "category": "lynx-api/fetch",
@@ -95716,7 +95881,7 @@
       }
     },
     {
-      "id": "feature-918",
+      "id": "feature-919",
       "query": "lynx-api/fetch/Response.text",
       "name": "text",
       "category": "lynx-api/fetch",
@@ -95752,7 +95917,7 @@
       }
     },
     {
-      "id": "feature-919",
+      "id": "feature-920",
       "query": "lynx-api/fetch/Response.type",
       "name": "type",
       "category": "lynx-api/fetch",
@@ -95788,7 +95953,7 @@
       }
     },
     {
-      "id": "feature-920",
+      "id": "feature-921",
       "query": "lynx-api/fetch/Response.url",
       "name": "url",
       "category": "lynx-api/fetch",
@@ -95824,7 +95989,7 @@
       }
     },
     {
-      "id": "feature-921",
+      "id": "feature-922",
       "query": "lynx-api/fetch/fetch",
       "name": "<code>fetch</code>",
       "category": "lynx-api/fetch",
@@ -95860,7 +96025,7 @@
       }
     },
     {
-      "id": "feature-922",
+      "id": "feature-923",
       "query": "lynx-api/lynx/accessibilityAnnounce",
       "name": "Used to have the specified text content read by the screen reader.",
       "category": "lynx-api/lynx",
@@ -95896,7 +96061,7 @@
       }
     },
     {
-      "id": "feature-923",
+      "id": "feature-924",
       "query": "lynx-api/lynx/addFont",
       "name": "Used for dynamically adding fonts.",
       "category": "lynx-api/lynx",
@@ -95932,7 +96097,7 @@
       }
     },
     {
-      "id": "feature-924",
+      "id": "feature-925",
       "query": "lynx-api/lynx/animateAPI.compat",
       "name": "Used to import modules.",
       "category": "lynx-api/lynx",
@@ -95968,7 +96133,7 @@
       }
     },
     {
-      "id": "feature-925",
+      "id": "feature-926",
       "query": "lynx-api/lynx/animateAPI.multiple animation implementation",
       "name": "Multiple animate",
       "category": "lynx-api/lynx",
@@ -96004,7 +96169,7 @@
       }
     },
     {
-      "id": "feature-926",
+      "id": "feature-927",
       "query": "lynx-api/lynx/cancelAnimationFrame",
       "name": "Cancel a `requestAnimationFrame` callback.",
       "category": "lynx-api/lynx",
@@ -96040,7 +96205,7 @@
       }
     },
     {
-      "id": "feature-927",
+      "id": "feature-928",
       "query": "lynx-api/lynx/cancelResourcePrefetch",
       "name": "Used to cancel the prefetch of resource.",
       "category": "lynx-api/lynx",
@@ -96076,7 +96241,7 @@
       }
     },
     {
-      "id": "feature-928",
+      "id": "feature-929",
       "query": "lynx-api/lynx/createIntersectionObserver",
       "name": "Create an IntersectionObserver object.",
       "category": "lynx-api/lynx",
@@ -96112,7 +96277,7 @@
       }
     },
     {
-      "id": "feature-929",
+      "id": "feature-930",
       "query": "lynx-api/lynx/createSelectorQuery",
       "name": " Create a `SelectorQuery` with the root node of the page as the root.",
       "category": "lynx-api/lynx",
@@ -96148,7 +96313,7 @@
       }
     },
     {
-      "id": "feature-930",
+      "id": "feature-931",
       "query": "lynx-api/lynx/getElementById",
       "name": "Used to import modules.",
       "category": "lynx-api/lynx",
@@ -96184,7 +96349,7 @@
       }
     },
     {
-      "id": "feature-931",
+      "id": "feature-932",
       "query": "lynx-api/lynx/getJSModule",
       "name": "getJSModule",
       "category": "lynx-api/lynx",
@@ -96220,7 +96385,7 @@
       }
     },
     {
-      "id": "feature-932",
+      "id": "feature-933",
       "query": "lynx-api/lynx/getSessionStorageItem",
       "name": "The `lynx.getSessionStorageItem` method is used to retrieve data shared across multiple LynxViews. This enables data sharing between multiple pages via `SessionStorage`. You can call [lynx.setSessionStorageItem](./lynx-set-session-storage.mdx) to set the cached data.",
       "category": "lynx-api/lynx",
@@ -96256,7 +96421,7 @@
       }
     },
     {
-      "id": "feature-933",
+      "id": "feature-934",
       "query": "lynx-api/lynx/getSharedData",
       "name": "Get the shared data set by `lynx.setSharedData()` used on pages belonging to the same LynxGroup.",
       "category": "lynx-api/lynx",
@@ -96292,7 +96457,7 @@
       }
     },
     {
-      "id": "feature-934",
+      "id": "feature-935",
       "query": "lynx-api/lynx/getTextInfo",
       "name": "Used to measure the width of text content.",
       "category": "lynx-api/lynx",
@@ -96328,7 +96493,7 @@
       }
     },
     {
-      "id": "feature-935",
+      "id": "feature-936",
       "query": "lynx-api/lynx/globalProps",
       "name": "global data set by client.",
       "category": "lynx-api/lynx",
@@ -96364,7 +96529,7 @@
       }
     },
     {
-      "id": "feature-936",
+      "id": "feature-937",
       "query": "lynx-api/lynx/lynx-before-publish-event/BeforePublishEvent",
       "name": "Used to register/remove monitoring of an element event",
       "category": "lynx-api/lynx",
@@ -96400,7 +96565,7 @@
       }
     },
     {
-      "id": "feature-937",
+      "id": "feature-938",
       "query": "lynx-api/lynx/lynx-before-publish-event/BeforePublishEvent.add",
       "name": "Register to listen for an element event.",
       "category": "lynx-api/lynx",
@@ -96436,7 +96601,7 @@
       }
     },
     {
-      "id": "feature-938",
+      "id": "feature-939",
       "query": "lynx-api/lynx/lynx-before-publish-event/BeforePublishEvent.remove",
       "name": "Remove monitoring of an element event.",
       "category": "lynx-api/lynx",
@@ -96472,7 +96637,7 @@
       }
     },
     {
-      "id": "feature-939",
+      "id": "feature-940",
       "query": "lynx-api/lynx/lynx-before-publish-event/add",
       "name": "Register to listen for an element event.",
       "category": "lynx-api/lynx",
@@ -96508,7 +96673,7 @@
       }
     },
     {
-      "id": "feature-940",
+      "id": "feature-941",
       "query": "lynx-api/lynx/lynx-before-publish-event/remove",
       "name": "Remove monitoring of an element event.",
       "category": "lynx-api/lynx",
@@ -96544,7 +96709,7 @@
       }
     },
     {
-      "id": "feature-941",
+      "id": "feature-942",
       "query": "lynx-api/lynx/performance.lynx.performance",
       "name": "performance",
       "category": "lynx-api/lynx",
@@ -96580,7 +96745,7 @@
       }
     },
     {
-      "id": "feature-942",
+      "id": "feature-943",
       "query": "lynx-api/lynx/performance.createObserver()",
       "name": "createObserver()",
       "category": "lynx-api/lynx",
@@ -96616,7 +96781,7 @@
       }
     },
     {
-      "id": "feature-943",
+      "id": "feature-944",
       "query": "lynx-api/lynx/performance.profileStart()",
       "name": "profileStart()",
       "category": "lynx-api/lynx",
@@ -96652,7 +96817,7 @@
       }
     },
     {
-      "id": "feature-944",
+      "id": "feature-945",
       "query": "lynx-api/lynx/performance.profileEnd()",
       "name": "profileEnd()",
       "category": "lynx-api/lynx",
@@ -96688,7 +96853,7 @@
       }
     },
     {
-      "id": "feature-945",
+      "id": "feature-946",
       "query": "lynx-api/lynx/performance.profileMark()",
       "name": "profileMark()",
       "category": "lynx-api/lynx",
@@ -96724,7 +96889,7 @@
       }
     },
     {
-      "id": "feature-946",
+      "id": "feature-947",
       "query": "lynx-api/lynx/performance.profileFlowId()",
       "name": "profileFlowId()",
       "category": "lynx-api/lynx",
@@ -96760,7 +96925,7 @@
       }
     },
     {
-      "id": "feature-947",
+      "id": "feature-948",
       "query": "lynx-api/lynx/performance.isProfileRecording()",
       "name": "isProfileRecording()",
       "category": "lynx-api/lynx",
@@ -96796,7 +96961,7 @@
       }
     },
     {
-      "id": "feature-948",
+      "id": "feature-949",
       "query": "lynx-api/lynx/querySelector",
       "name": "querySelector",
       "category": "lynx-api/lynx",
@@ -96832,7 +96997,7 @@
       }
     },
     {
-      "id": "feature-949",
+      "id": "feature-950",
       "query": "lynx-api/lynx/querySelectorAll",
       "name": "querySelectorAll",
       "category": "lynx-api/lynx",
@@ -96868,7 +97033,7 @@
       }
     },
     {
-      "id": "feature-950",
+      "id": "feature-951",
       "query": "lynx-api/lynx/queueMicrotask",
       "name": "insert a task into microtask queue",
       "category": "lynx-api/lynx",
@@ -96904,7 +97069,7 @@
       }
     },
     {
-      "id": "feature-951",
+      "id": "feature-952",
       "query": "lynx-api/lynx/registerModule",
       "name": "registerModule",
       "category": "lynx-api/lynx",
@@ -96940,7 +97105,7 @@
       }
     },
     {
-      "id": "feature-952",
+      "id": "feature-953",
       "query": "lynx-api/lynx/registerSharedDataObserver",
       "name": "Listen for shared data updates initiated by `lynx.setSharedData()` within pages in the same LynxGroup.",
       "category": "lynx-api/lynx",
@@ -96976,7 +97141,7 @@
       }
     },
     {
-      "id": "feature-953",
+      "id": "feature-954",
       "query": "lynx-api/lynx/reload",
       "name": "Reloads the current page, like the Refresh button.",
       "category": "lynx-api/lynx",
@@ -97012,7 +97177,7 @@
       }
     },
     {
-      "id": "feature-954",
+      "id": "feature-955",
       "query": "lynx-api/lynx/removeSharedDataObserver",
       "name": "取消使用 `lynx.registerSharedDataObserver()` 进行的监听。",
       "category": "lynx-api/lynx",
@@ -97048,7 +97213,7 @@
       }
     },
     {
-      "id": "feature-955",
+      "id": "feature-956",
       "query": "lynx-api/lynx/reportError",
       "name": "Used to report a JavaScript Error.",
       "category": "lynx-api/lynx",
@@ -97084,7 +97249,7 @@
       }
     },
     {
-      "id": "feature-956",
+      "id": "feature-957",
       "query": "lynx-api/lynx/requestAnimationFrame",
       "name": "Invoke the specified callback function at the next VSYNC.",
       "category": "lynx-api/lynx",
@@ -97120,7 +97285,7 @@
       }
     },
     {
-      "id": "feature-957",
+      "id": "feature-958",
       "query": "lynx-api/lynx/requestResourcePrefetch",
       "name": "Used to request the prefetch of resource.",
       "category": "lynx-api/lynx",
@@ -97156,7 +97321,7 @@
       }
     },
     {
-      "id": "feature-958",
+      "id": "feature-959",
       "query": "lynx-api/lynx/requireModule",
       "name": "Used to import modules and JSON.",
       "category": "lynx-api/lynx",
@@ -97192,7 +97357,7 @@
       }
     },
     {
-      "id": "feature-959",
+      "id": "feature-960",
       "query": "lynx-api/lynx/requireModuleAsync",
       "name": "Used to import modules.",
       "category": "lynx-api/lynx",
@@ -97228,7 +97393,7 @@
       }
     },
     {
-      "id": "feature-960",
+      "id": "feature-961",
       "query": "lynx-api/lynx/resumeExposure",
       "name": "Turn on exposure detection, that is, to restart the detection of the visibility of the target node, and subsequently trigger the exposure/anti-exposure event normally.",
       "category": "lynx-api/lynx",
@@ -97264,7 +97429,7 @@
       }
     },
     {
-      "id": "feature-961",
+      "id": "feature-962",
       "query": "lynx-api/lynx/setObserverFrameRate",
       "name": "Set the frequency of exposure detection.",
       "category": "lynx-api/lynx",
@@ -97300,7 +97465,7 @@
       }
     },
     {
-      "id": "feature-962",
+      "id": "feature-963",
       "query": "lynx-api/lynx/setSessionStorageItem",
       "name": "The `lynx.setSessionStorageItem` method is used to set data shared across multiple LynxViews.",
       "category": "lynx-api/lynx",
@@ -97336,7 +97501,7 @@
       }
     },
     {
-      "id": "feature-963",
+      "id": "feature-964",
       "query": "lynx-api/lynx/setSharedData",
       "name": "设置同 LynxGroup 的页面间的共享数据。",
       "category": "lynx-api/lynx",
@@ -97372,7 +97537,7 @@
       }
     },
     {
-      "id": "feature-964",
+      "id": "feature-965",
       "query": "lynx-api/lynx/stopExposure",
       "name": "Stop exposure detection, that is, the visibility of the target node will no longer be detected, and exposure/anti-exposure events will no longer be triggered in the future.",
       "category": "lynx-api/lynx",
@@ -97408,7 +97573,7 @@
       }
     },
     {
-      "id": "feature-965",
+      "id": "feature-966",
       "query": "lynx-api/lynx/subscribeSessionStorage",
       "name": "The `lynx.subscribeSessionStorage` method is used to listen for changes in data shared across multiple LynxViews. This enables data sharing between multiple pages via `SessionStorage`. You can call [lynx.setSessionStorageItem](./lynx-set-session-storage.mdx) to set the cached data.",
       "category": "lynx-api/lynx",
@@ -97444,7 +97609,7 @@
       }
     },
     {
-      "id": "feature-966",
+      "id": "feature-967",
       "query": "lynx-api/lynx/unsubscribeSessionStorage",
       "name": "The `lynx.unsubscribeSessionStorage` method is used to cancel the listener for changes in data shared across multiple LynxViews. This enables data sharing between multiple pages via `SessionStorage`. You can call [lynx.setSessionStorageItem](./lynx-set-session-storage.mdx) to set the cached data. After cancellation, the cached data corresponding to this key will no longer be listened to.",
       "category": "lynx-api/lynx",
@@ -97480,7 +97645,7 @@
       }
     },
     {
-      "id": "feature-967",
+      "id": "feature-968",
       "query": "lynx-api/selector-query/SelectorQuery",
       "name": "Gets a reference to the specified node in order to call its methods or get its properties.",
       "category": "lynx-api/selector-query",
@@ -97516,7 +97681,7 @@
       }
     },
     {
-      "id": "feature-968",
+      "id": "feature-969",
       "query": "lynx-api/selector-query/SelectorQuery.`exec`",
       "name": "Execute all submitted operations.",
       "category": "lynx-api/selector-query",
@@ -97552,7 +97717,7 @@
       }
     },
     {
-      "id": "feature-969",
+      "id": "feature-970",
       "query": "lynx-api/selector-query/SelectorQuery.`select`",
       "name": "Select the first node that matches the specified selector in the descendants of the root node specified in `SelectorQuery`.",
       "category": "lynx-api/selector-query",
@@ -97588,7 +97753,7 @@
       }
     },
     {
-      "id": "feature-970",
+      "id": "feature-971",
       "query": "lynx-api/selector-query/SelectorQuery.`selectAll`",
       "name": "Select all nodes that match the specified CSS selector under the root node specified by `SelectorQuery`.",
       "category": "lynx-api/selector-query",
@@ -97624,7 +97789,7 @@
       }
     },
     {
-      "id": "feature-971",
+      "id": "feature-972",
       "query": "lynx-api/selector-query/SelectorQuery.`selectRoot`",
       "name": "Select the root node specified by `SelectorQuery`.",
       "category": "lynx-api/selector-query",
@@ -97660,7 +97825,7 @@
       }
     },
     {
-      "id": "feature-972",
+      "id": "feature-973",
       "query": "lynx-api/selector-query/SelectorQuery.`selectUniqueID`",
       "name": "Select nodes by specifying `uid`.",
       "category": "lynx-api/selector-query",
@@ -97696,7 +97861,7 @@
       }
     },
     {
-      "id": "feature-973",
+      "id": "feature-974",
       "query": "lynx-api/selector-query/exec",
       "name": "Execute all submitted operations.",
       "category": "lynx-api/selector-query",
@@ -97732,7 +97897,7 @@
       }
     },
     {
-      "id": "feature-974",
+      "id": "feature-975",
       "query": "lynx-api/selector-query/select",
       "name": "Select the first node that matches the specified selector in the descendants of the root node specified in `SelectorQuery`.",
       "category": "lynx-api/selector-query",
@@ -97768,7 +97933,7 @@
       }
     },
     {
-      "id": "feature-975",
+      "id": "feature-976",
       "query": "lynx-api/selector-query/select.`selector` parameter supporting `tag` selector",
       "name": "`selector` parameter supporting `tag` selector.",
       "category": "lynx-api/selector-query",
@@ -97804,7 +97969,7 @@
       }
     },
     {
-      "id": "feature-976",
+      "id": "feature-977",
       "query": "lynx-api/selector-query/select.`selector` parameter supporting `attribute` selector `[attr]`, `[attr=value]",
       "name": "`selector` parameter supporting `attribute` selector `[attr]`, `[attr=value].",
       "category": "lynx-api/selector-query",
@@ -97840,7 +98005,7 @@
       }
     },
     {
-      "id": "feature-977",
+      "id": "feature-978",
       "query": "lynx-api/selector-query/select.`selector` parameter supporting `attribute` selector `[attr*=value]`, `[attr^=value]`, `[attr$=value]`",
       "name": "`selector` parameter supporting `attribute` selector `[attr*=value]`, `[attr^=value]`, `[attr$=value]`.",
       "category": "lynx-api/selector-query",
@@ -97876,7 +98041,7 @@
       }
     },
     {
-      "id": "feature-978",
+      "id": "feature-979",
       "query": "lynx-api/selector-query/selectAll",
       "name": "Select all nodes that match the specified CSS selector under the root node specified by `SelectorQuery`.",
       "category": "lynx-api/selector-query",
@@ -97912,7 +98077,7 @@
       }
     },
     {
-      "id": "feature-979",
+      "id": "feature-980",
       "query": "lynx-api/selector-query/selectRoot",
       "name": "Select the root node specified by `SelectorQuery`.",
       "category": "lynx-api/selector-query",
@@ -97948,7 +98113,7 @@
       }
     },
     {
-      "id": "feature-980",
+      "id": "feature-981",
       "query": "lynx-api/selector-query/selectUniqueID",
       "name": "Select nodes by specifying `uid`.",
       "category": "lynx-api/selector-query",
@@ -97984,7 +98149,7 @@
       }
     },
     {
-      "id": "feature-981",
+      "id": "feature-982",
       "query": "lynx-api/nodes-ref/NodesRef",
       "name": "Represents a reference to one or more UI nodes. It can be used to call methods, get and set properties on UI nodes.",
       "category": "lynx-api/nodes-ref",
@@ -98020,7 +98185,7 @@
       }
     },
     {
-      "id": "feature-982",
+      "id": "feature-983",
       "query": "lynx-api/nodes-ref/NodesRef.`fields`",
       "name": "Query the attributes of the selected node.",
       "category": "lynx-api/nodes-ref",
@@ -98056,7 +98221,7 @@
       }
     },
     {
-      "id": "feature-983",
+      "id": "feature-984",
       "query": "lynx-api/nodes-ref/NodesRef.`invoke`",
       "name": "Execute the UI method of the selected node.",
       "category": "lynx-api/nodes-ref",
@@ -98092,7 +98257,7 @@
       }
     },
     {
-      "id": "feature-984",
+      "id": "feature-985",
       "query": "lynx-api/nodes-ref/NodesRef.`path`",
       "name": "Query the path information from the node to the root node of the page.",
       "category": "lynx-api/nodes-ref",
@@ -98128,7 +98293,7 @@
       }
     },
     {
-      "id": "feature-985",
+      "id": "feature-986",
       "query": "lynx-api/nodes-ref/NodesRef.`setNativeProps`",
       "name": "Directly set the attributes of the selected node.",
       "category": "lynx-api/nodes-ref",
@@ -98164,7 +98329,7 @@
       }
     },
     {
-      "id": "feature-986",
+      "id": "feature-987",
       "query": "lynx-api/nodes-ref/fields",
       "name": "Query the attributes of the selected node.",
       "category": "lynx-api/nodes-ref",
@@ -98200,7 +98365,7 @@
       }
     },
     {
-      "id": "feature-987",
+      "id": "feature-988",
       "query": "lynx-api/nodes-ref/fields.`fields` parameter supporting the `attribute` property",
       "name": "`fields` parameter supporting the `attribute` property.",
       "category": "lynx-api/nodes-ref",
@@ -98236,7 +98401,7 @@
       }
     },
     {
-      "id": "feature-988",
+      "id": "feature-989",
       "query": "lynx-api/nodes-ref/invoke",
       "name": "Execute the UI method of the selected node.",
       "category": "lynx-api/nodes-ref",
@@ -98272,7 +98437,7 @@
       }
     },
     {
-      "id": "feature-989",
+      "id": "feature-990",
       "query": "lynx-api/nodes-ref/path",
       "name": "Query the path information from the node to the root node of the page.",
       "category": "lynx-api/nodes-ref",
@@ -98308,7 +98473,7 @@
       }
     },
     {
-      "id": "feature-990",
+      "id": "feature-991",
       "query": "lynx-api/nodes-ref/setNativeProps",
       "name": "Directly set the attributes of the selected node.",
       "category": "lynx-api/nodes-ref",
@@ -98344,7 +98509,7 @@
       }
     },
     {
-      "id": "feature-991",
+      "id": "feature-992",
       "query": "lynx-api/intersection-observer/IntersectionObserver",
       "name": "Observe the intersection status between the target node and the reference node and the target node and the ancestor node. When the intersection status changes, the corresponding callback is triggered. Based on this, you can monitor whether the target node is exposed/de-exposed.",
       "category": "lynx-api/intersection-observer",
@@ -98380,7 +98545,7 @@
       }
     },
     {
-      "id": "feature-992",
+      "id": "feature-993",
       "query": "lynx-api/intersection-observer/IntersectionObserver.relativeTo",
       "name": "Specify a reference node. The reference node is specified by id.",
       "category": "lynx-api/intersection-observer",
@@ -98416,7 +98581,7 @@
       }
     },
     {
-      "id": "feature-993",
+      "id": "feature-994",
       "query": "lynx-api/intersection-observer/IntersectionObserver.relativeToViewport",
       "name": "Specify a LynxView as a reference node.",
       "category": "lynx-api/intersection-observer",
@@ -98452,7 +98617,7 @@
       }
     },
     {
-      "id": "feature-994",
+      "id": "feature-995",
       "query": "lynx-api/intersection-observer/IntersectionObserver.relativeToScreen",
       "name": "Specify the screen as the reference node.",
       "category": "lynx-api/intersection-observer",
@@ -98488,7 +98653,7 @@
       }
     },
     {
-      "id": "feature-995",
+      "id": "feature-996",
       "query": "lynx-api/intersection-observer/IntersectionObserver.observe",
       "name": "Specify the target node and callback, and the target node is specified according to id.",
       "category": "lynx-api/intersection-observer",
@@ -98524,7 +98689,7 @@
       }
     },
     {
-      "id": "feature-996",
+      "id": "feature-997",
       "query": "lynx-api/intersection-observer/IntersectionObserver.disconnect",
       "name": "Clear the target node and callback. The target node will no longer be observed and the corresponding callback will not be triggered.",
       "category": "lynx-api/intersection-observer",
@@ -98560,7 +98725,7 @@
       }
     },
     {
-      "id": "feature-997",
+      "id": "feature-998",
       "query": "lynx-api/intersection-observer/disconnect",
       "name": "Clear the target node and callback. The target node will no longer be observed and the corresponding callback will not be triggered.",
       "category": "lynx-api/intersection-observer",
@@ -98596,7 +98761,7 @@
       }
     },
     {
-      "id": "feature-998",
+      "id": "feature-999",
       "query": "lynx-api/intersection-observer/observe",
       "name": "Specify the target node and callback, and the target node is specified according to id.",
       "category": "lynx-api/intersection-observer",
@@ -98632,7 +98797,7 @@
       }
     },
     {
-      "id": "feature-999",
+      "id": "feature-1000",
       "query": "lynx-api/intersection-observer/relativeTo",
       "name": "Specify a reference node. The reference node is specified by id.",
       "category": "lynx-api/intersection-observer",
@@ -98668,7 +98833,7 @@
       }
     },
     {
-      "id": "feature-1000",
+      "id": "feature-1001",
       "query": "lynx-api/intersection-observer/relativeToScreen",
       "name": "Specify the screen as the reference node.",
       "category": "lynx-api/intersection-observer",
@@ -98704,7 +98869,7 @@
       }
     },
     {
-      "id": "feature-1001",
+      "id": "feature-1002",
       "query": "lynx-api/intersection-observer/relativeToViewport",
       "name": "Specify a LynxView as a reference node.",
       "category": "lynx-api/intersection-observer",
@@ -98740,7 +98905,7 @@
       }
     },
     {
-      "id": "feature-1002",
+      "id": "feature-1003",
       "query": "lynx-api/main-thread/Element",
       "name": "Represents an element in the main thread.",
       "category": "lynx-api/main-thread",
@@ -98776,7 +98941,7 @@
       }
     },
     {
-      "id": "feature-1003",
+      "id": "feature-1004",
       "query": "lynx-api/main-thread/Element.Element.animate",
       "name": "animate",
       "category": "lynx-api/main-thread",
@@ -98812,7 +98977,7 @@
       }
     },
     {
-      "id": "feature-1004",
+      "id": "feature-1005",
       "query": "lynx-api/main-thread/Element.Element.getComputedStyleProperty",
       "name": "getComputedStyleProperty",
       "category": "lynx-api/main-thread",
@@ -98848,7 +99013,7 @@
       }
     },
     {
-      "id": "feature-1005",
+      "id": "feature-1006",
       "query": "lynx-api/main-thread/ElementAnimate",
       "name": "Create An Animation in MTS",
       "category": "lynx-api/main-thread",
@@ -98884,7 +99049,7 @@
       }
     },
     {
-      "id": "feature-1006",
+      "id": "feature-1007",
       "query": "lynx-api/main-thread/ElementAnimate.Animation.play()",
       "name": "play()",
       "category": "lynx-api/main-thread",
@@ -98920,7 +99085,7 @@
       }
     },
     {
-      "id": "feature-1007",
+      "id": "feature-1008",
       "query": "lynx-api/main-thread/ElementAnimate.Animation.pause()",
       "name": "pause()",
       "category": "lynx-api/main-thread",
@@ -98956,7 +99121,7 @@
       }
     },
     {
-      "id": "feature-1008",
+      "id": "feature-1009",
       "query": "lynx-api/main-thread/ElementAnimate.Animation.cancel()",
       "name": "cancel()",
       "category": "lynx-api/main-thread",
@@ -98992,7 +99157,7 @@
       }
     },
     {
-      "id": "feature-1009",
+      "id": "feature-1010",
       "query": "lynx-api/main-thread/ElementAnimate.Animation.finish()",
       "name": "finish()",
       "category": "lynx-api/main-thread",
@@ -99028,7 +99193,7 @@
       }
     },
     {
-      "id": "feature-1010",
+      "id": "feature-1011",
       "query": "lynx-api/main-thread/ElementGetComputedStyle",
       "name": "Create An Animation in MTS",
       "category": "lynx-api/main-thread",
@@ -99064,7 +99229,7 @@
       }
     },
     {
-      "id": "feature-1011",
+      "id": "feature-1012",
       "query": "lynx-api/main-thread/MainThread-APIs",
       "name": "APIs available on the main thread.",
       "category": "lynx-api/main-thread",
@@ -99100,7 +99265,7 @@
       }
     },
     {
-      "id": "feature-1012",
+      "id": "feature-1013",
       "query": "lynx-api/main-thread/MainThread-APIs.Element",
       "name": "Element",
       "category": "lynx-api/main-thread",
@@ -99136,7 +99301,7 @@
       }
     },
     {
-      "id": "feature-1013",
+      "id": "feature-1014",
       "query": "lynx-api/main-thread/MainThread-APIs.Element.animate",
       "name": "animate",
       "category": "lynx-api/main-thread",
@@ -99172,7 +99337,7 @@
       }
     },
     {
-      "id": "feature-1014",
+      "id": "feature-1015",
       "query": "lynx-api/main-thread/MainThread-APIs.Element.getComputedStyleProperty",
       "name": "getComputedStyleProperty",
       "category": "lynx-api/main-thread",
@@ -99208,7 +99373,7 @@
       }
     },
     {
-      "id": "feature-1015",
+      "id": "feature-1016",
       "query": "lynx-api/main-thread/MainThread-APIs.lynx.getTextInfo",
       "name": "getTextInfo",
       "category": "lynx-api/main-thread",
@@ -99244,7 +99409,7 @@
       }
     },
     {
-      "id": "feature-1016",
+      "id": "feature-1017",
       "query": "lynx-api/main-thread/MainThread-APIs.lynx.querySelector",
       "name": "querySelector",
       "category": "lynx-api/main-thread",
@@ -99280,7 +99445,7 @@
       }
     },
     {
-      "id": "feature-1017",
+      "id": "feature-1018",
       "query": "lynx-api/main-thread/MainThread-APIs.lynx.querySelectorAll",
       "name": "querySelectorAll",
       "category": "lynx-api/main-thread",
@@ -99316,7 +99481,7 @@
       }
     },
     {
-      "id": "feature-1018",
+      "id": "feature-1019",
       "query": "lynx-api/main-thread/MainThread-APIs.lynx.requestAnimationFrame",
       "name": "requestAnimationFrame",
       "category": "lynx-api/main-thread",
@@ -99352,7 +99517,7 @@
       }
     },
     {
-      "id": "feature-1019",
+      "id": "feature-1020",
       "query": "lynx-api/main-thread/MainThread-APIs.lynx.__globalProps",
       "name": "__globalProps",
       "category": "lynx-api/main-thread",
@@ -99388,7 +99553,7 @@
       }
     },
     {
-      "id": "feature-1020",
+      "id": "feature-1021",
       "query": "lynx-api/performance-api/framework-pipeline-timing",
       "name": "framework-pipeline-timing",
       "category": "lynx-api/performance-api",
@@ -99424,7 +99589,7 @@
       }
     },
     {
-      "id": "feature-1021",
+      "id": "feature-1022",
       "query": "lynx-api/performance-api/host-platform-timing/android-host-platform-timing",
       "name": "android-host-platform-timing",
       "category": "lynx-api/performance-api",
@@ -99460,7 +99625,7 @@
       }
     },
     {
-      "id": "feature-1022",
+      "id": "feature-1023",
       "query": "lynx-api/performance-api/host-platform-timing/harmony-host-platform-timing",
       "name": "harmony-host-platform-timing",
       "category": "lynx-api/performance-api",
@@ -99496,7 +99661,7 @@
       }
     },
     {
-      "id": "feature-1023",
+      "id": "feature-1024",
       "query": "lynx-api/performance-api/host-platform-timing/ios-host-platform-timing",
       "name": "ios-host-platform-timing",
       "category": "lynx-api/performance-api",
@@ -99532,7 +99697,7 @@
       }
     },
     {
-      "id": "feature-1024",
+      "id": "feature-1025",
       "query": "lynx-api/performance-api/performance-entry/entry-type",
       "name": "entry-type",
       "category": "lynx-api/performance-api",
@@ -99568,7 +99733,7 @@
       }
     },
     {
-      "id": "feature-1025",
+      "id": "feature-1026",
       "query": "lynx-api/performance-api/performance-entry/init-background-runtime-entry",
       "name": "Entry for background runtime initialization performance data.",
       "category": "lynx-api/performance-api",
@@ -99604,7 +99769,7 @@
       }
     },
     {
-      "id": "feature-1026",
+      "id": "feature-1027",
       "query": "lynx-api/performance-api/performance-entry/init-container-entry",
       "name": "init-container-entry",
       "category": "lynx-api/performance-api",
@@ -99640,7 +99805,7 @@
       }
     },
     {
-      "id": "feature-1027",
+      "id": "feature-1028",
       "query": "lynx-api/performance-api/performance-entry/init-lynxview-entry",
       "name": "init-lynxview-entry",
       "category": "lynx-api/performance-api",
@@ -99676,7 +99841,7 @@
       }
     },
     {
-      "id": "feature-1028",
+      "id": "feature-1029",
       "query": "lynx-api/performance-api/performance-entry/lazy-bundle-entry",
       "name": "lazy-bundle-entry",
       "category": "lynx-api/performance-api",
@@ -99712,7 +99877,7 @@
       }
     },
     {
-      "id": "feature-1029",
+      "id": "feature-1030",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry",
       "name": "load-bundle-entry",
       "category": "lynx-api/performance-api",
@@ -99748,7 +99913,7 @@
       }
     },
     {
-      "id": "feature-1030",
+      "id": "feature-1031",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.entryType",
       "name": "entryType",
       "category": "lynx-api/performance-api",
@@ -99784,7 +99949,7 @@
       }
     },
     {
-      "id": "feature-1031",
+      "id": "feature-1032",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.name",
       "name": "name",
       "category": "lynx-api/performance-api",
@@ -99820,7 +99985,7 @@
       }
     },
     {
-      "id": "feature-1032",
+      "id": "feature-1033",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.identifier",
       "name": "identifier",
       "category": "lynx-api/performance-api",
@@ -99856,7 +100021,7 @@
       }
     },
     {
-      "id": "feature-1033",
+      "id": "feature-1034",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.loadBundleStart",
       "name": "loadBundleStart",
       "category": "lynx-api/performance-api",
@@ -99892,7 +100057,7 @@
       }
     },
     {
-      "id": "feature-1034",
+      "id": "feature-1035",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.loadBundleEnd",
       "name": "loadBundleEnd",
       "category": "lynx-api/performance-api",
@@ -99928,7 +100093,7 @@
       }
     },
     {
-      "id": "feature-1035",
+      "id": "feature-1036",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.parseStart",
       "name": "parseStart",
       "category": "lynx-api/performance-api",
@@ -99964,7 +100129,7 @@
       }
     },
     {
-      "id": "feature-1036",
+      "id": "feature-1037",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.parseEnd",
       "name": "parseEnd",
       "category": "lynx-api/performance-api",
@@ -100000,7 +100165,7 @@
       }
     },
     {
-      "id": "feature-1037",
+      "id": "feature-1038",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.loadBackgroundStart",
       "name": "loadBackgroundStart",
       "category": "lynx-api/performance-api",
@@ -100036,7 +100201,7 @@
       }
     },
     {
-      "id": "feature-1038",
+      "id": "feature-1039",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.loadBackgroundEnd",
       "name": "loadBackgroundEnd",
       "category": "lynx-api/performance-api",
@@ -100072,7 +100237,7 @@
       }
     },
     {
-      "id": "feature-1039",
+      "id": "feature-1040",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.pipelineStart",
       "name": "pipelineStart",
       "category": "lynx-api/performance-api",
@@ -100108,7 +100273,7 @@
       }
     },
     {
-      "id": "feature-1040",
+      "id": "feature-1041",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.pipelineEnd",
       "name": "pipelineEnd",
       "category": "lynx-api/performance-api",
@@ -100144,7 +100309,7 @@
       }
     },
     {
-      "id": "feature-1041",
+      "id": "feature-1042",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.mtsRenderStart",
       "name": "mtsRenderStart",
       "category": "lynx-api/performance-api",
@@ -100180,7 +100345,7 @@
       }
     },
     {
-      "id": "feature-1042",
+      "id": "feature-1043",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.mtsRenderEnd",
       "name": "mtsRenderEnd",
       "category": "lynx-api/performance-api",
@@ -100216,7 +100381,7 @@
       }
     },
     {
-      "id": "feature-1043",
+      "id": "feature-1044",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.resolveStart",
       "name": "resolveStart",
       "category": "lynx-api/performance-api",
@@ -100252,7 +100417,7 @@
       }
     },
     {
-      "id": "feature-1044",
+      "id": "feature-1045",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.resolveEnd",
       "name": "resolveEnd",
       "category": "lynx-api/performance-api",
@@ -100288,7 +100453,7 @@
       }
     },
     {
-      "id": "feature-1045",
+      "id": "feature-1046",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.layoutStart",
       "name": "layoutStart",
       "category": "lynx-api/performance-api",
@@ -100324,7 +100489,7 @@
       }
     },
     {
-      "id": "feature-1046",
+      "id": "feature-1047",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.paintingUiOperationExecuteEnd",
       "name": "paintingUiOperationExecuteEnd",
       "category": "lynx-api/performance-api",
@@ -100360,7 +100525,7 @@
       }
     },
     {
-      "id": "feature-1047",
+      "id": "feature-1048",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.layoutUiOperationExecuteStart",
       "name": "layoutUiOperationExecuteStart",
       "category": "lynx-api/performance-api",
@@ -100396,7 +100561,7 @@
       }
     },
     {
-      "id": "feature-1048",
+      "id": "feature-1049",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.layoutUiOperationExecuteEnd",
       "name": "layoutUiOperationExecuteEnd",
       "category": "lynx-api/performance-api",
@@ -100432,7 +100597,7 @@
       }
     },
     {
-      "id": "feature-1049",
+      "id": "feature-1050",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.paintEnd",
       "name": "paintEnd",
       "category": "lynx-api/performance-api",
@@ -100468,7 +100633,7 @@
       }
     },
     {
-      "id": "feature-1050",
+      "id": "feature-1051",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.frameworkPipelineTiming",
       "name": "frameworkPipelineTiming",
       "category": "lynx-api/performance-api",
@@ -100504,7 +100669,7 @@
       }
     },
     {
-      "id": "feature-1051",
+      "id": "feature-1052",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.loadCoreStart",
       "name": "loadCoreStart",
       "category": "lynx-api/performance-api",
@@ -100540,7 +100705,7 @@
       }
     },
     {
-      "id": "feature-1052",
+      "id": "feature-1053",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.loadCoreEnd",
       "name": "loadCoreEnd",
       "category": "lynx-api/performance-api",
@@ -100576,7 +100741,7 @@
       }
     },
     {
-      "id": "feature-1053",
+      "id": "feature-1054",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.openTime",
       "name": "openTime",
       "category": "lynx-api/performance-api",
@@ -100612,7 +100777,7 @@
       }
     },
     {
-      "id": "feature-1054",
+      "id": "feature-1055",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.containerInitStart",
       "name": "containerInitStart",
       "category": "lynx-api/performance-api",
@@ -100648,7 +100813,7 @@
       }
     },
     {
-      "id": "feature-1055",
+      "id": "feature-1056",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.containerInitEnd",
       "name": "containerInitEnd",
       "category": "lynx-api/performance-api",
@@ -100684,7 +100849,7 @@
       }
     },
     {
-      "id": "feature-1056",
+      "id": "feature-1057",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.prepareTemplateStart",
       "name": "prepareTemplateStart",
       "category": "lynx-api/performance-api",
@@ -100720,7 +100885,7 @@
       }
     },
     {
-      "id": "feature-1057",
+      "id": "feature-1058",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.prepareTemplateEnd",
       "name": "prepareTemplateEnd",
       "category": "lynx-api/performance-api",
@@ -100756,7 +100921,7 @@
       }
     },
     {
-      "id": "feature-1058",
+      "id": "feature-1059",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.createLynxStart",
       "name": "createLynxStart",
       "category": "lynx-api/performance-api",
@@ -100792,7 +100957,7 @@
       }
     },
     {
-      "id": "feature-1059",
+      "id": "feature-1060",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.createLynxEnd",
       "name": "createLynxEnd",
       "category": "lynx-api/performance-api",
@@ -100828,7 +100993,7 @@
       }
     },
     {
-      "id": "feature-1060",
+      "id": "feature-1061",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.fcp",
       "name": "fcp",
       "category": "lynx-api/performance-api",
@@ -100864,7 +101029,7 @@
       }
     },
     {
-      "id": "feature-1061",
+      "id": "feature-1062",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.lynxFcp",
       "name": "lynxFcp",
       "category": "lynx-api/performance-api",
@@ -100900,7 +101065,7 @@
       }
     },
     {
-      "id": "feature-1062",
+      "id": "feature-1063",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.totalFcp",
       "name": "totalFcp",
       "category": "lynx-api/performance-api",
@@ -100936,7 +101101,7 @@
       }
     },
     {
-      "id": "feature-1063",
+      "id": "feature-1064",
       "query": "lynx-api/performance-api/performance-entry/metric-actual-fmp-entry",
       "name": "metric-actual-fmp-entry",
       "category": "lynx-api/performance-api",
@@ -100972,7 +101137,7 @@
       }
     },
     {
-      "id": "feature-1064",
+      "id": "feature-1065",
       "query": "lynx-api/performance-api/performance-entry/metric-fcp-entry",
       "name": "metric-fcp-entry",
       "category": "lynx-api/performance-api",
@@ -101008,7 +101173,7 @@
       }
     },
     {
-      "id": "feature-1065",
+      "id": "feature-1066",
       "query": "lynx-api/performance-api/performance-entry/name",
       "name": "name",
       "category": "lynx-api/performance-api",
@@ -101044,7 +101209,7 @@
       }
     },
     {
-      "id": "feature-1066",
+      "id": "feature-1067",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry",
       "name": "pipeline-entry",
       "category": "lynx-api/performance-api",
@@ -101080,7 +101245,7 @@
       }
     },
     {
-      "id": "feature-1067",
+      "id": "feature-1068",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.entryType",
       "name": "entryType",
       "category": "lynx-api/performance-api",
@@ -101116,7 +101281,7 @@
       }
     },
     {
-      "id": "feature-1068",
+      "id": "feature-1069",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.name",
       "name": "name",
       "category": "lynx-api/performance-api",
@@ -101152,7 +101317,7 @@
       }
     },
     {
-      "id": "feature-1069",
+      "id": "feature-1070",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.identifier",
       "name": "identifier",
       "category": "lynx-api/performance-api",
@@ -101188,7 +101353,7 @@
       }
     },
     {
-      "id": "feature-1070",
+      "id": "feature-1071",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.pipelineStart",
       "name": "pipelineStart",
       "category": "lynx-api/performance-api",
@@ -101224,7 +101389,7 @@
       }
     },
     {
-      "id": "feature-1071",
+      "id": "feature-1072",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.pipelineEnd",
       "name": "pipelineEnd",
       "category": "lynx-api/performance-api",
@@ -101260,7 +101425,7 @@
       }
     },
     {
-      "id": "feature-1072",
+      "id": "feature-1073",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.mtsRenderStart",
       "name": "mtsRenderStart",
       "category": "lynx-api/performance-api",
@@ -101296,7 +101461,7 @@
       }
     },
     {
-      "id": "feature-1073",
+      "id": "feature-1074",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.mtsRenderEnd",
       "name": "mtsRenderEnd",
       "category": "lynx-api/performance-api",
@@ -101332,7 +101497,7 @@
       }
     },
     {
-      "id": "feature-1074",
+      "id": "feature-1075",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.resolveStart",
       "name": "resolveStart",
       "category": "lynx-api/performance-api",
@@ -101368,7 +101533,7 @@
       }
     },
     {
-      "id": "feature-1075",
+      "id": "feature-1076",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.resolveEnd",
       "name": "resolveEnd",
       "category": "lynx-api/performance-api",
@@ -101404,7 +101569,7 @@
       }
     },
     {
-      "id": "feature-1076",
+      "id": "feature-1077",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.layoutStart",
       "name": "layoutStart",
       "category": "lynx-api/performance-api",
@@ -101440,7 +101605,7 @@
       }
     },
     {
-      "id": "feature-1077",
+      "id": "feature-1078",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.paintingUiOperationExecuteEnd",
       "name": "paintingUiOperationExecuteEnd",
       "category": "lynx-api/performance-api",
@@ -101476,7 +101641,7 @@
       }
     },
     {
-      "id": "feature-1078",
+      "id": "feature-1079",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.layoutUiOperationExecuteStart",
       "name": "layoutUiOperationExecuteStart",
       "category": "lynx-api/performance-api",
@@ -101512,7 +101677,7 @@
       }
     },
     {
-      "id": "feature-1079",
+      "id": "feature-1080",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.layoutUiOperationExecuteEnd",
       "name": "layoutUiOperationExecuteEnd",
       "category": "lynx-api/performance-api",
@@ -101548,7 +101713,7 @@
       }
     },
     {
-      "id": "feature-1080",
+      "id": "feature-1081",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.paintEnd",
       "name": "paintEnd",
       "category": "lynx-api/performance-api",
@@ -101584,7 +101749,7 @@
       }
     },
     {
-      "id": "feature-1081",
+      "id": "feature-1082",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.frameworkPipelineTiming",
       "name": "frameworkPipelineTiming",
       "category": "lynx-api/performance-api",
@@ -101620,7 +101785,7 @@
       }
     },
     {
-      "id": "feature-1082",
+      "id": "feature-1083",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.hostPlatformTiming",
       "name": "hostPlatformTiming",
       "category": "lynx-api/performance-api",
@@ -101656,7 +101821,7 @@
       }
     },
     {
-      "id": "feature-1083",
+      "id": "feature-1084",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.actualFmp",
       "name": "actualFmp",
       "category": "lynx-api/performance-api",
@@ -101692,7 +101857,7 @@
       }
     },
     {
-      "id": "feature-1084",
+      "id": "feature-1085",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.lynxActualFmp",
       "name": "lynxActualFmp",
       "category": "lynx-api/performance-api",
@@ -101728,7 +101893,7 @@
       }
     },
     {
-      "id": "feature-1085",
+      "id": "feature-1086",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.totalActualFmp",
       "name": "totalActualFmp",
       "category": "lynx-api/performance-api",
@@ -101764,7 +101929,7 @@
       }
     },
     {
-      "id": "feature-1086",
+      "id": "feature-1087",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry",
       "name": "reload-bundle-entry",
       "category": "lynx-api/performance-api",
@@ -101800,7 +101965,7 @@
       }
     },
     {
-      "id": "feature-1087",
+      "id": "feature-1088",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.entryType",
       "name": "entryType",
       "category": "lynx-api/performance-api",
@@ -101836,7 +102001,7 @@
       }
     },
     {
-      "id": "feature-1088",
+      "id": "feature-1089",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.name",
       "name": "name",
       "category": "lynx-api/performance-api",
@@ -101872,7 +102037,7 @@
       }
     },
     {
-      "id": "feature-1089",
+      "id": "feature-1090",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.identifier",
       "name": "identifier",
       "category": "lynx-api/performance-api",
@@ -101908,7 +102073,7 @@
       }
     },
     {
-      "id": "feature-1090",
+      "id": "feature-1091",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.reloadBundleStart",
       "name": "reloadBundleStart",
       "category": "lynx-api/performance-api",
@@ -101944,7 +102109,7 @@
       }
     },
     {
-      "id": "feature-1091",
+      "id": "feature-1092",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.reloadBundleEnd",
       "name": "reloadBundleEnd",
       "category": "lynx-api/performance-api",
@@ -101980,7 +102145,7 @@
       }
     },
     {
-      "id": "feature-1092",
+      "id": "feature-1093",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.reloadBackgroundStart",
       "name": "reloadBackgroundStart",
       "category": "lynx-api/performance-api",
@@ -102016,7 +102181,7 @@
       }
     },
     {
-      "id": "feature-1093",
+      "id": "feature-1094",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.reloadBackgroundEnd",
       "name": "reloadBackgroundEnd",
       "category": "lynx-api/performance-api",
@@ -102052,7 +102217,7 @@
       }
     },
     {
-      "id": "feature-1094",
+      "id": "feature-1095",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.pipelineStart",
       "name": "pipelineStart",
       "category": "lynx-api/performance-api",
@@ -102088,7 +102253,7 @@
       }
     },
     {
-      "id": "feature-1095",
+      "id": "feature-1096",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.pipelineEnd",
       "name": "pipelineEnd",
       "category": "lynx-api/performance-api",
@@ -102124,7 +102289,7 @@
       }
     },
     {
-      "id": "feature-1096",
+      "id": "feature-1097",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.mtsRenderStart",
       "name": "mtsRenderStart",
       "category": "lynx-api/performance-api",
@@ -102160,7 +102325,7 @@
       }
     },
     {
-      "id": "feature-1097",
+      "id": "feature-1098",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.mtsRenderEnd",
       "name": "mtsRenderEnd",
       "category": "lynx-api/performance-api",
@@ -102196,7 +102361,7 @@
       }
     },
     {
-      "id": "feature-1098",
+      "id": "feature-1099",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.resolveStart",
       "name": "resolveStart",
       "category": "lynx-api/performance-api",
@@ -102232,7 +102397,7 @@
       }
     },
     {
-      "id": "feature-1099",
+      "id": "feature-1100",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.resolveEnd",
       "name": "resolveEnd",
       "category": "lynx-api/performance-api",
@@ -102268,7 +102433,7 @@
       }
     },
     {
-      "id": "feature-1100",
+      "id": "feature-1101",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.layoutStart",
       "name": "layoutStart",
       "category": "lynx-api/performance-api",
@@ -102304,7 +102469,7 @@
       }
     },
     {
-      "id": "feature-1101",
+      "id": "feature-1102",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.paintingUiOperationExecuteEnd",
       "name": "paintingUiOperationExecuteEnd",
       "category": "lynx-api/performance-api",
@@ -102340,7 +102505,7 @@
       }
     },
     {
-      "id": "feature-1102",
+      "id": "feature-1103",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.layoutUiOperationExecuteStart",
       "name": "layoutUiOperationExecuteStart",
       "category": "lynx-api/performance-api",
@@ -102376,7 +102541,7 @@
       }
     },
     {
-      "id": "feature-1103",
+      "id": "feature-1104",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.layoutUiOperationExecuteEnd",
       "name": "layoutUiOperationExecuteEnd",
       "category": "lynx-api/performance-api",
@@ -102412,7 +102577,7 @@
       }
     },
     {
-      "id": "feature-1104",
+      "id": "feature-1105",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.paintEnd",
       "name": "paintEnd",
       "category": "lynx-api/performance-api",
@@ -102448,7 +102613,7 @@
       }
     },
     {
-      "id": "feature-1105",
+      "id": "feature-1106",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.frameworkPipelineTiming",
       "name": "frameworkPipelineTiming",
       "category": "lynx-api/performance-api",
@@ -102484,7 +102649,7 @@
       }
     },
     {
-      "id": "feature-1106",
+      "id": "feature-1107",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.loadCoreStart",
       "name": "loadCoreStart",
       "category": "lynx-api/performance-api",
@@ -102520,7 +102685,7 @@
       }
     },
     {
-      "id": "feature-1107",
+      "id": "feature-1108",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.loadCoreEnd",
       "name": "loadCoreEnd",
       "category": "lynx-api/performance-api",
@@ -102556,7 +102721,7 @@
       }
     },
     {
-      "id": "feature-1108",
+      "id": "feature-1109",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.openTime",
       "name": "openTime",
       "category": "lynx-api/performance-api",
@@ -102592,7 +102757,7 @@
       }
     },
     {
-      "id": "feature-1109",
+      "id": "feature-1110",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.containerInitStart",
       "name": "containerInitStart",
       "category": "lynx-api/performance-api",
@@ -102628,7 +102793,7 @@
       }
     },
     {
-      "id": "feature-1110",
+      "id": "feature-1111",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.containerInitEnd",
       "name": "containerInitEnd",
       "category": "lynx-api/performance-api",
@@ -102664,7 +102829,7 @@
       }
     },
     {
-      "id": "feature-1111",
+      "id": "feature-1112",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.prepareTemplateStart",
       "name": "prepareTemplateStart",
       "category": "lynx-api/performance-api",
@@ -102700,7 +102865,7 @@
       }
     },
     {
-      "id": "feature-1112",
+      "id": "feature-1113",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.prepareTemplateEnd",
       "name": "prepareTemplateEnd",
       "category": "lynx-api/performance-api",
@@ -102736,7 +102901,7 @@
       }
     },
     {
-      "id": "feature-1113",
+      "id": "feature-1114",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.createLynxStart",
       "name": "createLynxStart",
       "category": "lynx-api/performance-api",
@@ -102772,7 +102937,7 @@
       }
     },
     {
-      "id": "feature-1114",
+      "id": "feature-1115",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.createLynxEnd",
       "name": "createLynxEnd",
       "category": "lynx-api/performance-api",
@@ -102808,7 +102973,7 @@
       }
     },
     {
-      "id": "feature-1115",
+      "id": "feature-1116",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.fcp",
       "name": "fcp",
       "category": "lynx-api/performance-api",
@@ -102844,7 +103009,7 @@
       }
     },
     {
-      "id": "feature-1116",
+      "id": "feature-1117",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.lynxFcp",
       "name": "lynxFcp",
       "category": "lynx-api/performance-api",
@@ -102880,7 +103045,7 @@
       }
     },
     {
-      "id": "feature-1117",
+      "id": "feature-1118",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.totalFcp",
       "name": "totalFcp",
       "category": "lynx-api/performance-api",
@@ -102916,7 +103081,7 @@
       }
     },
     {
-      "id": "feature-1118",
+      "id": "feature-1119",
       "query": "lynx-api/performance-api/performance-entry",
       "name": "performance-entry",
       "category": "lynx-api/performance-api",
@@ -102952,7 +103117,7 @@
       }
     },
     {
-      "id": "feature-1119",
+      "id": "feature-1120",
       "query": "lynx-api/performance-api/performance-metric",
       "name": "performance-metric",
       "category": "lynx-api/performance-api",
@@ -102988,7 +103153,7 @@
       }
     },
     {
-      "id": "feature-1120",
+      "id": "feature-1121",
       "query": "lynx-api/performance-api/performance-observer/disconnect",
       "name": "disconnect",
       "category": "lynx-api/performance-api",
@@ -103024,7 +103189,7 @@
       }
     },
     {
-      "id": "feature-1121",
+      "id": "feature-1122",
       "query": "lynx-api/performance-api/performance-observer/observe",
       "name": "observe",
       "category": "lynx-api/performance-api",
@@ -103060,7 +103225,7 @@
       }
     },
     {
-      "id": "feature-1122",
+      "id": "feature-1123",
       "query": "lynx-api/performance-api/performance-observer",
       "name": "performance-observer",
       "category": "lynx-api/performance-api",
@@ -103096,7 +103261,7 @@
       }
     },
     {
-      "id": "feature-1123",
+      "id": "feature-1124",
       "query": "lynx-api/performance-api/timing-flag",
       "name": "timing-flag",
       "category": "lynx-api/performance-api",
@@ -103132,7 +103297,7 @@
       }
     },
     {
-      "id": "feature-1124",
+      "id": "feature-1125",
       "query": "lynx-native-api/lynx-background-runtime/add-lynx-background-runtime-client",
       "name": "register lifecycle observer for background runtime",
       "category": "lynx-native-api",
@@ -103168,7 +103333,7 @@
       }
     },
     {
-      "id": "feature-1125",
+      "id": "feature-1126",
       "query": "lynx-native-api/lynx-background-runtime/call-js-function",
       "name": "invoke js function from background runtime",
       "category": "lynx-native-api",
@@ -103204,7 +103369,7 @@
       }
     },
     {
-      "id": "feature-1126",
+      "id": "feature-1127",
       "query": "lynx-native-api/lynx-background-runtime/destroy",
       "name": "manually destroy background runtime instance",
       "category": "lynx-native-api",
@@ -103240,7 +103405,7 @@
       }
     },
     {
-      "id": "feature-1127",
+      "id": "feature-1128",
       "query": "lynx-native-api/lynx-background-runtime/evaluate-java-script",
       "name": "evaluate background runtime script",
       "category": "lynx-native-api",
@@ -103276,7 +103441,7 @@
       }
     },
     {
-      "id": "feature-1128",
+      "id": "feature-1129",
       "query": "lynx-native-api/lynx-background-runtime/remove-lynx-background-runtime-client",
       "name": "remove lifecycle observer for background runtime",
       "category": "lynx-native-api",
@@ -103312,7 +103477,7 @@
       }
     },
     {
-      "id": "feature-1129",
+      "id": "feature-1130",
       "query": "lynx-native-api/lynx-background-runtime/send-global-event",
       "name": "send global event to js enviroment from background runtime",
       "category": "lynx-native-api",
@@ -103348,7 +103513,7 @@
       }
     },
     {
-      "id": "feature-1130",
+      "id": "feature-1131",
       "query": "lynx-native-api/lynx-background-runtime-client/on-evaluate-java-script-end",
       "name": "Called when background script evaluation finished.",
       "category": "lynx-native-api",
@@ -103384,7 +103549,7 @@
       }
     },
     {
-      "id": "feature-1131",
+      "id": "feature-1132",
       "query": "lynx-native-api/lynx-background-runtime-client/on-module-method-invoked",
       "name": "Called when a module method invocation completed in background runtime.",
       "category": "lynx-native-api",
@@ -103420,7 +103585,7 @@
       }
     },
     {
-      "id": "feature-1132",
+      "id": "feature-1133",
       "query": "lynx-native-api/lynx-background-runtime-client/on-received-error",
       "name": "Called when an error is received in background runtime.",
       "category": "lynx-native-api",
@@ -103456,7 +103621,7 @@
       }
     },
     {
-      "id": "feature-1133",
+      "id": "feature-1134",
       "query": "lynx-native-api/lynx-context/send-global-event",
       "name": "send global event to js enviroment",
       "category": "lynx-native-api",
@@ -103492,7 +103657,7 @@
       }
     },
     {
-      "id": "feature-1134",
+      "id": "feature-1135",
       "query": "lynx-native-api/lynx-context/set-extra-timing",
       "name": "set extra timing from outside.",
       "category": "lynx-native-api",
@@ -103528,7 +103693,7 @@
       }
     },
     {
-      "id": "feature-1135",
+      "id": "feature-1136",
       "query": "lynx-native-api/lynx-context/update-font-scale",
       "name": "update font scale of lynxView",
       "category": "lynx-native-api",
@@ -103564,7 +103729,7 @@
       }
     },
     {
-      "id": "feature-1136",
+      "id": "feature-1137",
       "query": "lynx-native-api/lynx-context/update-meta-data",
       "name": "update lynx page by new data.",
       "category": "lynx-native-api",
@@ -103600,7 +103765,7 @@
       }
     },
     {
-      "id": "feature-1137",
+      "id": "feature-1138",
       "query": "lynx-native-api/lynx-context/update-viewport",
       "name": "update viewport of lynxView",
       "category": "lynx-native-api",
@@ -103636,7 +103801,7 @@
       }
     },
     {
-      "id": "feature-1138",
+      "id": "feature-1139",
       "query": "lynx-native-api/lynx-env/trim-memory",
       "name": "dispatch memory pressure signal to registered callbacks",
       "category": "lynx-native-api",
@@ -103672,7 +103837,7 @@
       }
     },
     {
-      "id": "feature-1139",
+      "id": "feature-1140",
       "query": "lynx-native-api/lynx-extension-module",
       "name": "Desktop-only extension module entry for lifecycle hooks, NAPI binding, VSync, and native view registration.",
       "category": "lynx-native-api",
@@ -103708,7 +103873,7 @@
       }
     },
     {
-      "id": "feature-1140",
+      "id": "feature-1141",
       "query": "lynx-native-api/lynx-generic-resource-fetcher/cancel",
       "name": "Cancel the request of the requiring resource.",
       "category": "lynx-native-api",
@@ -103744,7 +103909,7 @@
       }
     },
     {
-      "id": "feature-1141",
+      "id": "feature-1142",
       "query": "lynx-native-api/lynx-generic-resource-fetcher/fetch-resource-path",
       "name": "LynxEngine internally calls this method to obtain the path of the common resource on the local disk, and the return result is required to be of String type.",
       "category": "lynx-native-api",
@@ -103780,7 +103945,7 @@
       }
     },
     {
-      "id": "feature-1142",
+      "id": "feature-1143",
       "query": "lynx-native-api/lynx-generic-resource-fetcher/fetch-resource",
       "name": "LynxEngine internally calls this method to obtain the general resource content, and the return result is required to be the resource content byte[] type.",
       "category": "lynx-native-api",
@@ -103816,7 +103981,7 @@
       }
     },
     {
-      "id": "feature-1143",
+      "id": "feature-1144",
       "query": "lynx-native-api/lynx-generic-resource-fetcher/fetch-stream",
       "name": "LynxEngine internally calls this method to obtain resource content in a streaming manner.",
       "category": "lynx-native-api",
@@ -103852,7 +104017,7 @@
       }
     },
     {
-      "id": "feature-1144",
+      "id": "feature-1145",
       "query": "lynx-native-api/lynx-load-meta",
       "name": "MetaData of LynxEngine loadProcess",
       "category": "lynx-native-api",
@@ -103888,7 +104053,7 @@
       }
     },
     {
-      "id": "feature-1145",
+      "id": "feature-1146",
       "query": "lynx-native-api/lynx-media-resource-fetcher/fetch-image",
       "name": "LynxEngine will use this method to obtain the bitmap information of the image, and the return content must be of Closeable type.",
       "category": "lynx-native-api",
@@ -103924,7 +104089,7 @@
       }
     },
     {
-      "id": "feature-1146",
+      "id": "feature-1147",
       "query": "lynx-native-api/lynx-media-resource-fetcher/is-local-resource",
       "name": "LynxEngine internally calls this method to determine whether the resource path exists on disk.",
       "category": "lynx-native-api",
@@ -103960,7 +104125,7 @@
       }
     },
     {
-      "id": "feature-1147",
+      "id": "feature-1148",
       "query": "lynx-native-api/lynx-media-resource-fetcher/should-redirect-url",
       "name": "LynxEngine redirects the image path by calling this method internally, and the return result is required to be of String type.",
       "category": "lynx-native-api",
@@ -103996,7 +104161,7 @@
       }
     },
     {
-      "id": "feature-1148",
+      "id": "feature-1149",
       "query": "lynx-native-api/lynx-service/lynx-service",
       "name": "LynxService API",
       "category": "lynx-native-api",
@@ -104032,7 +104197,7 @@
       }
     },
     {
-      "id": "feature-1149",
+      "id": "feature-1150",
       "query": "lynx-native-api/lynx-template-resource-fetcher/fetch-template",
       "name": "LynxEngine internally calls this method to obtain the contents of Bundle and Lazy Bundle. The returned result type can contain byte[] or TemplateBundle.",
       "category": "lynx-native-api",
@@ -104068,7 +104233,7 @@
       }
     },
     {
-      "id": "feature-1150",
+      "id": "feature-1151",
       "query": "lynx-native-api/lynx-update-meta",
       "name": "MetaData of LynxEngine updateProcess",
       "category": "lynx-native-api",
@@ -104104,7 +104269,7 @@
       }
     },
     {
-      "id": "feature-1151",
+      "id": "feature-1152",
       "query": "lynx-native-api/lynx-view/add-lynx-view-client",
       "name": "register lifecycle observer for lynxView",
       "category": "lynx-native-api",
@@ -104140,7 +104305,7 @@
       }
     },
     {
-      "id": "feature-1152",
+      "id": "feature-1153",
       "query": "lynx-native-api/lynx-view/destroy",
       "name": "manually destroy lynxView instance",
       "category": "lynx-native-api",
@@ -104176,7 +104341,7 @@
       }
     },
     {
-      "id": "feature-1153",
+      "id": "feature-1154",
       "query": "lynx-native-api/lynx-view/find-ui-by-id-selector",
       "name": "find ui by idselector",
       "category": "lynx-native-api",
@@ -104212,7 +104377,7 @@
       }
     },
     {
-      "id": "feature-1154",
+      "id": "feature-1155",
       "query": "lynx-native-api/lynx-view/find-ui-by-name",
       "name": "find ui by name",
       "category": "lynx-native-api",
@@ -104248,7 +104413,7 @@
       }
     },
     {
-      "id": "feature-1155",
+      "id": "feature-1156",
       "query": "lynx-native-api/lynx-view/find-view-by-id-selector",
       "name": "find view by idselector",
       "category": "lynx-native-api",
@@ -104284,7 +104449,7 @@
       }
     },
     {
-      "id": "feature-1156",
+      "id": "feature-1157",
       "query": "lynx-native-api/lynx-view/find-view-by-name",
       "name": "find view by name",
       "category": "lynx-native-api",
@@ -104320,7 +104485,7 @@
       }
     },
     {
-      "id": "feature-1157",
+      "id": "feature-1158",
       "query": "lynx-native-api/lynx-view/load-template",
       "name": "load a lynx template file by LynxView.",
       "category": "lynx-native-api",
@@ -104356,7 +104521,7 @@
       }
     },
     {
-      "id": "feature-1158",
+      "id": "feature-1159",
       "query": "lynx-native-api/lynx-view/lynx-view-custom-element",
       "name": "<code>lynx-view</code> The custom element of LynxView.",
       "category": "lynx-native-api",
@@ -104392,7 +104557,7 @@
       }
     },
     {
-      "id": "feature-1159",
+      "id": "feature-1160",
       "query": "lynx-native-api/lynx-view/reload",
       "name": "reload lynx page.",
       "category": "lynx-native-api",
@@ -104428,7 +104593,7 @@
       }
     },
     {
-      "id": "feature-1160",
+      "id": "feature-1161",
       "query": "lynx-native-api/lynx-view/remove-lynx-view-client",
       "name": "remove lifecycle observer of lynxView",
       "category": "lynx-native-api",
@@ -104464,7 +104629,7 @@
       }
     },
     {
-      "id": "feature-1161",
+      "id": "feature-1162",
       "query": "lynx-native-api/lynx-view/send-global-event",
       "name": "send global event to js enviroment",
       "category": "lynx-native-api",
@@ -104500,7 +104665,7 @@
       }
     },
     {
-      "id": "feature-1162",
+      "id": "feature-1163",
       "query": "lynx-native-api/lynx-view/set-extra-timing",
       "name": "set extra timing from outside.",
       "category": "lynx-native-api",
@@ -104536,7 +104701,7 @@
       }
     },
     {
-      "id": "feature-1163",
+      "id": "feature-1164",
       "query": "lynx-native-api/lynx-view/update-font-scale",
       "name": "update font scale of lynxView",
       "category": "lynx-native-api",
@@ -104572,7 +104737,7 @@
       }
     },
     {
-      "id": "feature-1164",
+      "id": "feature-1165",
       "query": "lynx-native-api/lynx-view/update-meta-data",
       "name": "update lynx page by new data.",
       "category": "lynx-native-api",
@@ -104608,7 +104773,7 @@
       }
     },
     {
-      "id": "feature-1165",
+      "id": "feature-1166",
       "query": "lynx-native-api/lynx-view/update-screen-metrics",
       "name": "update screen metrics",
       "category": "lynx-native-api",
@@ -104644,7 +104809,7 @@
       }
     },
     {
-      "id": "feature-1166",
+      "id": "feature-1167",
       "query": "lynx-native-api/lynx-view/update-viewport",
       "name": "update viewport of lynxView",
       "category": "lynx-native-api",
@@ -104680,7 +104845,7 @@
       }
     },
     {
-      "id": "feature-1167",
+      "id": "feature-1168",
       "query": "lynx-native-api/lynx-view-client/on-data-updated",
       "name": "Called when data update, but the view may not be updated.",
       "category": "lynx-native-api",
@@ -104716,7 +104881,7 @@
       }
     },
     {
-      "id": "feature-1168",
+      "id": "feature-1169",
       "query": "lynx-native-api/lynx-view-client/on-destroy",
       "name": "Called after the page is destroyed.",
       "category": "lynx-native-api",
@@ -104752,7 +104917,7 @@
       }
     },
     {
-      "id": "feature-1169",
+      "id": "feature-1170",
       "query": "lynx-native-api/lynx-view-client/on-first-load-perf-ready",
       "name": "Performance data statistics callback after the first load is completed.",
       "category": "lynx-native-api",
@@ -104788,7 +104953,7 @@
       }
     },
     {
-      "id": "feature-1170",
+      "id": "feature-1171",
       "query": "lynx-native-api/lynx-view-client/on-first-screen",
       "name": "Called when first screen layout completed.",
       "category": "lynx-native-api",
@@ -104824,7 +104989,7 @@
       }
     },
     {
-      "id": "feature-1171",
+      "id": "feature-1172",
       "query": "lynx-native-api/lynx-view-client/on-fling",
       "name": "Called when inertial scrolling starts after releasing the finger.",
       "category": "lynx-native-api",
@@ -104860,7 +105025,7 @@
       }
     },
     {
-      "id": "feature-1172",
+      "id": "feature-1173",
       "query": "lynx-native-api/lynx-view-client/on-flush-finish",
       "name": "Called when UI flush end in async render mode.",
       "category": "lynx-native-api",
@@ -104896,7 +105061,7 @@
       }
     },
     {
-      "id": "feature-1173",
+      "id": "feature-1174",
       "query": "lynx-native-api/lynx-view-client/on-key-event",
       "name": "Report all android key events with flag indicating whether has been handled.",
       "category": "lynx-native-api",
@@ -104932,7 +105097,7 @@
       }
     },
     {
-      "id": "feature-1174",
+      "id": "feature-1175",
       "query": "lynx-native-api/lynx-view-client/on-load-success",
       "name": "Called when page load finish.",
       "category": "lynx-native-api",
@@ -104968,7 +105133,7 @@
       }
     },
     {
-      "id": "feature-1175",
+      "id": "feature-1176",
       "query": "lynx-native-api/lynx-view-client/on-lynx-event",
       "name": "Report Lynx events that sended to frontend.",
       "category": "lynx-native-api",
@@ -105004,7 +105169,7 @@
       }
     },
     {
-      "id": "feature-1176",
+      "id": "feature-1177",
       "query": "lynx-native-api/lynx-view-client/on-lynx-view-and-js-runtime-destroy",
       "name": "Called when lynx view and js runtime destroy.",
       "category": "lynx-native-api",
@@ -105040,7 +105205,7 @@
       }
     },
     {
-      "id": "feature-1177",
+      "id": "feature-1178",
       "query": "lynx-native-api/lynx-view-client/on-module-method-invoked",
       "name": "Called when module method invocation completed.",
       "category": "lynx-native-api",
@@ -105076,7 +105241,7 @@
       }
     },
     {
-      "id": "feature-1178",
+      "id": "feature-1179",
       "query": "lynx-native-api/lynx-view-client/on-page-start",
       "name": "Called when page start loading.",
       "category": "lynx-native-api",
@@ -105112,7 +105277,7 @@
       }
     },
     {
-      "id": "feature-1179",
+      "id": "feature-1180",
       "query": "lynx-native-api/lynx-view-client/on-page-update",
       "name": "Called when page update.",
       "category": "lynx-native-api",
@@ -105148,7 +105313,7 @@
       }
     },
     {
-      "id": "feature-1180",
+      "id": "feature-1181",
       "query": "lynx-native-api/lynx-view-client/on-performance-event",
       "name": "Notify the client that a performance event has been sent. It will be called every time a performance event is generated, including but not limited to container initialization, engine rendering, rendering metrics update, etc.",
       "category": "lynx-native-api",
@@ -105184,7 +105349,7 @@
       }
     },
     {
-      "id": "feature-1181",
+      "id": "feature-1182",
       "query": "lynx-native-api/lynx-view-client/on-piper-invoked",
       "name": "Called when JSBridge invoked.",
       "category": "lynx-native-api",
@@ -105220,7 +105385,7 @@
       }
     },
     {
-      "id": "feature-1182",
+      "id": "feature-1183",
       "query": "lynx-native-api/lynx-view-client/on-received-error",
       "name": "Called when error received.",
       "category": "lynx-native-api",
@@ -105256,7 +105421,7 @@
       }
     },
     {
-      "id": "feature-1183",
+      "id": "feature-1184",
       "query": "lynx-native-api/lynx-view-client/on-received-java-error",
       "name": "Called when java error received.",
       "category": "lynx-native-api",
@@ -105292,7 +105457,7 @@
       }
     },
     {
-      "id": "feature-1184",
+      "id": "feature-1185",
       "query": "lynx-native-api/lynx-view-client/on-received-js-error",
       "name": "Called when JS error received.",
       "category": "lynx-native-api",
@@ -105328,7 +105493,7 @@
       }
     },
     {
-      "id": "feature-1185",
+      "id": "feature-1186",
       "query": "lynx-native-api/lynx-view-client/on-received-native-error",
       "name": "Called when C++ layer error received.",
       "category": "lynx-native-api",
@@ -105364,7 +105529,7 @@
       }
     },
     {
-      "id": "feature-1186",
+      "id": "feature-1187",
       "query": "lynx-native-api/lynx-view-client/on-report-component-info",
       "name": "Return the used component tagName.",
       "category": "lynx-native-api",
@@ -105400,7 +105565,7 @@
       }
     },
     {
-      "id": "feature-1187",
+      "id": "feature-1188",
       "query": "lynx-native-api/lynx-view-client/on-runtime-ready",
       "name": "Called when JS environment preparation completed.",
       "category": "lynx-native-api",
@@ -105436,7 +105601,7 @@
       }
     },
     {
-      "id": "feature-1188",
+      "id": "feature-1189",
       "query": "lynx-native-api/lynx-view-client/on-scroll-start",
       "name": "Called when the UI start scrolling.",
       "category": "lynx-native-api",
@@ -105472,7 +105637,7 @@
       }
     },
     {
-      "id": "feature-1189",
+      "id": "feature-1190",
       "query": "lynx-native-api/lynx-view-client/on-scroll-stop",
       "name": "Called when the UI finished scrolling.",
       "category": "lynx-native-api",
@@ -105508,7 +105673,7 @@
       }
     },
     {
-      "id": "feature-1190",
+      "id": "feature-1191",
       "query": "lynx-native-api/lynx-view-client/on-tasm-finished-by-native",
       "name": "Called when native layout finish in ui or most_on_tasm mode, or diff finish in multi_thread mode.",
       "category": "lynx-native-api",
@@ -105544,7 +105709,7 @@
       }
     },
     {
-      "id": "feature-1191",
+      "id": "feature-1192",
       "query": "lynx-native-api/lynx-view-client/on-template-bundle-ready",
       "name": "Provide a reusable TemplateBundle after template is decode.",
       "category": "lynx-native-api",
@@ -105580,7 +105745,7 @@
       }
     },
     {
-      "id": "feature-1192",
+      "id": "feature-1193",
       "query": "lynx-native-api/lynx-view-client/on-update-data-without-change",
       "name": "If there is no need to update the UI after calling updateData, this method is called back.",
       "category": "lynx-native-api",
@@ -105616,7 +105781,7 @@
       }
     },
     {
-      "id": "feature-1193",
+      "id": "feature-1194",
       "query": "lynx-native-api/lynx-view-client/on-update-perf-ready",
       "name": "Performance data statistics callback after the interface update is completed.",
       "category": "lynx-native-api",
@@ -105652,7 +105817,7 @@
       }
     },
     {
-      "id": "feature-1194",
+      "id": "feature-1195",
       "query": "lynx-native-api/template-bundle/from-template-async-with-option",
       "name": "Asynchronously creates a TemplateBundle from a template binary data with options. This method avoids blocking the main thread.",
       "category": "lynx-native-api",
@@ -105688,7 +105853,7 @@
       }
     },
     {
-      "id": "feature-1195",
+      "id": "feature-1196",
       "query": "lynx-native-api/template-bundle/from-template-async",
       "name": "Asynchronously creates a TemplateBundle from a template binary data. This method avoids blocking the main thread.",
       "category": "lynx-native-api",
@@ -105724,7 +105889,7 @@
       }
     },
     {
-      "id": "feature-1196",
+      "id": "feature-1197",
       "query": "lynx-native-api/template-bundle/from-template",
       "name": "Input Lynx template binary content and return the parsed TemplateBundle object.",
       "category": "lynx-native-api",
@@ -105760,7 +105925,7 @@
       }
     },
     {
-      "id": "feature-1197",
+      "id": "feature-1198",
       "query": "lynx-native-api/template-bundle/get-error-message",
       "name": "When TemplateBundle is an invalid object, use this method to obtain the exception information that occurred during template parsing.",
       "category": "lynx-native-api",
@@ -105796,7 +105961,7 @@
       }
     },
     {
-      "id": "feature-1198",
+      "id": "feature-1199",
       "query": "lynx-native-api/template-bundle/get-extra-info",
       "name": "Read the content of the extraInfo field configured in the pageConfig of the front-end template.",
       "category": "lynx-native-api",
@@ -105832,7 +105997,7 @@
       }
     },
     {
-      "id": "feature-1199",
+      "id": "feature-1200",
       "query": "lynx-native-api/template-bundle/get-template-size",
       "name": "Get the size of current template.",
       "category": "lynx-native-api",
@@ -105868,7 +106033,7 @@
       }
     },
     {
-      "id": "feature-1200",
+      "id": "feature-1201",
       "query": "lynx-native-api/template-bundle/is-element-bundle-valid",
       "name": "Whether the TemplateBundle contains a Valid ElementBundle.",
       "category": "lynx-native-api",
@@ -105904,7 +106069,7 @@
       }
     },
     {
-      "id": "feature-1201",
+      "id": "feature-1202",
       "query": "lynx-native-api/template-bundle/is-valid",
       "name": "Determines whether the current TemplateBundle object is valid.",
       "category": "lynx-native-api",
@@ -105940,7 +106105,7 @@
       }
     },
     {
-      "id": "feature-1202",
+      "id": "feature-1203",
       "query": "lynx-native-api/template-bundle/post-js-cache-generation-task",
       "name": "Start a sub-thread task to generate the js code cache of the current template.",
       "category": "lynx-native-api",
@@ -105976,7 +106141,7 @@
       }
     },
     {
-      "id": "feature-1203",
+      "id": "feature-1204",
       "query": "lynx-native-api/template-bundle/release",
       "name": "Release the Native memory held by the current TemplateBundle object. After executing the release method, the TemplateBundle will become the inValid state.",
       "category": "lynx-native-api",
@@ -106012,7 +106177,7 @@
       }
     },
     {
-      "id": "feature-1204",
+      "id": "feature-1205",
       "query": "lynx-native-api/template-data/constructor",
       "name": "Input data in string, key-value or json format and return the parsed TemplateData object.",
       "category": "lynx-native-api",
@@ -106048,7 +106213,7 @@
       }
     },
     {
-      "id": "feature-1205",
+      "id": "feature-1206",
       "query": "lynx-native-api/template-data/data",
       "name": "Get the data in TemplateData object.",
       "category": "lynx-native-api",
@@ -106084,7 +106249,7 @@
       }
     },
     {
-      "id": "feature-1206",
+      "id": "feature-1207",
       "query": "lynx-native-api/template-data/from-map",
       "name": "Input data in key-value format and return the parsed TemplateData object.",
       "category": "lynx-native-api",
@@ -106120,7 +106285,7 @@
       }
     },
     {
-      "id": "feature-1207",
+      "id": "feature-1208",
       "query": "lynx-native-api/template-data/from-string",
       "name": "Input data in json and return the parsed TemplateData object.",
       "category": "lynx-native-api",
@@ -106156,7 +106321,7 @@
       }
     },
     {
-      "id": "feature-1208",
+      "id": "feature-1209",
       "query": "lynx-native-api/template-data/mark-state",
       "name": "Mark the current TemplateData with the associated dataProcessor name. When this TemplateData is used in UpdateData, the corresponding dataProcessor will be found based on this name for data preprocessing.",
       "category": "lynx-native-api",
@@ -106192,7 +106357,7 @@
       }
     },
     {
-      "id": "feature-1209",
+      "id": "feature-1210",
       "query": "lynx-native-api/template-data/merge",
       "name": "Merge the incoming data with the current data.",
       "category": "lynx-native-api",
@@ -106228,7 +106393,7 @@
       }
     },
     {
-      "id": "feature-1210",
+      "id": "feature-1211",
       "query": "lynx-native-api/trace-event",
       "name": "TraceEvent",
       "category": "lynx-native-api",
@@ -106264,7 +106429,7 @@
       }
     },
     {
-      "id": "feature-1211",
+      "id": "feature-1212",
       "query": "react/main-thread/MainThread-APIs",
       "name": "APIs available on the main thread.",
       "category": "react",
@@ -106300,7 +106465,7 @@
       }
     },
     {
-      "id": "feature-1212",
+      "id": "feature-1213",
       "query": "react/main-thread/MainThread-APIs.runOnBackground",
       "name": "runOnBackground: Create a value that can be shared between main thread scripts.",
       "category": "react",
@@ -106336,7 +106501,7 @@
       }
     },
     {
-      "id": "feature-1213",
+      "id": "feature-1214",
       "query": "devtool/integration.lazy_load",
       "name": "Lazy load",
       "category": "devtool",
@@ -106372,7 +106537,7 @@
       }
     },
     {
-      "id": "feature-1214",
+      "id": "feature-1215",
       "query": "devtool/integration.switch.switchPage",
       "name": "Switch page",
       "category": "devtool",
@@ -106408,7 +106573,7 @@
       }
     },
     {
-      "id": "feature-1215",
+      "id": "feature-1216",
       "query": "devtool/integration.connection.usb",
       "name": "USB connection",
       "category": "devtool",
@@ -106444,7 +106609,7 @@
       }
     },
     {
-      "id": "feature-1216",
+      "id": "feature-1217",
       "query": "devtool/logbox",
       "name": "Shows logbox details",
       "category": "devtool",
@@ -106480,7 +106645,7 @@
       }
     },
     {
-      "id": "feature-1217",
+      "id": "feature-1218",
       "query": "devtool/logbox.notification",
       "name": "Notification with a brief message",
       "category": "devtool",
@@ -106516,7 +106681,7 @@
       }
     },
     {
-      "id": "feature-1218",
+      "id": "feature-1219",
       "query": "devtool/logbox.MTS Analysis",
       "name": "MTS Analysis",
       "category": "devtool",
@@ -106552,7 +106717,7 @@
       }
     },
     {
-      "id": "feature-1219",
+      "id": "feature-1220",
       "query": "devtool/logbox.BTS Analysis",
       "name": "BTS Analysis",
       "category": "devtool",
@@ -106588,7 +106753,7 @@
       }
     },
     {
-      "id": "feature-1220",
+      "id": "feature-1221",
       "query": "devtool/panels.elements.preview.reload",
       "name": "Reload",
       "category": "devtool",
@@ -106624,7 +106789,7 @@
       }
     },
     {
-      "id": "feature-1221",
+      "id": "feature-1222",
       "query": "devtool/panels.elements.preview.lynxview",
       "name": "LynxView mirroring",
       "category": "devtool",
@@ -106660,7 +106825,7 @@
       }
     },
     {
-      "id": "feature-1222",
+      "id": "feature-1223",
       "query": "devtool/panels.elements.preview.fullscreen",
       "name": "Fullscreen mirroring",
       "category": "devtool",
@@ -106696,7 +106861,7 @@
       }
     },
     {
-      "id": "feature-1223",
+      "id": "feature-1224",
       "query": "devtool/panels.elements.preview.box_model",
       "name": "Interact via the box model",
       "category": "devtool",
@@ -106732,7 +106897,7 @@
       }
     },
     {
-      "id": "feature-1224",
+      "id": "feature-1225",
       "query": "devtool/panels.elements.view-and-edit.element_tree",
       "name": "View and edit the element tree",
       "category": "devtool",
@@ -106768,7 +106933,7 @@
       }
     },
     {
-      "id": "feature-1225",
+      "id": "feature-1226",
       "query": "devtool/panels.elements.view-and-edit.hot_reload",
       "name": "View and edit CSS styles",
       "category": "devtool",
@@ -106804,7 +106969,7 @@
       }
     },
     {
-      "id": "feature-1226",
+      "id": "feature-1227",
       "query": "devtool/panels.console.print",
       "name": "View Logged messages",
       "category": "devtool",
@@ -106840,7 +107005,7 @@
       }
     },
     {
-      "id": "feature-1227",
+      "id": "feature-1228",
       "query": "devtool/panels.console.execution",
       "name": "Run JavaScript",
       "category": "devtool",
@@ -106876,7 +107041,7 @@
       }
     },
     {
-      "id": "feature-1228",
+      "id": "feature-1229",
       "query": "devtool/panels.sources.breakpoints.BTS",
       "name": "Background thread breakpoints",
       "category": "devtool",
@@ -106912,7 +107077,7 @@
       }
     },
     {
-      "id": "feature-1229",
+      "id": "feature-1230",
       "query": "devtool/panels.sources.breakpoints.MTS",
       "name": "Main thread breakpoints",
       "category": "devtool",
@@ -106948,7 +107113,7 @@
       }
     },
     {
-      "id": "feature-1230",
+      "id": "feature-1231",
       "query": "devtool/panels.sources.JSEngine.PrimJS",
       "name": "PrimJS",
       "category": "devtool",
@@ -106984,7 +107149,7 @@
       }
     },
     {
-      "id": "feature-1231",
+      "id": "feature-1232",
       "query": "devtool/panels.sources.JSEngine.V8",
       "name": "V8",
       "category": "devtool",
@@ -107020,7 +107185,7 @@
       }
     },
     {
-      "id": "feature-1232",
+      "id": "feature-1233",
       "query": "devtool/panels.layers",
       "name": "View page layers",
       "category": "devtool",
@@ -107056,7 +107221,7 @@
       }
     },
     {
-      "id": "feature-1233",
+      "id": "feature-1234",
       "query": "devtool/recorder",
       "name": "Lynx Recorder Support",
       "category": "devtool",
@@ -107092,7 +107257,7 @@
       }
     },
     {
-      "id": "feature-1234",
+      "id": "feature-1235",
       "query": "devtool/trace",
       "name": "Trace Tool",
       "category": "devtool",
@@ -107128,7 +107293,7 @@
       }
     },
     {
-      "id": "feature-1235",
+      "id": "feature-1236",
       "query": "errors/lynx-error",
       "name": "Structure used to represent an error",
       "category": "errors",
@@ -107203,7 +107368,7 @@
         },
         "clay": {
           "supported": 466,
-          "coverage": 46
+          "coverage": 45
         }
       }
     },
@@ -107245,7 +107410,7 @@
         },
         "clay": {
           "supported": 466,
-          "coverage": 46
+          "coverage": 45
         }
       }
     },
@@ -107465,7 +107630,7 @@
       "platforms": {
         "android": {
           "supported": 743,
-          "coverage": 73
+          "coverage": 72
         },
         "ios": {
           "supported": 745,

--- a/packages/lynx-compat-data/css/properties/-x-auto-font-size-line-ranges.json
+++ b/packages/lynx-compat-data/css/properties/-x-auto-font-size-line-ranges.json
@@ -1,0 +1,42 @@
+{
+  "css": {
+    "properties": {
+      "-x-auto-font-size-line-ranges": {
+        "__compat": {
+          "lynx_path": "api/css/properties/-x-auto-font-size-line-ranges",
+          "spec_url": [],
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "3.8"
+            },
+            "ios": {
+              "version_added": "3.8"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/lynx-example-packages/package.json
+++ b/packages/lynx-example-packages/package.json
@@ -16,7 +16,7 @@
     "@lynx-example/blur-view": "0.1.0",
     "@lynx-example/composing-elements": "0.6.5",
     "@lynx-example/css": "0.6.5",
-    "@lynx-example/css-api": "0.9.0",
+    "@lynx-example/css-api": "0.9.2",
     "@lynx-example/design-guide": "0.4.2",
     "@lynx-example/desktop": "0.2.0",
     "@lynx-example/element-manipulation": "0.6.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -284,8 +284,8 @@ importers:
         specifier: 0.6.5
         version: 0.6.5(@lynx-js/types@3.7.0)(@types/react@18.3.28)
       '@lynx-example/css-api':
-        specifier: 0.9.0
-        version: 0.9.0(@lynx-js/types@3.7.0)(@types/react@18.3.28)
+        specifier: 0.9.2
+        version: 0.9.2(@lynx-js/types@3.7.0)(@types/react@18.3.28)
       '@lynx-example/design-guide':
         specifier: 0.4.2
         version: 0.4.2(@lynx-js/types@3.7.0)(@types/react@18.3.28)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -1364,8 +1364,8 @@ packages:
     resolution: {integrity: sha512-McxesZ9cBeCDE9wkfW/55UGB7Bh5Gwceq/WZ1aKONk8LmQqdtrfLF/5jwfMOu5NYUl+2g20yPmvudFW1bluT2A==}
     engines: {node: '>=18'}
 
-  '@lynx-example/css-api@0.9.0':
-    resolution: {integrity: sha512-fjjEp+twYZw8Du+WcBS+5QexvKfhZx7lhYNcZEfSg6W6vRijiil+yxl1mtyudqhigYjwQofzB759juYZgnjo2g==}
+  '@lynx-example/css-api@0.9.2':
+    resolution: {integrity: sha512-xXOln1/Yv01K5rNb3DmWbdccSBh31l2m3jjcZS3QuCbgqtNA1ix92ICXh3c3qCx+e+bIK6zG866U/CXkVscjoQ==}
     engines: {node: '>=18'}
 
   '@lynx-example/css@0.6.5':
@@ -7193,9 +7193,9 @@ snapshots:
       - '@lynx-js/types'
       - '@types/react'
 
-  '@lynx-example/css-api@0.9.0(@lynx-js/types@3.7.0)(@types/react@18.3.28)':
+  '@lynx-example/css-api@0.9.2(@lynx-js/types@3.7.0)(@types/react@18.3.28)':
     dependencies:
-      '@lynx-js/react': 0.117.0(@lynx-js/types@3.7.0)(@types/react@18.3.28)
+      '@lynx-js/react': 0.120.0(@lynx-js/types@3.7.0)(@types/react@18.3.28)
     transitivePeerDependencies:
       - '@lynx-js/types'
       - '@types/react'


### PR DESCRIPTION
Document the new CSS property, update compat metadata and API stats, and bump the css-api example package to 0.9.2 so the docs reference the new example bundle.

Change-Id: I6ebe95ea45b9eabc5f5a756303a7d214776577d0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Add documentation for the CSS property `-x-auto-font-size-line-ranges`, providing guides for both English and Chinese documentation sites, including syntax, value format specifications (`line-range()` with exact or `to infinity` ranges), formal definitions, behavioral notes, and compatibility tables.

## Changes

- Add API documentation page for `-x-auto-font-size-line-ranges` CSS property in English
- Add API documentation page for `-x-auto-font-size-line-ranges` CSS property in Chinese, with specifications for the property's usage with `-x-auto-font-size: true`, value syntax, and distinctions from Web standards
- Add compatibility metadata for `-x-auto-font-size-line-ranges` with platform support information for Android and iOS (version 3.8+)
- Bump `@lynx-example/css-api` package from 0.9.0 to 0.9.2 to reference the updated example bundle

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/1026?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->