### PR TITLE
docs(lynx-ui): explain semantic tokens and theme activation

### DIFF
--- a/docs/en/lynx-ui/styling-theming.mdx
+++ b/docs/en/lynx-ui/styling-theming.mdx
@@ -3,7 +3,7 @@ description: 'How to style and theme lynx-ui headless components.'
 title: Styling and Theming
 ---
 
-import { Go } from '@lynx';
+import { Details, Go } from '@lynx';
 
 # Styling and Theming
 
@@ -180,8 +180,7 @@ with transitions or animations.
 
 :::
 
-When multiple states can be active at the same time, such as checked _and_
-pressed, make priority explicit. The `ui-checked:ui-active:` chain above is
+When multiple states can be active at the same time, such as `checked` and `pressed`, make priority explicit. The `ui-checked:ui-active:` chain above is
 intentional: it overrides the plain `ui-checked` translation when both states
 apply, so the visual stays coherent during interaction. Whether you use
 selectors or utilities, treat overlapping states as a design decision rather
@@ -200,27 +199,87 @@ than something to leave to specificity.
 
 ## Consuming Tokens
 
-Notice that the styles above never write a literal color. They reference
-tokens (`var(--primary)` in CSS, `bg-primary` in Tailwind) that resolve to
-the same semantic value.
+Notice that the styles above never hard-code literal colors. Instead, they
+reference semantic tokens such as `primary` and `content`.
 
-Tokens matter for two reasons:
+Semantic tokens name the intent of a value in the interface, not the raw value
+itself. For example, `primary` means “the main accent in the current theme”,
+and `content` means “primary foreground content”.
 
-- **Consistency.** A `Switch`, a `Button`, and a `Tab` that all read from
-  `--primary` stay in sync automatically. Changing the token changes every
-  surface that uses it.
-- **Themeability.** Light mode, dark mode, and brand variants become a matter
-  of swapping token values, not editing every component.
+In this guide, you will most often see those tokens consumed as CSS property
+values (`var(--primary)` and `var(--content)`) or Tailwind utilities
+(`bg-primary` and `text-content`). These forms all resolve to the same runtime
+token values.
 
-LUNA, the token layer used throughout these examples, defines semantic token
-names, exposes them as CSS variables, and maps the same tokens into Tailwind
-utilities. That is why the same primitive can be styled in either syntax
-without losing the shared visual language. `var(--primary)` and `bg-primary`
-resolve to the same value, and a themed wrapper built on top inherits it
-automatically.
+Semantic tokens matter for two reasons:
 
-For token names, surface hierarchy, and theme generation, see the [LUNA
-Themes and Tokens](./luna-themes-tokens.mdx) documentation.
+- **Consistency.** A `Button`, a `Switch`, and a `Checkbox` that all read from
+  `primary` stay in sync automatically. Changing the token updates every
+  surface that consumes it.
+- **Themeability.** Components depend on roles such as `primary` and `content`,
+  rather than concrete colors. A theme can change what those roles resolve to
+  across light, dark, or brand variants without rewriting component styles.
+
+In practice, this means the concrete values for these semantic roles are
+provided by the active theme scope on an ancestor node, following the same ancestor-based
+theme switching pattern described in the [custom theming guide](/guide/styling/custom-theming.html),
+where a theme class is applied at the container level and descendant styles resolve against that
+shared theme scope.
+
+Instead of branching styles per theme:
+
+```tsx
+<Button className="bg-pink-500 dark:bg-pink-300 text-white dark:text-black" />
+```
+
+<Details title="Prefer semantic tokens over color scales">
+
+In Tailwind utilities, the prefix describes the CSS property, such as `bg-` for
+background color or `text-` for text color. The value after the prefix is what
+matters for theming.
+
+Values such as `pink-500` and `pink-300` may still come from a design scale,
+but that scale is usually global: `pink-500` means the same concrete color
+regardless of whether the current theme is light, dark, or brand-specific.
+This makes it less suitable for components that need to adapt across multiple
+themes.
+
+Semantic values such as `primary` and `primary-content` describe the role of a
+style instead. The active theme decides what those roles resolve to, so the
+same component style can stay stable while the visual result changes with the
+theme.
+
+</Details>
+
+Components should consume semantic tokens and stay visually stable:
+
+```tsx
+<Button className="bg-primary text-primary-content" />
+```
+
+Theme switching then happens at the container level:
+
+```tsx
+<view className="lunaris-dark">
+  {/* themed subtree */}
+  <Button className="bg-primary text-primary-content" />
+  <Switch className="switch">
+    <SwitchTrack className="switch-track" />
+    <SwitchThumb className="switch-thumb" />
+  </Switch>
+</view>
+```
+
+Changing the ancestor theme class, for example from `lunaris-dark` to
+`lunaris-light`, updates the token values for the entire subtree without
+rewriting individual component styles.
+
+In `lynx-ui`, this container-scoped theme model is implemented by LUNA, which
+provides four built-in theme classes: `luna-light`, `luna-dark`,
+`lunaris-light`, and `lunaris-dark`.
+
+For token names, surface hierarchy, and theme overriding,
+see the [LUNA Themes and Tokens](./luna-themes-tokens.mdx) documentation.
 
 ## Composing Themed Wrappers
 
@@ -304,9 +363,11 @@ A few things to notice in this final form:
 - The token layer (`bg-primary`, `bg-neutral-faint`, `bg-primary-content`)
   carries through unchanged; the wrapper adds defaults, not new colors.
 
-This is a typical shadcn-style composition pattern: primitives stay public and composable, while themed components become the default product-facing implementation.
+This is a typical shadcn-style composition pattern: primitives stay public and composable, while
+themed components become the default product-facing implementation.
 
-The example below applies the pattern in a real UI: a controlled switch drives container theme, and nested surfaces can override theme independently. The same demo is embedded on the [`<Switch>`](./components/switch.mdx) page.
+The example below applies the pattern in a real UI: a controlled switch drives container theme,
+and nested surfaces can override theme independently. The same demo is embedded on the [`<Switch>`](./components/switch.mdx) page.
 
 <Go
   img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/lynx-ui/lynx-ui-cover-switch_themed.webm"

--- a/docs/zh/lynx-ui/styling-theming.mdx
+++ b/docs/zh/lynx-ui/styling-theming.mdx
@@ -3,7 +3,7 @@ title: 样式与主题
 description: 'lynx-ui 无头组件的样式与主题定制。'
 ---
 
-import { Go } from '@lynx';
+import { Details, Go } from '@lynx';
 
 # 样式与主题
 
@@ -171,7 +171,7 @@ transform 写法。
 
 :::
 
-当多个状态可能同时生效时，比如 checked 和 pressed，需要明确设计状态优先级。
+当多个状态可能同时生效时，比如 `checked` 和 `pressed`，需要明确设计状态优先级。
 
 上面的 `ui-checked:ui-active:` 是有意设计的：当两个状态同时存在时，它会覆盖单独
 `ui-checked` 的 translation，从而保证交互过程中的视觉连续性。
@@ -190,27 +190,66 @@ transform 写法。
   webPreviewMode="auto"
 />
 
-## 消费 Token
+## 使用 Token
 
-注意，上面的样式从来没有直接写字面颜色。它们引用的是 token：在 CSS 中是
-`var(--primary)`，在 Tailwind 中是 `bg-primary`，最终都会解析为同一个语义化值。
+注意，上面的样式并没有硬编码具体颜色值，而是引用语义化 token，例如 `primary` 和
+`content`。
 
-token 的价值主要体现在两个方面：
+语义化 token 命名的是一个值在界面中的意图，而不是这个值本身。例如，`primary`
+表示“当前主题下的主要强调色”，`content` 表示“主要前景内容”。
 
-- **一致性。** 如果 `Switch`、`Button`、`Tab` 都引用 `--primary`，它们的视觉
-  表现会自动保持一致。修改 token，就等于修改所有引用它的组件。
-- **可主题化。** 深色模式、浅色模式，以及不同品牌主题，本质上都只是 token 值
-  的替换，而不需要逐个修改组件。
+在这篇指南中，你最常看到的是两种消费方式：在 CSS 属性值中使用
+`var(--primary)`、`var(--content)`，或在 Tailwind 中使用 `bg-primary`、
+`text-content` 等原子类。它们最终都会解析到同一套运行时 token 值。
 
-LUNA 是本文示例使用的 token 层。它定义语义化 token 名称，将它们暴露为 CSS
-变量，同时也映射到 Tailwind utility 中。
+语义化 token 的价值主要体现在两个方面：
 
-因此，同一个 primitive 无论使用 plain CSS 还是 Tailwind，都能共享同一套视觉语
-言：`var(--primary)` 与 `bg-primary` 最终解析的是同一个值，基于它们构建的
-themed wrapper 也会自然继承这一点。
+- **一致性。** 如果 `Button`、`Switch` 和 `Checkbox` 都引用 `primary`，它们的视觉表现会自动保持一致。修改 token，就会同步更新所有引用它的组件。
+- **可主题化。** 组件依赖的是 `primary`、`content` 这类语义角色，而不是具体颜色。主题可以在浅色、深色或品牌变体中改变这些角色的实际取值，而不需要重写组件样式。
 
-关于 token 命名、surface 层级以及主题生成方式，可以参考
-[LUNA 主题与 Token](./luna-themes-tokens.mdx)。
+在实际使用中，这些语义角色的具体取值由祖先节点上的主题作用域提供。这与
+[自定义主题指南](/zh/guide/styling/custom-theming.html) 中描述的模式一致：在容器层应用主题 class，让子树中的样式在同一个主题作用域下解析。
+
+因此，不推荐按主题为每个组件分叉写样式：
+
+```tsx
+<Button className="bg-pink-500 dark:bg-pink-300 text-white dark:text-black" />
+```
+
+<Details title="优先使用语义化 token，而不是色阶">
+
+在 Tailwind 工具类中，前缀描述的是 CSS 属性，例如 `bg-` 表示背景色，`text-` 表示文本颜色。真正与主题相关的是前缀后面的取值。
+
+`pink-500`、`pink-300` 这类取值也可能来自一套设计色阶，但这套色阶通常是全局的：无论当前是浅色、深色，还是品牌主题，`pink-500` 都指向同一个具体颜色。因此，它不太适合需要适配多主题的组件样式。
+
+相比之下，`primary`、`primary-content` 这类语义化取值描述的是样式角色。至于这些角色最终对应什么颜色，则由当前激活的主题决定。这样组件样式可以保持稳定，而视觉结果会随主题变化。
+
+</Details>
+
+组件应该保持稳定，只消费语义化 token：
+
+```tsx
+<Button className="bg-primary text-primary-content" />
+```
+
+主题切换则发生在容器层：
+
+```tsx
+<view className="lunaris-dark">
+  <Button className="bg-primary text-primary-content" />
+  <Switch className="switch">
+    <SwitchTrack className="switch-track" />
+    <SwitchThumb className="switch-thumb" />
+  </Switch>
+</view>
+```
+
+当祖先节点上的主题 class 从 `lunaris-dark` 切换为 `lunaris-light` 时，整棵子树的 token 值都会更新，而不需要重写单个组件样式。
+
+在 `lynx-ui` 中，这种容器级主题切换模型由 LUNA 实现。LUNA 提供了四个内置主题 class：`luna-light`、`luna-dark`、`lunaris-light`
+和 `lunaris-dark`。
+
+关于 token 命名、surface 层级以及主题覆写方式，可以参考 [LUNA 主题与 Token](./luna-themes-tokens.mdx)。
 
 ## 组合 Themed Wrapper
 


### PR DESCRIPTION
Clarify the Styling and Theming guide by explaining how semantic tokens work with ancestor-scoped themes.

This update defines semantic tokens as UI roles rather than concrete color values, shows how they can be consumed through both CSS variables and Tailwind utilities, and connects the model to Lynx's custom theming pattern.

It also adds missing guidance on activating a LUNA theme by applying a theme class such as `lunaris-dark` to an ancestor node. Theme classes provide runtime token values at the container level, so component styles can stay stable across light, dark, and brand variants.

Change-Id: Iaea508193e5e720396ef8dd7acbd147497f87039

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Clarify semantic tokens and theme activation in the lynx-ui styling and theming guide

- Add `Details` component to both English and Chinese documentation for callout sections
- Clarify UI state priority guidance when multiple states overlap in the "Styling States" section
- Rewrite "Consuming Tokens" section to contrast semantic tokens with hard-coded colors and explain token intent versus concrete values
- Describe container-scoped theme resolution and how LUNA maps tokens to CSS variables and Tailwind utilities
- Document LUNA theme activation by applying theme classes (e.g., `lunaris-dark`) to ancestor nodes
- Rename token consumption section in Chinese documentation from `## 消费 Token` to `## 使用 Token` for clarity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/1027?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->