### PR TITLE
docs(blog): restructure lynx-ui launch blog and expand LUNA section

### DIFF
--- a/docs/en/blog/lynx-ui.mdx
+++ b/docs/en/blog/lynx-ui.mdx
@@ -19,7 +19,16 @@ Lynx's native elements are powerful, but they cannot solve every product problem
 
 But products are not built from atoms alone. That is where the [frontend component layer](/guide/ui/elements-components.html#components-composition-of-elements) belongs. Native provides the performance-critical foundation; [JavaScript](/guide/scripting-runtime/index.html) provides the extension layer for composition, state, styling, and product-specific behavior. lynx-ui is built around this boundary, so teams can keep the performance of native primitives while gaining the flexibility and iteration speed of frontend development.
 
-## Composability and Unlocking Design Systems
+<Go
+  example="lynx-ui-scroll-view"
+  defaultFile="Basic/index.tsx"
+  img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/lynx-ui/lynx-ui-cover-scroll-view.webm"
+  defaultEntryFile="dist/ScrollViewBasic.lynx.bundle"
+  schema="{{{url}}}?fullscreen=true&bar_color=0d0d0d&bg_color=0d0d0d"
+  webPreviewMode="auto"
+/>
+
+## Headless Components
 
 Abstraction only becomes truly useful when it stays composable. lynx-ui does not treat components as black boxes with endlessly growing prop surfaces. Instead, it exposes structured primitives that let teams decide how pieces fit together in their own product context. A dialog is not a single opaque component, but a composition of roles such as trigger, content, and state boundary. This model unlocks more than flexibility. It gives teams a stable way to compose behavior, structure, and state without turning components into rigid black boxes. lynx-ui provides the interaction logic and native integration, while leaving product teams free to decide how each piece should be assembled in real scenarios.
 
@@ -59,20 +68,19 @@ export function BrandedPopover() {
 }
 ```
 
+<Go
+  example="lynx-ui-popover"
+  defaultFile="Basic/index.tsx"
+  img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/lynx-ui/lynx-ui-cover-popover.webm"
+  defaultEntryFile="dist/PopoverBasic.lynx.bundle"
+  schema="{{{url}}}?fullscreen=true&bar_color=0d0d0d&bg_color=0d0d0d"
+  webPreviewMode="auto"
+  webPreview={false}
+/>
+
 The important part is not the visual style of this example, but the separation of responsibilities: `PopoverRoot` owns state, `PopoverTrigger` defines intent, `PopoverPositioner` handles placement, and `PopoverContent` stays structurally independent. That is the kind of composition model that makes advanced reuse natural instead of fragile.
 
-### LUNA: A Design Language for lynx-ui
-
-This same composable model also creates the foundation for Design Systems.
-
-We are obsessed with design. LUNA is the proof.
-
-- lynx-ui components are headless: no opinions on visual style, fully open to your design system
-- LUNA (lynx-ui Neo-Aesthetics) is a reference design system built on top of lynx-ui, used across all examples and demos
-- Design token system: dark/light mode, color, spacing, motion timing, all codified
-- Extensible: LUNA is the default; your design system is the override
-
-## Low-Latency Interaction
+## Main-Thread Interaction
 
 The difference between good and great is not only in the curve, but also in the timing.
 
@@ -80,11 +88,18 @@ Lynx uses a dual-thread model: the main thread handles graphics rendering, while
 
 MTS moves interaction logic onto the main thread. That means gesture input, per-frame updates, and visual response can stay in sync, making interactions feel immediate instead of approximate. Swiper is a simple example: `delta in, transform out`, frame by frame, directly on the main thread.
 
-{/* TODO(@fzx2666-fz): Insert a `<Go>` with a Swiper example to demonstrate low-latency interaction. */}
+<Go
+  example="lynx-ui-swiper"
+  defaultFile="CustomTinder/index.tsx"
+  img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/lynx-ui/lynx-ui-cover-swiper.webm"
+  defaultEntryFile="dist/SwiperCustomTinder.lynx.bundle"
+  schema="{{{url}}}?fullscreen=true&bar_color=0d0d0d&bg_color=0d0d0d"
+  webPreviewMode="auto"
+/>
 
 ## Motion
 
-With that foundation in place, low-latency interaction is what makes motion physics practical, not just decorative.
+With native foundations and main thread interaction in place, motion becomes practical, not just decorative.
 
 And that is exactly where Motion.js comes in:
 
@@ -93,6 +108,19 @@ And that is exactly where Motion.js comes in:
 - Adapted the Motion.js imperative API fully into Lynx
 - **Same code. Same API. Web and native.**
 - We're now sponsoring the Motion.js project
+
+## LUNA
+
+The sections above form the stable, headless foundation of `lynx-ui`. With LUNA, we begin exploring a shared design language for how `lynx-ui` appears in real interfaces.
+
+It grows from Lynx's signature gradient, adapting the brand expression into a softer palette for UI: warm pinks and rose tones moving into lavender and aqua.
+In LUNA, gradients act as first-class visual materials for expressing form and movement, giving components a sense of changing mediums.
+That sensitivity also carries into token names: LUNA describes how surfaces are felt, not where they are placed:
+`ambient` dissolves into the background, `faint` sits near the threshold of perception, `veil` and `film` create soft translucent layers.
+
+This is still an early answer, shaped by today's constraints. Interfaces are expanding across platforms and modalities, into the spaces and environments around us, and the vocabulary for that is still being written.
+
+We hope LUNA can be a starting point for that conversation.
 
 ## Try it today
 


### PR DESCRIPTION
Reorganize top-level headings for a product release narrative
- Rename Composability to Headless Components
- Rename Low-Latency Interaction to Main Thread Interaction
- Elevate LUNA to a standalone closing section
- Rewrite LUNA section as a launch note rather than a feature checklist. The section now frames the preceding four sections as lynx-ui's stable, headless foundation, and positions LUNA as an early attempt at a design language for Lynx

Change-Id: I8aa63c9a905e61cef34688e81f566048e38ae118