### PR TITLE
feat(luna): support container-query responsive in LunaStudioShowcase

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@radix-ui/react-tooltip": "^1.1.3",
     "@rspress/core": "2.0.6",
     "@shikijs/transformers": "^4.0.2",
+    "@tailwindcss/container-queries": "^0.1.1",
     "class-variance-authority": "^0.7.1",
     "classnames": "^2.5.1",
     "clsx": "^1.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@shikijs/transformers':
         specifier: ^4.0.2
         version: 4.0.2
+      '@tailwindcss/container-queries':
+        specifier: ^0.1.1
+        version: 0.1.1(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2801,6 +2804,11 @@ packages:
 
   '@swc/helpers@0.5.21':
     resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
+
+  '@tailwindcss/container-queries@0.1.1':
+    resolution: {integrity: sha512-p18dswChx6WnTSaJCSGx6lTmrGzNNvm2FtXmiO6AuA1V4U5REyoqwmT6kgAsIMdjo07QdAfYXHJ4hnMtfHzWgA==}
+    peerDependencies:
+      tailwindcss: '>=3.2.0'
 
   '@tanstack/history@1.139.0':
     resolution: {integrity: sha512-l6wcxwDBeh/7Dhles23U1O8lp9kNJmAb2yNjekR6olZwCRNAVA8TCXlVCrueELyFlYZqvQkh0ofxnzG62A1Kkg==}
@@ -9108,6 +9116,10 @@ snapshots:
   '@swc/helpers@0.5.21':
     dependencies:
       tslib: 2.8.1
+
+  '@tailwindcss/container-queries@0.1.1(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.3)
 
   '@tanstack/history@1.139.0': {}
 

--- a/src/luna/luna-studio.tsx
+++ b/src/luna/luna-studio.tsx
@@ -288,11 +288,13 @@ function LunaStudioShowcase({
   defaultViewMode = 'lineup',
   defaultThemeMode,
   defaultThemeModeLocked = true,
+  responsiveMode = 'viewport',
 }: {
   className?: string;
   defaultViewMode?: StudioViewMode;
   defaultThemeMode?: LunaThemeMode;
   defaultThemeModeLocked?: boolean;
+  responsiveMode?: 'viewport' | 'container';
 }) {
   const pageIsDark = useDark();
   const pageThemeMode: LunaThemeMode = pageIsDark ? 'dark' : 'light';
@@ -347,15 +349,44 @@ function LunaStudioShowcase({
       ? 'bg-[#ffffffbb]'
       : 'bg-[#0000001a]';
 
+  const isContainerResponsive = responsiveMode === 'container';
+  const rootBaseClassName =
+    'relative isolate w-full overflow-hidden rounded-[24px] transition-all duration-300';
+  const rootClassName = cn(
+    rootBaseClassName,
+    isContainerResponsive ? '@container' : undefined,
+    containerClassName,
+    className,
+  );
+
+  const rootViewportClassName =
+    'p-8 px-4 md:px-6 md:py-6 h-[420px] sm:h-[520px] md:h-[580px] lg:h-[640px] xl:h-[700px] 2xl:h-[760px]';
+  const rootContainerClassName =
+    'p-8 px-10 @xl:px-12 @3xl:px-14 h-[360px] @sm:h-[400px] @md:h-[440px] @lg:h-[480px] @xl:h-[500px] @2xl:h-[520px] @3xl:h-[580px]';
+
+  const stageWrapperClassName = cn(
+    'relative z-0 w-full',
+    isContainerResponsive ? rootContainerClassName : rootViewportClassName,
+  );
+
+  const controlsWrapperClassName = cn(
+    'absolute z-50 rounded-full shadow-sm backdrop-blur transform-gpu',
+    isContainerResponsive
+      ? 'bottom-2 left-1/2 -translate-x-1/2 @3xl:left-auto @3xl:right-2 @3xl:translate-x-0'
+      : 'bottom-2 sm:bottom-4 left-1/2 -translate-x-1/2 md:left-auto md:right-4 md:translate-x-0',
+    controlsBgClassName,
+  );
+
+  const controlsInnerClassName = cn(
+    'flex items-center gap-1 px-2 py-2',
+    isContainerResponsive
+      ? '@3xl:flex-col @3xl:justify-between @3xl:gap-2 @3xl:px-2 @3xl:py-3'
+      : 'md:flex-col md:justify-between md:gap-2 md:px-2 md:py-3',
+  );
+
   return (
-    <div
-      className={cn(
-        'relative isolate w-full overflow-hidden rounded-[24px] transition-all duration-300 h-[420px] sm:h-[520px] md:h-[580px] lg:h-[640px] xl:h-[700px] 2xl:h-[760px]',
-        containerClassName,
-        className,
-      )}
-    >
-      <div className="relative z-0 h-full w-full p-6 px-4">
+    <div className={rootClassName}>
+      <div className={stageWrapperClassName}>
         <Choreography
           bundleRoot={BUNDLE_ROOT}
           className="gap-4"
@@ -374,13 +405,8 @@ function LunaStudioShowcase({
         />
       </div>
 
-      <div
-        className={cn(
-          'absolute bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-full shadow-sm backdrop-blur transform-gpu md:left-auto md:right-4 md:translate-x-0',
-          controlsBgClassName,
-        )}
-      >
-        <div className="flex items-center gap-1 px-2 py-2 md:flex-col md:justify-between md:gap-2 md:px-2 md:py-3">
+      <div className={controlsWrapperClassName}>
+        <div className={controlsInnerClassName}>
           {VIEW_MODE_ITEMS.map((item) => (
             <IconToggleButton
               key={item.value}
@@ -394,7 +420,10 @@ function LunaStudioShowcase({
 
           <div
             className={cn(
-              'mx-1 h-px w-2 md:mx-0 md:h-6 md:w-px',
+              'mx-1 h-px w-2',
+              isContainerResponsive
+                ? '@3xl:mx-0 @3xl:h-6 @3xl:w-px'
+                : 'md:mx-0 md:h-6 md:w-px',
               dividerClassName,
             )}
           />
@@ -412,7 +441,10 @@ function LunaStudioShowcase({
 
           <div
             className={cn(
-              'mx-1 h-px w-2 md:mx-0 md:h-6 md:w-px',
+              'mx-1 h-px w-2',
+              isContainerResponsive
+                ? '@3xl:mx-0 @3xl:h-6 @3xl:w-px'
+                : 'md:mx-0 md:h-6 md:w-px',
               dividerClassName,
             )}
           />
@@ -431,7 +463,10 @@ function LunaStudioShowcase({
 
           <div
             className={cn(
-              'mx-1 h-px w-1 md:mx-0 md:h-6 md:w-px',
+              'mx-1 h-px w-1',
+              isContainerResponsive
+                ? '@3xl:mx-0 @3xl:h-6 @3xl:w-px'
+                : 'md:mx-0 md:h-6 md:w-px',
               dividerClassName,
             )}
           />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -141,5 +141,8 @@ export default {
       },
     },
   },
-  plugins: [require('tailwindcss-animate')],
+  plugins: [
+    require('@tailwindcss/container-queries'),
+    require('tailwindcss-animate'),
+  ],
 };


### PR DESCRIPTION
- Add `responsiveMode` prop to switch between viewport breakpoints and container-query breakpoints.
- Use Tailwind container query variants (`@container`, `@md:` etc.) to drive height/controls layout based on content column width.
- Register `@tailwindcss/container-queries` in Tailwind config and move it to runtime dependencies for downstream consumers.
- This is primarily to support blog/docs layouts with sidebars (single/double sidebar), where the content column width is not a monotonic function of viewport width (e.g. smaller viewports may drop sidebars and end up with a wider content column), so container-based breakpoints are a better fit than viewport-based ones.

Change-Id: I7256f2afb5d973ce0605670196ca62f93c911020

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## feat(luna): support container-query responsive in LunaStudioShowcase

- Add `@tailwindcss/container-queries` to runtime dependencies in `package.json`
- Register `@tailwindcss/container-queries` plugin in Tailwind configuration
- Introduce `responsiveMode` prop to `LunaStudioShowcase` to toggle between viewport and container-based breakpoints
- Refactor `LunaStudioShowcase` layout logic to compute responsive state and apply `@container` scoping for container-mode styling
- Update divider elements to use container-query variants (`@3xl`) when container-responsive, and viewport variants (`md`) when viewport-responsive

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/1030?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->