### PR TITLE
docs(luna): document missing secondary and neutral tokens

### DIFF
--- a/docs/en/lynx-ui/luna-themes-tokens.mdx
+++ b/docs/en/lynx-ui/luna-themes-tokens.mdx
@@ -100,20 +100,32 @@ Primary tokens define high-emphasis actions and active states.
 Use `primary` for action emphasis, not as a replacement for every surface in
 the interface.
 
+### Secondary
+
+Secondary tokens define supporting accents and complementary emphasis.
+
+| Token                     | Use For                                              |
+| ------------------------- | ---------------------------------------------------- |
+| `secondary`               | Supporting accent                                    |
+| `secondary-2`             | Softened variant of `secondary`                      |
+| `secondary-content`       | Text and icons placed on secondary surfaces          |
+| `secondary-content-faded` | Reduced-presence text or icons on secondary surfaces |
+
 ### Neutral
 
 Neutral tokens provide structural contrast and low-emphasis fills.
 
-| Token             | Use For                                  |
-| ----------------- | ---------------------------------------- |
-| `neutral`         | Strong neutral surfaces                  |
-| `neutral-2`       | Slightly softened neutral surfaces       |
-| `neutral-subtle`  | Quiet structural fills                   |
-| `neutral-faint`   | Low-emphasis fills and inactive states   |
-| `neutral-ambient` | Near-background structural fill          |
-| `neutral-content` | Foreground on neutral surfaces           |
-| `neutral-veil`    | Strong translucent layer toward presence |
-| `neutral-film`    | Light translucent layer toward presence  |
+| Token                   | Use For                                         |
+| ----------------------- | ----------------------------------------------- |
+| `neutral`               | Strong neutral surfaces                         |
+| `neutral-2`             | Slightly softened neutral surfaces              |
+| `neutral-subtle`        | Quiet structural fills                          |
+| `neutral-faint`         | Low-emphasis fills and inactive states          |
+| `neutral-ambient`       | Near-background structural fill                 |
+| `neutral-content`       | Foreground on neutral surfaces                  |
+| `neutral-content-faded` | Reduced-presence foreground on neutral surfaces |
+| `neutral-veil`          | Strong translucent layer toward presence        |
+| `neutral-film`          | Light translucent layer toward presence         |
 
 In practice, `neutral-faint` is one of the most useful tokens for form controls,
 tracks, and supporting UI chrome.

--- a/docs/zh/lynx-ui/luna-themes-tokens.mdx
+++ b/docs/zh/lynx-ui/luna-themes-tokens.mdx
@@ -54,7 +54,7 @@ token，已经足够覆盖绝大多数产品 surface。
 如果你正在为 `lynx-ui` 组件做样式，或者希望用 AI 生成 UI，建议优先从这些 token
 开始。
 
-### Surface
+### Surface：表面层
 
 Surface token 用于定义界面的背景层级。
 
@@ -75,7 +75,7 @@ Surface token 用于定义界面的背景层级。
 - `paper` 定义内容区域
 - `paper-clear` 用于 popover、sheet 等浮层 surface
 
-### Content
+### Content：内容前景
 
 Content token 用于定义文字与图标的视觉存在感。
 
@@ -93,7 +93,7 @@ Content token 用于定义文字与图标的视觉存在感。
 - 主文案优先使用 `content`
 - 辅助文案优先使用 `content-2` 或 `content-muted`
 
-### Primary
+### Primary：主强调
 
 Primary token 用于定义高强调度的操作与激活态。
 
@@ -107,24 +107,36 @@ Primary token 用于定义高强调度的操作与激活态。
 
 `primary` 应该用于强调操作，而不是替代所有 surface 的默认颜色。
 
-### Neutral
+### Secondary：辅助强调
+
+Secondary token 用于定义辅助强调色与互补的强调层级。
+
+| Token                     | 用途                                 |
+| ------------------------- | ------------------------------------ |
+| `secondary`               | 辅助强调色                           |
+| `secondary-2`             | `secondary` 的柔和变体               |
+| `secondary-content`       | secondary surface 上的文字与图标     |
+| `secondary-content-faded` | secondary surface 上弱化存在感的前景 |
+
+### Neutral：中性结构
 
 Neutral token 用于提供结构性对比与低强调度填充。
 
-| Token             | 用途                     |
-| ----------------- | ------------------------ |
-| `neutral`         | 强中性 surface           |
-| `neutral-2`       | 更柔和的中性 surface     |
-| `neutral-subtle`  | 安静的结构性填充         |
-| `neutral-faint`   | 低强调度填充与未激活状态 |
-| `neutral-ambient` | 接近背景的结构性填充     |
-| `neutral-content` | 中性 surface 上的前景    |
-| `neutral-veil`    | 更强调存在感的强半透明层 |
-| `neutral-film`    | 更轻的半透明层           |
+| Token                   | 用途                            |
+| ----------------------- | ------------------------------- |
+| `neutral`               | 强中性 surface                  |
+| `neutral-2`             | 更柔和的中性 surface            |
+| `neutral-subtle`        | 安静的结构性填充                |
+| `neutral-faint`         | 低强调度填充与未激活状态        |
+| `neutral-ambient`       | 接近背景的结构性填充            |
+| `neutral-content`       | 中性 surface 上的前景           |
+| `neutral-content-faded` | 中性 surface 上弱化存在感的前景 |
+| `neutral-veil`          | 更强调存在感的强半透明层        |
+| `neutral-film`          | 更轻的半透明层                  |
 
 实际使用中，`neutral-faint` 是最常用的 token 之一，非常适合表单控件、轨道以及辅助性 UI chrome。
 
-### 分隔与 Backdrop
+### Line / Backdrop：分隔线与遮罩层
 
 这一组 token 用于处理分隔线与屏幕级覆盖层。
 
@@ -140,7 +152,7 @@ Neutral token 用于提供结构性对比与低强调度填充。
 
 它们的区别在于语义角色，而不是粗细。
 
-### Gradient
+### Gradient：渐变
 
 Gradient token 是可选的，但它们能帮助 container 较多的 `lynx-ui` 示例建立更清晰的视觉识别。
 


### PR DESCRIPTION
- Add the missing Secondary token group (`secondary` , `secondary-2` , `secondary-content` , `secondary-content-faded`).
- Add `neutral-content-faded` to the Neutral token table.
- Apply the same token coverage updates to both EN and ZH LUNA token docs.
- Refine ZH section titles

Change-Id: I9948e0ecaadef96154b09db83f25a2b90bee9594

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Document missing Secondary and Neutral token groups in LUNA themes:

- Add Secondary token group section to `lynx-ui` LUNA token documentation, defining `secondary`, `secondary-2`, `secondary-content`, and `secondary-content-faded` roles
- Include `neutral-content-faded` in the Neutral token table to complete the token coverage
- Refine Chinese documentation section titles with explicit H2/H3 headings for Surface, Content, Primary, Secondary, Neutral, Line/Backdrop, and Gradient categories
- Apply token updates consistently across both English and Chinese language versions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/1035?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->