### PR TITLE
fix: limit mobile drawer height to prevent overflow

### DIFF
--- a/theme/AfterNavTitle.tsx
+++ b/theme/AfterNavTitle.tsx
@@ -427,7 +427,7 @@ export default function AfterNavTitle() {
             <Trigger />
           </DrawerTrigger>
           <DrawerContent>
-            <div className="py-5 px-4 pb-7">
+            <div className="py-5 px-4 pb-7 max-h-[70dvh] overflow-y-auto">
               <NavContent onSelect={() => setIsOpen(false)} isDrawer />
             </div>
           </DrawerContent>


### PR DESCRIPTION
## Summary
- Cap the subsite navigation drawer content at `70dvh` on mobile, making it scrollable when there are many entries
- Prevents the drawer from exceeding the screen height, similar to iOS bottom sheet behavior

## Test plan
- [ ] Open the site on a mobile viewport (or responsive mode)
- [ ] Click the chevron dropdown to open the drawer
- [ ] Verify the drawer does not exceed ~70% of the viewport height
- [ ] Verify the content is scrollable within the drawer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Limit mobile drawer height to prevent overflow

Constrain the subsite navigation drawer content to a maximum of 70dvh on mobile and enable vertical scrolling when content exceeds the viewport. This prevents the drawer from overflowing the screen and mirrors iOS bottom sheet behavior, while leaving desktop dropdown behavior unchanged.

**Changes:**
- Add `max-h-[70dvh]` and `overflow-y-auto` to the DrawerContent wrapper in mobile layout

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/1037?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->