### PR TITLE
fix(docs): disable web preview for motion full entry examples

### DIFF
--- a/docs/en/lynx-ui/motion.mdx
+++ b/docs/en/lynx-ui/motion.mdx
@@ -59,7 +59,7 @@ The usual pattern is:
   defaultEntryFile="dist/basic.lynx.bundle"
   entry="src/Basic"
   highlight={motionBasicDemoMeta.highlight}
-  defaultTab="web"
+  webPreview={false}
 />
 
 ## Use Springs
@@ -72,7 +72,7 @@ Set `type: 'spring'` when a value should settle with spring physics instead of f
   defaultEntryFile="dist/spring.lynx.bundle"
   entry="src/Spring"
   highlight={motionSpringDemoMeta.highlight}
-  defaultTab="web"
+  webPreview={false}
 />
 
 ## Use Motion Values

--- a/docs/zh/lynx-ui/motion.mdx
+++ b/docs/zh/lynx-ui/motion.mdx
@@ -59,7 +59,7 @@ import { animate, motionValue, styleEffect } from '@lynx-js/motion';
   defaultEntryFile="dist/basic.lynx.bundle"
   entry="src/Basic"
   highlight={motionBasicDemoMeta.highlight}
-  defaultTab="web"
+  webPreview={false}
 />
 
 ## 使用弹簧动画
@@ -72,7 +72,7 @@ import { animate, motionValue, styleEffect } from '@lynx-js/motion';
   defaultEntryFile="dist/spring.lynx.bundle"
   entry="src/Spring"
   highlight={motionSpringDemoMeta.highlight}
-  defaultTab="web"
+  webPreview={false}
 />
 
 ## 使用 MotionValue


### PR DESCRIPTION
## Summary

- Disable `webPreview` for the first two `<Go>` examples (Basic, Spring) on the `@lynx-js/motion` page (EN + ZH)
- These examples use the full motion entry which hits a `window.MotionHandoffAnimation` TypeError on Lynx for Web due to web-core's MTS IIFE shadowing `window = void 0`

The other examples (MotionValue, Gesture, Mini) keep web preview enabled.

## Related

- Upstream motion-dom issue: https://github.com/motiondivision/motion/issues/3735
- Web-core fix: lynx-family/lynx-stack#2696
- Motion build-time fix: lynx-family/lynx-stack#2697