### PR TITLE
feat: make lynx-ui homepage badge link to release blog post

### DIFF
--- a/theme/hooks/use-blog-btn-dom.ts
+++ b/theme/hooks/use-blog-btn-dom.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo } from 'react';
 import { useLang, useNavigate, usePageData } from '@rspress/core/runtime';
 import { useLatestBlog, type LatestBlogConfig } from '@site/src/hooks';
 
-type ConfigKey = '/' | '/react/' | '/rspeedy/';
+type ConfigKey = '/' | '/react/' | '/rspeedy/' | '/lynx-ui/';
 
 /**
  * Configuration for the blog button on different subsites.
@@ -48,6 +48,15 @@ const config: Record<
       en: 'Rspeedy',
     },
   },
+  '/lynx-ui/': {
+    text: {
+      zh: 'lynx-ui 正式发布',
+      en: 'lynx-ui is officially released',
+    },
+    latestBlogConfig: {
+      filename: 'lynx-ui',
+    },
+  },
 };
 
 const useBlogBtnDom = (src: string) => {
@@ -61,7 +70,9 @@ const useBlogBtnDom = (src: string) => {
         ? '/react/'
         : src.startsWith('/rspeedy/')
           ? '/rspeedy/'
-          : '/'
+          : src.startsWith('/lynx-ui/')
+            ? '/lynx-ui/'
+            : '/'
     ) as ConfigKey;
   }, [src]);
 
@@ -82,15 +93,17 @@ const useBlogBtnDom = (src: string) => {
     }
   }, [navigate, blogLink, isExternal]);
 
+  const hasLinkedBlog = !!latestBlogConfig;
+
   // Determine the display text
   const displayText = useMemo(() => {
-    if (configKey === '/') {
-      // For main site, use dynamic blog text or fallback
+    if (hasLinkedBlog) {
+      // Use dynamic blog text or fallback
       return blogText || config[configKey].text[lang];
     }
-    // For subsites, use static text
+    // For subsites without blog config, use static text
     return config[configKey].text[lang];
-  }, [configKey, blogText, lang]);
+  }, [hasLinkedBlog, configKey, blogText, lang]);
 
   useEffect(() => {
     if (page.pageType !== 'home') return;
@@ -106,14 +119,13 @@ const useBlogBtnDom = (src: string) => {
     if (!targetElement) return;
     if (!badgeElement) return;
 
-    badgeElement.className =
-      configKey === '/'
-        ? `rp-home-hero__badge active-hover`
-        : `rp-home-hero__badge`;
+    badgeElement.className = hasLinkedBlog
+      ? `rp-home-hero__badge active-hover`
+      : `rp-home-hero__badge`;
     badgeElement.textContent = displayText;
     badgeElement.style.opacity = '1';
 
-    if (configKey === '/') {
+    if (hasLinkedBlog) {
       badgeElement.addEventListener('click', handleInteraction);
       badgeElement.addEventListener('touchstart', handleInteraction);
     }


### PR DESCRIPTION
## Summary
- Add `/lynx-ui/` to the blog button config in `use-blog-btn-dom.ts` so the hero badge on the lynx-ui homepage navigates to the lynx-ui release blog post on click
- Generalize the clickable badge logic from `configKey === '/'` to `hasLinkedBlog` (checks if `latestBlogConfig` is defined), making it easy to add blog-linked badges to other subsites in the future

## Test plan
- [ ] Visit the lynx-ui homepage and verify the badge shows "lynx-ui is released!" with a hover effect
- [ ] Click the badge and verify it navigates to the lynx-ui blog post
- [ ] Visit the main site homepage and verify the badge still works as before
- [ ] Visit `/react/` and `/rspeedy/` homepages and verify their badges remain static (no click behavior)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Make lynx-ui homepage badge link to release blog post

- Extend `ConfigKey` type to include `'/lynx-ui/'`
- Add `/lynx-ui/` to blog button configuration with static text "lynx-ui 正式发布" / "lynx-ui is officially released" and `latestBlogConfig` pointing to the 'lynx-ui' blog post
- Enhance `configKey` derivation logic to map `/lynx-ui/` routes to the new config entry
- Generalize clickable-badge activation: replace `configKey === '/'` condition with `hasLinkedBlog` check so any subsite with a defined `latestBlogConfig` gains interactive badge behavior with hover styling and navigation functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/1040?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->