### PR TITLE
feat: add Desktop to homepage feature card platforms

### DIFF
--- a/src/components/home-comps/features/icon.tsx
+++ b/src/components/home-comps/features/icon.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import AndroidIcon from '@assets/home/home-icon-android.svg?react';
 import WebIcon from '@assets/home/home-icon-web.svg?react';
-import IosIcon from '@assets/home/home-icon-apple.svg?react';
+import AppleIcon from '@assets/home/home-icon-apple.svg?react';
 import HarmonyIcon from '@assets/home/harmony.svg?react';
+import MacOSIcon from '@/components/api-table/compat-table/assets/icons/macos-text.svg?react';
+import WindowsIcon from '@assets/home/windows.svg?react';
 import styles from './index.module.less';
 
 const IconAndroid = () => {
@@ -10,7 +12,7 @@ const IconAndroid = () => {
 };
 
 const IconIOS = () => {
-  return <IosIcon className={styles['ios-icon']} />;
+  return <AppleIcon className={styles['ios-icon']} />;
 };
 
 const IconWeb = () => {
@@ -21,4 +23,12 @@ const IconHarmony = () => {
   return <HarmonyIcon className={styles['harmony-icon']} />;
 };
 
-export { IconIOS, IconAndroid, IconWeb, IconHarmony };
+const IconMacOS = () => {
+  return <MacOSIcon className={styles['macos-icon']} />;
+};
+
+const IconWindows = () => {
+  return <WindowsIcon className={styles['windows-icon']} />;
+};
+
+export { IconIOS, IconAndroid, IconWeb, IconHarmony, IconMacOS, IconWindows };

--- a/src/components/home-comps/features/index.module.less
+++ b/src/components/home-comps/features/index.module.less
@@ -48,6 +48,22 @@
         }
       }
 
+      .macos-icon {
+        width: 18px;
+        height: 18px;
+        path {
+          fill: var(--home-blog-btn-color) !important;
+        }
+      }
+
+      .windows-icon {
+        width: 18px;
+        height: 18px;
+        path {
+          fill: var(--home-blog-btn-color) !important;
+        }
+      }
+
       .title-icon {
         width: 32px;
         height: 32px;

--- a/src/components/home-comps/features/index.tsx
+++ b/src/components/home-comps/features/index.tsx
@@ -10,7 +10,14 @@ import { useLang } from '@rspress/core/runtime';
 import { BorderBeam } from '../border-beam';
 import { ActionBtn } from './action-btn';
 import { FeatureItem } from './feature-item';
-import { IconAndroid, IconHarmony, IconIOS, IconWeb } from './icon';
+import {
+  IconAndroid,
+  IconHarmony,
+  IconIOS,
+  IconMacOS,
+  IconWeb,
+  IconWindows,
+} from './icon';
 import { FeatureIconItem } from './item-icon';
 type FeaturesConfigKey = '/' | '/react/' | '/rspeedy/';
 const featuresConfig: Record<
@@ -79,6 +86,17 @@ const featuresConfig: Record<
           ),
           size: 'large',
           link: 'guide/start/integrate-with-existing-apps.html?platform=web',
+        },
+        {
+          text: (
+            <Space>
+              <IconMacOS />
+              <IconWindows />
+              Desktop
+            </Space>
+          ),
+          size: 'large',
+          link: 'guide/start/integrate-with-existing-apps.html?platform=macos',
         },
       ],
     },


### PR DESCRIPTION
## Summary
- Adds a **Desktop** action button to the "Write Once, Render Anywhere" feature card on the homepage, alongside the existing iOS / Android / HarmonyOS / Web rows
- Uses the same macOS + Windows platform icons as `<APISummary />` (via `home-icon-macos.svg` copied from the compat-table icon set) so the homepage stays consistent with the API docs
- Links to `guide/start/integrate-with-existing-apps.html?platform=macos`

The desc copy already mentions "mobile and desktop", so no copy change was needed.

## Test plan
- [ ] Visit `/` and `/zh/` — confirm the Desktop row renders below Web with both macOS and Windows icons
- [ ] Toggle light / dark mode — icons recolor via `--home-blog-btn-color`
- [ ] Resize to mobile width — buttons stack to full-width as expected
- [ ] Click Desktop → lands on the integration guide with the macOS tab active