### PR TITLE
feat(api-table): use macos-text icon for macOS column

### DIFF
--- a/src/components/api-table/compat-table/headers.tsx
+++ b/src/components/api-table/compat-table/headers.tsx
@@ -30,9 +30,10 @@ function mapPlatformKindToIconName(platformType: BCD.PlatformType) {
 export function mapPlatformNameToIconName(platformName: BCD.PlatformName) {
   switch (platformName) {
     case 'ios':
-    case 'clay_macos':
     case 'clay_ios':
       return 'apple';
+    case 'clay_macos':
+      return 'macos-text';
     case 'android':
     case 'clay_android':
       return 'android';

--- a/src/components/api-table/compat-table/ui/_icon.scss
+++ b/src/components/api-table/compat-table/ui/_icon.scss
@@ -27,7 +27,7 @@ $icons:
   'simple-firefox', 'small-arrow', 'theme-light', 'star-filled', 'star',
   'theme-os-default', 'thumbs-down', 'thumbs-up', 'trash', 'trash-filled',
   'twitter-x', 'unknown', 'warning', 'webview', 'yes', 'yes-circle', 'apple',
-  'android', 'windows', 'web', 'clay', 'harmony', 'reactlynx';
+  'macos-text', 'android', 'windows', 'web', 'clay', 'harmony', 'reactlynx';
 
 .icon {
   --size: var(--icon-size, 1rem);


### PR DESCRIPTION
## Summary
- Previously, the compat table reused the Apple logo for both **iOS** and **macOS** (`clay_macos`) header columns, making the two visually indistinguishable
- Maps `clay_macos` to a dedicated `macos-text` icon — the same one `<APISummary />` already uses for the macOS platform badge
- iOS (`ios`, `clay_ios`) continues to use the Apple logo

## Before / After
**Before:** macOS column shows the Apple logo (same as iOS)
**After:** macOS column shows the rounded-square `macos-text` icon, matching how APISummary renders the macOS badge

## Test plan
- [ ] Visit any page with an `<APITable />` (e.g. `/guide/devtool`) — confirm the macOS column header now shows the macos-text icon instead of the Apple logo
- [ ] Confirm iOS column still shows the Apple logo
- [ ] Confirm the icon recolors correctly in dark mode (uses the same `currentColor` mask treatment as the other platform icons)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Use dedicated `macos-text` icon for macOS column

Differentiate the platform icons in the API table compatibility table by mapping `clay_macos` to the `macos-text` icon instead of the Apple logo. This aligns the macOS column with the icon used in `<APISummary />` for the macOS platform badge, while `clay_ios` continues to use the Apple logo.

**Changes:**
- Map `clay_macos` to `macos-text` and `clay_ios` to `apple` in the platform icon mapping
- Add `macos-text` to the SCSS icon mask classes in the compat table styling

The icon uses `currentColor` masking, ensuring correct recoloring across light and dark modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/1043?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->