### PR TITLE
feat(home): align Web icon with APISummary and APITable

### DIFF
--- a/src/components/home-comps/features/icon.tsx
+++ b/src/components/home-comps/features/icon.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import AndroidIcon from '@assets/home/home-icon-android.svg?react';
-import WebIcon from '@assets/home/home-icon-web.svg?react';
+import WebIcon from '@/components/api-table/compat-table/assets/icons/web.svg?react';
 import AppleIcon from '@assets/home/home-icon-apple.svg?react';
 import HarmonyIcon from '@assets/home/harmony.svg?react';
 import MacOSIcon from '@/components/api-table/compat-table/assets/icons/macos-text.svg?react';
@@ -16,7 +16,7 @@ const IconIOS = () => {
 };
 
 const IconWeb = () => {
-  return <WebIcon />;
+  return <WebIcon className={styles['web-icon']} />;
 };
 
 const IconHarmony = () => {

--- a/src/components/home-comps/features/index.module.less
+++ b/src/components/home-comps/features/index.module.less
@@ -41,6 +41,14 @@
         }
       }
 
+      .web-icon {
+        width: 18px;
+        height: 18px;
+        path {
+          fill: var(--home-blog-btn-color) !important;
+        }
+      }
+
       .harmony-icon {
         width: 21px;
         path {


### PR DESCRIPTION
## Summary
- The homepage feature card used a separate blue-globe SVG (`@assets/home/home-icon-web.svg`) for the **Web** action button
- Both `<APISummary />` and `<APITable />` already render an HTML5 shield from the compat-table icon set for Web
- This PR imports that same `web.svg` in the homepage and applies the shared `--home-blog-btn-color` treatment, so all three surfaces show the same Web logo

`home-icon-web.svg` stays in the repo because `PlatformIcon` (used by integration-guide tabs) still references it.

## Test plan
- [ ] Visit `/` — Web button now shows the HTML5 shield, matching APITable / APISummary
- [ ] Compare with the Web column of an `<APITable />` (e.g. `/guide/devtool`) — same glyph
- [ ] Toggle light / dark mode — icon recolors via `--home-blog-btn-color`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Replace home Web icon with compat-table Web SVG

Replace the custom blue-globe Web icon with the HTML5 shield from the compat-table icon set, ensuring consistency across the homepage, APISummary, and APITable components.

**Changes:**
- Import `web.svg` from the compat-table icon set instead of the custom `home-icon-web.svg` in the Web icon component
- Apply `--home-blog-btn-color` styling to the imported SVG for consistent theming with other home components
- Add CSS class styling to control the Web icon dimensions (18px × 18px) and fill color

**Testing:**
- Homepage Web button displays the HTML5 shield matching APITable and APISummary
- Icon recolors correctly in light and dark modes via the shared color variable

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/1044?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->