### PR TITLE
chore: rename debug-info-remapping skill docs with lynx prefix

### DIFF
--- a/docs/en/ai/_meta.json
+++ b/docs/en/ai/_meta.json
@@ -48,7 +48,7 @@
   },
   {
     "type": "file",
-    "name": "skills/debug-info-remapping.mdx"
+    "name": "skills/lynx-debug-info-remapping.mdx"
   },
   {
     "type": "divider"

--- a/docs/en/ai/skills/lynx-debug-info-remapping.mdx
+++ b/docs/en/ai/skills/lynx-debug-info-remapping.mdx
@@ -1,11 +1,11 @@
-# debug-info-remapping
+# lynx-debug-info-remapping
 
 Helps agents debug main-thread runtime errors by remapping minified error messages back to their original source, making stack traces actionable.
 
 ## Installation
 
 ```bash
-npx skills add lynx-community/skills -s debug-info-remapping
+npx skills add lynx-community/skills -s lynx-debug-info-remapping
 ```
 
 This adds the skill rules to your project so that compatible coding agents (such as Claude Code, Cursor, or Copilot) can automatically apply them.

--- a/docs/en/blog/lynx-3-7.mdx
+++ b/docs/en/blog/lynx-3-7.mdx
@@ -138,14 +138,14 @@ As part of the [Lynx for AI](/ai) initiative, six [agent skills](https://github.
 npx skills add lynx-community/skills -s <skill-name>
 ```
 
-| Skill                        | What it does                                                                                 |
-| ---------------------------- | -------------------------------------------------------------------------------------------- |
-| **reactlynx-best-practices** | Static analysis, auto-fix, and best-practice rules for writing dual-threaded ReactLynx code. |
-| **lynx-devtool**             | Inspect DOM, console output, and runtime state of a running Lynx app via CLI.                |
-| **lynx-typescript**          | Guidance on TypeScript setup, typing, and event handling in Lynx projects.                   |
-| **trace-analysis**           | Analyze `.ptrace` files to identify rendering bottlenecks and performance regressions.       |
-| **trace-record**             | Capture Lynx performance traces with system trace and JS profiling support.                  |
-| **debug-info-remapping**     | Remap minified main-thread error positions back to original source locations.                |
+| Skill                         | What it does                                                                                 |
+| ----------------------------- | -------------------------------------------------------------------------------------------- |
+| **reactlynx-best-practices**  | Static analysis, auto-fix, and best-practice rules for writing dual-threaded ReactLynx code. |
+| **lynx-devtool**              | Inspect DOM, console output, and runtime state of a running Lynx app via CLI.                |
+| **lynx-typescript**           | Guidance on TypeScript setup, typing, and event handling in Lynx projects.                   |
+| **trace-analysis**            | Analyze `.ptrace` files to identify rendering bottlenecks and performance regressions.       |
+| **trace-record**              | Capture Lynx performance traces with system trace and JS profiling support.                  |
+| **lynx-debug-info-remapping** | Remap minified main-thread error positions back to original source locations.                |
 
 Together with [Lynx DevTool MCP](/ai/lynx-devtool-mcp), coding agents can now inspect running pages, verify interactions, and debug their own changes with tighter feedback loops.
 

--- a/docs/zh/ai/_meta.json
+++ b/docs/zh/ai/_meta.json
@@ -48,7 +48,7 @@
   },
   {
     "type": "file",
-    "name": "skills/debug-info-remapping.mdx"
+    "name": "skills/lynx-debug-info-remapping.mdx"
   },
   {
     "type": "divider"

--- a/docs/zh/ai/skills/lynx-debug-info-remapping.mdx
+++ b/docs/zh/ai/skills/lynx-debug-info-remapping.mdx
@@ -2,14 +2,14 @@
 description: '将压缩后的主线程错误重映射回源码。'
 ---
 
-# debug-info-remapping
+# lynx-debug-info-remapping
 
 帮助 agent 调试主线程运行时错误，将压缩后的错误信息重新映射回原始源码，使堆栈跟踪变得可操作。
 
 ## 安装
 
 ```bash
-npx skills add lynx-community/skills -s debug-info-remapping
+npx skills add lynx-community/skills -s lynx-debug-info-remapping
 ```
 
 这会将 skill 规则添加到你的项目中，以便兼容的 coding agent（如 Claude Code、Cursor 或 Copilot）能够自动应用它们。

--- a/docs/zh/blog/lynx-3-7.mdx
+++ b/docs/zh/blog/lynx-3-7.mdx
@@ -132,14 +132,14 @@ Lynx 正式支持 **macOS** 和 **Windows** 作为一级平台。你现在可以
 npx skills add lynx-community/skills -s <skill-name>
 ```
 
-| 技能                         | 功能                                                              |
-| ---------------------------- | ----------------------------------------------------------------- |
-| **reactlynx-best-practices** | 静态分析、自动修复，以及编写双线程 ReactLynx 代码的最佳实践规则。 |
-| **lynx-devtool**             | 通过命令行检查运行中 Lynx 应用的 DOM、控制台输出和运行时状态。    |
-| **lynx-typescript**          | Lynx 项目中 TypeScript 环境配置、类型与事件处理的指导。           |
-| **trace-analysis**           | 分析 `.ptrace` 文件，定位渲染瓶颈与性能回退。                     |
-| **trace-record**             | 采集 Lynx 性能 trace，支持系统 trace 和 JS profiling。            |
-| **debug-info-remapping**     | 将主线程压缩后的错误位置映射回原始源码。                          |
+| 技能                          | 功能                                                              |
+| ----------------------------- | ----------------------------------------------------------------- |
+| **reactlynx-best-practices**  | 静态分析、自动修复，以及编写双线程 ReactLynx 代码的最佳实践规则。 |
+| **lynx-devtool**              | 通过命令行检查运行中 Lynx 应用的 DOM、控制台输出和运行时状态。    |
+| **lynx-typescript**           | Lynx 项目中 TypeScript 环境配置、类型与事件处理的指导。           |
+| **trace-analysis**            | 分析 `.ptrace` 文件，定位渲染瓶颈与性能回退。                     |
+| **trace-record**              | 采集 Lynx 性能 trace，支持系统 trace 和 JS profiling。            |
+| **lynx-debug-info-remapping** | 将主线程压缩后的错误位置映射回原始源码。                          |
 
 配合 [Lynx DevTool MCP](/ai/lynx-devtool-mcp)，coding agent 现在可以检查运行中的页面、验证交互并缩短自调试链路。
 


### PR DESCRIPTION
## Summary
- rename the `debug-info-remapping` skill docs to `lynx-debug-info-remapping`
- update installation commands and page headings to use the new skill name
- sync the AI docs navigation and Lynx 3.7 blog tables in both English and Chinese

## Why
The skill has been renamed to `lynx-debug-info-remapping`, so the docs need to match the published name and route.

## Validation
- `pnpm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Rename debug-info-remapping skill to lynx-debug-info-remapping in English AI docs
- Update English skill documentation page with new lynx-debug-info-remapping name
- Update installation commands in skill docs to reference lynx-debug-info-remapping
- Update AI docs metadata in Chinese to reference lynx-debug-info-remapping
- Rename debug-info-remapping skill to lynx-debug-info-remapping in Chinese skill docs
- Sync Lynx 3.7 blog post tables in English and Chinese with new skill name

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/1046?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->