### PR TITLE
docs: lynx-fiber-element skill

### DIFF
--- a/docs/en/ai/_meta.json
+++ b/docs/en/ai/_meta.json
@@ -36,6 +36,10 @@
   },
   {
     "type": "file",
+    "name": "skills/lynx-fiber-element.mdx"
+  },
+  {
+    "type": "file",
     "name": "skills/lynx-typescript.mdx"
   },
   {

--- a/docs/en/ai/skills/lynx-fiber-element.mdx
+++ b/docs/en/ai/skills/lynx-fiber-element.mdx
@@ -1,0 +1,51 @@
+---
+description: 'Agent skill for building Lynx apps directly with FiberElement and Element PAPI APIs.'
+---
+
+# lynx-fiber-element
+
+Helps coding agents build Lynx apps directly with FiberElement and Element PAPI APIs from `@lynx-js/type-element-api`, without ReactLynx JSX or other UI frameworks.
+
+Use it when an agent needs to:
+
+- build a Lynx app without ReactLynx, JSX, or a framework
+- use Element PAPI or FiberElement APIs such as `__CreatePage`, `__CreateView`, `__CreateText`, `__AppendElement`, `__SetAttribute`, or `__FlushElementTree`
+- assemble a template-webpack style Lynx bundle with explicit background-thread, main-thread, and CSS assets
+- debug main-thread rendering, event dispatch, or double-thread data synchronization in a non-React Lynx app
+
+## Installation
+
+```bash
+npx skills add lynx-community/skills -s lynx-fiber-element
+```
+
+This installs the `lynx-fiber-element` skill so compatible coding agents can load its workflow rules, references, and examples automatically.
+
+## What It Contains
+
+`lynx-fiber-element` is structured for progressive disclosure:
+
+- `SKILL.md`: entrypoint and workflow rules for framework-free Lynx apps
+- `references/template-webpack-build.md`: package setup and bundle assembly
+- `references/main-thread-rendering.md`: main-thread UI tree creation and mutation
+- `references/double-thread-data-sync.md`: background-thread events and patch-based synchronization
+- `examples/counter.md`: minimal app scaffold for the template-webpack path
+- `examples/todo-list.md`: composed example covering first-screen data, rerender patches, condition switching, repeat rendering, filters, and background event handling
+
+## Recommended Workflow
+
+Ask the agent to use `lynx-fiber-element` before implementing a framework-free Lynx app.
+
+1. Start with `references/template-webpack-build.md` for project setup and bundle outputs.
+2. Read `references/main-thread-rendering.md` for UI tree creation and mutation patterns.
+3. Read `references/double-thread-data-sync.md` for event dispatch and cross-thread synchronization.
+4. Use `examples/counter.md` for scaffolding or minimal debugging.
+5. Use `examples/todo-list.md` when a more complete patch-driven example is needed.
+
+The agent should avoid ReactLynx, JSX, virtual DOM, and browser DOM APIs unless the user explicitly asks for them.
+
+## Learn More
+
+- [lynx-community/skills on GitHub](https://github.com/lynx-community/skills)
+- [lynx-community/skills lynx-fiber-element](https://github.com/lynx-community/skills/tree/release/skills/lynx-fiber-element)
+- [Agent Skills specification](https://github.com/anthropics/skills)

--- a/docs/zh/ai/_meta.json
+++ b/docs/zh/ai/_meta.json
@@ -36,6 +36,10 @@
   },
   {
     "type": "file",
+    "name": "skills/lynx-fiber-element.mdx"
+  },
+  {
+    "type": "file",
     "name": "skills/lynx-typescript.mdx"
   },
   {

--- a/docs/zh/ai/skills/lynx-fiber-element.mdx
+++ b/docs/zh/ai/skills/lynx-fiber-element.mdx
@@ -1,0 +1,51 @@
+---
+description: '帮助 agent 直接使用 FiberElement 和 Element PAPI API 构建 Lynx 应用的技能。'
+---
+
+# lynx-fiber-element
+
+帮助 coding agent 直接使用 `@lynx-js/type-element-api` 中的 FiberElement 和 Element PAPI API 构建 Lynx 应用，而不依赖 ReactLynx JSX 或其他 UI 框架。
+
+适合在以下场景使用：
+
+- 构建不使用 ReactLynx、JSX 或框架的 Lynx 应用
+- 使用 Element PAPI 或 FiberElement API，例如 `__CreatePage`、`__CreateView`、`__CreateText`、`__AppendElement`、`__SetAttribute` 或 `__FlushElementTree`
+- 组装 template-webpack 风格的 Lynx bundle，并显式拆分后台线程、主线程和 CSS 资源
+- 在非 React 的 Lynx 应用中排查主线程渲染、事件分发或双线程数据同步问题
+
+## 安装
+
+```bash
+npx skills add lynx-community/skills -s lynx-fiber-element
+```
+
+这会安装 `lynx-fiber-element` skill，让兼容的 coding agent 自动加载它的工作流规则、参考资料和示例。
+
+## 包含内容
+
+`lynx-fiber-element` 按渐进读取方式组织：
+
+- `SKILL.md`：无框架 Lynx 应用的入口和工作流规则
+- `references/template-webpack-build.md`：项目初始化和 bundle 组装方式
+- `references/main-thread-rendering.md`：主线程 UI 树创建和更新
+- `references/double-thread-data-sync.md`：后台线程事件处理与 patch 同步
+- `examples/counter.md`：template-webpack 路径下的最小应用脚手架
+- `examples/todo-list.md`：覆盖首屏数据、patch 重渲染、条件切换、列表渲染、筛选和后台事件处理的组合示例
+
+## 推荐工作流
+
+在实现无框架 Lynx 应用前，让 agent 优先使用 `lynx-fiber-element`。
+
+1. 先阅读 `references/template-webpack-build.md`，确认项目结构和 bundle 输出。
+2. 再阅读 `references/main-thread-rendering.md`，理解 UI 树创建和更新模式。
+3. 然后阅读 `references/double-thread-data-sync.md`，处理事件分发和跨线程同步。
+4. 需要脚手架或最小复现时，使用 `examples/counter.md`。
+5. 需要更完整的 patch 驱动示例时，使用 `examples/todo-list.md`。
+
+除非用户明确要求，否则 agent 应避免使用 ReactLynx、JSX、虚拟 DOM 和浏览器 DOM API。
+
+## 了解更多
+
+- [GitHub 上的 lynx-community/skills](https://github.com/lynx-community/skills)
+- [lynx-fiber-element skill 页面](https://github.com/lynx-community/skills/tree/release/skills/lynx-fiber-element)
+- [Agent Skills 规范](https://github.com/anthropics/skills)


### PR DESCRIPTION
## Summary
- add English and Chinese docs pages for the new `lynx-fiber-element` skill
- document when to use the skill, its bundled references/examples, and the recommended workflow
- add the new skill page to the AI docs navigation in both locales

## Why
`lynx-fiber-element` is a new skill in `lynx-community/skills`, and the Lynx docs should expose it alongside the existing AI skills.

## Validation
- `pnpm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Add documentation pages for `lynx-fiber-element` skill in English and Chinese
- Register `lynx-fiber-element` in navigation metadata for both English and Chinese docs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/1047?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->