### PR TITLE
[codex] clarify Codex network setup for lynx-devtool

### DIFF
--- a/docs/en/ai/skills/lynx-devtool.mdx
+++ b/docs/en/ai/skills/lynx-devtool.mdx
@@ -2,6 +2,8 @@
 description: 'Agent skill for inspecting and debugging running Lynx apps via DevTool.'
 ---
 
+import { Tab, Tabs } from '@rspress/core/theme';
+
 # lynx-devtool
 
 Lets agents interact with Lynx DevTool to inspect and debug running Lynx applications on connected devices (Android, iOS, Desktop):
@@ -18,6 +20,43 @@ npx skills add lynx-community/skills -s lynx-devtool
 ```
 
 This adds the skill rules to your project so that compatible coding agents (such as Claude Code, Cursor, or Copilot) can automatically apply them.
+
+## Codex
+
+When using this skill with Codex, make sure network access is enabled. Lynx DevTool needs network access to discover and connect to running clients.
+
+Put one of the following configuration snippets in your project config at `<project>/.codex/config.toml` or in your global config at `~/.codex/config.toml`.
+
+<Tabs groupId="codex-cli-version">
+<Tab label="Codex CLI >= 0.133.0">
+
+Use a dedicated permission profile:
+
+```toml
+default_permissions = "lynx-devtool"
+
+[permissions.lynx-devtool]
+extends = ":workspace"
+
+[permissions.lynx-devtool.network]
+enabled = true
+```
+
+</Tab>
+<Tab label="Older Codex CLI">
+
+Enable network access in the workspace-write sandbox:
+
+```toml
+sandbox_mode = "workspace-write"
+approval_policy = "on-request"
+
+[sandbox_workspace_write]
+network_access = true
+```
+
+</Tab>
+</Tabs>
 
 ## Learn More
 

--- a/docs/zh/ai/skills/lynx-devtool.mdx
+++ b/docs/zh/ai/skills/lynx-devtool.mdx
@@ -2,6 +2,8 @@
 description: 'AI 技能：使用 Lynx DevTool 调试应用'
 ---
 
+import { Tab, Tabs } from '@rspress/core/theme';
+
 # lynx-devtool
 
 让 agent 与 Lynx DevTool 交互，在已连接的设备（Android、iOS、桌面端）上检查和调试运行中的 Lynx 应用：
@@ -18,6 +20,43 @@ npx skills add lynx-community/skills -s lynx-devtool
 ```
 
 这会将 skill 规则添加到你的项目中，以便兼容的 coding agent（如 Claude Code、Cursor 或 Copilot）能够自动应用它们。
+
+## Codex
+
+在 Codex 中使用这个 skill 时，请确保已启用网络访问。Lynx DevTool 需要网络访问来发现并连接正在运行的客户端。
+
+将以下配置片段之一放到项目配置 `<project>/.codex/config.toml`，或全局配置 `~/.codex/config.toml` 中。
+
+<Tabs groupId="codex-cli-version">
+<Tab label="Codex CLI >= 0.133.0">
+
+使用专用的权限配置：
+
+```toml
+default_permissions = "lynx-devtool"
+
+[permissions.lynx-devtool]
+extends = ":workspace"
+
+[permissions.lynx-devtool.network]
+enabled = true
+```
+
+</Tab>
+<Tab label="旧版 Codex CLI">
+
+在 workspace-write sandbox 中启用网络访问：
+
+```toml
+sandbox_mode = "workspace-write"
+approval_policy = "on-request"
+
+[sandbox_workspace_write]
+network_access = true
+```
+
+</Tab>
+</Tabs>
 
 ## 了解更多
 


### PR DESCRIPTION
## Summary

- Add Codex setup guidance to the English and Chinese `lynx-devtool` skill docs.
- Show Codex CLI >= 0.133.0 and older Codex CLI network configuration in version tabs.
- Clarify that the config can live in `<project>/.codex/config.toml` or `~/.codex/config.toml`.

## Validation

- `pnpm exec prettier --check docs/en/ai/skills/lynx-devtool.mdx docs/zh/ai/skills/lynx-devtool.mdx`
- `pnpm exec cspell lint -c cspell.json --no-must-find-files docs/en/ai/skills/lynx-devtool.mdx docs/zh/ai/skills/lynx-devtool.mdx`
- `git diff --cached --check`

## Note

Full `pnpm run build` was previously blocked by an unrelated missing generated file: `docs/public/lynx-examples/desktop/example-metadata.json` while rendering `/api/css/properties/cursor`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Document Codex network setup for lynx-devtool

- Add Codex setup section to lynx-devtool skill documentation in English and Chinese, clarifying that network access must be enabled
- Include version-specific configuration guidance with tabs for Codex CLI >= 0.133.0 and earlier versions
- Specify that Codex configuration can reside at `<project>/.codex/config.toml` or `~/.codex/config.toml`
- Import `Tab`/`Tabs` components from `@rspress/core/theme` to enable version switching UI

**Files changed:** `docs/en/ai/skills/lynx-devtool.mdx`, `docs/zh/ai/skills/lynx-devtool.mdx`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/1048?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->