### PR TITLE
[codex] Add GenUI docs integration

### DIFF
--- a/docs/en/react/_meta.json
+++ b/docs/en/react/_meta.json
@@ -18,6 +18,25 @@
   },
   "data-fetching",
   {
+    "type": "custom-link",
+    "label": "GenUI Integration",
+    "link": "/react/genui/index.html",
+    "collapsible": true,
+    "collapsed": true,
+    "items": [
+      {
+        "type": "custom-link",
+        "label": "Overview",
+        "link": "/react/genui/index.html"
+      },
+      {
+        "type": "custom-link",
+        "label": "A2UI",
+        "link": "/react/genui/a2ui.html"
+      }
+    ]
+  },
+  {
     "type": "dir",
     "name": "state-management",
     "label": "State Management",

--- a/docs/zh/react/_meta.json
+++ b/docs/zh/react/_meta.json
@@ -18,6 +18,25 @@
   },
   "data-fetching",
   {
+    "type": "custom-link",
+    "label": "GenUI 集成",
+    "link": "/react/genui/index.html",
+    "collapsible": true,
+    "collapsed": true,
+    "items": [
+      {
+        "type": "custom-link",
+        "label": "概览",
+        "link": "/react/genui/index.html"
+      },
+      {
+        "type": "custom-link",
+        "label": "A2UI",
+        "link": "/react/genui/a2ui.html"
+      }
+    ]
+  },
+  {
     "type": "dir",
     "name": "state-management",
     "label": "状态管理",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "*.{md,mdx}": "cspell lint -c cspell.json --no-must-find-files"
   },
   "devDependencies": {
+    "@lynx-js/genui": "^0.0.2",
     "@lynx-js/lynx-compat-data": "workspace:*",
     "@lynx-js/react": "^0.107.1",
     "@lynx-js/rspress-plugin-llms-postprocess": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
         specifier: ^11.6.1
         version: 11.6.1
     devDependencies:
+      '@lynx-js/genui':
+        specifier: ^0.0.2
+        version: 0.0.2(@lynx-js/react@0.107.1(@types/react@18.3.18))(preact@10.29.2)(typescript@5.0.4)
       '@lynx-js/lynx-compat-data':
         specifier: workspace:*
         version: link:packages/lynx-compat-data
@@ -373,6 +376,9 @@ importers:
         version: 4.0.4
 
 packages:
+
+  '@a2ui/web_core@0.9.1':
+    resolution: {integrity: sha512-qKFKOgdtPqe0TdiEreTlyqw3TuGjxb7NzVuYejWFUVqy1NQNwe7Hcd4zz8EP+MzWXHSo2sjWsGjuvWBWlVcuOQ==}
 
   '@ai-sdk/gateway@1.0.37':
     resolution: {integrity: sha512-/Whwh/gF9Q4B07F8hRIC+gtymkR6efds6MxrMqh6a7VBwXsE4HyAVltEuWRghqUKMbDJHSRsRPis4dZRSxj8KQ==}
@@ -1192,6 +1198,9 @@ packages:
   '@floating-ui/utils@0.2.8':
     resolution: {integrity: sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==}
 
+  '@gerrit0/mini-shiki@3.23.0':
+    resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
+
   '@hongzhiyuan/preact@10.24.0-00213bad':
     resolution: {integrity: sha512-bHWp4ZDK5ZimcY+bTWw3S3xGiB8eROpZj0RK3FClNIaTOajb0b11CsT3K+pdeakgPgq1jWN3T2e2rfrPm40JsQ==}
 
@@ -1363,6 +1372,17 @@ packages:
     resolution: {integrity: sha512-qxkG6jsuGTcEGS8QpHxKv5Gpo5OJW2vPyQ5B1JevpKVYm1DxUmzAg8M8Nx5PvdWUr4mSazmLP2WRAg9J2eJM4A==}
     engines: {node: '>=18'}
 
+  '@lynx-js/genui@0.0.2':
+    resolution: {integrity: sha512-ZXpPkbEz/dSEIvWnaNJI0P2uHv+LSJjXDjLKjo99xGAyiAm7pWXnhpVSgE2RRDVMuDpI0X8KD1myZG3eqEL4Ng==}
+    engines: {node: '>=22'}
+    hasBin: true
+    peerDependencies:
+      '@lynx-js/lynx-ui': ^3.133.0
+      '@lynx-js/react': ^0.121.0
+    peerDependenciesMeta:
+      '@lynx-js/lynx-ui':
+        optional: true
+
   '@lynx-js/lynx-core@0.1.3':
     resolution: {integrity: sha512-uWzKKYJUK4Q09ZRZxWSAFINnmZb9piWPbvWF9SkLn+3snBl9u/BJa4ekPRcKWAhBmpbtxWH1x27fxe3Q3p5l3Q==}
 
@@ -1497,9 +1517,26 @@ packages:
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
 
+  '@openuidev/lang-core@0.2.5':
+    resolution: {integrity: sha512-cL01txOXWeDdOJY83F8R0QR7F1FPEsuUFft/8uRYiaN8LozKySNonc1g5nhreYKjcQ2YvvyvwHZn/AQZCaFtDQ==}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': '>=1.0.0'
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@preact/signals-core@1.14.2':
+    resolution: {integrity: sha512-RZHdBj9ZF4n40Rp4jS052EHHjBWf96P9oNdXPfhQTovCuWY9iQn3Gq+gOTJSgBO9A/JBuPfMOWsSX/lIU9Pc/A==}
+
+  '@preact/signals@2.9.1':
+    resolution: {integrity: sha512-xVqN8mJjbSN5IB/8Ubmd9NN+Ew6zJswoRxrjZbH3YsgkMshFeO6d8zxEFpHRTq9GJZx7cnPs2CnCpFqtGXGNsw==}
+    peerDependencies:
+      preact: '>= 10.25.0 || >=11.0.0-0'
 
   '@radix-ui/number@1.1.0':
     resolution: {integrity: sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ==}
@@ -2360,11 +2397,17 @@ packages:
   '@shikijs/engine-oniguruma@3.14.0':
     resolution: {integrity: sha512-TNcYTYMbJyy+ZjzWtt0bG5y4YyMIWC2nyePz+CFMWqm+HnZZyy9SWMgo8Z6KBJVIZnx8XUXS8U2afO6Y0g1Oug==}
 
+  '@shikijs/engine-oniguruma@3.23.0':
+    resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
+
   '@shikijs/langs@1.29.2':
     resolution: {integrity: sha512-FIBA7N3LZ+223U7cJDUYd5shmciFQlYkFXlkKVaHsCPgfVLiO+e12FmQE6Tf9vuyEsFe3dIl8qGWKXgEHL9wmQ==}
 
   '@shikijs/langs@3.14.0':
     resolution: {integrity: sha512-DIB2EQY7yPX1/ZH7lMcwrK5pl+ZkP/xoSpUzg9YC8R+evRCCiSQ7yyrvEyBsMnfZq4eBzLzBlugMyTAf13+pzg==}
+
+  '@shikijs/langs@3.23.0':
+    resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
 
   '@shikijs/rehype@3.14.0':
     resolution: {integrity: sha512-In2G6yvT0ZFDqNGbJumd7gEAwtxuaXuchCc0O3qOytIUTlpzs8/D0CQF3wktdfOB6B869eab6Z6EIJr4Td4hQQ==}
@@ -2375,6 +2418,9 @@ packages:
   '@shikijs/themes@3.14.0':
     resolution: {integrity: sha512-fAo/OnfWckNmv4uBoUu6dSlkcBc+SA1xzj5oUSaz5z3KqHtEbUypg/9xxgJARtM6+7RVm0Q6Xnty41xA1ma1IA==}
 
+  '@shikijs/themes@3.23.0':
+    resolution: {integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==}
+
   '@shikijs/transformers@3.4.2':
     resolution: {integrity: sha512-I5baLVi/ynLEOZoWSAMlACHNnG+yw5HDmse0oe+GW6U1u+ULdEB3UHiVWaHoJSSONV7tlcVxuaMy74sREDkSvg==}
 
@@ -2383,6 +2429,9 @@ packages:
 
   '@shikijs/types@3.14.0':
     resolution: {integrity: sha512-bQGgC6vrY8U/9ObG1Z/vTro+uclbjjD/uG58RvfxKZVD5p9Yc1ka3tVyEFy7BNJLzxuWyHH5NWynP9zZZS59eQ==}
+
+  '@shikijs/types@3.23.0':
+    resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
 
   '@shikijs/types@3.4.2':
     resolution: {integrity: sha512-zHC1l7L+eQlDXLnxvM9R91Efh2V4+rN3oMVS2swCBssbj2U/FBwybD1eeLaq8yl/iwT+zih8iUbTBCgGZOYlVg==}
@@ -2823,6 +2872,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   bezier-easing@2.1.0:
     resolution: {integrity: sha512-gbIqZ/eslnUFC1tjEvtz0sgx+xTK20wDnYMIA27VA04R7w6xxXQPZDbibjA9DTWZRA2CXtwHykkVzlCaAJAZig==}
 
@@ -2841,6 +2894,10 @@ packages:
 
   brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -3272,6 +3329,9 @@ packages:
   date-fns@2.30.0:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
     engines: {node: '>=0.11'}
+
+  date-fns@4.3.0:
+    resolution: {integrity: sha512-OYcL+3N/jyWbYdFGqoMAhytDgxP9pbYPUUiRCOgn4Fewaadk9l/Wam4Avciiyp2BgkpfQyBV9B+ehnVJych+eQ==}
 
   dayjs@1.11.13:
     resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
@@ -3900,6 +3960,9 @@ packages:
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
 
+  linkify-it@5.0.1:
+    resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
+
   lint-staged@15.3.0:
     resolution: {integrity: sha512-vHFahytLoF2enJklgtOtCtIjZrKD/LoxlaUusd5nh7dWv/dkKQJY74ndFSzxCdv7g0ueGg1ORgTSt4Y9LPZn9A==}
     engines: {node: '>=18.12.0'}
@@ -3969,6 +4032,10 @@ packages:
 
   markdown-it@14.1.0:
     resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
+    hasBin: true
+
+  markdown-it@14.2.0:
+    resolution: {integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==}
     hasBin: true
 
   markdown-table@3.0.4:
@@ -4297,6 +4364,10 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -4514,6 +4585,9 @@ packages:
   postcss@8.5.3:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
     engines: {node: ^10 || ^12 || >=14}
+
+  preact@10.29.2:
+    resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
 
   prettier@3.4.2:
     resolution: {integrity: sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==}
@@ -5278,6 +5352,13 @@ packages:
     peerDependencies:
       typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x
 
+  typedoc@0.28.19:
+    resolution: {integrity: sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==}
+    engines: {node: '>= 18', pnpm: '>= 10'}
+    hasBin: true
+    peerDependencies:
+      typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x
+
   typescript@5.0.4:
     resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
     engines: {node: '>=12.20'}
@@ -5557,6 +5638,11 @@ packages:
     engines: {node: '>= 14'}
     hasBin: true
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
     engines: {node: '>=6'}
@@ -5565,6 +5651,14 @@ packages:
     resolution: {integrity: sha512-C1UXU6WFJ4KC4fJ5sFwydKDRUUzAMoq5dLN7yGHwbYu2QFJ0gzGOpYA4JHQCfIlOUmik9I1e7hBlli3SvrJQ6Q==}
     hasBin: true
 
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.1.12:
     resolution: {integrity: sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==}
 
@@ -5572,6 +5666,13 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@a2ui/web_core@0.9.1':
+    dependencies:
+      '@preact/signals-core': 1.14.2
+      date-fns: 4.3.0
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
 
   '@ai-sdk/gateway@1.0.37(zod@4.1.12)':
     dependencies:
@@ -6368,6 +6469,14 @@ snapshots:
 
   '@floating-ui/utils@0.2.8': {}
 
+  '@gerrit0/mini-shiki@3.23.0':
+    dependencies:
+      '@shikijs/engine-oniguruma': 3.23.0
+      '@shikijs/langs': 3.23.0
+      '@shikijs/themes': 3.23.0
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+
   '@hongzhiyuan/preact@10.24.0-00213bad': {}
 
   '@hongzhiyuan/preact@10.24.0-319c684e': {}
@@ -6686,6 +6795,19 @@ snapshots:
       - '@lynx-js/types'
       - '@types/react'
 
+  '@lynx-js/genui@0.0.2(@lynx-js/react@0.107.1(@types/react@18.3.18))(preact@10.29.2)(typescript@5.0.4)':
+    dependencies:
+      '@a2ui/web_core': 0.9.1
+      '@lynx-js/react': 0.107.1(@types/react@18.3.18)
+      '@openuidev/lang-core': 0.2.5(zod@3.25.76)
+      '@preact/signals': 2.9.1(preact@10.29.2)
+      typedoc: 0.28.19(typescript@5.0.4)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - preact
+      - typescript
+
   '@lynx-js/lynx-core@0.1.3': {}
 
   '@lynx-js/offscreen-document@0.1.4': {}
@@ -6875,8 +6997,19 @@ snapshots:
 
   '@opentelemetry/api@1.9.0': {}
 
+  '@openuidev/lang-core@0.2.5(zod@3.25.76)':
+    dependencies:
+      zod: 3.25.76
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@preact/signals-core@1.14.2': {}
+
+  '@preact/signals@2.9.1(preact@10.29.2)':
+    dependencies:
+      '@preact/signals-core': 1.14.2
+      preact: 10.29.2
 
   '@radix-ui/number@1.1.0': {}
 
@@ -7757,6 +7890,11 @@ snapshots:
       '@shikijs/types': 3.14.0
       '@shikijs/vscode-textmate': 10.0.2
 
+  '@shikijs/engine-oniguruma@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+
   '@shikijs/langs@1.29.2':
     dependencies:
       '@shikijs/types': 1.29.2
@@ -7764,6 +7902,10 @@ snapshots:
   '@shikijs/langs@3.14.0':
     dependencies:
       '@shikijs/types': 3.14.0
+
+  '@shikijs/langs@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
 
   '@shikijs/rehype@3.14.0':
     dependencies:
@@ -7782,6 +7924,10 @@ snapshots:
     dependencies:
       '@shikijs/types': 3.14.0
 
+  '@shikijs/themes@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
   '@shikijs/transformers@3.4.2':
     dependencies:
       '@shikijs/core': 3.4.2
@@ -7793,6 +7939,11 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/types@3.14.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/types@3.23.0':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
@@ -8270,6 +8421,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   bezier-easing@2.1.0: {}
 
   big.js@5.2.2: {}
@@ -8283,6 +8436,10 @@ snapshots:
   brace-expansion@2.0.1:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -8777,6 +8934,8 @@ snapshots:
   date-fns@2.30.0:
     dependencies:
       '@babel/runtime': 7.26.0
+
+  date-fns@4.3.0: {}
 
   dayjs@1.11.13: {}
 
@@ -9449,6 +9608,10 @@ snapshots:
     dependencies:
       uc.micro: 2.1.0
 
+  linkify-it@5.0.1:
+    dependencies:
+      uc.micro: 2.1.0
+
   lint-staged@15.3.0:
     dependencies:
       chalk: 5.4.1
@@ -9535,6 +9698,15 @@ snapshots:
       argparse: 2.0.1
       entities: 4.5.0
       linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
+  markdown-it@14.2.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.1
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
@@ -10314,6 +10486,10 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.1
@@ -10517,6 +10693,8 @@ snapshots:
       nanoid: 3.3.8
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  preact@10.29.2: {}
 
   prettier@3.4.2: {}
 
@@ -11362,6 +11540,15 @@ snapshots:
       typescript: 5.0.4
       yaml: 2.7.0
 
+  typedoc@0.28.19(typescript@5.0.4):
+    dependencies:
+      '@gerrit0/mini-shiki': 3.23.0
+      lunr: 2.3.9
+      markdown-it: 14.2.0
+      minimatch: 10.2.5
+      typescript: 5.0.4
+      yaml: 2.9.0
+
   typescript@5.0.4: {}
 
   typescript@5.7.2: {}
@@ -11660,6 +11847,8 @@ snapshots:
 
   yaml@2.7.0: {}
 
+  yaml@2.9.0: {}
+
   yn@3.1.1: {}
 
   zhlint@0.8.2:
@@ -11675,6 +11864,12 @@ snapshots:
       unified: 10.1.2
     transitivePeerDependencies:
       - supports-color
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
+  zod@3.25.76: {}
 
   zod@4.1.12: {}
 

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -14,6 +14,7 @@ import {
   transformerNotationFocus,
   transformerNotationHighlight,
 } from '@shikijs/transformers';
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { pluginGoogleAnalytics } from 'rsbuild-plugin-google-analytics';
 import { pluginOpenGraph } from 'rsbuild-plugin-open-graph';
@@ -172,6 +173,7 @@ export default defineConfig({
         },
       ],
     }),
+    genuiDocsPlugin(),
     sharedSidebarPlugin(),
     pluginSitemap({
       siteUrl: PUBLISH_URL,
@@ -262,6 +264,136 @@ function sharedSidebarPlugin(): RspressPlugin {
         ) || [];
 
       return pages;
+    },
+  };
+}
+
+type GenUIDocPage = {
+  lang: 'en' | 'zh';
+  routePath: string;
+  sources: string[];
+};
+
+const GENUI_PACKAGE_ROOT = path.join(
+  __dirname,
+  'node_modules',
+  '@lynx-js',
+  'genui',
+);
+
+const GENUI_DOC_ROOTS = [
+  process.env.GENUI_SOURCE_ROOT,
+  path.join(__dirname, '..', 'lynx-stack', 'packages', 'genui'),
+  path.join(__dirname, '..', 'lynx-stack-upstream0', 'packages', 'genui'),
+  GENUI_PACKAGE_ROOT,
+].filter((root): root is string => Boolean(root));
+
+const GENUI_DOC_PAGES: GenUIDocPage[] = [
+  {
+    lang: 'en',
+    routePath: '/en/react/genui/index',
+    sources: ['README.md', 'readme.md'],
+  },
+  {
+    lang: 'en',
+    routePath: '/en/react/genui/a2ui',
+    sources: ['a2ui/README.md', 'a2ui/readme.md'],
+  },
+  {
+    lang: 'zh',
+    routePath: '/zh/react/genui/index',
+    sources: ['README_zh.md', 'readme_zh.md', 'README.md', 'readme.md'],
+  },
+  {
+    lang: 'zh',
+    routePath: '/zh/react/genui/a2ui',
+    sources: [
+      'a2ui/README_zh.md',
+      'a2ui/readme_zh.md',
+      'a2ui/README.md',
+      'a2ui/readme.md',
+    ],
+  },
+];
+
+function getGenUIDocUrl(lang: GenUIDocPage['lang'], page: string) {
+  const langPrefix = lang === 'zh' ? '/zh' : '';
+  return `${langPrefix}/react/genui/${page}.html`;
+}
+
+function resolveGenUIDocSource(sources: string[]) {
+  for (const root of GENUI_DOC_ROOTS) {
+    for (const source of sources) {
+      const filepath = path.join(root, source);
+      if (fs.existsSync(filepath)) {
+        return filepath;
+      }
+    }
+  }
+
+  throw new Error(
+    `Unable to find any @lynx-js/genui documentation source: ${sources.join(
+      ', ',
+    )}. Checked roots: ${GENUI_DOC_ROOTS.join(', ')}.`,
+  );
+}
+
+function normalizeGenUIDocLinks(content: string, lang: GenUIDocPage['lang']) {
+  const pageUrls = {
+    a2ui: getGenUIDocUrl(lang, 'a2ui'),
+    a2uiZh: getGenUIDocUrl('zh', 'a2ui'),
+  };
+
+  return content
+    .replace(
+      /A2UI rendering, OpenUI rendering, A2UI prompt\/catalog utilities, and the CLI/g,
+      'A2UI rendering, A2UI prompt/catalog utilities, and the CLI',
+    )
+    .replace(/^\s*createOpenUiLibrary,\n\s*createStreamingParser,\n/gm, '')
+    .replace(/^- OpenUI parser, library, and renderer APIs\.\n/gm, '')
+    .replace(
+      /^import \{ createOpenUiLibrary \} from '@lynx-js\/genui\/openui';\n/gm,
+      '',
+    )
+    .replace(
+      / New\nscripts should prefer the namespace-first `genui a2ui \.\.\.` form so OpenUI\ncommands can be added under `genui openui \.\.\.` later\./g,
+      ' Prefer the namespace-first `genui a2ui ...` form for new scripts.',
+    )
+    .replace(/^## OpenUI[\s\S]*?(?=^## CLI)/m, '')
+    .replace(
+      /\[([^\]]+)\]\(\.\/openui\/(?:README_zh|readme_zh|README|readme)\.md\)/g,
+      '$1',
+    )
+    .replace(
+      /\[([^\]]+)\]\((?:\.\/)?(?:docs\/(?:architecture|catalogs|custom-components)(?:_zh)?|src\/catalog\/(?:README_zh|readme_zh|README|readme))\.md\)/g,
+      '$1',
+    )
+    .replace(
+      /\[([^\]]+)\]\(\.\.\/a2ui-playground\/examples\/(?:README_zh|readme_zh|README|readme)\.md\)/g,
+      '$1',
+    )
+    .replace(/\]\(\.\/(?:README|readme)\.md\)/g, `](${pageUrls.a2ui})`)
+    .replace(/\]\(\.\/(?:README_zh|readme_zh)\.md\)/g, `](${pageUrls.a2uiZh})`)
+    .replace(/\]\(\.\/a2ui\/(?:README|readme)\.md\)/g, `](${pageUrls.a2ui})`)
+    .replace(
+      /\]\(\.\/a2ui\/(?:README_zh|readme_zh)\.md\)/g,
+      `](${pageUrls.a2uiZh})`,
+    );
+}
+
+function genuiDocsPlugin(): RspressPlugin {
+  return {
+    name: 'rspress:genui-docs',
+    addPages() {
+      return GENUI_DOC_PAGES.map((page) => {
+        const filepath = resolveGenUIDocSource(page.sources);
+        const content = fs.readFileSync(filepath, 'utf-8');
+
+        return {
+          routePath: page.routePath,
+          content: normalizeGenUIDocLinks(content, page.lang),
+        };
+      });
     },
   };
 }


### PR DESCRIPTION
## Summary

- Add `@lynx-js/genui` as a dev dependency.
- Generate ReactLynx GenUI overview and A2UI docs from the GenUI README sources.
- Add the GenUI Integration sidebar group under ReactLynx Architecting / 应用架构.
- Keep OpenUI docs unpublished for now and strip unresolved source-only links from generated pages.

## Notes

The published `@lynx-js/genui@0.0.2` package does not include the Chinese A2UI README. The Rspress plugin therefore prefers `GENUI_SOURCE_ROOT` and sibling local GenUI source checkouts before falling back to the installed package.

## Validation

- `pnpm exec prettier --write rspress.config.ts`
- `pnpm run build`

`pnpm run build` completes successfully. The output still includes existing unrelated SSG noise for missing example metadata and browser globals in other pages.