### PR TITLE
docs(autolink): keep library as package unit, mark Native Module bits optional

### DIFF
--- a/docs/en/guide/autolink.mdx
+++ b/docs/en/guide/autolink.mdx
@@ -2,7 +2,7 @@ import { PlatformTabs } from '@lynx';
 
 # Autolink Native Libraries
 
-Autolink helps a Lynx app discover native library packages from `node_modules` and register their Android and iOS capabilities automatically. Library packages declare their native entry points in `lynx.lib.json`; the host app enables the Autolink build integration once, then the generated registry takes effect during Lynx initialization instead of requiring manual wiring for each Element, Native Module, or Service.
+Autolink helps a Lynx app discover native libraries from `node_modules` and register their Android and iOS capabilities automatically. Each library is an npm package that declares its native entry points in `lynx.lib.json`; the host app enables the Autolink build integration once, then the generated registry takes effect during Lynx initialization instead of requiring manual wiring for each Element, Native Module, or Service.
 
 Autolink currently covers native Android and iOS libraries only. It does not generate Web or HarmonyOS integration code.
 
@@ -158,7 +158,7 @@ lynx-button/
 
 - `package.json` makes the package installable from npm and usually provides the `codegen` script.
 - `lynx.lib.json` is the Autolink contract. It tells the host app where Android and iOS source code lives.
-- `types/index.d.ts` describes the Native Module API that codegen uses to create platform specs and the JavaScript facade.
+- `types/index.d.ts` describes typed Native Module APIs, if the library exposes any. Codegen uses these declarations to create platform specs and the JavaScript facade.
 - `src/index.ts` exports the JavaScript API that app code imports.
 - `android/` and `ios/` contain native implementations and generated native specs.
 - `example/` is a local app used by the library author to verify the package.
@@ -188,7 +188,7 @@ The generated package includes:
 
 - `package.json` with `"codegen": "lynx-autolink-codegen"`
 - `lynx.lib.json` for Android and iOS Autolink discovery
-- `types/index.d.ts` for Native Module type declarations
+- `types/index.d.ts` for typed Native Module declarations, when the library exposes Native Modules
 - `src/index.ts` for the JavaScript facade
 - `android/` and `ios/` native source folders
 - `example/`, `tsconfig.json`, and `README.md`
@@ -199,7 +199,7 @@ Run codegen from the library root:
 npm run codegen
 ```
 
-`lynx-autolink-codegen` reads `lynx.lib.json` and scans `types/**/*.d.ts` for `@lynxmodule` declarations:
+`lynx-autolink-codegen` reads `lynx.lib.json`. For Native Modules, it scans `types/**/*.d.ts` for `@lynxmodule` declarations:
 
 ```ts
 /** @lynxmodule */
@@ -450,6 +450,6 @@ NS_ASSUME_NONNULL_END
 </PlatformTabs.Tab>
 </PlatformTabs>
 
-Autolink uses the `LynxAutolink` names as its public library authoring API.
+Autolink exposes the `LynxAutolink*` annotations and markers as the public authoring API for Lynx libraries.
 
 For iOS packages that already use Lynx native registration macros, Autolink also scans existing `LYNX_LAZY_REGISTER_UI`, `LYNX_LAZY_REGISTER_SHADOW_NODE`, and `@LynxServiceRegister(...)` declarations so those packages can be linked without rewriting their native code.

--- a/docs/en/guide/autolink.mdx
+++ b/docs/en/guide/autolink.mdx
@@ -2,7 +2,7 @@ import { PlatformTabs } from '@lynx';
 
 # Autolink Native Libraries
 
-Autolink helps a Lynx app discover native libraries from `node_modules` and register their Android and iOS capabilities automatically. Each library is an npm package that declares its native entry points in `lynx.lib.json`; the host app enables the Autolink build integration once, then the generated registry takes effect during Lynx initialization instead of requiring manual wiring for each Element, Native Module, or Service.
+Autolink is a mechanism that lets a Lynx app discover Elements, Native Modules, and Services provided by native libraries installed from `node_modules`, and register them automatically on Android and iOS during Lynx initialization. Each library is an npm package that declares its native entry points in `lynx.lib.json`; the host app enables the Autolink build integration once, and the generated registry replaces per-library manual wiring.
 
 Autolink currently covers native Android and iOS libraries only. It does not generate Web or HarmonyOS integration code.
 

--- a/docs/zh/guide/autolink.mdx
+++ b/docs/zh/guide/autolink.mdx
@@ -2,7 +2,7 @@ import { PlatformTabs } from '@lynx';
 
 # Autolink 原生库
 
-Autolink 会让 Lynx 应用从 `node_modules` 中发现原生库，并自动注册它们在 Android 和 iOS 上提供的能力。每个库都是一个 npm 包，并通过包根目录下的 `lynx.lib.json` 声明原生入口；宿主应用只需要接入一次 Autolink 构建集成，生成的 registry 就会随 Lynx 初始化自动生效，避免为每个元件、原生模块或 Service 手动写注册代码。
+Autolink 是一种机制，让 Lynx 应用自动发现 `node_modules` 中原生库提供的元件、原生模块和 Service，并在 Android 和 iOS 上随 Lynx 初始化统一完成注册。每个库都是一个 npm 包，并通过包根目录下的 `lynx.lib.json` 声明原生入口；宿主应用只需要接入一次 Autolink 构建集成，生成的 registry 就会取代逐库的手动注册代码。
 
 Autolink 当前只覆盖 Android 和 iOS 原生库，不生成 Web 或 HarmonyOS 的接入代码。
 

--- a/docs/zh/guide/autolink.mdx
+++ b/docs/zh/guide/autolink.mdx
@@ -2,7 +2,7 @@ import { PlatformTabs } from '@lynx';
 
 # Autolink 原生库
 
-Autolink 会让 Lynx 应用从 `node_modules` 中发现原生库，并自动注册它们在 Android 和 iOS 上提供的能力。库在包根目录声明 `lynx.lib.json`；宿主应用只需要接入一次 Autolink 构建集成，生成的 registry 就会随 Lynx 初始化自动生效，避免为每个元件、原生模块或 Service 手动写注册代码。
+Autolink 会让 Lynx 应用从 `node_modules` 中发现原生库，并自动注册它们在 Android 和 iOS 上提供的能力。每个库都是一个 npm 包，并通过包根目录下的 `lynx.lib.json` 声明原生入口；宿主应用只需要接入一次 Autolink 构建集成，生成的 registry 就会随 Lynx 初始化自动生效，避免为每个元件、原生模块或 Service 手动写注册代码。
 
 Autolink 当前只覆盖 Android 和 iOS 原生库，不生成 Web 或 HarmonyOS 的接入代码。
 
@@ -101,7 +101,7 @@ end
 npm install @example/lynx-button
 ```
 
-每个库都会在包根目录暴露 `lynx.lib.json` manifest。Autolink 会扫描已安装 npm 包中的这个文件。
+每个库包都会在包根目录暴露 `lynx.lib.json` manifest。Autolink 会扫描已安装 npm 包中的这个文件。
 
 ```json
 {
@@ -158,7 +158,7 @@ lynx-button/
 
 - `package.json` 让库可以通过 npm 安装，并通常提供 `codegen` 脚本。
 - `lynx.lib.json` 是 Autolink 清单文件，用来告诉宿主应用 Android 和 iOS 源码在哪里。
-- `types/index.d.ts` 描述原生模块 API，codegen 会基于它生成平台 spec 和 JavaScript facade。
+- `types/index.d.ts` 描述库中可选的原生模块类型声明；如果库暴露原生模块，codegen 会基于这些声明生成平台 spec 和 JavaScript facade。
 - `src/index.ts` 导出应用代码需要 import 的 JavaScript API。
 - `android/` 和 `ios/` 放置原生实现以及生成的原生 spec。
 - `example/` 是库作者用于本地验证的示例应用。
@@ -188,7 +188,7 @@ npm create lynx-library -- \
 
 - 带有 `"codegen": "lynx-autolink-codegen"` 的 `package.json`
 - 用于 Android 和 iOS Autolink 发现的 `lynx.lib.json`
-- 用于原生模块类型声明的 `types/index.d.ts`
+- `types/index.d.ts`，在库暴露原生模块时用于声明类型
 - JavaScript facade 入口 `src/index.ts`
 - 原生源码目录 `android/` 和 `ios/`
 - `example/`、`tsconfig.json` 和 `README.md`
@@ -199,7 +199,7 @@ npm create lynx-library -- \
 npm run codegen
 ```
 
-`lynx-autolink-codegen` 会读取 `lynx.lib.json`，并扫描 `types/**/*.d.ts` 中带有 `@lynxmodule` 的声明：
+`lynx-autolink-codegen` 会读取 `lynx.lib.json`。对于原生模块，它会扫描 `types/**/*.d.ts` 中带有 `@lynxmodule` 的声明：
 
 ```ts
 /** @lynxmodule */
@@ -450,6 +450,6 @@ NS_ASSUME_NONNULL_END
 </PlatformTabs.Tab>
 </PlatformTabs>
 
-Autolink 对外使用 `LynxAutolink` 命名作为库作者 API。
+Autolink 通过 `LynxAutolink*` 注解和标记，为 Lynx 库作者提供公开 API。
 
 对于已经使用 Lynx 既有原生注册宏的 iOS 包，Autolink 也会继续扫描 `LYNX_LAZY_REGISTER_UI`、`LYNX_LAZY_REGISTER_SHADOW_NODE` 和 `@LynxServiceRegister(...)`，让这些包无需改写原生代码即可被链接进来。


### PR DESCRIPTION
## Summary

Follow-up polish on #1053. The rename to "library" is the right direction; this PR sharpens a few sentences so the docs don't accidentally collapse the whole library concept into the Native Module sub-case.

- **Intro** — separate the developer-facing concept from the npm boundary: `native libraries` first, then `Each library is an npm package…`, instead of repeating `library packages`.
- **`types/index.d.ts` description + bullet** — make it explicit that typed Native Module declarations exist only when the library exposes Native Modules. A library may contain only Elements or Services.
- **Codegen sentence** — split manifest read from `@lynxmodule` scan so codegen isn't framed as Native-Module-only: `lynx-autolink-codegen reads lynx.lib.json. For Native Modules, it scans types/**/*.d.ts…`
- **Final authoring API sentence** — `Autolink exposes the LynxAutolink* annotations and markers as the public authoring API for Lynx libraries.` (was: `uses the LynxAutolink names`, which read oddly).
- **ZH** — use `库包` only where the npm package boundary matters (manifest at package root); keep `库` for the conceptual usage.

Mental model preserved: a **library** is the reusable npm package/distribution unit; **Element / Native Module / Service** are capability types a library *may* expose.

## Test plan

- [x] `pnpm exec prettier --check docs/en/guide/autolink.mdx docs/zh/guide/autolink.mdx`
- [x] `pnpm exec cspell lint -c cspell.json docs/en/guide/autolink.mdx docs/zh/guide/autolink.mdx --no-must-find-files`
- [x] `pnpm exec zhlint 'docs/zh/guide/autolink.mdx'`
- [x] `git diff --check`
- [x] lint-staged pre-commit hooks (prettier, cspell, asset URL check, API summary check) all pass
- [ ] Skim Netlify/Cloudflare deploy preview for the autolink guide (EN + ZH)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Clarify library concepts and mark Native Module specifics optional in autolink docs

- Lead with the conceptual capability model (Elements, Native Modules, Services) in the autolink intro
- Separate "native libraries" as a developer-facing concept from the npm package boundary and state that each library is an npm package with root `lynx.lib.json`
- State that `types/index.d.ts` typed Native Module declarations exist only when a library exposes Native Modules; a library may contain only Elements or Services
- Clarify that `lynx-autolink-codegen` reads `lynx.lib.json` for libraries generally and only scans `types/**/*.d.ts` for `@lynxmodule` markers when a library exposes Native Modules
- Replace the final authoring API sentence to reference the `LynxAutolink*` annotations and markers as the public authoring API
- Use Chinese terminology distinctions: "库包" where the npm package boundary matters and "库" for the conceptual library term

Changes: docs/en/guide/autolink.mdx (+5/-5), docs/zh/guide/autolink.mdx (+6/-6)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/1056?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->