### PR TITLE
[codex] Fix Netlify preview build OOM

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,12 @@
 [build]
-  command = "NODE_OPTIONS=--max-old-space-size=3072 RSPRESS_SSG_WORKER_THREAD_COUNT=1 npx rspress build"
+  command = "NODE_OPTIONS=--max-old-space-size=3072 RSPRESS_SSG_WORKER_THREAD_COUNT=1 pnpm exec rspress build"
   publish = "doc_build"
+
+[context.branch-deploy.environment]
+  RSPRESS_LIGHTWEIGHT_BUILD = "true"
+
+[context.deploy-preview.environment]
+  RSPRESS_LIGHTWEIGHT_BUILD = "true"
 
 [[headers]]
   for = "/*"

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -25,6 +25,11 @@ import {
 } from './shared-route-config.js';
 
 const PUBLISH_URL = 'https://lynxjs.org/';
+const NETLIFY_CONTEXT = process.env.CONTEXT ?? '';
+const IS_LIGHTWEIGHT_BUILD =
+  process.env.RSPRESS_LIGHTWEIGHT_BUILD === 'true' ||
+  NETLIFY_CONTEXT === 'branch-deploy' ||
+  NETLIFY_CONTEXT === 'deploy-preview';
 
 export default defineConfig({
   root: path.join(__dirname, 'docs'),
@@ -184,38 +189,42 @@ export default defineConfig({
       ],
     }),
     sharedSidebarPlugin(),
-    pluginSitemap({
-      siteUrl: PUBLISH_URL,
-    }),
-    pluginRss({
-      siteUrl: PUBLISH_URL,
-      feed: [
-        {
-          id: 'blog-rss',
-          test: '/blog',
-          title: 'Lynx Blog',
-          language: 'en',
-          output: {
-            type: 'rss',
-            filename: 'blog-rss.xml',
-          },
-        },
-        {
-          id: 'blog-rss-zh',
-          test: '/zh/blog',
-          title: 'Lynx 博客',
-          language: 'zh-CN',
-          output: {
-            type: 'rss',
-            filename: 'blog-rss-zh.xml',
-          },
-        },
-      ],
-    }),
+    ...(!IS_LIGHTWEIGHT_BUILD
+      ? [
+          pluginSitemap({
+            siteUrl: PUBLISH_URL,
+          }),
+          pluginRss({
+            siteUrl: PUBLISH_URL,
+            feed: [
+              {
+                id: 'blog-rss',
+                test: '/blog',
+                title: 'Lynx Blog',
+                language: 'en',
+                output: {
+                  type: 'rss',
+                  filename: 'blog-rss.xml',
+                },
+              },
+              {
+                id: 'blog-rss-zh',
+                test: '/zh/blog',
+                title: 'Lynx 博客',
+                language: 'zh-CN',
+                output: {
+                  type: 'rss',
+                  filename: 'blog-rss-zh.xml',
+                },
+              },
+            ],
+          }),
+          pluginLLMsPostprocess(),
+        ]
+      : []),
     pluginAlgolia({
       verificationContent: '6AD08DFB25B7234D',
     }),
-    pluginLLMsPostprocess(),
   ],
   markdown: {
     defaultWrapCode: false,
@@ -240,7 +249,7 @@ export default defineConfig({
       ],
     },
   },
-  llms: true,
+  llms: !IS_LIGHTWEIGHT_BUILD,
 });
 
 function remarkReplaceVersionJsonPlaceholders() {


### PR DESCRIPTION
## Summary
- switch the Netlify build command to `pnpm exec rspress build`
- mark branch deploys and deploy previews as lightweight Netlify builds
- skip `llms`, sitemap, RSS, and `pluginLLMsPostprocess()` during lightweight builds while keeping production builds unchanged

## Root cause
Netlify branch deploys were running the full Rspress build, including `llms` generation and post-processing after the main page render completed. That extra tail work pushed preview builds over Netlify's memory limit and led to exit code 137.

## Impact
Preview deployments keep the core documentation build intact but avoid the non-essential post-build artifacts that were triggering OOMs. Production builds still generate the full set of outputs.

## Validation
- `RSPRESS_LIGHTWEIGHT_BUILD=true NODE_OPTIONS=--max-old-space-size=3072 RSPRESS_SSG_WORKER_THREAD_COUNT=1 pnpm exec rspress build`
- local commit hooks: `prettier --write` and `node scripts/ci/check-asset-urls.mjs`

## Notes
A full local production-style build is currently blocked earlier by a missing example metadata file at `docs/public/lynx-examples/a2ui/example-metadata.json`, so this PR focuses on the preview-deploy OOM fix path that was reproduced and validated locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Update Netlify build configuration and implement lightweight build mode

Enable lightweight Netlify builds for branch and preview deployments to prevent out-of-memory errors during rspress builds.

- Update Netlify build command to use `pnpm exec rspress build` instead of `npx rspress build`
- Enable lightweight build mode via `RSPRESS_LIGHTWEIGHT_BUILD` environment variable for branch-deploy and deploy-preview contexts
- Conditionally disable LLMs generation, sitemap, RSS feeds, and `pluginLLMsPostprocess` in lightweight builds
- Preserve full build output and features for production deployments
- Keep Algolia plugin enabled in all build modes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/1059?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->