### PR TITLE
perf(memory): disable Rspress file size report

### DIFF
--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -55,6 +55,8 @@ export default defineConfig({
   builderConfig: {
     performance: {
       buildCache: false,
+      // Avoid generating the file size report to reduce peak memory during build.
+      printFileSize: false,
     },
     plugins: [
       pluginGoogleAnalytics({ id: 'G-WGP37JWP9M' }),


### PR DESCRIPTION
## Summary
- Disable Rspress file size reporting in the Lynx website build.
- Add a config comment documenting that this reduces peak build memory.

## Testing
- Pre-commit hooks passed for the staged config file.
- Not run: full `npm run build` was skipped because you requested direct PR submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Disable Rspress file size report to reduce peak build memory

Disable the Rspress file size report in the build configuration by setting `printFileSize: false` in `rspress.config.ts`, with an inline comment documenting that this reduces peak memory consumption during the build process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lynx-family/lynx-website/pull/1060?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->