### PR TITLE
update for MouseEvent align to W3C

### DIFF
--- a/docs/en/api/lynx-api/event/mouse-event.mdx
+++ b/docs/en/api/lynx-api/event/mouse-event.mdx
@@ -10,8 +10,18 @@ import { APISummary, APITable } from '@lynx';
 
 Represents a mouse event, inherited from [`Event`](./event), which is a type of event that describes the user's interaction with the mouse. For example, mouse click.
 
-:::warning
-In Lynx 3.7 and earlier, `MouseEvent` behavior is not fully aligned with the W3C Web standard. We plan to align it with the web standard in Lynx 3.8.
+:::info
+Starting from Lynx 3.8, you can enable W3C Web standard-aligned `MouseEvent` behavior in `pageConfig`.
+
+```js
+// pageConfig
+import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
+
+pluginReactLynx({
+  alignMouseEventWithW3C: true,
+});
+```
+
 :::
 
 ## Instance property
@@ -22,13 +32,13 @@ In Lynx 3.7 and earlier, `MouseEvent` behavior is not fully aligned with the W3C
 button: number;
 ```
 
-When a mouse event is triggered, if any mouse button is pressed or released, a integer value representing this mouse button will be returned.
+After `alignMouseEventWithW3C` is enabled, when a mouse event is triggered, if any mouse button is pressed or released, an integer value representing this mouse button will be returned.
 
 | Value | Description            |
 | ----- | ---------------------- |
-| 1     | primary mouse button   |
+| 0     | primary mouse button   |
+| 1     | middle mouse button    |
 | 2     | secondary mouse button |
-| 3     | middle mouse button    |
 
 ### buttons
 
@@ -36,7 +46,7 @@ When a mouse event is triggered, if any mouse button is pressed or released, a i
 buttons: number;
 ```
 
-When a mouse event is triggered, if any buttons are pressed, a integer value representing multiple buttons which user is pressing will be returned. Each button occupies one bit field.
+After `alignMouseEventWithW3C` is enabled, when a mouse event is triggered, if any buttons are pressed, an integer value representing multiple buttons which user is pressing will be returned. Each button occupies one bit field.
 
 | Bit | Description            |
 | --- | ---------------------- |

--- a/docs/zh/api/lynx-api/event/mouse-event.mdx
+++ b/docs/zh/api/lynx-api/event/mouse-event.mdx
@@ -10,8 +10,18 @@ import { APISummary, APITable } from '@lynx';
 
 表示鼠标事件，继承自 [`Event`](./event)，是一类描述用户与鼠标交互行为的事件。比如鼠标单击等。
 
-:::warning
-在 Lynx 3.7 及以下版本中，`MouseEvent` 的行为与 W3C Web 标准尚未完全一致。我们计划在 Lynx 3.8 中与 Web 标准对齐。
+:::info
+从 Lynx 3.8 起，可以在 `pageConfig` 中开启 `MouseEvent` 与 W3C Web 标准对齐的行为。
+
+```js
+// pageConfig
+import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
+
+pluginReactLynx({
+  alignMouseEventWithW3C: true,
+});
+```
+
 :::
 
 ## 实例属性
@@ -22,13 +32,13 @@ import { APISummary, APITable } from '@lynx';
 button: number;
 ```
 
-当鼠标事件触发时，如果有任意鼠标按键被按下或松开，将会返回一个代表该键的数值。例如用户按下左键时，[mousedown](./mouse-event#mousedown) 触发，该参数值为 1。数值代表的含义见下表。
+开启 `alignMouseEventWithW3C` 后，当鼠标事件触发时，如果有任意鼠标按键被按下或松开，将会返回一个代表该键的数值。例如用户按下左键时，[mousedown](./mouse-event#mousedown) 触发，该参数值为 0。数值代表的含义见下表。
 
 | 值  | 含义               |
 | --- | ------------------ |
-| 1   | 主键（通常是左键） |
+| 0   | 主键（通常是左键） |
+| 1   | 中键               |
 | 2   | 次键（通常是右键） |
-| 3   | 中键               |
 
 ### buttons
 
@@ -36,7 +46,7 @@ button: number;
 buttons: number;
 ```
 
-当鼠标事件触发时，如果有一个或多个鼠标按键被按下，将会返回一个数值，每个 bit 代表一个鼠标按键, 被按下的键对应的 bit 将会置为 1。
+开启 `alignMouseEventWithW3C` 后，当鼠标事件触发时，如果有一个或多个鼠标按键被按下，将会返回一个数值，每个 bit 代表一个鼠标按键, 被按下的键对应的 bit 将会置为 1。
 
 | Bit | 含义               |
 | --- | ------------------ |


### PR DESCRIPTION
In the previously provided MouseEvent, certain property names are consistent with W3C standards yet carry divergent semantics. This introduces additional cognitive burden for frontend developers and incurs extra cost in L4W isomorphic rendering.

Change-Id: I7430e10a57f29e70fba68d1747c3b5d8f33084dc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Update MouseEvent documentation to align with W3C standards

Update `MouseEvent` API documentation in both English and Chinese to reflect W3C-aligned behavior introduced in Lynx 3.8:

- Replace warnings about non-W3C-aligned behavior with informational notes
- Add `pageConfig`/`pluginReactLynx` configuration example demonstrating `alignMouseEventWithW3C: true` option
- Revise `button` property description to document W3C-style codes (0 for primary, 1 for middle, 2 for secondary) when alignment is enabled
- Revise `buttons` property description to document bitmask behavior where each pressed mouse button sets its corresponding bit

<!-- end of auto-generated comment: release notes by coderabbit.ai -->