### PR TITLE
[codex] Update element minimum versions

### DIFF
--- a/packages/lynx-compat-data/api-stats.json
+++ b/packages/lynx-compat-data/api-stats.json
@@ -1068,15 +1068,15 @@
           "name": "blur-view",
           "doc_url": "/api/elements/built-in/blur-view",
           "support": {
-            "android": true,
-            "ios": true,
-            "harmony": true,
+            "android": "4.0",
+            "ios": "4.0",
+            "harmony": "4.0",
             "web_lynx": false,
-            "clay_android": true,
-            "clay_ios": true,
+            "clay_android": "4.0",
+            "clay_ios": "4.0",
             "clay_macos": false,
             "clay_windows": false,
-            "clay": true
+            "clay": "4.0"
           }
         },
         {
@@ -1084,15 +1084,15 @@
           "name": "attributes",
           "doc_url": "/api/elements/built-in/blur-view",
           "support": {
-            "android": true,
-            "ios": true,
-            "harmony": true,
+            "android": "4.0",
+            "ios": "4.0",
+            "harmony": "4.0",
             "web_lynx": false,
-            "clay_android": true,
-            "clay_ios": true,
+            "clay_android": "4.0",
+            "clay_ios": "4.0",
             "clay_macos": false,
             "clay_windows": false,
-            "clay": true
+            "clay": "4.0"
           }
         },
         {
@@ -1100,15 +1100,15 @@
           "name": "<code>android-capture-target</code>",
           "doc_url": "/api/elements/built-in/blur-view",
           "support": {
-            "android": "3.9",
+            "android": "4.0",
             "ios": false,
             "harmony": false,
             "web_lynx": false,
-            "clay_android": "3.9",
+            "clay_android": "4.0",
             "clay_ios": false,
             "clay_macos": false,
             "clay_windows": false,
-            "clay": "3.9"
+            "clay": "4.0"
           }
         },
         {
@@ -1117,14 +1117,14 @@
           "doc_url": "/api/elements/built-in/blur-view",
           "support": {
             "android": false,
-            "ios": true,
+            "ios": "4.0",
             "harmony": false,
             "web_lynx": false,
             "clay_android": false,
-            "clay_ios": true,
+            "clay_ios": "4.0",
             "clay_macos": false,
             "clay_windows": false,
-            "clay": true
+            "clay": "4.0"
           }
         },
         {
@@ -1132,15 +1132,15 @@
           "name": "<code>blur-radius</code>",
           "doc_url": "/api/elements/built-in/blur-view",
           "support": {
-            "android": true,
-            "ios": true,
-            "harmony": true,
+            "android": "4.0",
+            "ios": "4.0",
+            "harmony": "4.0",
             "web_lynx": false,
-            "clay_android": true,
-            "clay_ios": true,
+            "clay_android": "4.0",
+            "clay_ios": "4.0",
             "clay_macos": false,
             "clay_windows": false,
-            "clay": true
+            "clay": "4.0"
           }
         },
         {
@@ -1148,15 +1148,15 @@
           "name": "<code>blur-sampling</code>",
           "doc_url": "/api/elements/built-in/blur-view",
           "support": {
-            "android": true,
+            "android": "4.0",
             "ios": false,
             "harmony": false,
             "web_lynx": false,
-            "clay_android": true,
+            "clay_android": "4.0",
             "clay_ios": false,
             "clay_macos": false,
             "clay_windows": false,
-            "clay": true
+            "clay": "4.0"
           }
         },
         {
@@ -1164,15 +1164,15 @@
           "name": "<code>enable-auto-blur</code>",
           "doc_url": "/api/elements/built-in/blur-view",
           "support": {
-            "android": true,
+            "android": "4.0",
             "ios": false,
             "harmony": false,
             "web_lynx": false,
-            "clay_android": true,
+            "clay_android": "4.0",
             "clay_ios": false,
             "clay_macos": false,
             "clay_windows": false,
-            "clay": true
+            "clay": "4.0"
           }
         },
         {
@@ -1180,15 +1180,15 @@
           "name": "<code>experimental-update-blur-radius</code>",
           "doc_url": "/api/elements/built-in/blur-view",
           "support": {
-            "android": "3.4",
+            "android": "4.0",
             "ios": false,
             "harmony": false,
             "web_lynx": false,
-            "clay_android": "3.4",
+            "clay_android": "4.0",
             "clay_ios": false,
             "clay_macos": false,
             "clay_windows": false,
-            "clay": "3.4"
+            "clay": "4.0"
           }
         },
         {
@@ -1197,14 +1197,14 @@
           "doc_url": "/api/elements/built-in/blur-view",
           "support": {
             "android": false,
-            "ios": "3.8",
+            "ios": "4.0",
             "harmony": false,
             "web_lynx": false,
             "clay_android": false,
-            "clay_ios": "3.8",
+            "clay_ios": "4.0",
             "clay_macos": false,
             "clay_windows": false,
-            "clay": "3.8"
+            "clay": "4.0"
           }
         },
         {
@@ -1213,14 +1213,14 @@
           "doc_url": "/api/elements/built-in/blur-view",
           "support": {
             "android": false,
-            "ios": "3.8",
+            "ios": "4.0",
             "harmony": false,
             "web_lynx": false,
             "clay_android": false,
-            "clay_ios": "3.8",
+            "clay_ios": "4.0",
             "clay_macos": false,
             "clay_windows": false,
-            "clay": "3.8"
+            "clay": "4.0"
           }
         },
         {
@@ -1229,14 +1229,14 @@
           "doc_url": "/api/elements/built-in/blur-view",
           "support": {
             "android": false,
-            "ios": "3.8",
+            "ios": "4.0",
             "harmony": false,
             "web_lynx": false,
             "clay_android": false,
-            "clay_ios": "3.8",
+            "clay_ios": "4.0",
             "clay_macos": false,
             "clay_windows": false,
-            "clay": "3.8"
+            "clay": "4.0"
           }
         },
         {
@@ -1245,14 +1245,14 @@
           "doc_url": "/api/elements/built-in/blur-view",
           "support": {
             "android": false,
-            "ios": true,
+            "ios": "4.0",
             "harmony": false,
             "web_lynx": false,
             "clay_android": false,
-            "clay_ios": true,
+            "clay_ios": "4.0",
             "clay_macos": false,
             "clay_windows": false,
-            "clay": true
+            "clay": "4.0"
           }
         },
         {
@@ -3436,15 +3436,15 @@
           "name": "scroll-coordinator",
           "doc_url": "/api/elements/built-in/scroll-coordinator",
           "support": {
-            "android": true,
-            "ios": true,
-            "harmony": true,
-            "web_lynx": true,
-            "clay_android": true,
-            "clay_ios": true,
-            "clay_macos": true,
-            "clay_windows": true,
-            "clay": true
+            "android": "3.9",
+            "ios": "3.9",
+            "harmony": "3.9",
+            "web_lynx": "3.9",
+            "clay_android": "3.9",
+            "clay_ios": "3.9",
+            "clay_macos": "3.9",
+            "clay_windows": "3.9",
+            "clay": "3.9"
           }
         },
         {
@@ -3452,15 +3452,15 @@
           "name": "attributes",
           "doc_url": "/api/elements/built-in/scroll-coordinator",
           "support": {
-            "android": true,
-            "ios": true,
-            "harmony": true,
-            "web_lynx": true,
-            "clay_android": true,
-            "clay_ios": true,
-            "clay_macos": true,
-            "clay_windows": true,
-            "clay": true
+            "android": "3.9",
+            "ios": "3.9",
+            "harmony": "3.9",
+            "web_lynx": "3.9",
+            "clay_android": "3.9",
+            "clay_ios": "3.9",
+            "clay_macos": "3.9",
+            "clay_windows": "3.9",
+            "clay": "3.9"
           }
         },
         {
@@ -3469,7 +3469,7 @@
           "doc_url": "/api/elements/built-in/scroll-coordinator",
           "support": {
             "android": false,
-            "ios": true,
+            "ios": "3.9",
             "harmony": false,
             "web_lynx": false,
             "clay_android": false,
@@ -3484,15 +3484,15 @@
           "name": "<code>header-over-slot</code>",
           "doc_url": "/api/elements/built-in/scroll-coordinator",
           "support": {
-            "android": true,
-            "ios": true,
-            "harmony": true,
+            "android": "3.9",
+            "ios": "3.9",
+            "harmony": "3.9",
             "web_lynx": false,
-            "clay_android": true,
-            "clay_ios": true,
-            "clay_macos": true,
-            "clay_windows": true,
-            "clay": true
+            "clay_android": "3.9",
+            "clay_ios": "3.9",
+            "clay_macos": "3.9",
+            "clay_windows": "3.9",
+            "clay": "3.9"
           }
         },
         {
@@ -3500,15 +3500,15 @@
           "name": "<code>enable-scroll</code>",
           "doc_url": "/api/elements/built-in/scroll-coordinator",
           "support": {
-            "android": true,
-            "ios": true,
-            "harmony": true,
-            "web_lynx": true,
-            "clay_android": true,
-            "clay_ios": true,
-            "clay_macos": true,
-            "clay_windows": true,
-            "clay": true
+            "android": "3.9",
+            "ios": "3.9",
+            "harmony": "3.9",
+            "web_lynx": "3.9",
+            "clay_android": "3.9",
+            "clay_ios": "3.9",
+            "clay_macos": "3.9",
+            "clay_windows": "3.9",
+            "clay": "3.9"
           }
         },
         {
@@ -3517,8 +3517,8 @@
           "doc_url": "/api/elements/built-in/scroll-coordinator",
           "support": {
             "android": false,
-            "ios": true,
-            "harmony": true,
+            "ios": "3.9",
+            "harmony": "3.9",
             "web_lynx": false,
             "clay_android": false,
             "clay_ios": false,
@@ -3533,9 +3533,9 @@
           "doc_url": "/api/elements/built-in/scroll-coordinator",
           "support": {
             "android": false,
-            "ios": true,
-            "harmony": true,
-            "web_lynx": true,
+            "ios": "3.9",
+            "harmony": "3.9",
+            "web_lynx": "3.9",
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": false,
@@ -3548,7 +3548,7 @@
           "name": "<code>android-nested-scroll-as-child</code>",
           "doc_url": "/api/elements/built-in/scroll-coordinator",
           "support": {
-            "android": true,
+            "android": "3.9",
             "ios": false,
             "harmony": false,
             "web_lynx": false,
@@ -3565,7 +3565,7 @@
           "doc_url": "/api/elements/built-in/scroll-coordinator",
           "support": {
             "android": false,
-            "ios": true,
+            "ios": "3.9",
             "harmony": false,
             "web_lynx": false,
             "clay_android": false,
@@ -3580,15 +3580,15 @@
           "name": "<code>granularity</code>",
           "doc_url": "/api/elements/built-in/scroll-coordinator",
           "support": {
-            "android": true,
-            "ios": true,
-            "harmony": true,
-            "web_lynx": true,
-            "clay_android": true,
-            "clay_ios": true,
-            "clay_macos": true,
-            "clay_windows": true,
-            "clay": true
+            "android": "3.9",
+            "ios": "3.9",
+            "harmony": "3.9",
+            "web_lynx": "3.9",
+            "clay_android": "3.9",
+            "clay_ios": "3.9",
+            "clay_macos": "3.9",
+            "clay_windows": "3.9",
+            "clay": "3.9"
           }
         },
         {
@@ -3597,7 +3597,7 @@
           "doc_url": "/api/elements/built-in/scroll-coordinator",
           "support": {
             "android": false,
-            "ios": true,
+            "ios": "3.9",
             "harmony": false,
             "web_lynx": false,
             "clay_android": false,
@@ -3612,15 +3612,15 @@
           "name": "events",
           "doc_url": "/api/elements/built-in/scroll-coordinator",
           "support": {
-            "android": true,
-            "ios": true,
-            "harmony": true,
-            "web_lynx": true,
-            "clay_android": true,
-            "clay_ios": true,
-            "clay_macos": true,
-            "clay_windows": true,
-            "clay": true
+            "android": "3.9",
+            "ios": "3.9",
+            "harmony": "3.9",
+            "web_lynx": "3.9",
+            "clay_android": "3.9",
+            "clay_ios": "3.9",
+            "clay_macos": "3.9",
+            "clay_windows": "3.9",
+            "clay": "3.9"
           }
         },
         {
@@ -3628,15 +3628,15 @@
           "name": "<code>bindoffset</code>",
           "doc_url": "/api/elements/built-in/scroll-coordinator",
           "support": {
-            "android": true,
-            "ios": true,
-            "harmony": true,
-            "web_lynx": true,
-            "clay_android": true,
-            "clay_ios": true,
-            "clay_macos": true,
-            "clay_windows": true,
-            "clay": true
+            "android": "3.9",
+            "ios": "3.9",
+            "harmony": "3.9",
+            "web_lynx": "3.9",
+            "clay_android": "3.9",
+            "clay_ios": "3.9",
+            "clay_macos": "3.9",
+            "clay_windows": "3.9",
+            "clay": "3.9"
           }
         },
         {
@@ -3644,15 +3644,15 @@
           "name": "methods",
           "doc_url": "/api/elements/built-in/scroll-coordinator",
           "support": {
-            "android": true,
-            "ios": true,
-            "harmony": true,
-            "web_lynx": true,
-            "clay_android": true,
-            "clay_ios": true,
-            "clay_macos": true,
-            "clay_windows": true,
-            "clay": true
+            "android": "3.9",
+            "ios": "3.9",
+            "harmony": "3.9",
+            "web_lynx": "3.9",
+            "clay_android": "3.9",
+            "clay_ios": "3.9",
+            "clay_macos": "3.9",
+            "clay_windows": "3.9",
+            "clay": "3.9"
           }
         },
         {
@@ -3660,15 +3660,15 @@
           "name": "<code>setFoldExpanded</code>",
           "doc_url": "/api/elements/built-in/scroll-coordinator",
           "support": {
-            "android": true,
-            "ios": true,
-            "harmony": true,
-            "web_lynx": true,
-            "clay_android": true,
-            "clay_ios": true,
-            "clay_macos": true,
-            "clay_windows": true,
-            "clay": true
+            "android": "3.9",
+            "ios": "3.9",
+            "harmony": "3.9",
+            "web_lynx": "3.9",
+            "clay_android": "3.9",
+            "clay_ios": "3.9",
+            "clay_macos": "3.9",
+            "clay_windows": "3.9",
+            "clay": "3.9"
           }
         },
         {
@@ -5228,15 +5228,15 @@
           "name": "viewpager",
           "doc_url": "/api/elements/built-in/viewpager",
           "support": {
-            "android": "1.5",
-            "ios": "1.5",
-            "harmony": "3.4",
-            "web_lynx": true,
-            "clay_android": "1.5",
-            "clay_ios": "1.5",
-            "clay_macos": "1.5",
-            "clay_windows": "1.5",
-            "clay": "1.5"
+            "android": "3.9",
+            "ios": "3.9",
+            "harmony": "3.9",
+            "web_lynx": "3.9",
+            "clay_android": "3.9",
+            "clay_ios": "3.9",
+            "clay_macos": "3.9",
+            "clay_windows": "3.9",
+            "clay": "3.9"
           }
         },
         {
@@ -5244,15 +5244,15 @@
           "name": "attributes",
           "doc_url": "/api/elements/built-in/viewpager",
           "support": {
-            "android": "1.5",
-            "ios": "1.5",
-            "harmony": "3.4",
-            "web_lynx": true,
-            "clay_android": "1.5",
-            "clay_ios": "1.5",
-            "clay_macos": "1.5",
-            "clay_windows": "1.5",
-            "clay": "1.5"
+            "android": "3.9",
+            "ios": "3.9",
+            "harmony": "3.9",
+            "web_lynx": "3.9",
+            "clay_android": "3.9",
+            "clay_ios": "3.9",
+            "clay_macos": "3.9",
+            "clay_windows": "3.9",
+            "clay": "3.9"
           }
         },
         {
@@ -5261,7 +5261,7 @@
           "doc_url": "/api/elements/built-in/viewpager",
           "support": {
             "android": false,
-            "ios": "1.5",
+            "ios": "3.9",
             "harmony": false,
             "web_lynx": false,
             "clay_android": false,
@@ -5277,7 +5277,7 @@
           "doc_url": "/api/elements/built-in/viewpager",
           "support": {
             "android": false,
-            "ios": "1.5",
+            "ios": "3.9",
             "harmony": false,
             "web_lynx": false,
             "clay_android": false,
@@ -5292,15 +5292,15 @@
           "name": "<code>initial-select-index</code>",
           "doc_url": "/api/elements/built-in/viewpager",
           "support": {
-            "android": "2.17",
-            "ios": "2.17",
-            "harmony": "3.4",
-            "web_lynx": true,
-            "clay_android": "2.17",
-            "clay_ios": "2.17",
-            "clay_macos": "2.17",
-            "clay_windows": "2.17",
-            "clay": "2.17"
+            "android": "3.9",
+            "ios": "3.9",
+            "harmony": "3.9",
+            "web_lynx": "3.9",
+            "clay_android": "3.9",
+            "clay_ios": "3.9",
+            "clay_macos": "3.9",
+            "clay_windows": "3.9",
+            "clay": "3.9"
           }
         },
         {
@@ -5308,15 +5308,15 @@
           "name": "<code>enable-scroll</code>",
           "doc_url": "/api/elements/built-in/viewpager",
           "support": {
-            "android": "2.17",
-            "ios": "2.17",
-            "harmony": "3.4",
-            "web_lynx": true,
-            "clay_android": "2.17",
-            "clay_ios": "2.17",
-            "clay_macos": "2.17",
-            "clay_windows": "2.17",
-            "clay": "2.17"
+            "android": "3.9",
+            "ios": "3.9",
+            "harmony": "3.9",
+            "web_lynx": "3.9",
+            "clay_android": "3.9",
+            "clay_ios": "3.9",
+            "clay_macos": "3.9",
+            "clay_windows": "3.9",
+            "clay": "3.9"
           }
         },
         {
@@ -5325,14 +5325,14 @@
           "doc_url": "/api/elements/built-in/viewpager",
           "support": {
             "android": false,
-            "ios": "1.5",
-            "harmony": "3.4",
-            "web_lynx": true,
-            "clay_android": "1.5",
-            "clay_ios": "1.5",
-            "clay_macos": "1.5",
-            "clay_windows": "1.5",
-            "clay": "1.5"
+            "ios": "3.9",
+            "harmony": "3.9",
+            "web_lynx": "3.9",
+            "clay_android": "3.9",
+            "clay_ios": "3.9",
+            "clay_macos": "3.9",
+            "clay_windows": "3.9",
+            "clay": "3.9"
           }
         },
         {
@@ -5341,7 +5341,7 @@
           "doc_url": "/api/elements/built-in/viewpager",
           "support": {
             "android": false,
-            "ios": "1.5",
+            "ios": "3.9",
             "harmony": false,
             "web_lynx": false,
             "clay_android": false,
@@ -5357,7 +5357,7 @@
           "doc_url": "/api/elements/built-in/viewpager",
           "support": {
             "android": false,
-            "ios": "1.5",
+            "ios": "3.9",
             "harmony": false,
             "web_lynx": false,
             "clay_android": false,
@@ -5372,8 +5372,8 @@
           "name": "<code>keep-item-view</code>",
           "doc_url": "/api/elements/built-in/viewpager",
           "support": {
-            "android": true,
-            "ios": true,
+            "android": "3.9",
+            "ios": "3.9",
             "harmony": false,
             "web_lynx": false,
             "clay_android": false,
@@ -5388,7 +5388,7 @@
           "name": "<code>android-always-overscroll</code>",
           "doc_url": "/api/elements/built-in/viewpager",
           "support": {
-            "android": true,
+            "android": "3.9",
             "ios": false,
             "harmony": false,
             "web_lynx": false,
@@ -5404,7 +5404,7 @@
           "name": "<code>android-force-can-scroll</code>",
           "doc_url": "/api/elements/built-in/viewpager",
           "support": {
-            "android": "3.0",
+            "android": "3.9",
             "ios": false,
             "harmony": false,
             "web_lynx": false,
@@ -5420,15 +5420,15 @@
           "name": "events",
           "doc_url": "/api/elements/built-in/viewpager",
           "support": {
-            "android": "1.5",
-            "ios": "1.5",
-            "harmony": "3.4",
-            "web_lynx": true,
-            "clay_android": "1.5",
-            "clay_ios": "1.5",
-            "clay_macos": "1.5",
-            "clay_windows": "1.5",
-            "clay": "1.5"
+            "android": "3.9",
+            "ios": "3.9",
+            "harmony": "3.9",
+            "web_lynx": "3.9",
+            "clay_android": "3.9",
+            "clay_ios": "3.9",
+            "clay_macos": "3.9",
+            "clay_windows": "3.9",
+            "clay": "3.9"
           }
         },
         {
@@ -5436,15 +5436,15 @@
           "name": "<code>bindchange</code>",
           "doc_url": "/api/elements/built-in/viewpager",
           "support": {
-            "android": "1.5",
-            "ios": "1.5",
-            "harmony": "3.4",
-            "web_lynx": true,
-            "clay_android": "1.5",
-            "clay_ios": "1.5",
-            "clay_macos": "1.5",
-            "clay_windows": "1.5",
-            "clay": "1.5"
+            "android": "3.9",
+            "ios": "3.9",
+            "harmony": "3.9",
+            "web_lynx": "3.9",
+            "clay_android": "3.9",
+            "clay_ios": "3.9",
+            "clay_macos": "3.9",
+            "clay_windows": "3.9",
+            "clay": "3.9"
           }
         },
         {
@@ -5452,15 +5452,15 @@
           "name": "<code>bindwillchange</code>",
           "doc_url": "/api/elements/built-in/viewpager",
           "support": {
-            "android": "2.17",
-            "ios": "2.17",
-            "harmony": "3.4",
-            "web_lynx": true,
-            "clay_android": "2.17",
-            "clay_ios": "2.17",
-            "clay_macos": "2.17",
-            "clay_windows": "2.17",
-            "clay": "2.17"
+            "android": "3.9",
+            "ios": "3.9",
+            "harmony": "3.9",
+            "web_lynx": "3.9",
+            "clay_android": "3.9",
+            "clay_ios": "3.9",
+            "clay_macos": "3.9",
+            "clay_windows": "3.9",
+            "clay": "3.9"
           }
         },
         {
@@ -5468,15 +5468,15 @@
           "name": "<code>bindoffsetchange</code>",
           "doc_url": "/api/elements/built-in/viewpager",
           "support": {
-            "android": "1.5",
-            "ios": "1.5",
-            "harmony": "3.4",
-            "web_lynx": true,
-            "clay_android": "1.5",
-            "clay_ios": "1.5",
-            "clay_macos": "1.5",
-            "clay_windows": "1.5",
-            "clay": "1.5"
+            "android": "3.9",
+            "ios": "3.9",
+            "harmony": "3.9",
+            "web_lynx": "3.9",
+            "clay_android": "3.9",
+            "clay_ios": "3.9",
+            "clay_macos": "3.9",
+            "clay_windows": "3.9",
+            "clay": "3.9"
           }
         },
         {
@@ -5484,15 +5484,15 @@
           "name": "methods",
           "doc_url": "/api/elements/built-in/viewpager",
           "support": {
-            "android": "1.5",
-            "ios": "1.5",
-            "harmony": "3.4",
-            "web_lynx": true,
-            "clay_android": "1.5",
-            "clay_ios": "1.5",
-            "clay_macos": "1.5",
-            "clay_windows": "1.5",
-            "clay": "1.5"
+            "android": "3.9",
+            "ios": "3.9",
+            "harmony": "3.9",
+            "web_lynx": "3.9",
+            "clay_android": "3.9",
+            "clay_ios": "3.9",
+            "clay_macos": "3.9",
+            "clay_windows": "3.9",
+            "clay": "3.9"
           }
         },
         {
@@ -5500,15 +5500,15 @@
           "name": "<code>selectTab</code>",
           "doc_url": "/api/elements/built-in/viewpager",
           "support": {
-            "android": "1.5",
-            "ios": "1.5",
-            "harmony": "3.4",
-            "web_lynx": true,
-            "clay_android": "1.5",
-            "clay_ios": "1.5",
-            "clay_macos": "1.5",
-            "clay_windows": "1.5",
-            "clay": "1.5"
+            "android": "3.9",
+            "ios": "3.9",
+            "harmony": "3.9",
+            "web_lynx": "3.9",
+            "clay_android": "3.9",
+            "clay_ios": "3.9",
+            "clay_macos": "3.9",
+            "clay_windows": "3.9",
+            "clay": "3.9"
           }
         },
         {
@@ -5516,15 +5516,15 @@
           "name": "webview",
           "doc_url": "/api/elements/built-in/webview",
           "support": {
-            "android": true,
-            "ios": true,
-            "harmony": true,
+            "android": "4.0",
+            "ios": "4.0",
+            "harmony": "4.0",
             "web_lynx": false,
-            "clay_android": true,
-            "clay_ios": true,
-            "clay_macos": true,
-            "clay_windows": true,
-            "clay": true
+            "clay_android": "4.0",
+            "clay_ios": "4.0",
+            "clay_macos": "4.0",
+            "clay_windows": "4.0",
+            "clay": "4.0"
           }
         },
         {
@@ -5532,15 +5532,15 @@
           "name": "attributes",
           "doc_url": "/api/elements/built-in/webview",
           "support": {
-            "android": true,
-            "ios": true,
-            "harmony": true,
+            "android": "4.0",
+            "ios": "4.0",
+            "harmony": "4.0",
             "web_lynx": false,
-            "clay_android": true,
-            "clay_ios": true,
-            "clay_macos": true,
-            "clay_windows": true,
-            "clay": true
+            "clay_android": "4.0",
+            "clay_ios": "4.0",
+            "clay_macos": "4.0",
+            "clay_windows": "4.0",
+            "clay": "4.0"
           }
         },
         {
@@ -5548,15 +5548,15 @@
           "name": "<code>src</code>",
           "doc_url": "/api/elements/built-in/webview",
           "support": {
-            "android": true,
-            "ios": true,
-            "harmony": true,
+            "android": "4.0",
+            "ios": "4.0",
+            "harmony": "4.0",
             "web_lynx": false,
-            "clay_android": true,
-            "clay_ios": true,
-            "clay_macos": true,
-            "clay_windows": true,
-            "clay": true
+            "clay_android": "4.0",
+            "clay_ios": "4.0",
+            "clay_macos": "4.0",
+            "clay_windows": "4.0",
+            "clay": "4.0"
           }
         },
         {
@@ -5564,9 +5564,9 @@
           "name": "<code>html</code>",
           "doc_url": "/api/elements/built-in/webview",
           "support": {
-            "android": "3.6",
-            "ios": "3.6",
-            "harmony": "3.6",
+            "android": "4.0",
+            "ios": "4.0",
+            "harmony": "4.0",
             "web_lynx": false,
             "clay_android": false,
             "clay_ios": false,
@@ -5581,7 +5581,7 @@
           "doc_url": "/api/elements/built-in/webview",
           "support": {
             "android": false,
-            "ios": true,
+            "ios": "4.0",
             "harmony": false,
             "web_lynx": false,
             "clay_android": false,
@@ -5597,7 +5597,7 @@
           "doc_url": "/api/elements/built-in/webview",
           "support": {
             "android": false,
-            "ios": true,
+            "ios": "4.0",
             "harmony": false,
             "web_lynx": false,
             "clay_android": false,
@@ -5612,8 +5612,8 @@
           "name": "<code>params</code>",
           "doc_url": "/api/elements/built-in/webview",
           "support": {
-            "android": true,
-            "ios": true,
+            "android": "4.0",
+            "ios": "4.0",
             "harmony": false,
             "web_lynx": false,
             "clay_android": false,
@@ -5628,9 +5628,9 @@
           "name": "<code>webview-type</code>",
           "doc_url": "/api/elements/built-in/webview",
           "support": {
-            "android": true,
-            "ios": true,
-            "harmony": true,
+            "android": "4.0",
+            "ios": "4.0",
+            "harmony": "4.0",
             "web_lynx": false,
             "clay_android": false,
             "clay_ios": false,
@@ -5644,15 +5644,15 @@
           "name": "<code>enable-debug</code>",
           "doc_url": "/api/elements/built-in/webview",
           "support": {
-            "android": true,
-            "ios": true,
-            "harmony": true,
+            "android": "4.0",
+            "ios": "4.0",
+            "harmony": "4.0",
             "web_lynx": false,
-            "clay_android": true,
-            "clay_ios": true,
-            "clay_macos": true,
-            "clay_windows": true,
-            "clay": true
+            "clay_android": "4.0",
+            "clay_ios": "4.0",
+            "clay_macos": "4.0",
+            "clay_windows": "4.0",
+            "clay": "4.0"
           }
         },
         {
@@ -5664,11 +5664,11 @@
             "ios": false,
             "harmony": false,
             "web_lynx": false,
-            "clay_android": "3.5",
-            "clay_ios": "3.5",
-            "clay_macos": "3.5",
-            "clay_windows": "3.5",
-            "clay": "3.5"
+            "clay_android": "4.0",
+            "clay_ios": "4.0",
+            "clay_macos": "4.0",
+            "clay_windows": "4.0",
+            "clay": "4.0"
           }
         },
         {
@@ -5680,11 +5680,11 @@
             "ios": false,
             "harmony": false,
             "web_lynx": false,
-            "clay_android": "3.5",
-            "clay_ios": "3.5",
-            "clay_macos": "3.5",
-            "clay_windows": "3.5",
-            "clay": "3.5"
+            "clay_android": "4.0",
+            "clay_ios": "4.0",
+            "clay_macos": "4.0",
+            "clay_windows": "4.0",
+            "clay": "4.0"
           }
         },
         {
@@ -5696,11 +5696,11 @@
             "ios": false,
             "harmony": false,
             "web_lynx": false,
-            "clay_android": "3.5",
-            "clay_ios": "3.5",
-            "clay_macos": "3.5",
-            "clay_windows": "3.5",
-            "clay": "3.5"
+            "clay_android": "4.0",
+            "clay_ios": "4.0",
+            "clay_macos": "4.0",
+            "clay_windows": "4.0",
+            "clay": "4.0"
           }
         },
         {
@@ -5708,15 +5708,15 @@
           "name": "events",
           "doc_url": "/api/elements/built-in/webview",
           "support": {
-            "android": true,
-            "ios": true,
-            "harmony": true,
+            "android": "4.0",
+            "ios": "4.0",
+            "harmony": "4.0",
             "web_lynx": false,
-            "clay_android": true,
-            "clay_ios": true,
-            "clay_macos": true,
-            "clay_windows": true,
-            "clay": true
+            "clay_android": "4.0",
+            "clay_ios": "4.0",
+            "clay_macos": "4.0",
+            "clay_windows": "4.0",
+            "clay": "4.0"
           }
         },
         {
@@ -5724,15 +5724,15 @@
           "name": "<code>bindload</code>",
           "doc_url": "/api/elements/built-in/webview",
           "support": {
-            "android": true,
-            "ios": true,
-            "harmony": true,
+            "android": "4.0",
+            "ios": "4.0",
+            "harmony": "4.0",
             "web_lynx": false,
-            "clay_android": true,
-            "clay_ios": true,
-            "clay_macos": true,
-            "clay_windows": true,
-            "clay": true
+            "clay_android": "4.0",
+            "clay_ios": "4.0",
+            "clay_macos": "4.0",
+            "clay_windows": "4.0",
+            "clay": "4.0"
           }
         },
         {
@@ -5740,15 +5740,15 @@
           "name": "<code>binderror</code>",
           "doc_url": "/api/elements/built-in/webview",
           "support": {
-            "android": true,
-            "ios": true,
-            "harmony": true,
+            "android": "4.0",
+            "ios": "4.0",
+            "harmony": "4.0",
             "web_lynx": false,
-            "clay_android": true,
-            "clay_ios": true,
-            "clay_macos": true,
-            "clay_windows": true,
-            "clay": true
+            "clay_android": "4.0",
+            "clay_ios": "4.0",
+            "clay_macos": "4.0",
+            "clay_windows": "4.0",
+            "clay": "4.0"
           }
         },
         {
@@ -5756,15 +5756,15 @@
           "name": "<code>bindmessage</code>",
           "doc_url": "/api/elements/built-in/webview",
           "support": {
-            "android": true,
-            "ios": true,
-            "harmony": true,
+            "android": "4.0",
+            "ios": "4.0",
+            "harmony": "4.0",
             "web_lynx": false,
-            "clay_android": true,
-            "clay_ios": true,
-            "clay_macos": true,
-            "clay_windows": true,
-            "clay": true
+            "clay_android": "4.0",
+            "clay_ios": "4.0",
+            "clay_macos": "4.0",
+            "clay_windows": "4.0",
+            "clay": "4.0"
           }
         },
         {
@@ -5776,11 +5776,11 @@
             "ios": false,
             "harmony": false,
             "web_lynx": false,
-            "clay_android": "3.5",
-            "clay_ios": "3.5",
-            "clay_macos": "3.5",
-            "clay_windows": "3.5",
-            "clay": "3.5"
+            "clay_android": "4.0",
+            "clay_ios": "4.0",
+            "clay_macos": "4.0",
+            "clay_windows": "4.0",
+            "clay": "4.0"
           }
         },
         {
@@ -5792,11 +5792,11 @@
             "ios": false,
             "harmony": false,
             "web_lynx": false,
-            "clay_android": "3.5",
-            "clay_ios": "3.5",
-            "clay_macos": "3.5",
-            "clay_windows": "3.5",
-            "clay": "3.5"
+            "clay_android": "4.0",
+            "clay_ios": "4.0",
+            "clay_macos": "4.0",
+            "clay_windows": "4.0",
+            "clay": "4.0"
           }
         },
         {
@@ -5804,15 +5804,15 @@
           "name": "methods",
           "doc_url": "/api/elements/built-in/webview",
           "support": {
-            "android": true,
-            "ios": true,
-            "harmony": true,
+            "android": "4.0",
+            "ios": "4.0",
+            "harmony": "4.0",
             "web_lynx": false,
-            "clay_android": true,
-            "clay_ios": true,
-            "clay_macos": true,
-            "clay_windows": true,
-            "clay": true
+            "clay_android": "4.0",
+            "clay_ios": "4.0",
+            "clay_macos": "4.0",
+            "clay_windows": "4.0",
+            "clay": "4.0"
           }
         },
         {
@@ -5820,15 +5820,15 @@
           "name": "<code>reload</code>",
           "doc_url": "/api/elements/built-in/webview",
           "support": {
-            "android": true,
-            "ios": true,
-            "harmony": true,
+            "android": "4.0",
+            "ios": "4.0",
+            "harmony": "4.0",
             "web_lynx": false,
-            "clay_android": true,
-            "clay_ios": true,
-            "clay_macos": true,
-            "clay_windows": true,
-            "clay": true
+            "clay_android": "4.0",
+            "clay_ios": "4.0",
+            "clay_macos": "4.0",
+            "clay_windows": "4.0",
+            "clay": "4.0"
           }
         },
         {
@@ -5836,15 +5836,15 @@
           "name": "<code>eval</code>",
           "doc_url": "/api/elements/built-in/webview",
           "support": {
-            "android": true,
-            "ios": true,
-            "harmony": true,
+            "android": "4.0",
+            "ios": "4.0",
+            "harmony": "4.0",
             "web_lynx": false,
-            "clay_android": true,
-            "clay_ios": true,
-            "clay_macos": true,
-            "clay_windows": true,
-            "clay": true
+            "clay_android": "4.0",
+            "clay_ios": "4.0",
+            "clay_macos": "4.0",
+            "clay_windows": "4.0",
+            "clay": "4.0"
           }
         },
         {
@@ -5856,11 +5856,11 @@
             "ios": false,
             "harmony": false,
             "web_lynx": false,
-            "clay_android": "3.5",
-            "clay_ios": "3.5",
-            "clay_macos": "3.5",
-            "clay_windows": "3.5",
-            "clay": "3.5"
+            "clay_android": "4.0",
+            "clay_ios": "4.0",
+            "clay_macos": "4.0",
+            "clay_windows": "4.0",
+            "clay": "4.0"
           }
         },
         {
@@ -5872,11 +5872,11 @@
             "ios": false,
             "harmony": false,
             "web_lynx": false,
-            "clay_android": "3.5",
-            "clay_ios": "3.5",
-            "clay_macos": "3.5",
-            "clay_windows": "3.5",
-            "clay": "3.5"
+            "clay_android": "4.0",
+            "clay_ios": "4.0",
+            "clay_macos": "4.0",
+            "clay_windows": "4.0",
+            "clay": "4.0"
           }
         },
         {
@@ -5888,11 +5888,11 @@
             "ios": false,
             "harmony": false,
             "web_lynx": false,
-            "clay_android": "3.5",
-            "clay_ios": "3.5",
-            "clay_macos": "3.5",
-            "clay_windows": "3.5",
-            "clay": "3.5"
+            "clay_android": "4.0",
+            "clay_ios": "4.0",
+            "clay_macos": "4.0",
+            "clay_windows": "4.0",
+            "clay": "4.0"
           }
         },
         {
@@ -5904,11 +5904,11 @@
             "ios": false,
             "harmony": false,
             "web_lynx": false,
-            "clay_android": "3.5",
-            "clay_ios": "3.5",
-            "clay_macos": "3.5",
-            "clay_windows": "3.5",
-            "clay": "3.5"
+            "clay_android": "4.0",
+            "clay_ios": "4.0",
+            "clay_macos": "4.0",
+            "clay_windows": "4.0",
+            "clay": "4.0"
           }
         },
         {
@@ -6480,14 +6480,14 @@
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
               "android": false,
-              "ios": true,
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
-              "clay_ios": true,
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -6496,14 +6496,14 @@
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
               "android": false,
-              "ios": "3.8",
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
-              "clay_ios": "3.8",
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": "3.8"
+              "clay": "4.0"
             }
           },
           {
@@ -6512,14 +6512,14 @@
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
               "android": false,
-              "ios": "3.8",
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
-              "clay_ios": "3.8",
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": "3.8"
+              "clay": "4.0"
             }
           },
           {
@@ -6528,14 +6528,14 @@
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
               "android": false,
-              "ios": "3.8",
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
-              "clay_ios": "3.8",
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": "3.8"
+              "clay": "4.0"
             }
           },
           {
@@ -6544,14 +6544,14 @@
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
               "android": false,
-              "ios": true,
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
-              "clay_ios": true,
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -6608,8 +6608,8 @@
             "doc_url": "/api/elements/built-in/scroll-coordinator",
             "support": {
               "android": false,
-              "ios": true,
-              "harmony": true,
+              "ios": "3.9",
+              "harmony": "3.9",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -6624,9 +6624,9 @@
             "doc_url": "/api/elements/built-in/scroll-coordinator",
             "support": {
               "android": false,
-              "ios": true,
-              "harmony": true,
-              "web_lynx": true,
+              "ios": "3.9",
+              "harmony": "3.9",
+              "web_lynx": "3.9",
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": false,
@@ -6688,14 +6688,14 @@
             "doc_url": "/api/elements/built-in/viewpager",
             "support": {
               "android": false,
-              "ios": "1.5",
-              "harmony": "3.4",
-              "web_lynx": true,
-              "clay_android": "1.5",
-              "clay_ios": "1.5",
-              "clay_macos": "1.5",
-              "clay_windows": "1.5",
-              "clay": "1.5"
+              "ios": "3.9",
+              "harmony": "3.9",
+              "web_lynx": "3.9",
+              "clay_android": "3.9",
+              "clay_ios": "3.9",
+              "clay_macos": "3.9",
+              "clay_windows": "3.9",
+              "clay": "3.9"
             }
           },
           {
@@ -6707,11 +6707,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -6723,11 +6723,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -6739,11 +6739,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -6755,11 +6755,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -6771,11 +6771,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -6787,11 +6787,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -6803,11 +6803,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -6819,11 +6819,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -6835,11 +6835,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -7393,15 +7393,15 @@
             "name": "<code>android-capture-target</code>",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": "3.9",
+              "android": "4.0",
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.9",
+              "clay_android": "4.0",
               "clay_ios": false,
               "clay_macos": false,
               "clay_windows": false,
-              "clay": "3.9"
+              "clay": "4.0"
             }
           },
           {
@@ -7409,15 +7409,15 @@
             "name": "<code>blur-sampling</code>",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": true,
+              "android": "4.0",
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": true,
+              "clay_android": "4.0",
               "clay_ios": false,
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -7425,15 +7425,15 @@
             "name": "<code>enable-auto-blur</code>",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": true,
+              "android": "4.0",
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": true,
+              "clay_android": "4.0",
               "clay_ios": false,
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -7441,15 +7441,15 @@
             "name": "<code>experimental-update-blur-radius</code>",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": "3.4",
+              "android": "4.0",
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.4",
+              "clay_android": "4.0",
               "clay_ios": false,
               "clay_macos": false,
               "clay_windows": false,
-              "clay": "3.4"
+              "clay": "4.0"
             }
           },
           {
@@ -7589,11 +7589,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -7605,11 +7605,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -7621,11 +7621,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -7637,11 +7637,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -7653,11 +7653,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -7669,11 +7669,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -7685,11 +7685,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -7701,11 +7701,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -7717,11 +7717,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -8275,15 +8275,15 @@
             "name": "<code>android-capture-target</code>",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": "3.9",
+              "android": "4.0",
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.9",
+              "clay_android": "4.0",
               "clay_ios": false,
               "clay_macos": false,
               "clay_windows": false,
-              "clay": "3.9"
+              "clay": "4.0"
             }
           },
           {
@@ -8292,14 +8292,14 @@
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
               "android": false,
-              "ios": true,
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
-              "clay_ios": true,
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -8307,15 +8307,15 @@
             "name": "<code>blur-sampling</code>",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": true,
+              "android": "4.0",
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": true,
+              "clay_android": "4.0",
               "clay_ios": false,
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -8323,15 +8323,15 @@
             "name": "<code>enable-auto-blur</code>",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": true,
+              "android": "4.0",
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": true,
+              "clay_android": "4.0",
               "clay_ios": false,
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -8339,15 +8339,15 @@
             "name": "<code>experimental-update-blur-radius</code>",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": "3.4",
+              "android": "4.0",
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.4",
+              "clay_android": "4.0",
               "clay_ios": false,
               "clay_macos": false,
               "clay_windows": false,
-              "clay": "3.4"
+              "clay": "4.0"
             }
           },
           {
@@ -8356,14 +8356,14 @@
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
               "android": false,
-              "ios": "3.8",
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
-              "clay_ios": "3.8",
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": "3.8"
+              "clay": "4.0"
             }
           },
           {
@@ -8372,14 +8372,14 @@
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
               "android": false,
-              "ios": "3.8",
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
-              "clay_ios": "3.8",
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": "3.8"
+              "clay": "4.0"
             }
           },
           {
@@ -8388,14 +8388,14 @@
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
               "android": false,
-              "ios": "3.8",
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
-              "clay_ios": "3.8",
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": "3.8"
+              "clay": "4.0"
             }
           },
           {
@@ -8404,14 +8404,14 @@
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
               "android": false,
-              "ios": true,
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
-              "clay_ios": true,
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -8995,8 +8995,8 @@
             "name": "<code>keep-item-view</code>",
             "doc_url": "/api/elements/built-in/viewpager",
             "support": {
-              "android": true,
-              "ios": true,
+              "android": "3.9",
+              "ios": "3.9",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
@@ -9011,8 +9011,8 @@
             "name": "<code>params</code>",
             "doc_url": "/api/elements/built-in/webview",
             "support": {
-              "android": true,
-              "ios": true,
+              "android": "4.0",
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
@@ -9031,11 +9031,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -9047,11 +9047,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -9063,11 +9063,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -9079,11 +9079,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -9095,11 +9095,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -9111,11 +9111,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -9127,11 +9127,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -9143,11 +9143,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -9159,11 +9159,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -9717,15 +9717,15 @@
             "name": "blur-view",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": true,
-              "ios": true,
-              "harmony": true,
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
-              "clay_android": true,
-              "clay_ios": true,
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -9733,15 +9733,15 @@
             "name": "attributes",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": true,
-              "ios": true,
-              "harmony": true,
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
-              "clay_android": true,
-              "clay_ios": true,
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -9749,15 +9749,15 @@
             "name": "<code>android-capture-target</code>",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": "3.9",
+              "android": "4.0",
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.9",
+              "clay_android": "4.0",
               "clay_ios": false,
               "clay_macos": false,
               "clay_windows": false,
-              "clay": "3.9"
+              "clay": "4.0"
             }
           },
           {
@@ -9766,14 +9766,14 @@
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
               "android": false,
-              "ios": true,
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
-              "clay_ios": true,
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -9781,15 +9781,15 @@
             "name": "<code>blur-radius</code>",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": true,
-              "ios": true,
-              "harmony": true,
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
-              "clay_android": true,
-              "clay_ios": true,
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -9797,15 +9797,15 @@
             "name": "<code>blur-sampling</code>",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": true,
+              "android": "4.0",
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": true,
+              "clay_android": "4.0",
               "clay_ios": false,
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -9813,15 +9813,15 @@
             "name": "<code>enable-auto-blur</code>",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": true,
+              "android": "4.0",
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": true,
+              "clay_android": "4.0",
               "clay_ios": false,
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -9829,15 +9829,15 @@
             "name": "<code>experimental-update-blur-radius</code>",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": "3.4",
+              "android": "4.0",
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.4",
+              "clay_android": "4.0",
               "clay_ios": false,
               "clay_macos": false,
               "clay_windows": false,
-              "clay": "3.4"
+              "clay": "4.0"
             }
           },
           {
@@ -9846,14 +9846,14 @@
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
               "android": false,
-              "ios": "3.8",
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
-              "clay_ios": "3.8",
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": "3.8"
+              "clay": "4.0"
             }
           },
           {
@@ -9862,14 +9862,14 @@
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
               "android": false,
-              "ios": "3.8",
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
-              "clay_ios": "3.8",
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": "3.8"
+              "clay": "4.0"
             }
           },
           {
@@ -9878,14 +9878,14 @@
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
               "android": false,
-              "ios": "3.8",
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
-              "clay_ios": "3.8",
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": "3.8"
+              "clay": "4.0"
             }
           },
           {
@@ -9894,14 +9894,14 @@
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
               "android": false,
-              "ios": true,
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
-              "clay_ios": true,
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -10645,15 +10645,15 @@
             "name": "<code>header-over-slot</code>",
             "doc_url": "/api/elements/built-in/scroll-coordinator",
             "support": {
-              "android": true,
-              "ios": true,
-              "harmony": true,
+              "android": "3.9",
+              "ios": "3.9",
+              "harmony": "3.9",
               "web_lynx": false,
-              "clay_android": true,
-              "clay_ios": true,
-              "clay_macos": true,
-              "clay_windows": true,
-              "clay": true
+              "clay_android": "3.9",
+              "clay_ios": "3.9",
+              "clay_macos": "3.9",
+              "clay_windows": "3.9",
+              "clay": "3.9"
             }
           },
           {
@@ -10662,8 +10662,8 @@
             "doc_url": "/api/elements/built-in/scroll-coordinator",
             "support": {
               "android": false,
-              "ios": true,
-              "harmony": true,
+              "ios": "3.9",
+              "harmony": "3.9",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -11301,8 +11301,8 @@
             "name": "<code>keep-item-view</code>",
             "doc_url": "/api/elements/built-in/viewpager",
             "support": {
-              "android": true,
-              "ios": true,
+              "android": "3.9",
+              "ios": "3.9",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
@@ -11317,15 +11317,15 @@
             "name": "webview",
             "doc_url": "/api/elements/built-in/webview",
             "support": {
-              "android": true,
-              "ios": true,
-              "harmony": true,
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
-              "clay_android": true,
-              "clay_ios": true,
-              "clay_macos": true,
-              "clay_windows": true,
-              "clay": true
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -11333,15 +11333,15 @@
             "name": "attributes",
             "doc_url": "/api/elements/built-in/webview",
             "support": {
-              "android": true,
-              "ios": true,
-              "harmony": true,
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
-              "clay_android": true,
-              "clay_ios": true,
-              "clay_macos": true,
-              "clay_windows": true,
-              "clay": true
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -11349,15 +11349,15 @@
             "name": "<code>src</code>",
             "doc_url": "/api/elements/built-in/webview",
             "support": {
-              "android": true,
-              "ios": true,
-              "harmony": true,
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
-              "clay_android": true,
-              "clay_ios": true,
-              "clay_macos": true,
-              "clay_windows": true,
-              "clay": true
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -11365,9 +11365,9 @@
             "name": "<code>html</code>",
             "doc_url": "/api/elements/built-in/webview",
             "support": {
-              "android": "3.6",
-              "ios": "3.6",
-              "harmony": "3.6",
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -11381,8 +11381,8 @@
             "name": "<code>params</code>",
             "doc_url": "/api/elements/built-in/webview",
             "support": {
-              "android": true,
-              "ios": true,
+              "android": "4.0",
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
@@ -11397,9 +11397,9 @@
             "name": "<code>webview-type</code>",
             "doc_url": "/api/elements/built-in/webview",
             "support": {
-              "android": true,
-              "ios": true,
-              "harmony": true,
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -11413,15 +11413,15 @@
             "name": "<code>enable-debug</code>",
             "doc_url": "/api/elements/built-in/webview",
             "support": {
-              "android": true,
-              "ios": true,
-              "harmony": true,
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
-              "clay_android": true,
-              "clay_ios": true,
-              "clay_macos": true,
-              "clay_windows": true,
-              "clay": true
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -11433,11 +11433,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -11449,11 +11449,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -11465,11 +11465,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -11477,15 +11477,15 @@
             "name": "events",
             "doc_url": "/api/elements/built-in/webview",
             "support": {
-              "android": true,
-              "ios": true,
-              "harmony": true,
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
-              "clay_android": true,
-              "clay_ios": true,
-              "clay_macos": true,
-              "clay_windows": true,
-              "clay": true
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -11493,15 +11493,15 @@
             "name": "<code>bindload</code>",
             "doc_url": "/api/elements/built-in/webview",
             "support": {
-              "android": true,
-              "ios": true,
-              "harmony": true,
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
-              "clay_android": true,
-              "clay_ios": true,
-              "clay_macos": true,
-              "clay_windows": true,
-              "clay": true
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -11509,15 +11509,15 @@
             "name": "<code>binderror</code>",
             "doc_url": "/api/elements/built-in/webview",
             "support": {
-              "android": true,
-              "ios": true,
-              "harmony": true,
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
-              "clay_android": true,
-              "clay_ios": true,
-              "clay_macos": true,
-              "clay_windows": true,
-              "clay": true
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -11525,15 +11525,15 @@
             "name": "<code>bindmessage</code>",
             "doc_url": "/api/elements/built-in/webview",
             "support": {
-              "android": true,
-              "ios": true,
-              "harmony": true,
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
-              "clay_android": true,
-              "clay_ios": true,
-              "clay_macos": true,
-              "clay_windows": true,
-              "clay": true
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -11545,11 +11545,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -11561,11 +11561,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -11573,15 +11573,15 @@
             "name": "methods",
             "doc_url": "/api/elements/built-in/webview",
             "support": {
-              "android": true,
-              "ios": true,
-              "harmony": true,
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
-              "clay_android": true,
-              "clay_ios": true,
-              "clay_macos": true,
-              "clay_windows": true,
-              "clay": true
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -11589,15 +11589,15 @@
             "name": "<code>reload</code>",
             "doc_url": "/api/elements/built-in/webview",
             "support": {
-              "android": true,
-              "ios": true,
-              "harmony": true,
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
-              "clay_android": true,
-              "clay_ios": true,
-              "clay_macos": true,
-              "clay_windows": true,
-              "clay": true
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -11605,15 +11605,15 @@
             "name": "<code>eval</code>",
             "doc_url": "/api/elements/built-in/webview",
             "support": {
-              "android": true,
-              "ios": true,
-              "harmony": true,
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
-              "clay_android": true,
-              "clay_ios": true,
-              "clay_macos": true,
-              "clay_windows": true,
-              "clay": true
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -11625,11 +11625,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -11641,11 +11641,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -11657,11 +11657,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -11673,11 +11673,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           }
         ],
@@ -11688,14 +11688,14 @@
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
               "android": false,
-              "ios": true,
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
-              "clay_ios": true,
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -11704,14 +11704,14 @@
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
               "android": false,
-              "ios": "3.8",
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
-              "clay_ios": "3.8",
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": "3.8"
+              "clay": "4.0"
             }
           },
           {
@@ -11720,14 +11720,14 @@
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
               "android": false,
-              "ios": "3.8",
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
-              "clay_ios": "3.8",
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": "3.8"
+              "clay": "4.0"
             }
           },
           {
@@ -11736,14 +11736,14 @@
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
               "android": false,
-              "ios": "3.8",
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
-              "clay_ios": "3.8",
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": "3.8"
+              "clay": "4.0"
             }
           },
           {
@@ -11752,14 +11752,14 @@
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
               "android": false,
-              "ios": true,
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
-              "clay_ios": true,
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -12408,8 +12408,8 @@
             "doc_url": "/api/elements/built-in/scroll-coordinator",
             "support": {
               "android": false,
-              "ios": true,
-              "harmony": true,
+              "ios": "3.9",
+              "harmony": "3.9",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -12424,9 +12424,9 @@
             "doc_url": "/api/elements/built-in/scroll-coordinator",
             "support": {
               "android": false,
-              "ios": true,
-              "harmony": true,
-              "web_lynx": true,
+              "ios": "3.9",
+              "harmony": "3.9",
+              "web_lynx": "3.9",
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": false,
@@ -12791,8 +12791,8 @@
             "name": "<code>keep-item-view</code>",
             "doc_url": "/api/elements/built-in/viewpager",
             "support": {
-              "android": true,
-              "ios": true,
+              "android": "3.9",
+              "ios": "3.9",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
@@ -12807,9 +12807,9 @@
             "name": "<code>html</code>",
             "doc_url": "/api/elements/built-in/webview",
             "support": {
-              "android": "3.6",
-              "ios": "3.6",
-              "harmony": "3.6",
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -12823,8 +12823,8 @@
             "name": "<code>params</code>",
             "doc_url": "/api/elements/built-in/webview",
             "support": {
-              "android": true,
-              "ios": true,
+              "android": "4.0",
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
@@ -12839,9 +12839,9 @@
             "name": "<code>webview-type</code>",
             "doc_url": "/api/elements/built-in/webview",
             "support": {
-              "android": true,
-              "ios": true,
-              "harmony": true,
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -12857,15 +12857,15 @@
             "name": "<code>android-capture-target</code>",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": "3.9",
+              "android": "4.0",
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.9",
+              "clay_android": "4.0",
               "clay_ios": false,
               "clay_macos": false,
               "clay_windows": false,
-              "clay": "3.9"
+              "clay": "4.0"
             }
           },
           {
@@ -12873,15 +12873,15 @@
             "name": "<code>blur-sampling</code>",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": true,
+              "android": "4.0",
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": true,
+              "clay_android": "4.0",
               "clay_ios": false,
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -12889,15 +12889,15 @@
             "name": "<code>enable-auto-blur</code>",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": true,
+              "android": "4.0",
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": true,
+              "clay_android": "4.0",
               "clay_ios": false,
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -12905,15 +12905,15 @@
             "name": "<code>experimental-update-blur-radius</code>",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": "3.4",
+              "android": "4.0",
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.4",
+              "clay_android": "4.0",
               "clay_ios": false,
               "clay_macos": false,
               "clay_windows": false,
-              "clay": "3.4"
+              "clay": "4.0"
             }
           },
           {
@@ -13562,8 +13562,8 @@
             "doc_url": "/api/elements/built-in/scroll-coordinator",
             "support": {
               "android": false,
-              "ios": true,
-              "harmony": true,
+              "ios": "3.9",
+              "harmony": "3.9",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -13578,9 +13578,9 @@
             "doc_url": "/api/elements/built-in/scroll-coordinator",
             "support": {
               "android": false,
-              "ios": true,
-              "harmony": true,
-              "web_lynx": true,
+              "ios": "3.9",
+              "harmony": "3.9",
+              "web_lynx": "3.9",
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": false,
@@ -14025,8 +14025,8 @@
             "name": "<code>keep-item-view</code>",
             "doc_url": "/api/elements/built-in/viewpager",
             "support": {
-              "android": true,
-              "ios": true,
+              "android": "3.9",
+              "ios": "3.9",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
@@ -14041,9 +14041,9 @@
             "name": "<code>html</code>",
             "doc_url": "/api/elements/built-in/webview",
             "support": {
-              "android": "3.6",
-              "ios": "3.6",
-              "harmony": "3.6",
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -14057,8 +14057,8 @@
             "name": "<code>params</code>",
             "doc_url": "/api/elements/built-in/webview",
             "support": {
-              "android": true,
-              "ios": true,
+              "android": "4.0",
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
@@ -14073,9 +14073,9 @@
             "name": "<code>webview-type</code>",
             "doc_url": "/api/elements/built-in/webview",
             "support": {
-              "android": true,
-              "ios": true,
-              "harmony": true,
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -14091,15 +14091,15 @@
             "name": "blur-view",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": true,
-              "ios": true,
-              "harmony": true,
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
-              "clay_android": true,
-              "clay_ios": true,
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -14107,15 +14107,15 @@
             "name": "attributes",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": true,
-              "ios": true,
-              "harmony": true,
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
-              "clay_android": true,
-              "clay_ios": true,
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -14123,15 +14123,15 @@
             "name": "<code>android-capture-target</code>",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": "3.9",
+              "android": "4.0",
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.9",
+              "clay_android": "4.0",
               "clay_ios": false,
               "clay_macos": false,
               "clay_windows": false,
-              "clay": "3.9"
+              "clay": "4.0"
             }
           },
           {
@@ -14140,14 +14140,14 @@
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
               "android": false,
-              "ios": true,
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
-              "clay_ios": true,
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -14155,15 +14155,15 @@
             "name": "<code>blur-radius</code>",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": true,
-              "ios": true,
-              "harmony": true,
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
-              "clay_android": true,
-              "clay_ios": true,
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -14171,15 +14171,15 @@
             "name": "<code>blur-sampling</code>",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": true,
+              "android": "4.0",
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": true,
+              "clay_android": "4.0",
               "clay_ios": false,
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -14187,15 +14187,15 @@
             "name": "<code>enable-auto-blur</code>",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": true,
+              "android": "4.0",
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": true,
+              "clay_android": "4.0",
               "clay_ios": false,
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -14203,15 +14203,15 @@
             "name": "<code>experimental-update-blur-radius</code>",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": "3.4",
+              "android": "4.0",
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.4",
+              "clay_android": "4.0",
               "clay_ios": false,
               "clay_macos": false,
               "clay_windows": false,
-              "clay": "3.4"
+              "clay": "4.0"
             }
           },
           {
@@ -14220,14 +14220,14 @@
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
               "android": false,
-              "ios": "3.8",
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
-              "clay_ios": "3.8",
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": "3.8"
+              "clay": "4.0"
             }
           },
           {
@@ -14236,14 +14236,14 @@
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
               "android": false,
-              "ios": "3.8",
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
-              "clay_ios": "3.8",
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": "3.8"
+              "clay": "4.0"
             }
           },
           {
@@ -14252,14 +14252,14 @@
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
               "android": false,
-              "ios": "3.8",
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
-              "clay_ios": "3.8",
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": "3.8"
+              "clay": "4.0"
             }
           },
           {
@@ -14268,14 +14268,14 @@
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
               "android": false,
-              "ios": true,
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
-              "clay_ios": true,
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -14604,8 +14604,8 @@
             "doc_url": "/api/elements/built-in/scroll-coordinator",
             "support": {
               "android": false,
-              "ios": true,
-              "harmony": true,
+              "ios": "3.9",
+              "harmony": "3.9",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -14620,9 +14620,9 @@
             "doc_url": "/api/elements/built-in/scroll-coordinator",
             "support": {
               "android": false,
-              "ios": true,
-              "harmony": true,
-              "web_lynx": true,
+              "ios": "3.9",
+              "harmony": "3.9",
+              "web_lynx": "3.9",
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": false,
@@ -15051,8 +15051,8 @@
             "name": "<code>keep-item-view</code>",
             "doc_url": "/api/elements/built-in/viewpager",
             "support": {
-              "android": true,
-              "ios": true,
+              "android": "3.9",
+              "ios": "3.9",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
@@ -15067,9 +15067,9 @@
             "name": "<code>html</code>",
             "doc_url": "/api/elements/built-in/webview",
             "support": {
-              "android": "3.6",
-              "ios": "3.6",
-              "harmony": "3.6",
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -15083,8 +15083,8 @@
             "name": "<code>params</code>",
             "doc_url": "/api/elements/built-in/webview",
             "support": {
-              "android": true,
-              "ios": true,
+              "android": "4.0",
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
@@ -15099,9 +15099,9 @@
             "name": "<code>webview-type</code>",
             "doc_url": "/api/elements/built-in/webview",
             "support": {
-              "android": true,
-              "ios": true,
-              "harmony": true,
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -15117,15 +15117,15 @@
             "name": "blur-view",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": true,
-              "ios": true,
-              "harmony": true,
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
-              "clay_android": true,
-              "clay_ios": true,
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -15133,15 +15133,15 @@
             "name": "attributes",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": true,
-              "ios": true,
-              "harmony": true,
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
-              "clay_android": true,
-              "clay_ios": true,
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -15149,15 +15149,15 @@
             "name": "<code>android-capture-target</code>",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": "3.9",
+              "android": "4.0",
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.9",
+              "clay_android": "4.0",
               "clay_ios": false,
               "clay_macos": false,
               "clay_windows": false,
-              "clay": "3.9"
+              "clay": "4.0"
             }
           },
           {
@@ -15166,14 +15166,14 @@
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
               "android": false,
-              "ios": true,
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
-              "clay_ios": true,
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -15181,15 +15181,15 @@
             "name": "<code>blur-radius</code>",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": true,
-              "ios": true,
-              "harmony": true,
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
-              "clay_android": true,
-              "clay_ios": true,
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -15197,15 +15197,15 @@
             "name": "<code>blur-sampling</code>",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": true,
+              "android": "4.0",
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": true,
+              "clay_android": "4.0",
               "clay_ios": false,
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -15213,15 +15213,15 @@
             "name": "<code>enable-auto-blur</code>",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": true,
+              "android": "4.0",
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": true,
+              "clay_android": "4.0",
               "clay_ios": false,
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -15229,15 +15229,15 @@
             "name": "<code>experimental-update-blur-radius</code>",
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
-              "android": "3.4",
+              "android": "4.0",
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.4",
+              "clay_android": "4.0",
               "clay_ios": false,
               "clay_macos": false,
               "clay_windows": false,
-              "clay": "3.4"
+              "clay": "4.0"
             }
           },
           {
@@ -15246,14 +15246,14 @@
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
               "android": false,
-              "ios": "3.8",
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
-              "clay_ios": "3.8",
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": "3.8"
+              "clay": "4.0"
             }
           },
           {
@@ -15262,14 +15262,14 @@
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
               "android": false,
-              "ios": "3.8",
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
-              "clay_ios": "3.8",
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": "3.8"
+              "clay": "4.0"
             }
           },
           {
@@ -15278,14 +15278,14 @@
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
               "android": false,
-              "ios": "3.8",
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
-              "clay_ios": "3.8",
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": "3.8"
+              "clay": "4.0"
             }
           },
           {
@@ -15294,14 +15294,14 @@
             "doc_url": "/api/elements/built-in/blur-view",
             "support": {
               "android": false,
-              "ios": true,
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
-              "clay_ios": true,
+              "clay_ios": "4.0",
               "clay_macos": false,
               "clay_windows": false,
-              "clay": true
+              "clay": "4.0"
             }
           },
           {
@@ -15630,8 +15630,8 @@
             "doc_url": "/api/elements/built-in/scroll-coordinator",
             "support": {
               "android": false,
-              "ios": true,
-              "harmony": true,
+              "ios": "3.9",
+              "harmony": "3.9",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -15646,9 +15646,9 @@
             "doc_url": "/api/elements/built-in/scroll-coordinator",
             "support": {
               "android": false,
-              "ios": true,
-              "harmony": true,
-              "web_lynx": true,
+              "ios": "3.9",
+              "harmony": "3.9",
+              "web_lynx": "3.9",
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": false,
@@ -16077,8 +16077,8 @@
             "name": "<code>keep-item-view</code>",
             "doc_url": "/api/elements/built-in/viewpager",
             "support": {
-              "android": true,
-              "ios": true,
+              "android": "3.9",
+              "ios": "3.9",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
@@ -16093,9 +16093,9 @@
             "name": "<code>html</code>",
             "doc_url": "/api/elements/built-in/webview",
             "support": {
-              "android": "3.6",
-              "ios": "3.6",
-              "harmony": "3.6",
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -16109,8 +16109,8 @@
             "name": "<code>params</code>",
             "doc_url": "/api/elements/built-in/webview",
             "support": {
-              "android": true,
-              "ios": true,
+              "android": "4.0",
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
@@ -16125,9 +16125,9 @@
             "name": "<code>webview-type</code>",
             "doc_url": "/api/elements/built-in/webview",
             "support": {
-              "android": true,
-              "ios": true,
-              "harmony": true,
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -16464,8 +16464,8 @@
             "doc_url": "/api/elements/built-in/scroll-coordinator",
             "support": {
               "android": false,
-              "ios": true,
-              "harmony": true,
+              "ios": "3.9",
+              "harmony": "3.9",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -16480,9 +16480,9 @@
             "doc_url": "/api/elements/built-in/scroll-coordinator",
             "support": {
               "android": false,
-              "ios": true,
-              "harmony": true,
-              "web_lynx": true,
+              "ios": "3.9",
+              "harmony": "3.9",
+              "web_lynx": "3.9",
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": false,
@@ -16815,8 +16815,8 @@
             "name": "<code>keep-item-view</code>",
             "doc_url": "/api/elements/built-in/viewpager",
             "support": {
-              "android": true,
-              "ios": true,
+              "android": "3.9",
+              "ios": "3.9",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
@@ -16831,9 +16831,9 @@
             "name": "<code>html</code>",
             "doc_url": "/api/elements/built-in/webview",
             "support": {
-              "android": "3.6",
-              "ios": "3.6",
-              "harmony": "3.6",
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -16847,8 +16847,8 @@
             "name": "<code>params</code>",
             "doc_url": "/api/elements/built-in/webview",
             "support": {
-              "android": true,
-              "ios": true,
+              "android": "4.0",
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
@@ -16863,9 +16863,9 @@
             "name": "<code>webview-type</code>",
             "doc_url": "/api/elements/built-in/webview",
             "support": {
-              "android": true,
-              "ios": true,
-              "harmony": true,
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": "4.0",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -16899,7 +16899,7 @@
             "name": "<code>android-nested-scroll-as-child</code>",
             "doc_url": "/api/elements/built-in/scroll-coordinator",
             "support": {
-              "android": true,
+              "android": "3.9",
               "ios": false,
               "harmony": false,
               "web_lynx": false,
@@ -16947,7 +16947,7 @@
             "name": "<code>android-always-overscroll</code>",
             "doc_url": "/api/elements/built-in/viewpager",
             "support": {
-              "android": true,
+              "android": "3.9",
               "ios": false,
               "harmony": false,
               "web_lynx": false,
@@ -16963,7 +16963,7 @@
             "name": "<code>android-force-can-scroll</code>",
             "doc_url": "/api/elements/built-in/viewpager",
             "support": {
-              "android": "3.0",
+              "android": "3.9",
               "ios": false,
               "harmony": false,
               "web_lynx": false,
@@ -17014,7 +17014,7 @@
             "doc_url": "/api/elements/built-in/scroll-coordinator",
             "support": {
               "android": false,
-              "ios": true,
+              "ios": "3.9",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
@@ -17030,7 +17030,7 @@
             "doc_url": "/api/elements/built-in/scroll-coordinator",
             "support": {
               "android": false,
-              "ios": true,
+              "ios": "3.9",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
@@ -17046,7 +17046,7 @@
             "doc_url": "/api/elements/built-in/scroll-coordinator",
             "support": {
               "android": false,
-              "ios": true,
+              "ios": "3.9",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
@@ -17078,7 +17078,7 @@
             "doc_url": "/api/elements/built-in/viewpager",
             "support": {
               "android": false,
-              "ios": "1.5",
+              "ios": "3.9",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
@@ -17094,7 +17094,7 @@
             "doc_url": "/api/elements/built-in/viewpager",
             "support": {
               "android": false,
-              "ios": "1.5",
+              "ios": "3.9",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
@@ -17110,7 +17110,7 @@
             "doc_url": "/api/elements/built-in/viewpager",
             "support": {
               "android": false,
-              "ios": "1.5",
+              "ios": "3.9",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
@@ -17126,7 +17126,7 @@
             "doc_url": "/api/elements/built-in/viewpager",
             "support": {
               "android": false,
-              "ios": "1.5",
+              "ios": "3.9",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
@@ -17142,7 +17142,7 @@
             "doc_url": "/api/elements/built-in/webview",
             "support": {
               "android": false,
-              "ios": true,
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
@@ -17158,7 +17158,7 @@
             "doc_url": "/api/elements/built-in/webview",
             "support": {
               "android": false,
-              "ios": true,
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
@@ -17282,11 +17282,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -17298,11 +17298,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -17314,11 +17314,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -17330,11 +17330,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -17346,11 +17346,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -17362,11 +17362,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -17378,11 +17378,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -17394,11 +17394,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           },
           {
@@ -17410,11 +17410,11 @@
               "ios": false,
               "harmony": false,
               "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
+              "clay_android": "4.0",
+              "clay_ios": "4.0",
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           }
         ]
@@ -62085,23 +62085,6 @@
       }
     },
     {
-      "path": "elements/viewpager.events.bindchange",
-      "name": "<code>bindchange</code>",
-      "category": "elements",
-      "doc_url": "/api/elements/built-in/viewpager",
-      "versions": {
-        "android": "1.5",
-        "ios": "1.5",
-        "harmony": "3.4",
-        "web_lynx": true,
-        "clay_android": "1.5",
-        "clay_ios": "1.5",
-        "clay_macos": "1.5",
-        "clay_windows": "1.5",
-        "clay": "1.5"
-      }
-    },
-    {
       "path": "elements/overlay.attributes.binddismissoverlay",
       "name": "<code>binddismissoverlay</code>",
       "category": "elements",
@@ -62133,57 +62116,6 @@
         "clay_macos": false,
         "clay_windows": false,
         "clay": false
-      }
-    },
-    {
-      "path": "elements/webview.events.bindlocationchange",
-      "name": "<code>bindlocationchange</code>",
-      "category": "elements",
-      "doc_url": "/api/elements/built-in/webview",
-      "versions": {
-        "android": false,
-        "ios": false,
-        "harmony": false,
-        "web_lynx": false,
-        "clay_android": "3.5",
-        "clay_ios": "3.5",
-        "clay_macos": "3.5",
-        "clay_windows": "3.5",
-        "clay": "3.5"
-      }
-    },
-    {
-      "path": "elements/viewpager.events.bindoffsetchange",
-      "name": "<code>bindoffsetchange</code>",
-      "category": "elements",
-      "doc_url": "/api/elements/built-in/viewpager",
-      "versions": {
-        "android": "1.5",
-        "ios": "1.5",
-        "harmony": "3.4",
-        "web_lynx": true,
-        "clay_android": "1.5",
-        "clay_ios": "1.5",
-        "clay_macos": "1.5",
-        "clay_windows": "1.5",
-        "clay": "1.5"
-      }
-    },
-    {
-      "path": "elements/webview.events.bindopenwindow",
-      "name": "<code>bindopenwindow</code>",
-      "category": "elements",
-      "doc_url": "/api/elements/built-in/webview",
-      "versions": {
-        "android": false,
-        "ios": false,
-        "harmony": false,
-        "web_lynx": false,
-        "clay_android": "3.5",
-        "clay_ios": "3.5",
-        "clay_macos": "3.5",
-        "clay_windows": "3.5",
-        "clay": "3.5"
       }
     },
     {
@@ -62235,23 +62167,6 @@
         "clay_macos": "3.5",
         "clay_windows": "3.5",
         "clay": "3.5"
-      }
-    },
-    {
-      "path": "elements/viewpager.events.bindwillchange",
-      "name": "<code>bindwillchange</code>",
-      "category": "elements",
-      "doc_url": "/api/elements/built-in/viewpager",
-      "versions": {
-        "android": "2.17",
-        "ios": "2.17",
-        "harmony": "3.4",
-        "web_lynx": true,
-        "clay_android": "2.17",
-        "clay_ios": "2.17",
-        "clay_macos": "2.17",
-        "clay_windows": "2.17",
-        "clay": "2.17"
       }
     },
     {
@@ -62371,23 +62286,6 @@
         "clay_macos": "3.2",
         "clay_windows": "3.2",
         "clay": "3.2"
-      }
-    },
-    {
-      "path": "elements/viewpager.attributes.bounces",
-      "name": "<code>bounces</code>",
-      "category": "elements",
-      "doc_url": "/api/elements/built-in/viewpager",
-      "versions": {
-        "android": false,
-        "ios": "1.5",
-        "harmony": "3.4",
-        "web_lynx": true,
-        "clay_android": "1.5",
-        "clay_ios": "1.5",
-        "clay_macos": "1.5",
-        "clay_windows": "1.5",
-        "clay": "1.5"
       }
     },
     {
@@ -62629,91 +62527,6 @@
       }
     },
     {
-      "path": "elements/webview.methods.cookies.flushStore",
-      "name": "<code>cookies.flushStore</code>",
-      "category": "elements",
-      "doc_url": "/api/elements/built-in/webview",
-      "versions": {
-        "android": false,
-        "ios": false,
-        "harmony": false,
-        "web_lynx": false,
-        "clay_android": "3.5",
-        "clay_ios": "3.5",
-        "clay_macos": "3.5",
-        "clay_windows": "3.5",
-        "clay": "3.5"
-      }
-    },
-    {
-      "path": "elements/webview.methods.cookies.get",
-      "name": "<code>cookies.get</code>",
-      "category": "elements",
-      "doc_url": "/api/elements/built-in/webview",
-      "versions": {
-        "android": false,
-        "ios": false,
-        "harmony": false,
-        "web_lynx": false,
-        "clay_android": "3.5",
-        "clay_ios": "3.5",
-        "clay_macos": "3.5",
-        "clay_windows": "3.5",
-        "clay": "3.5"
-      }
-    },
-    {
-      "path": "elements/webview.methods.cookies.remove",
-      "name": "<code>cookies.remove</code>",
-      "category": "elements",
-      "doc_url": "/api/elements/built-in/webview",
-      "versions": {
-        "android": false,
-        "ios": false,
-        "harmony": false,
-        "web_lynx": false,
-        "clay_android": "3.5",
-        "clay_ios": "3.5",
-        "clay_macos": "3.5",
-        "clay_windows": "3.5",
-        "clay": "3.5"
-      }
-    },
-    {
-      "path": "elements/webview.methods.cookies.set",
-      "name": "<code>cookies.set</code>",
-      "category": "elements",
-      "doc_url": "/api/elements/built-in/webview",
-      "versions": {
-        "android": false,
-        "ios": false,
-        "harmony": false,
-        "web_lynx": false,
-        "clay_android": "3.5",
-        "clay_ios": "3.5",
-        "clay_macos": "3.5",
-        "clay_windows": "3.5",
-        "clay": "3.5"
-      }
-    },
-    {
-      "path": "elements/webview.attributes.cookies",
-      "name": "<code>cookies</code>",
-      "category": "elements",
-      "doc_url": "/api/elements/built-in/webview",
-      "versions": {
-        "android": false,
-        "ios": false,
-        "harmony": false,
-        "web_lynx": false,
-        "clay_android": "3.5",
-        "clay_ios": "3.5",
-        "clay_macos": "3.5",
-        "clay_windows": "3.5",
-        "clay": "3.5"
-      }
-    },
-    {
       "path": "css/data-type/length.relative.value_em",
       "name": "<code>em</code> unit",
       "category": "css/data-type",
@@ -62721,6 +62534,193 @@
       "versions": {
         "android": "1.0",
         "ios": "1.0",
+        "harmony": "3.4",
+        "web_lynx": true,
+        "clay_android": "1.5",
+        "clay_ios": "1.5",
+        "clay_macos": "1.5",
+        "clay_windows": "1.5",
+        "clay": "1.5"
+      }
+    },
+    {
+      "path": "elements/view.event-related-attributes.enable-touch-pseudo-propagation",
+      "name": "<code>enable-touch-pseudo-propagation</code>",
+      "category": "elements",
+      "doc_url": "/api/elements/built-in/view",
+      "versions": {
+        "android": "1.0",
+        "ios": "1.0",
+        "harmony": "3.4",
+        "web_lynx": false,
+        "clay_android": "1.5",
+        "clay_ios": "1.5",
+        "clay_macos": "1.5",
+        "clay_windows": "1.5",
+        "clay": "1.5"
+      }
+    },
+    {
+      "path": "elements/view.event-related-attributes.event-through",
+      "name": "<code>event-through</code>",
+      "category": "elements",
+      "doc_url": "/api/elements/built-in/view",
+      "versions": {
+        "android": "1.0",
+        "ios": "1.0",
+        "harmony": "3.4",
+        "web_lynx": false,
+        "clay_android": false,
+        "clay_ios": false,
+        "clay_macos": false,
+        "clay_windows": false,
+        "clay": false
+      }
+    },
+    {
+      "path": "lynx-api/fetch/fetch",
+      "name": "<code>fetch</code>",
+      "category": "lynx-api/fetch",
+      "doc_url": "guide/networking",
+      "versions": {
+        "android": "2.18",
+        "ios": "2.18",
+        "harmony": "3.5",
+        "web_lynx": true,
+        "clay_android": false,
+        "clay_ios": false,
+        "clay_macos": "3.7",
+        "clay_windows": "3.7",
+        "clay": "3.7"
+      }
+    },
+    {
+      "path": "css/properties/flex-basis",
+      "name": "<code>flex-basis</code>",
+      "category": "css/properties",
+      "doc_url": "api/css/properties/flex-basis",
+      "versions": {
+        "android": "1.0",
+        "ios": "1.0",
+        "harmony": "3.4",
+        "web_lynx": true,
+        "clay_android": "1.0",
+        "clay_ios": "1.0",
+        "clay_macos": "1.0",
+        "clay_windows": "1.0",
+        "clay": "1.0"
+      }
+    },
+    {
+      "path": "css/properties/align-items.supported_in_linear_layout.flex-start-flex-end-center",
+      "name": "<code>flex-start</code>, <code>flex-end</code>, <code>center</code>",
+      "category": "css/properties",
+      "doc_url": "/api/css/properties/align-items",
+      "versions": {
+        "android": "2.2",
+        "ios": "2.2",
+        "harmony": "3.4",
+        "web_lynx": true,
+        "clay_android": "2.2",
+        "clay_ios": "2.2",
+        "clay_macos": "2.2",
+        "clay_windows": "2.2",
+        "clay": "2.2"
+      }
+    },
+    {
+      "path": "css/properties/justify-content.supported_in_flex_layout.nested_value_1",
+      "name": "<code>flex-start</code>, <code>flex-end</code>, <code>center</code>, <code>space-between</code>, <code>space-around</code>, <code>space-evenly</code>",
+      "category": "css/properties",
+      "doc_url": "/api/css/properties/justify-content",
+      "versions": {
+        "android": "1.0",
+        "ios": "1.0",
+        "harmony": "3.4",
+        "web_lynx": true,
+        "clay_android": "1.0",
+        "clay_ios": "1.0",
+        "clay_macos": "1.0",
+        "clay_windows": "1.0",
+        "clay": "1.0"
+      }
+    },
+    {
+      "path": "css/properties/justify-content.supported_in_grid_layout.nested_value_1",
+      "name": "<code>flex-start</code>, <code>flex-end</code>, <code>center</code>, <code>space-between</code>, <code>space-around</code>, <code>space-evenly</code>, <code>start</code>, <code>end</code>, <code>stretch</code>",
+      "category": "css/properties",
+      "doc_url": "/api/css/properties/justify-content",
+      "versions": {
+        "android": "2.1",
+        "ios": "2.1",
+        "harmony": "3.4",
+        "web_lynx": true,
+        "clay_android": "2.1",
+        "clay_ios": "2.1",
+        "clay_macos": "2.1",
+        "clay_windows": "2.1",
+        "clay": "2.1"
+      }
+    },
+    {
+      "path": "css/properties/justify-content.supported_in_linear_layout.nested_value_1",
+      "name": "<code>flex-start</code>, <code>flex-end</code>, <code>center</code>, <code>space-between</code>, <code>start</code>, <code>end</code>",
+      "category": "css/properties",
+      "doc_url": "/api/css/properties/justify-content",
+      "versions": {
+        "android": "2.2",
+        "ios": "2.2",
+        "harmony": "3.4",
+        "web_lynx": true,
+        "clay_android": "2.2",
+        "clay_ios": "2.2",
+        "clay_macos": "2.2",
+        "clay_windows": "2.2",
+        "clay": "2.2"
+      }
+    },
+    {
+      "path": "elements/nested-text.CSS.font-family",
+      "name": "<code>font-family</code>",
+      "category": "elements",
+      "doc_url": "/api/elements/built-in/nested-text",
+      "versions": {
+        "android": "1.5",
+        "ios": "1.5",
+        "harmony": "3.4",
+        "web_lynx": true,
+        "clay_android": "1.5",
+        "clay_ios": "1.5",
+        "clay_macos": "1.5",
+        "clay_windows": "1.5",
+        "clay": "1.5"
+      }
+    },
+    {
+      "path": "elements/nested-text.CSS.font-size",
+      "name": "<code>font-size</code>",
+      "category": "elements",
+      "doc_url": "/api/elements/built-in/nested-text",
+      "versions": {
+        "android": "1.5",
+        "ios": "1.5",
+        "harmony": "3.4",
+        "web_lynx": true,
+        "clay_android": "1.5",
+        "clay_ios": "1.5",
+        "clay_macos": "1.5",
+        "clay_windows": "1.5",
+        "clay": "1.5"
+      }
+    },
+    {
+      "path": "elements/nested-text.CSS.font-style",
+      "name": "<code>font-style</code>",
+      "category": "elements",
+      "doc_url": "/api/elements/built-in/nested-text",
+      "versions": {
+        "android": "1.5",
+        "ios": "1.5",
         "harmony": "3.4",
         "web_lynx": true,
         "clay_android": "1.5",
@@ -62740,22 +62740,22 @@
       "source_file": "elements/blur-view.json",
       "support": {
         "android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "harmony": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "web_lynx": {
           "version_added": false
         },
         "clay_android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_macos": {
           "version_added": false
@@ -62764,7 +62764,7 @@
           "version_added": false
         },
         "clay": {
-          "version_added": true
+          "version_added": "4.0"
         }
       }
     },
@@ -62776,22 +62776,22 @@
       "source_file": "elements/blur-view.json",
       "support": {
         "android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "harmony": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "web_lynx": {
           "version_added": false
         },
         "clay_android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_macos": {
           "version_added": false
@@ -62800,7 +62800,7 @@
           "version_added": false
         },
         "clay": {
-          "version_added": true
+          "version_added": "4.0"
         }
       }
     },
@@ -62812,7 +62812,7 @@
       "source_file": "elements/blur-view.json",
       "support": {
         "android": {
-          "version_added": "3.9"
+          "version_added": "4.0"
         },
         "ios": {
           "version_added": false
@@ -62824,7 +62824,7 @@
           "version_added": false
         },
         "clay_android": {
-          "version_added": "3.9"
+          "version_added": "4.0"
         },
         "clay_ios": {
           "version_added": false
@@ -62836,7 +62836,7 @@
           "version_added": false
         },
         "clay": {
-          "version_added": "3.9"
+          "version_added": "4.0"
         }
       }
     },
@@ -62851,7 +62851,7 @@
           "version_added": false
         },
         "ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "harmony": {
           "version_added": false
@@ -62863,7 +62863,7 @@
           "version_added": false
         },
         "clay_ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_macos": {
           "version_added": false
@@ -62872,7 +62872,7 @@
           "version_added": false
         },
         "clay": {
-          "version_added": true
+          "version_added": "4.0"
         }
       }
     },
@@ -62884,22 +62884,22 @@
       "source_file": "elements/blur-view.json",
       "support": {
         "android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "harmony": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "web_lynx": {
           "version_added": false
         },
         "clay_android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_macos": {
           "version_added": false
@@ -62908,7 +62908,7 @@
           "version_added": false
         },
         "clay": {
-          "version_added": true
+          "version_added": "4.0"
         }
       }
     },
@@ -62920,7 +62920,7 @@
       "source_file": "elements/blur-view.json",
       "support": {
         "android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "ios": {
           "version_added": false
@@ -62932,7 +62932,7 @@
           "version_added": false
         },
         "clay_android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_ios": {
           "version_added": false
@@ -62944,7 +62944,7 @@
           "version_added": false
         },
         "clay": {
-          "version_added": true
+          "version_added": "4.0"
         }
       }
     },
@@ -62956,7 +62956,7 @@
       "source_file": "elements/blur-view.json",
       "support": {
         "android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "ios": {
           "version_added": false
@@ -62968,7 +62968,7 @@
           "version_added": false
         },
         "clay_android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_ios": {
           "version_added": false
@@ -62980,7 +62980,7 @@
           "version_added": false
         },
         "clay": {
-          "version_added": true
+          "version_added": "4.0"
         }
       }
     },
@@ -62992,7 +62992,7 @@
       "source_file": "elements/blur-view.json",
       "support": {
         "android": {
-          "version_added": "3.4"
+          "version_added": "4.0"
         },
         "ios": {
           "version_added": false
@@ -63004,7 +63004,7 @@
           "version_added": false
         },
         "clay_android": {
-          "version_added": "3.4"
+          "version_added": "4.0"
         },
         "clay_ios": {
           "version_added": false
@@ -63016,7 +63016,7 @@
           "version_added": false
         },
         "clay": {
-          "version_added": "3.4"
+          "version_added": "4.0"
         }
       }
     },
@@ -63031,7 +63031,7 @@
           "version_added": false
         },
         "ios": {
-          "version_added": "3.8"
+          "version_added": "4.0"
         },
         "harmony": {
           "version_added": false
@@ -63043,7 +63043,7 @@
           "version_added": false
         },
         "clay_ios": {
-          "version_added": "3.8"
+          "version_added": "4.0"
         },
         "clay_macos": {
           "version_added": false
@@ -63052,7 +63052,7 @@
           "version_added": false
         },
         "clay": {
-          "version_added": "3.8"
+          "version_added": "4.0"
         }
       }
     },
@@ -63067,7 +63067,7 @@
           "version_added": false
         },
         "ios": {
-          "version_added": "3.8"
+          "version_added": "4.0"
         },
         "harmony": {
           "version_added": false
@@ -63079,7 +63079,7 @@
           "version_added": false
         },
         "clay_ios": {
-          "version_added": "3.8"
+          "version_added": "4.0"
         },
         "clay_macos": {
           "version_added": false
@@ -63088,7 +63088,7 @@
           "version_added": false
         },
         "clay": {
-          "version_added": "3.8"
+          "version_added": "4.0"
         }
       }
     },
@@ -63103,7 +63103,7 @@
           "version_added": false
         },
         "ios": {
-          "version_added": "3.8"
+          "version_added": "4.0"
         },
         "harmony": {
           "version_added": false
@@ -63115,7 +63115,7 @@
           "version_added": false
         },
         "clay_ios": {
-          "version_added": "3.8"
+          "version_added": "4.0"
         },
         "clay_macos": {
           "version_added": false
@@ -63124,7 +63124,7 @@
           "version_added": false
         },
         "clay": {
-          "version_added": "3.8"
+          "version_added": "4.0"
         }
       }
     },
@@ -63139,7 +63139,7 @@
           "version_added": false
         },
         "ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "harmony": {
           "version_added": false
@@ -63151,7 +63151,7 @@
           "version_added": false
         },
         "clay_ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_macos": {
           "version_added": false
@@ -63160,7 +63160,7 @@
           "version_added": false
         },
         "clay": {
-          "version_added": true
+          "version_added": "4.0"
         }
       }
     },
@@ -68068,31 +68068,31 @@
       "source_file": "elements/scroll-coordinator.json",
       "support": {
         "android": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "ios": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "harmony": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "web_lynx": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_android": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_ios": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_macos": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_windows": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay": {
-          "version_added": true
+          "version_added": "3.9"
         }
       }
     },
@@ -68104,31 +68104,31 @@
       "source_file": "elements/scroll-coordinator.json",
       "support": {
         "android": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "ios": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "harmony": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "web_lynx": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_android": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_ios": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_macos": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_windows": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay": {
-          "version_added": true
+          "version_added": "3.9"
         }
       }
     },
@@ -68143,7 +68143,7 @@
           "version_added": false
         },
         "ios": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "harmony": {
           "version_added": false
@@ -68176,31 +68176,31 @@
       "source_file": "elements/scroll-coordinator.json",
       "support": {
         "android": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "ios": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "harmony": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "web_lynx": {
           "version_added": false
         },
         "clay_android": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_ios": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_macos": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_windows": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay": {
-          "version_added": true
+          "version_added": "3.9"
         }
       }
     },
@@ -68212,31 +68212,31 @@
       "source_file": "elements/scroll-coordinator.json",
       "support": {
         "android": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "ios": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "harmony": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "web_lynx": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_android": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_ios": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_macos": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_windows": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay": {
-          "version_added": true
+          "version_added": "3.9"
         }
       }
     },
@@ -68251,10 +68251,10 @@
           "version_added": false
         },
         "ios": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "harmony": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "web_lynx": {
           "version_added": false
@@ -68287,13 +68287,13 @@
           "version_added": false
         },
         "ios": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "harmony": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "web_lynx": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_android": {
           "version_added": false
@@ -68320,7 +68320,7 @@
       "source_file": "elements/scroll-coordinator.json",
       "support": {
         "android": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "ios": {
           "version_added": false
@@ -68359,7 +68359,7 @@
           "version_added": false
         },
         "ios": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "harmony": {
           "version_added": false
@@ -68392,31 +68392,31 @@
       "source_file": "elements/scroll-coordinator.json",
       "support": {
         "android": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "ios": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "harmony": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "web_lynx": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_android": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_ios": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_macos": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_windows": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay": {
-          "version_added": true
+          "version_added": "3.9"
         }
       }
     },
@@ -68431,7 +68431,7 @@
           "version_added": false
         },
         "ios": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "harmony": {
           "version_added": false
@@ -68464,31 +68464,31 @@
       "source_file": "elements/scroll-coordinator.json",
       "support": {
         "android": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "ios": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "harmony": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "web_lynx": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_android": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_ios": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_macos": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_windows": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay": {
-          "version_added": true
+          "version_added": "3.9"
         }
       }
     },
@@ -68500,31 +68500,31 @@
       "source_file": "elements/scroll-coordinator.json",
       "support": {
         "android": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "ios": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "harmony": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "web_lynx": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_android": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_ios": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_macos": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_windows": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay": {
-          "version_added": true
+          "version_added": "3.9"
         }
       }
     },
@@ -68536,31 +68536,31 @@
       "source_file": "elements/scroll-coordinator.json",
       "support": {
         "android": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "ios": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "harmony": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "web_lynx": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_android": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_ios": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_macos": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_windows": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay": {
-          "version_added": true
+          "version_added": "3.9"
         }
       }
     },
@@ -68572,31 +68572,31 @@
       "source_file": "elements/scroll-coordinator.json",
       "support": {
         "android": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "ios": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "harmony": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "web_lynx": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_android": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_ios": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_macos": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_windows": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay": {
-          "version_added": true
+          "version_added": "3.9"
         }
       }
     },
@@ -72100,31 +72100,31 @@
       "source_file": "elements/viewpager.json",
       "support": {
         "android": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "ios": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "harmony": {
-          "version_added": "3.4"
+          "version_added": "3.9"
         },
         "web_lynx": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_android": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay_ios": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay_macos": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay_windows": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         }
       }
     },
@@ -72136,31 +72136,31 @@
       "source_file": "elements/viewpager.json",
       "support": {
         "android": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "ios": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "harmony": {
-          "version_added": "3.4"
+          "version_added": "3.9"
         },
         "web_lynx": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_android": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay_ios": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay_macos": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay_windows": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         }
       }
     },
@@ -72175,7 +72175,7 @@
           "version_added": false
         },
         "ios": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "harmony": {
           "version_added": false
@@ -72211,7 +72211,7 @@
           "version_added": false
         },
         "ios": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "harmony": {
           "version_added": false
@@ -72244,31 +72244,31 @@
       "source_file": "elements/viewpager.json",
       "support": {
         "android": {
-          "version_added": "2.17"
+          "version_added": "3.9"
         },
         "ios": {
-          "version_added": "2.17"
+          "version_added": "3.9"
         },
         "harmony": {
-          "version_added": "3.4"
+          "version_added": "3.9"
         },
         "web_lynx": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_android": {
-          "version_added": "2.17"
+          "version_added": "3.9"
         },
         "clay_ios": {
-          "version_added": "2.17"
+          "version_added": "3.9"
         },
         "clay_macos": {
-          "version_added": "2.17"
+          "version_added": "3.9"
         },
         "clay_windows": {
-          "version_added": "2.17"
+          "version_added": "3.9"
         },
         "clay": {
-          "version_added": "2.17"
+          "version_added": "3.9"
         }
       }
     },
@@ -72280,31 +72280,31 @@
       "source_file": "elements/viewpager.json",
       "support": {
         "android": {
-          "version_added": "2.17"
+          "version_added": "3.9"
         },
         "ios": {
-          "version_added": "2.17"
+          "version_added": "3.9"
         },
         "harmony": {
-          "version_added": "3.4"
+          "version_added": "3.9"
         },
         "web_lynx": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_android": {
-          "version_added": "2.17"
+          "version_added": "3.9"
         },
         "clay_ios": {
-          "version_added": "2.17"
+          "version_added": "3.9"
         },
         "clay_macos": {
-          "version_added": "2.17"
+          "version_added": "3.9"
         },
         "clay_windows": {
-          "version_added": "2.17"
+          "version_added": "3.9"
         },
         "clay": {
-          "version_added": "2.17"
+          "version_added": "3.9"
         }
       }
     },
@@ -72319,28 +72319,28 @@
           "version_added": false
         },
         "ios": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "harmony": {
-          "version_added": "3.4"
+          "version_added": "3.9"
         },
         "web_lynx": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_android": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay_ios": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay_macos": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay_windows": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         }
       }
     },
@@ -72355,7 +72355,7 @@
           "version_added": false
         },
         "ios": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "harmony": {
           "version_added": false
@@ -72391,7 +72391,7 @@
           "version_added": false
         },
         "ios": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "harmony": {
           "version_added": false
@@ -72424,10 +72424,10 @@
       "source_file": "elements/viewpager.json",
       "support": {
         "android": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "ios": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "harmony": {
           "version_added": false
@@ -72460,7 +72460,7 @@
       "source_file": "elements/viewpager.json",
       "support": {
         "android": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "ios": {
           "version_added": false
@@ -72496,7 +72496,7 @@
       "source_file": "elements/viewpager.json",
       "support": {
         "android": {
-          "version_added": "3.0"
+          "version_added": "3.9"
         },
         "ios": {
           "version_added": false
@@ -72532,31 +72532,31 @@
       "source_file": "elements/viewpager.json",
       "support": {
         "android": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "ios": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "harmony": {
-          "version_added": "3.4"
+          "version_added": "3.9"
         },
         "web_lynx": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_android": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay_ios": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay_macos": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay_windows": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         }
       }
     },
@@ -72568,31 +72568,31 @@
       "source_file": "elements/viewpager.json",
       "support": {
         "android": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "ios": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "harmony": {
-          "version_added": "3.4"
+          "version_added": "3.9"
         },
         "web_lynx": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_android": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay_ios": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay_macos": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay_windows": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         }
       }
     },
@@ -72604,31 +72604,31 @@
       "source_file": "elements/viewpager.json",
       "support": {
         "android": {
-          "version_added": "2.17"
+          "version_added": "3.9"
         },
         "ios": {
-          "version_added": "2.17"
+          "version_added": "3.9"
         },
         "harmony": {
-          "version_added": "3.4"
+          "version_added": "3.9"
         },
         "web_lynx": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_android": {
-          "version_added": "2.17"
+          "version_added": "3.9"
         },
         "clay_ios": {
-          "version_added": "2.17"
+          "version_added": "3.9"
         },
         "clay_macos": {
-          "version_added": "2.17"
+          "version_added": "3.9"
         },
         "clay_windows": {
-          "version_added": "2.17"
+          "version_added": "3.9"
         },
         "clay": {
-          "version_added": "2.17"
+          "version_added": "3.9"
         }
       }
     },
@@ -72640,31 +72640,31 @@
       "source_file": "elements/viewpager.json",
       "support": {
         "android": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "ios": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "harmony": {
-          "version_added": "3.4"
+          "version_added": "3.9"
         },
         "web_lynx": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_android": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay_ios": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay_macos": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay_windows": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         }
       }
     },
@@ -72676,31 +72676,31 @@
       "source_file": "elements/viewpager.json",
       "support": {
         "android": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "ios": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "harmony": {
-          "version_added": "3.4"
+          "version_added": "3.9"
         },
         "web_lynx": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_android": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay_ios": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay_macos": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay_windows": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         }
       }
     },
@@ -72712,31 +72712,31 @@
       "source_file": "elements/viewpager.json",
       "support": {
         "android": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "ios": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "harmony": {
-          "version_added": "3.4"
+          "version_added": "3.9"
         },
         "web_lynx": {
-          "version_added": true
+          "version_added": "3.9"
         },
         "clay_android": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay_ios": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay_macos": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay_windows": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         },
         "clay": {
-          "version_added": "1.5"
+          "version_added": "3.9"
         }
       }
     },
@@ -72748,31 +72748,31 @@
       "source_file": "elements/webview.json",
       "support": {
         "android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "harmony": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "web_lynx": {
           "version_added": false
         },
         "clay_android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_macos": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_windows": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay": {
-          "version_added": true
+          "version_added": "4.0"
         }
       }
     },
@@ -72784,31 +72784,31 @@
       "source_file": "elements/webview.json",
       "support": {
         "android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "harmony": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "web_lynx": {
           "version_added": false
         },
         "clay_android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_macos": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_windows": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay": {
-          "version_added": true
+          "version_added": "4.0"
         }
       }
     },
@@ -72820,31 +72820,31 @@
       "source_file": "elements/webview.json",
       "support": {
         "android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "harmony": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "web_lynx": {
           "version_added": false
         },
         "clay_android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_macos": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_windows": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay": {
-          "version_added": true
+          "version_added": "4.0"
         }
       }
     },
@@ -72856,13 +72856,13 @@
       "source_file": "elements/webview.json",
       "support": {
         "android": {
-          "version_added": "3.6"
+          "version_added": "4.0"
         },
         "ios": {
-          "version_added": "3.6"
+          "version_added": "4.0"
         },
         "harmony": {
-          "version_added": "3.6"
+          "version_added": "4.0"
         },
         "web_lynx": {
           "version_added": false
@@ -72895,7 +72895,7 @@
           "version_added": false
         },
         "ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "harmony": {
           "version_added": false
@@ -72931,7 +72931,7 @@
           "version_added": false
         },
         "ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "harmony": {
           "version_added": false
@@ -72964,10 +72964,10 @@
       "source_file": "elements/webview.json",
       "support": {
         "android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "harmony": {
           "version_added": false
@@ -73000,13 +73000,13 @@
       "source_file": "elements/webview.json",
       "support": {
         "android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "harmony": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "web_lynx": {
           "version_added": false
@@ -73036,31 +73036,31 @@
       "source_file": "elements/webview.json",
       "support": {
         "android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "harmony": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "web_lynx": {
           "version_added": false
         },
         "clay_android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_macos": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_windows": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay": {
-          "version_added": true
+          "version_added": "4.0"
         }
       }
     },
@@ -73084,19 +73084,19 @@
           "version_added": false
         },
         "clay_android": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay_ios": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay_macos": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay_windows": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         }
       }
     },
@@ -73120,19 +73120,19 @@
           "version_added": false
         },
         "clay_android": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay_ios": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay_macos": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay_windows": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         }
       }
     },
@@ -73156,19 +73156,19 @@
           "version_added": false
         },
         "clay_android": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay_ios": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay_macos": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay_windows": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         }
       }
     },
@@ -73180,31 +73180,31 @@
       "source_file": "elements/webview.json",
       "support": {
         "android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "harmony": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "web_lynx": {
           "version_added": false
         },
         "clay_android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_macos": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_windows": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay": {
-          "version_added": true
+          "version_added": "4.0"
         }
       }
     },
@@ -73216,31 +73216,31 @@
       "source_file": "elements/webview.json",
       "support": {
         "android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "harmony": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "web_lynx": {
           "version_added": false
         },
         "clay_android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_macos": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_windows": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay": {
-          "version_added": true
+          "version_added": "4.0"
         }
       }
     },
@@ -73252,31 +73252,31 @@
       "source_file": "elements/webview.json",
       "support": {
         "android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "harmony": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "web_lynx": {
           "version_added": false
         },
         "clay_android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_macos": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_windows": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay": {
-          "version_added": true
+          "version_added": "4.0"
         }
       }
     },
@@ -73288,31 +73288,31 @@
       "source_file": "elements/webview.json",
       "support": {
         "android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "harmony": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "web_lynx": {
           "version_added": false
         },
         "clay_android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_macos": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_windows": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay": {
-          "version_added": true
+          "version_added": "4.0"
         }
       }
     },
@@ -73336,19 +73336,19 @@
           "version_added": false
         },
         "clay_android": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay_ios": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay_macos": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay_windows": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         }
       }
     },
@@ -73372,19 +73372,19 @@
           "version_added": false
         },
         "clay_android": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay_ios": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay_macos": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay_windows": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         }
       }
     },
@@ -73396,31 +73396,31 @@
       "source_file": "elements/webview.json",
       "support": {
         "android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "harmony": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "web_lynx": {
           "version_added": false
         },
         "clay_android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_macos": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_windows": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay": {
-          "version_added": true
+          "version_added": "4.0"
         }
       }
     },
@@ -73432,31 +73432,31 @@
       "source_file": "elements/webview.json",
       "support": {
         "android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "harmony": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "web_lynx": {
           "version_added": false
         },
         "clay_android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_macos": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_windows": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay": {
-          "version_added": true
+          "version_added": "4.0"
         }
       }
     },
@@ -73468,31 +73468,31 @@
       "source_file": "elements/webview.json",
       "support": {
         "android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "harmony": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "web_lynx": {
           "version_added": false
         },
         "clay_android": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_ios": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_macos": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay_windows": {
-          "version_added": true
+          "version_added": "4.0"
         },
         "clay": {
-          "version_added": true
+          "version_added": "4.0"
         }
       }
     },
@@ -73516,19 +73516,19 @@
           "version_added": false
         },
         "clay_android": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay_ios": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay_macos": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay_windows": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         }
       }
     },
@@ -73552,19 +73552,19 @@
           "version_added": false
         },
         "clay_android": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay_ios": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay_macos": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay_windows": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         }
       }
     },
@@ -73588,19 +73588,19 @@
           "version_added": false
         },
         "clay_android": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay_ios": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay_macos": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay_windows": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         }
       }
     },
@@ -73624,19 +73624,19 @@
           "version_added": false
         },
         "clay_android": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay_ios": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay_macos": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay_windows": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         },
         "clay": {
-          "version_added": "3.5"
+          "version_added": "4.0"
         }
       }
     },
@@ -107271,40 +107271,40 @@
       "release_date": "2024/1/23",
       "platforms": {
         "android": {
-          "supported": 607,
-          "coverage": 59
+          "supported": 572,
+          "coverage": 56
         },
         "ios": {
-          "supported": 609,
-          "coverage": 59
+          "supported": 571,
+          "coverage": 56
         },
         "harmony": {
-          "supported": 26,
-          "coverage": 3
+          "supported": 0,
+          "coverage": 0
         },
         "web_lynx": {
-          "supported": 701,
-          "coverage": 68
+          "supported": 681,
+          "coverage": 66
         },
         "clay_android": {
-          "supported": 464,
-          "coverage": 45
+          "supported": 431,
+          "coverage": 42
         },
         "clay_ios": {
-          "supported": 459,
-          "coverage": 45
+          "supported": 426,
+          "coverage": 42
         },
         "clay_macos": {
-          "supported": 459,
-          "coverage": 45
+          "supported": 431,
+          "coverage": 42
         },
         "clay_windows": {
-          "supported": 459,
-          "coverage": 45
+          "supported": 431,
+          "coverage": 42
         },
         "clay": {
-          "supported": 466,
-          "coverage": 45
+          "supported": 431,
+          "coverage": 42
         }
       }
     },
@@ -107313,40 +107313,40 @@
       "release_date": "2024/3/18",
       "platforms": {
         "android": {
-          "supported": 608,
-          "coverage": 59
+          "supported": 573,
+          "coverage": 56
         },
         "ios": {
-          "supported": 610,
-          "coverage": 60
+          "supported": 572,
+          "coverage": 56
         },
         "harmony": {
-          "supported": 26,
-          "coverage": 3
+          "supported": 0,
+          "coverage": 0
         },
         "web_lynx": {
-          "supported": 701,
-          "coverage": 68
+          "supported": 681,
+          "coverage": 66
         },
         "clay_android": {
-          "supported": 464,
-          "coverage": 45
+          "supported": 431,
+          "coverage": 42
         },
         "clay_ios": {
-          "supported": 459,
-          "coverage": 45
+          "supported": 426,
+          "coverage": 42
         },
         "clay_macos": {
-          "supported": 459,
-          "coverage": 45
+          "supported": 431,
+          "coverage": 42
         },
         "clay_windows": {
-          "supported": 459,
-          "coverage": 45
+          "supported": 431,
+          "coverage": 42
         },
         "clay": {
-          "supported": 466,
-          "coverage": 45
+          "supported": 431,
+          "coverage": 42
         }
       }
     },
@@ -107355,40 +107355,40 @@
       "release_date": "2024/5/20",
       "platforms": {
         "android": {
-          "supported": 616,
-          "coverage": 60
+          "supported": 581,
+          "coverage": 57
         },
         "ios": {
-          "supported": 618,
-          "coverage": 60
+          "supported": 580,
+          "coverage": 57
         },
         "harmony": {
-          "supported": 26,
-          "coverage": 3
+          "supported": 0,
+          "coverage": 0
         },
         "web_lynx": {
-          "supported": 701,
-          "coverage": 68
+          "supported": 681,
+          "coverage": 66
         },
         "clay_android": {
-          "supported": 470,
-          "coverage": 46
+          "supported": 437,
+          "coverage": 43
         },
         "clay_ios": {
-          "supported": 465,
-          "coverage": 45
+          "supported": 432,
+          "coverage": 42
         },
         "clay_macos": {
-          "supported": 465,
-          "coverage": 45
+          "supported": 437,
+          "coverage": 43
         },
         "clay_windows": {
-          "supported": 465,
-          "coverage": 45
+          "supported": 437,
+          "coverage": 43
         },
         "clay": {
-          "supported": 472,
-          "coverage": 46
+          "supported": 437,
+          "coverage": 43
         }
       }
     },
@@ -107397,40 +107397,40 @@
       "release_date": "2024/7/22",
       "platforms": {
         "android": {
-          "supported": 619,
-          "coverage": 60
+          "supported": 581,
+          "coverage": 57
         },
         "ios": {
-          "supported": 621,
-          "coverage": 61
+          "supported": 580,
+          "coverage": 57
         },
         "harmony": {
-          "supported": 26,
-          "coverage": 3
+          "supported": 0,
+          "coverage": 0
         },
         "web_lynx": {
-          "supported": 701,
-          "coverage": 68
+          "supported": 681,
+          "coverage": 66
         },
         "clay_android": {
-          "supported": 473,
-          "coverage": 46
+          "supported": 437,
+          "coverage": 43
         },
         "clay_ios": {
-          "supported": 468,
-          "coverage": 46
+          "supported": 432,
+          "coverage": 42
         },
         "clay_macos": {
-          "supported": 468,
-          "coverage": 46
+          "supported": 437,
+          "coverage": 43
         },
         "clay_windows": {
-          "supported": 468,
-          "coverage": 46
+          "supported": 437,
+          "coverage": 43
         },
         "clay": {
-          "supported": 475,
-          "coverage": 46
+          "supported": 437,
+          "coverage": 43
         }
       }
     },
@@ -107439,40 +107439,40 @@
       "release_date": "2024/9/23",
       "platforms": {
         "android": {
-          "supported": 663,
-          "coverage": 65
+          "supported": 625,
+          "coverage": 61
         },
         "ios": {
-          "supported": 665,
-          "coverage": 65
+          "supported": 624,
+          "coverage": 61
         },
         "harmony": {
-          "supported": 26,
-          "coverage": 3
+          "supported": 0,
+          "coverage": 0
         },
         "web_lynx": {
-          "supported": 701,
-          "coverage": 68
+          "supported": 681,
+          "coverage": 66
         },
         "clay_android": {
-          "supported": 484,
-          "coverage": 47
+          "supported": 448,
+          "coverage": 44
         },
         "clay_ios": {
-          "supported": 474,
-          "coverage": 46
+          "supported": 438,
+          "coverage": 43
         },
         "clay_macos": {
-          "supported": 474,
-          "coverage": 46
+          "supported": 443,
+          "coverage": 43
         },
         "clay_windows": {
-          "supported": 474,
-          "coverage": 46
+          "supported": 443,
+          "coverage": 43
         },
         "clay": {
-          "supported": 486,
-          "coverage": 47
+          "supported": 448,
+          "coverage": 44
         }
       }
     },
@@ -107481,40 +107481,40 @@
       "release_date": "2024/11/18",
       "platforms": {
         "android": {
-          "supported": 667,
-          "coverage": 65
+          "supported": 629,
+          "coverage": 61
         },
         "ios": {
-          "supported": 669,
-          "coverage": 65
+          "supported": 628,
+          "coverage": 61
         },
         "harmony": {
-          "supported": 26,
-          "coverage": 3
+          "supported": 0,
+          "coverage": 0
         },
         "web_lynx": {
-          "supported": 701,
-          "coverage": 68
+          "supported": 681,
+          "coverage": 66
         },
         "clay_android": {
-          "supported": 488,
-          "coverage": 48
+          "supported": 452,
+          "coverage": 44
         },
         "clay_ios": {
-          "supported": 478,
-          "coverage": 47
+          "supported": 442,
+          "coverage": 43
         },
         "clay_macos": {
-          "supported": 478,
-          "coverage": 47
+          "supported": 447,
+          "coverage": 44
         },
         "clay_windows": {
-          "supported": 478,
-          "coverage": 47
+          "supported": 447,
+          "coverage": 44
         },
         "clay": {
-          "supported": 490,
-          "coverage": 48
+          "supported": 452,
+          "coverage": 44
         }
       }
     },
@@ -107523,40 +107523,40 @@
       "release_date": "2025/1/21",
       "platforms": {
         "android": {
-          "supported": 725,
-          "coverage": 71
+          "supported": 687,
+          "coverage": 67
         },
         "ios": {
-          "supported": 727,
-          "coverage": 71
+          "supported": 686,
+          "coverage": 67
         },
         "harmony": {
-          "supported": 26,
-          "coverage": 3
+          "supported": 0,
+          "coverage": 0
         },
         "web_lynx": {
-          "supported": 701,
-          "coverage": 68
+          "supported": 681,
+          "coverage": 66
         },
         "clay_android": {
-          "supported": 488,
-          "coverage": 48
+          "supported": 452,
+          "coverage": 44
         },
         "clay_ios": {
-          "supported": 478,
-          "coverage": 47
+          "supported": 442,
+          "coverage": 43
         },
         "clay_macos": {
-          "supported": 478,
-          "coverage": 47
+          "supported": 447,
+          "coverage": 44
         },
         "clay_windows": {
-          "supported": 478,
-          "coverage": 47
+          "supported": 447,
+          "coverage": 44
         },
         "clay": {
-          "supported": 490,
-          "coverage": 48
+          "supported": 452,
+          "coverage": 44
         }
       }
     },
@@ -107565,40 +107565,40 @@
       "release_date": "2025/3/31",
       "platforms": {
         "android": {
-          "supported": 743,
-          "coverage": 72
+          "supported": 705,
+          "coverage": 69
         },
         "ios": {
-          "supported": 745,
-          "coverage": 73
+          "supported": 704,
+          "coverage": 69
         },
         "harmony": {
-          "supported": 26,
-          "coverage": 3
+          "supported": 0,
+          "coverage": 0
         },
         "web_lynx": {
-          "supported": 701,
-          "coverage": 68
+          "supported": 681,
+          "coverage": 66
         },
         "clay_android": {
-          "supported": 493,
-          "coverage": 48
+          "supported": 457,
+          "coverage": 45
         },
         "clay_ios": {
-          "supported": 483,
-          "coverage": 47
+          "supported": 447,
+          "coverage": 44
         },
         "clay_macos": {
-          "supported": 483,
-          "coverage": 47
+          "supported": 452,
+          "coverage": 44
         },
         "clay_windows": {
-          "supported": 483,
-          "coverage": 47
+          "supported": 452,
+          "coverage": 44
         },
         "clay": {
-          "supported": 495,
-          "coverage": 48
+          "supported": 457,
+          "coverage": 45
         }
       }
     },
@@ -107607,40 +107607,40 @@
       "release_date": "2025/5/26",
       "platforms": {
         "android": {
-          "supported": 748,
-          "coverage": 73
+          "supported": 710,
+          "coverage": 69
         },
         "ios": {
-          "supported": 750,
-          "coverage": 73
+          "supported": 709,
+          "coverage": 69
         },
         "harmony": {
-          "supported": 26,
-          "coverage": 3
+          "supported": 0,
+          "coverage": 0
         },
         "web_lynx": {
-          "supported": 701,
-          "coverage": 68
+          "supported": 681,
+          "coverage": 66
         },
         "clay_android": {
-          "supported": 493,
-          "coverage": 48
+          "supported": 457,
+          "coverage": 45
         },
         "clay_ios": {
-          "supported": 483,
-          "coverage": 47
+          "supported": 447,
+          "coverage": 44
         },
         "clay_macos": {
-          "supported": 483,
-          "coverage": 47
+          "supported": 452,
+          "coverage": 44
         },
         "clay_windows": {
-          "supported": 483,
-          "coverage": 47
+          "supported": 452,
+          "coverage": 44
         },
         "clay": {
-          "supported": 495,
-          "coverage": 48
+          "supported": 457,
+          "coverage": 45
         }
       }
     },
@@ -107649,40 +107649,40 @@
       "release_date": "2025/7/21",
       "platforms": {
         "android": {
-          "supported": 808,
-          "coverage": 79
+          "supported": 769,
+          "coverage": 75
         },
         "ios": {
-          "supported": 809,
-          "coverage": 79
+          "supported": 768,
+          "coverage": 75
         },
         "harmony": {
-          "supported": 708,
-          "coverage": 69
+          "supported": 671,
+          "coverage": 65
         },
         "web_lynx": {
-          "supported": 701,
-          "coverage": 68
+          "supported": 681,
+          "coverage": 66
         },
         "clay_android": {
-          "supported": 522,
-          "coverage": 51
+          "supported": 485,
+          "coverage": 47
         },
         "clay_ios": {
-          "supported": 511,
-          "coverage": 50
+          "supported": 475,
+          "coverage": 46
         },
         "clay_macos": {
-          "supported": 511,
-          "coverage": 50
+          "supported": 480,
+          "coverage": 47
         },
         "clay_windows": {
-          "supported": 511,
-          "coverage": 50
+          "supported": 480,
+          "coverage": 47
         },
         "clay": {
-          "supported": 524,
-          "coverage": 51
+          "supported": 485,
+          "coverage": 47
         }
       }
     }

--- a/packages/lynx-compat-data/elements/blur-view.json
+++ b/packages/lynx-compat-data/elements/blur-view.json
@@ -5,19 +5,19 @@
         "description": "blur-view",
         "support": {
           "android": {
-            "version_added": true
+            "version_added": "4.0"
           },
           "ios": {
-            "version_added": true
+            "version_added": "4.0"
           },
           "harmony": {
-            "version_added": true
+            "version_added": "4.0"
           },
           "clay_android": {
-            "version_added": true
+            "version_added": "4.0"
           },
           "clay_ios": {
-            "version_added": true
+            "version_added": "4.0"
           },
           "clay_windows": {
             "version_added": false
@@ -35,19 +35,19 @@
           "description": "attributes",
           "support": {
             "android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "ios": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "harmony": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "clay_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "clay_ios": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "clay_windows": {
               "version_added": false
@@ -69,7 +69,7 @@
             },
             "support": {
               "android": {
-                "version_added": "3.9"
+                "version_added": "4.0"
               },
               "ios": {
                 "version_added": false
@@ -78,7 +78,7 @@
                 "version_added": false
               },
               "clay_android": {
-                "version_added": "3.9"
+                "version_added": "4.0"
               },
               "clay_ios": {
                 "version_added": false
@@ -107,7 +107,7 @@
                 "version_added": false
               },
               "ios": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "harmony": {
                 "version_added": false
@@ -116,7 +116,7 @@
                 "version_added": false
               },
               "clay_ios": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_windows": {
                 "version_added": false
@@ -139,19 +139,19 @@
             },
             "support": {
               "android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "ios": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "harmony": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_ios": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_windows": {
                 "version_added": false
@@ -174,7 +174,7 @@
             },
             "support": {
               "android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "ios": {
                 "version_added": false
@@ -183,7 +183,7 @@
                 "version_added": false
               },
               "clay_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_ios": {
                 "version_added": false
@@ -209,7 +209,7 @@
             },
             "support": {
               "android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "ios": {
                 "version_added": false
@@ -218,7 +218,7 @@
                 "version_added": false
               },
               "clay_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_ios": {
                 "version_added": false
@@ -244,7 +244,7 @@
             },
             "support": {
               "android": {
-                "version_added": "3.4"
+                "version_added": "4.0"
               },
               "ios": {
                 "version_added": false
@@ -253,7 +253,7 @@
                 "version_added": false
               },
               "clay_android": {
-                "version_added": "3.4"
+                "version_added": "4.0"
               },
               "clay_ios": {
                 "version_added": false
@@ -282,7 +282,7 @@
                 "version_added": false
               },
               "ios": {
-                "version_added": "3.8"
+                "version_added": "4.0"
               },
               "harmony": {
                 "version_added": false
@@ -291,7 +291,7 @@
                 "version_added": false
               },
               "clay_ios": {
-                "version_added": "3.8"
+                "version_added": "4.0"
               },
               "clay_windows": {
                 "version_added": false
@@ -317,7 +317,7 @@
                 "version_added": false
               },
               "ios": {
-                "version_added": "3.8"
+                "version_added": "4.0"
               },
               "harmony": {
                 "version_added": false
@@ -326,7 +326,7 @@
                 "version_added": false
               },
               "clay_ios": {
-                "version_added": "3.8"
+                "version_added": "4.0"
               },
               "clay_windows": {
                 "version_added": false
@@ -352,7 +352,7 @@
                 "version_added": false
               },
               "ios": {
-                "version_added": "3.8"
+                "version_added": "4.0"
               },
               "harmony": {
                 "version_added": false
@@ -361,7 +361,7 @@
                 "version_added": false
               },
               "clay_ios": {
-                "version_added": "3.8"
+                "version_added": "4.0"
               },
               "clay_windows": {
                 "version_added": false
@@ -387,7 +387,7 @@
                 "version_added": false
               },
               "ios": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "harmony": {
                 "version_added": false
@@ -396,7 +396,7 @@
                 "version_added": false
               },
               "clay_ios": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_windows": {
                 "version_added": false

--- a/packages/lynx-compat-data/elements/scroll-coordinator.json
+++ b/packages/lynx-compat-data/elements/scroll-coordinator.json
@@ -5,28 +5,28 @@
         "description": "scroll-coordinator",
         "support": {
           "android": {
-            "version_added": true
+            "version_added": "3.9"
           },
           "ios": {
-            "version_added": true
+            "version_added": "3.9"
           },
           "harmony": {
-            "version_added": true
+            "version_added": "3.9"
           },
           "clay_android": {
-            "version_added": true
+            "version_added": "3.9"
           },
           "clay_ios": {
-            "version_added": true
+            "version_added": "3.9"
           },
           "clay_windows": {
-            "version_added": true
+            "version_added": "3.9"
           },
           "clay_macos": {
-            "version_added": true
+            "version_added": "3.9"
           },
           "web_lynx": {
-            "version_added": true
+            "version_added": "3.9"
           }
         }
       },
@@ -35,28 +35,28 @@
           "description": "attributes",
           "support": {
             "android": {
-              "version_added": true
+              "version_added": "3.9"
             },
             "ios": {
-              "version_added": true
+              "version_added": "3.9"
             },
             "harmony": {
-              "version_added": true
+              "version_added": "3.9"
             },
             "clay_android": {
-              "version_added": true
+              "version_added": "3.9"
             },
             "clay_ios": {
-              "version_added": true
+              "version_added": "3.9"
             },
             "clay_windows": {
-              "version_added": true
+              "version_added": "3.9"
             },
             "clay_macos": {
-              "version_added": true
+              "version_added": "3.9"
             },
             "web_lynx": {
-              "version_added": true
+              "version_added": "3.9"
             }
           }
         },
@@ -68,7 +68,7 @@
                 "version_added": false
               },
               "ios": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "harmony": {
                 "version_added": false
@@ -96,25 +96,25 @@
             "description": "<code>header-over-slot</code>",
             "support": {
               "android": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "ios": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "harmony": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "clay_android": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "clay_ios": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "clay_windows": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "clay_macos": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "web_lynx": {
                 "version_added": false
@@ -127,28 +127,28 @@
             "description": "<code>enable-scroll</code>",
             "support": {
               "android": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "ios": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "harmony": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "clay_android": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "clay_ios": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "clay_windows": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "clay_macos": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": "3.9"
               }
             }
           }
@@ -161,10 +161,10 @@
                 "version_added": false
               },
               "ios": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "harmony": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "clay_android": {
                 "version_added": false
@@ -192,10 +192,10 @@
                 "version_added": false
               },
               "ios": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "harmony": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "clay_android": {
                 "version_added": false
@@ -210,7 +210,7 @@
                 "version_added": false
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": "3.9"
               }
             }
           }
@@ -220,7 +220,7 @@
             "description": "<code>android-nested-scroll-as-child</code>",
             "support": {
               "android": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "ios": {
                 "version_added": false
@@ -254,7 +254,7 @@
                 "version_added": false
               },
               "ios": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "harmony": {
                 "version_added": false
@@ -282,28 +282,28 @@
             "description": "<code>granularity</code>",
             "support": {
               "android": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "ios": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "harmony": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "clay_android": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "clay_ios": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "clay_windows": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "clay_macos": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": "3.9"
               }
             }
           }
@@ -316,7 +316,7 @@
                 "version_added": false
               },
               "ios": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "harmony": {
                 "version_added": false
@@ -345,28 +345,28 @@
           "description": "events",
           "support": {
             "android": {
-              "version_added": true
+              "version_added": "3.9"
             },
             "ios": {
-              "version_added": true
+              "version_added": "3.9"
             },
             "harmony": {
-              "version_added": true
+              "version_added": "3.9"
             },
             "clay_android": {
-              "version_added": true
+              "version_added": "3.9"
             },
             "clay_ios": {
-              "version_added": true
+              "version_added": "3.9"
             },
             "clay_windows": {
-              "version_added": true
+              "version_added": "3.9"
             },
             "clay_macos": {
-              "version_added": true
+              "version_added": "3.9"
             },
             "web_lynx": {
-              "version_added": true
+              "version_added": "3.9"
             }
           }
         },
@@ -379,28 +379,28 @@
             },
             "support": {
               "android": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "ios": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "harmony": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "clay_android": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "clay_ios": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "clay_windows": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "clay_macos": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": "3.9"
               }
             }
           }
@@ -411,28 +411,28 @@
           "description": "methods",
           "support": {
             "android": {
-              "version_added": true
+              "version_added": "3.9"
             },
             "ios": {
-              "version_added": true
+              "version_added": "3.9"
             },
             "harmony": {
-              "version_added": true
+              "version_added": "3.9"
             },
             "clay_android": {
-              "version_added": true
+              "version_added": "3.9"
             },
             "clay_ios": {
-              "version_added": true
+              "version_added": "3.9"
             },
             "clay_windows": {
-              "version_added": true
+              "version_added": "3.9"
             },
             "clay_macos": {
-              "version_added": true
+              "version_added": "3.9"
             },
             "web_lynx": {
-              "version_added": true
+              "version_added": "3.9"
             }
           }
         },
@@ -445,28 +445,28 @@
             },
             "support": {
               "android": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "ios": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "harmony": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "clay_android": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "clay_ios": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "clay_windows": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "clay_macos": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": "3.9"
               }
             }
           }

--- a/packages/lynx-compat-data/elements/viewpager.json
+++ b/packages/lynx-compat-data/elements/viewpager.json
@@ -5,28 +5,28 @@
         "description": "viewpager",
         "support": {
           "android": {
-            "version_added": "1.5"
+            "version_added": "3.9"
           },
           "ios": {
-            "version_added": "1.5"
+            "version_added": "3.9"
           },
           "harmony": {
-            "version_added": "3.4"
+            "version_added": "3.9"
           },
           "clay_android": {
-            "version_added": "1.5"
+            "version_added": "3.9"
           },
           "clay_ios": {
-            "version_added": "1.5"
+            "version_added": "3.9"
           },
           "clay_windows": {
-            "version_added": "1.5"
+            "version_added": "3.9"
           },
           "clay_macos": {
-            "version_added": "1.5"
+            "version_added": "3.9"
           },
           "web_lynx": {
-            "version_added": true
+            "version_added": "3.9"
           }
         }
       },
@@ -35,28 +35,28 @@
           "description": "attributes",
           "support": {
             "android": {
-              "version_added": "1.5"
+              "version_added": "3.9"
             },
             "ios": {
-              "version_added": "1.5"
+              "version_added": "3.9"
             },
             "harmony": {
-              "version_added": "3.4"
+              "version_added": "3.9"
             },
             "clay_android": {
-              "version_added": "1.5"
+              "version_added": "3.9"
             },
             "clay_ios": {
-              "version_added": "1.5"
+              "version_added": "3.9"
             },
             "clay_windows": {
-              "version_added": "1.5"
+              "version_added": "3.9"
             },
             "clay_macos": {
-              "version_added": "1.5"
+              "version_added": "3.9"
             },
             "web_lynx": {
-              "version_added": true
+              "version_added": "3.9"
             }
           }
         },
@@ -68,7 +68,7 @@
                 "version_added": false
               },
               "ios": {
-                "version_added": "1.5"
+                "version_added": "3.9"
               },
               "harmony": {
                 "version_added": false
@@ -99,7 +99,7 @@
                 "version_added": false
               },
               "ios": {
-                "version_added": "1.5"
+                "version_added": "3.9"
               },
               "harmony": {
                 "version_added": false
@@ -127,28 +127,28 @@
             "description": "<code>initial-select-index</code>",
             "support": {
               "android": {
-                "version_added": "2.17"
+                "version_added": "3.9"
               },
               "ios": {
-                "version_added": "2.17"
+                "version_added": "3.9"
               },
               "harmony": {
-                "version_added": "3.4"
+                "version_added": "3.9"
               },
               "clay_android": {
-                "version_added": "2.17"
+                "version_added": "3.9"
               },
               "clay_ios": {
-                "version_added": "2.17"
+                "version_added": "3.9"
               },
               "clay_windows": {
-                "version_added": "2.17"
+                "version_added": "3.9"
               },
               "clay_macos": {
-                "version_added": "2.17"
+                "version_added": "3.9"
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": "3.9"
               }
             }
           }
@@ -158,28 +158,28 @@
             "description": "<code>enable-scroll</code>",
             "support": {
               "android": {
-                "version_added": "2.17"
+                "version_added": "3.9"
               },
               "ios": {
-                "version_added": "2.17"
+                "version_added": "3.9"
               },
               "harmony": {
-                "version_added": "3.4"
+                "version_added": "3.9"
               },
               "clay_android": {
-                "version_added": "2.17"
+                "version_added": "3.9"
               },
               "clay_ios": {
-                "version_added": "2.17"
+                "version_added": "3.9"
               },
               "clay_windows": {
-                "version_added": "2.17"
+                "version_added": "3.9"
               },
               "clay_macos": {
-                "version_added": "2.17"
+                "version_added": "3.9"
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": "3.9"
               }
             }
           }
@@ -192,25 +192,25 @@
                 "version_added": false
               },
               "ios": {
-                "version_added": "1.5"
+                "version_added": "3.9"
               },
               "harmony": {
-                "version_added": "3.4"
+                "version_added": "3.9"
               },
               "clay_android": {
-                "version_added": "1.5"
+                "version_added": "3.9"
               },
               "clay_ios": {
-                "version_added": "1.5"
+                "version_added": "3.9"
               },
               "clay_windows": {
-                "version_added": "1.5"
+                "version_added": "3.9"
               },
               "clay_macos": {
-                "version_added": "1.5"
+                "version_added": "3.9"
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": "3.9"
               }
             }
           }
@@ -223,7 +223,7 @@
                 "version_added": false
               },
               "ios": {
-                "version_added": "1.5"
+                "version_added": "3.9"
               },
               "harmony": {
                 "version_added": false
@@ -254,7 +254,7 @@
                 "version_added": false
               },
               "ios": {
-                "version_added": "1.5"
+                "version_added": "3.9"
               },
               "harmony": {
                 "version_added": false
@@ -286,10 +286,10 @@
             },
             "support": {
               "android": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "ios": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "harmony": {
                 "version_added": false
@@ -317,7 +317,7 @@
             "description": "<code>android-always-overscroll</code>",
             "support": {
               "android": {
-                "version_added": true
+                "version_added": "3.9"
               },
               "ios": {
                 "version_added": false
@@ -348,7 +348,7 @@
             "description": "<code>android-force-can-scroll</code>",
             "support": {
               "android": {
-                "version_added": "3.0"
+                "version_added": "3.9"
               },
               "ios": {
                 "version_added": false
@@ -380,28 +380,28 @@
           "description": "events",
           "support": {
             "android": {
-              "version_added": "1.5"
+              "version_added": "3.9"
             },
             "ios": {
-              "version_added": "1.5"
+              "version_added": "3.9"
             },
             "harmony": {
-              "version_added": "3.4"
+              "version_added": "3.9"
             },
             "clay_android": {
-              "version_added": "1.5"
+              "version_added": "3.9"
             },
             "clay_ios": {
-              "version_added": "1.5"
+              "version_added": "3.9"
             },
             "clay_windows": {
-              "version_added": "1.5"
+              "version_added": "3.9"
             },
             "clay_macos": {
-              "version_added": "1.5"
+              "version_added": "3.9"
             },
             "web_lynx": {
-              "version_added": true
+              "version_added": "3.9"
             }
           }
         },
@@ -414,28 +414,28 @@
             },
             "support": {
               "android": {
-                "version_added": "1.5"
+                "version_added": "3.9"
               },
               "ios": {
-                "version_added": "1.5"
+                "version_added": "3.9"
               },
               "harmony": {
-                "version_added": "3.4"
+                "version_added": "3.9"
               },
               "clay_android": {
-                "version_added": "1.5"
+                "version_added": "3.9"
               },
               "clay_ios": {
-                "version_added": "1.5"
+                "version_added": "3.9"
               },
               "clay_windows": {
-                "version_added": "1.5"
+                "version_added": "3.9"
               },
               "clay_macos": {
-                "version_added": "1.5"
+                "version_added": "3.9"
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": "3.9"
               }
             }
           }
@@ -449,28 +449,28 @@
             },
             "support": {
               "android": {
-                "version_added": "2.17"
+                "version_added": "3.9"
               },
               "ios": {
-                "version_added": "2.17"
+                "version_added": "3.9"
               },
               "harmony": {
-                "version_added": "3.4"
+                "version_added": "3.9"
               },
               "clay_android": {
-                "version_added": "2.17"
+                "version_added": "3.9"
               },
               "clay_ios": {
-                "version_added": "2.17"
+                "version_added": "3.9"
               },
               "clay_windows": {
-                "version_added": "2.17"
+                "version_added": "3.9"
               },
               "clay_macos": {
-                "version_added": "2.17"
+                "version_added": "3.9"
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": "3.9"
               }
             }
           }
@@ -484,28 +484,28 @@
             },
             "support": {
               "android": {
-                "version_added": "1.5"
+                "version_added": "3.9"
               },
               "ios": {
-                "version_added": "1.5"
+                "version_added": "3.9"
               },
               "harmony": {
-                "version_added": "3.4"
+                "version_added": "3.9"
               },
               "clay_android": {
-                "version_added": "1.5"
+                "version_added": "3.9"
               },
               "clay_ios": {
-                "version_added": "1.5"
+                "version_added": "3.9"
               },
               "clay_windows": {
-                "version_added": "1.5"
+                "version_added": "3.9"
               },
               "clay_macos": {
-                "version_added": "1.5"
+                "version_added": "3.9"
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": "3.9"
               }
             }
           }
@@ -516,28 +516,28 @@
           "description": "methods",
           "support": {
             "android": {
-              "version_added": "1.5"
+              "version_added": "3.9"
             },
             "ios": {
-              "version_added": "1.5"
+              "version_added": "3.9"
             },
             "harmony": {
-              "version_added": "3.4"
+              "version_added": "3.9"
             },
             "clay_android": {
-              "version_added": "1.5"
+              "version_added": "3.9"
             },
             "clay_ios": {
-              "version_added": "1.5"
+              "version_added": "3.9"
             },
             "clay_windows": {
-              "version_added": "1.5"
+              "version_added": "3.9"
             },
             "clay_macos": {
-              "version_added": "1.5"
+              "version_added": "3.9"
             },
             "web_lynx": {
-              "version_added": true
+              "version_added": "3.9"
             }
           }
         },
@@ -550,28 +550,28 @@
             },
             "support": {
               "android": {
-                "version_added": "1.5"
+                "version_added": "3.9"
               },
               "ios": {
-                "version_added": "1.5"
+                "version_added": "3.9"
               },
               "harmony": {
-                "version_added": "3.4"
+                "version_added": "3.9"
               },
               "clay_android": {
-                "version_added": "1.5"
+                "version_added": "3.9"
               },
               "clay_ios": {
-                "version_added": "1.5"
+                "version_added": "3.9"
               },
               "clay_windows": {
-                "version_added": "1.5"
+                "version_added": "3.9"
               },
               "clay_macos": {
-                "version_added": "1.5"
+                "version_added": "3.9"
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": "3.9"
               }
             }
           }

--- a/packages/lynx-compat-data/elements/webview.json
+++ b/packages/lynx-compat-data/elements/webview.json
@@ -5,25 +5,25 @@
         "description": "webview",
         "support": {
           "android": {
-            "version_added": true
+            "version_added": "4.0"
           },
           "ios": {
-            "version_added": true
+            "version_added": "4.0"
           },
           "harmony": {
-            "version_added": true
+            "version_added": "4.0"
           },
           "clay_android": {
-            "version_added": true
+            "version_added": "4.0"
           },
           "clay_ios": {
-            "version_added": true
+            "version_added": "4.0"
           },
           "clay_windows": {
-            "version_added": true
+            "version_added": "4.0"
           },
           "clay_macos": {
-            "version_added": true
+            "version_added": "4.0"
           },
           "web_lynx": {
             "version_added": false
@@ -35,25 +35,25 @@
           "description": "attributes",
           "support": {
             "android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "ios": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "harmony": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "clay_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "clay_ios": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "clay_windows": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "clay_macos": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "web_lynx": {
               "version_added": false
@@ -69,25 +69,25 @@
             },
             "support": {
               "android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "ios": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "harmony": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_ios": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_windows": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_macos": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "web_lynx": {
                 "version_added": false
@@ -104,13 +104,13 @@
             },
             "support": {
               "android": {
-                "version_added": "3.6"
+                "version_added": "4.0"
               },
               "ios": {
-                "version_added": "3.6"
+                "version_added": "4.0"
               },
               "harmony": {
-                "version_added": "3.6"
+                "version_added": "4.0"
               },
               "clay_android": {
                 "version_added": false
@@ -142,7 +142,7 @@
                 "version_added": false
               },
               "ios": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "harmony": {
                 "version_added": false
@@ -177,7 +177,7 @@
                 "version_added": false
               },
               "ios": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "harmony": {
                 "version_added": false
@@ -209,10 +209,10 @@
             },
             "support": {
               "android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "ios": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "harmony": {
                 "version_added": false
@@ -244,13 +244,13 @@
             },
             "support": {
               "android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "ios": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "harmony": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_android": {
                 "version_added": false
@@ -279,25 +279,25 @@
             },
             "support": {
               "android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "ios": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "harmony": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_ios": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_windows": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_macos": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "web_lynx": {
                 "version_added": false
@@ -323,16 +323,16 @@
                 "version_added": false
               },
               "clay_android": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "clay_ios": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "clay_windows": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "clay_macos": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "web_lynx": {
                 "version_added": false
@@ -358,16 +358,16 @@
                 "version_added": false
               },
               "clay_android": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "clay_ios": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "clay_windows": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "clay_macos": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "web_lynx": {
                 "version_added": false
@@ -393,16 +393,16 @@
                 "version_added": false
               },
               "clay_android": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "clay_ios": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "clay_windows": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "clay_macos": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "web_lynx": {
                 "version_added": false
@@ -416,25 +416,25 @@
           "description": "events",
           "support": {
             "android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "ios": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "harmony": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "clay_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "clay_ios": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "clay_windows": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "clay_macos": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "web_lynx": {
               "version_added": false
@@ -450,25 +450,25 @@
             },
             "support": {
               "android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "ios": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "harmony": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_ios": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_windows": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_macos": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "web_lynx": {
                 "version_added": false
@@ -485,25 +485,25 @@
             },
             "support": {
               "android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "ios": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "harmony": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_ios": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_windows": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_macos": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "web_lynx": {
                 "version_added": false
@@ -520,25 +520,25 @@
             },
             "support": {
               "android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "ios": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "harmony": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_ios": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_windows": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_macos": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "web_lynx": {
                 "version_added": false
@@ -564,16 +564,16 @@
                 "version_added": false
               },
               "clay_android": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "clay_ios": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "clay_windows": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "clay_macos": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "web_lynx": {
                 "version_added": false
@@ -599,16 +599,16 @@
                 "version_added": false
               },
               "clay_android": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "clay_ios": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "clay_windows": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "clay_macos": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "web_lynx": {
                 "version_added": false
@@ -622,25 +622,25 @@
           "description": "methods",
           "support": {
             "android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "ios": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "harmony": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "clay_android": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "clay_ios": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "clay_windows": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "clay_macos": {
-              "version_added": true
+              "version_added": "4.0"
             },
             "web_lynx": {
               "version_added": false
@@ -656,25 +656,25 @@
             },
             "support": {
               "android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "ios": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "harmony": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_ios": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_windows": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_macos": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "web_lynx": {
                 "version_added": false
@@ -691,25 +691,25 @@
             },
             "support": {
               "android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "ios": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "harmony": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_android": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_ios": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_windows": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "clay_macos": {
-                "version_added": true
+                "version_added": "4.0"
               },
               "web_lynx": {
                 "version_added": false
@@ -735,16 +735,16 @@
                 "version_added": false
               },
               "clay_android": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "clay_ios": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "clay_windows": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "clay_macos": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "web_lynx": {
                 "version_added": false
@@ -770,16 +770,16 @@
                 "version_added": false
               },
               "clay_android": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "clay_ios": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "clay_windows": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "clay_macos": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "web_lynx": {
                 "version_added": false
@@ -805,16 +805,16 @@
                 "version_added": false
               },
               "clay_android": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "clay_ios": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "clay_windows": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "clay_macos": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "web_lynx": {
                 "version_added": false
@@ -840,16 +840,16 @@
                 "version_added": false
               },
               "clay_android": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "clay_ios": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "clay_windows": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "clay_macos": {
-                "version_added": "3.5"
+                "version_added": "4.0"
               },
               "web_lynx": {
                 "version_added": false


### PR DESCRIPTION
## Summary

Update the Lynx compatibility data minimum versions for selected built-in elements:

- Set `viewpager` and `scroll-coordinator` supported entries to a minimum of `3.9`.
- Set `blur-view` and `webview` supported entries to a minimum of `4.0`.
- Regenerate `packages/lynx-compat-data/api-stats.json` from the updated source data.

## Validation

- `pnpm --filter @lynx-js/lynx-compat-data run gen-stats`
- Targeted source/stat minimum-version check
- `git diff --check HEAD~1..HEAD`

Note: `pnpm --filter @lynx-js/lynx-compat-data run lint` currently fails under local Node v24.8.0 at the `ts-node` loader startup layer with an empty-object uncaught exception before producing schema output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Update element minimum versions in Lynx compatibility data

Update `version_added` values for compatibility metadata across multiple built-in elements:
- Set `viewpager` and `scroll-coordinator` element support to minimum `3.9`
- Set `blur-view` and `webview` element support to minimum `4.0`
- Apply version updates across each element's attributes, events, and methods sections

Regenerate `packages/lynx-compat-data/api-stats.json` from updated source data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->