### PR TITLE
correct information in 3.8 blog

### DIFF
--- a/docs/en/blog/lynx-3-8.mdx
+++ b/docs/en/blog/lynx-3-8.mdx
@@ -79,11 +79,9 @@ This is useful for titles, cards, and feed layouts where one-line, two-line, and
   highlight="{20-23}"
 />
 
-### Desktop Exposure and HarmonyOS Animation
+### Desktop Exposure
 
 macOS and Windows now support [`enable-exposure-ui-clip`](/api/elements/built-in/view.html#enable-exposure-ui-clip), giving developers more control over exposure calculations in complex layouts.
-
-HarmonyOS `<view>` also gains [keyframe animation](/api/css/properties/animation) pipeline support.
 
 ## Native Integration
 

--- a/docs/zh/blog/lynx-3-8.mdx
+++ b/docs/zh/blog/lynx-3-8.mdx
@@ -79,11 +79,9 @@ const result = instance.exports.add(1, 2);
   highlight="{20-23}"
 />
 
-### 桌面端曝光与 HarmonyOS 动画
+### 桌面端曝光
 
 macOS 和 Windows 现在支持 [`enable-exposure-ui-clip`](/api/elements/built-in/view.html#enable-exposure-ui-clip)，让开发者可以在复杂布局中更精细地控制曝光计算。
-
-HarmonyOS `<view>` 也新增了[关键帧动画](/api/css/properties/animation)管线支持。
 
 ## 原生侧集成
 


### PR DESCRIPTION
Change-Id: Id4c1194648d5d46f891b8b2bed12ca4b1e6ad68b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Remove HarmonyOS animation references from 3.8 blog posts

- Separate "Desktop Exposure and HarmonyOS Animation" into standalone "Desktop Exposure" section heading
- Remove HarmonyOS `<view>` keyframe animation pipeline support mention
- Apply changes to both English and Chinese blog versions in `docs/en/blog/lynx-3-8.mdx` and `docs/zh/blog/lynx-3-8.mdx`
- Preserve macOS/Windows `enable-exposure-ui-clip` capability documentation under Desktop Exposure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->