### PR TITLE
fix: add version info (release, blog)

### DIFF
--- a/docs/public/version.json
+++ b/docs/public/version.json
@@ -13,19 +13,25 @@
       "type": "latest",
       "version_number": "3.8",
       "repo_branch": "release/3.8",
-      "docs_link": "/3.8"
+      "docs_link": "/3.8",
+      "release_number": "3.8.0",
+      "release_blog": "/3.8/blog/lynx-3-8.html"
     },
     {
       "type": "previous",
       "version_number": "3.7",
       "repo_branch": "release/3.7",
-      "docs_link": "/3.7"
+      "docs_link": "/3.7",
+      "release_number": "3.7.0",
+      "release_blog": "/3.7/blog/lynx-3-7.html"
     },
     {
       "type": "previous",
       "version_number": "3.6",
       "repo_branch": "release/3.6",
-      "docs_link": "/3.6"
+      "docs_link": "/3.6",
+      "release_number": "3.6.0",
+      "release_blog": "/3.6/blog/lynx-3-6.html"
     },
     {
       "type": "previous",


### PR DESCRIPTION
Change-Id: I31837fc7caa0add368b377946e243278413c2cfe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Enrich version metadata with release information

Expand `docs/public/version.json` to include `release_number` and `release_blog` fields for version 3.8 (latest) and versions 3.7 and 3.6 (previous), providing complete release metadata alongside existing documentation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->