### PR TITLE
The docs_link of latest branch should be root

### DIFF
--- a/docs/public/version.json
+++ b/docs/public/version.json
@@ -13,7 +13,7 @@
       "type": "latest",
       "version_number": "3.8",
       "repo_branch": "release/3.8",
-      "docs_link": "/3.8",
+      "docs_link": "/",
       "release_number": "3.8.0",
       "release_blog": "/3.8/blog/lynx-3-8.html"
     },


### PR DESCRIPTION
Change-Id: Ibdfbb07017b87c7cda08b1d1a2487a09208c2b64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Update `docs_link` for latest documentation to point to root path

- Change the latest documentation link in `docs/public/version.json` from `/3.8` to `/` to direct users to the documentation root for the latest version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->