### PR TITLE
fix: only deploy-previews use lightweight build, not branch deploys

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,9 +2,6 @@
   command = "NODE_OPTIONS=--max-old-space-size=3072 RSPRESS_SSG_WORKER_THREAD_COUNT=1 pnpm exec rspress build"
   publish = "doc_build"
 
-[context.branch-deploy.environment]
-  RSPRESS_LIGHTWEIGHT_BUILD = "true"
-
 [context.deploy-preview.environment]
   RSPRESS_LIGHTWEIGHT_BUILD = "true"
 

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -28,7 +28,6 @@ const PUBLISH_URL = 'https://lynxjs.org/';
 const NETLIFY_CONTEXT = process.env.CONTEXT ?? '';
 const IS_LIGHTWEIGHT_BUILD =
   process.env.RSPRESS_LIGHTWEIGHT_BUILD === 'true' ||
-  NETLIFY_CONTEXT === 'branch-deploy' ||
   NETLIFY_CONTEXT === 'deploy-preview';
 
 export default defineConfig({


### PR DESCRIPTION
## Summary

- #1059 disabled `llms` for both `branch-deploy` and `deploy-preview` contexts to avoid Netlify OOM. The branch deploy serving `/next/` on lynxjs.org lost its Copy Markdown button as a side effect, and also stopped emitting per-page `.md` files and `llms.txt`.
- Root cause: rspress 2.0.6 derives `process.env.ENABLE_LLMS_UI` and gates `rsbuildPluginSSGMD` on the same `config.llms` flag (`node_modules/@rspress/core/dist/node/initRsbuild.js:154`), so `llms: false` both tree-shakes the UI button and skips MD emission.
- Narrow the lightweight trigger to throwaway PR previews so branch deploys (including the one behind `/next/`) get the full build. OOM mitigation for `deploy-preview` is preserved.

Before, on `/next/`:

| URL | Copy Markdown | `*.md` | `llms.txt` |
|---|---|---|---|
| `/` | yes | yes | yes |
| `/3.7/...` | yes | yes | yes |
| `/next/...` | **no** | **404** | **404** |

After, `/next/` should match `/` and `/3.7/`.

## Test plan

- [ ] Netlify branch-deploy of this PR shows the Copy Markdown button on `/next/guide/start/quick-start.html` (or whatever the branch-deploy URL is)
- [ ] `*.md` and `llms.txt` exist on that branch-deploy
- [ ] Netlify deploy-preview (this PR's own preview) stays lightweight: smaller build, no OOM
- [ ] No regression on `/` and `/3.7/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Restrict lightweight build to deploy-previews, use full build for branch deploys

Limit the lightweight (llms-disabled) build configuration to deploy-preview contexts only, allowing branch deploys to use the full build. This resolves issues where `/next/` and other branch deploys were missing the Copy Markdown button and not emitting per-page `.md` files and `llms.txt` due to rspress v2.0.6 gating both the UI button and MD file emission on the same `config.llms` flag.

**Changes:**

- Remove `RSPRESS_LIGHTWEIGHT_BUILD` environment override from `[context.branch-deploy.environment]` in netlify.toml
- Update lightweight build detection in rspress.config.ts to check only `RSPRESS_LIGHTWEIGHT_BUILD === 'true'` or `NETLIFY_CONTEXT === 'deploy-preview'` (remove `NETLIFY_CONTEXT === 'branch-deploy'` condition)

**Expected outcome:**

Branch deploys (including `/next/`) now match the behavior of production builds (`/` and `/3.7/`) with the Copy Markdown button present and per-page `.md` and `llms.txt` files emitted, while deploy-previews retain the lightweight build behavior to avoid OOM issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->