### PR TITLE
fix(border-beam): inherit host border-radius to stop beam leaking past corners

### DIFF
--- a/src/components/home-comps/border-beam/index.module.less
+++ b/src/components/home-comps/border-beam/index.module.less
@@ -6,7 +6,11 @@
   width: 100%;
   height: 100%;
   overflow: hidden;
-  border-radius: 24px;
+  // Match the host card's rounded corners so the rectangular canvas
+  // stroke is clipped at the same curve. A hardcoded radius would let
+  // the beam bleed past the parent's corners on any host that doesn't
+  // use the same value.
+  border-radius: inherit;
   box-sizing: border-box;
   z-index: -1;
   pointer-events: none;

--- a/src/components/home-comps/border-beam/index.tsx
+++ b/src/components/home-comps/border-beam/index.tsx
@@ -25,6 +25,15 @@ const BorderBeam: React.FC<BorderBeamProps> = ({
     const ctx = canvas.getContext('2d', { alpha: true });
     if (!ctx) return;
 
+    // CSS pixels — kept separate from canvas.width/height so HiDPI scaling
+    // doesn't distort the drawn path.
+    let cssWidth = 0;
+    let cssHeight = 0;
+    // Corner radius inherited from the host card. Keeping the beam path on
+    // the same curve the host clips to is what stops it bleeding past the
+    // rounded corners.
+    let radius = 0;
+
     const resizeObserver = new ResizeObserver(() => {
       updateCanvasSize();
     });
@@ -36,8 +45,16 @@ const BorderBeam: React.FC<BorderBeamProps> = ({
       const container = containerRef.current;
       if (!canvas || !container) return;
       const { width, height } = container.getBoundingClientRect();
-      canvas.width = width;
-      canvas.height = height;
+      const dpr = window.devicePixelRatio || 1;
+      cssWidth = width;
+      cssHeight = height;
+      canvas.width = Math.round(width * dpr);
+      canvas.height = Math.round(height * dpr);
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      // `.border-beam-frame` uses `border-radius: inherit`, so its computed
+      // value matches the host's actual corner radius.
+      const parsed = parseFloat(getComputedStyle(container).borderRadius);
+      radius = Number.isFinite(parsed) ? parsed : 0;
     }
 
     updateCanvasSize();
@@ -49,39 +66,46 @@ const BorderBeam: React.FC<BorderBeamProps> = ({
       const elapsed = (currentTime - startTime) / 1000;
       const progress = (elapsed % duration) / duration;
 
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.clearRect(0, 0, cssWidth, cssHeight);
       drawBeam(progress);
 
       animationFrameId = requestAnimationFrame(animate);
     };
 
+    // Geometry helpers for the rounded-rect path. The path is inset by
+    // `lineWidth / 2` so the stroke sits fully inside the host's clip rather
+    // than riding the very edge, where the rounded clip leaves a 1–2px tick.
+    const getGeometry = () => {
+      const inset = size / 2;
+      const w = Math.max(cssWidth - 2 * inset, 0);
+      const h = Math.max(cssHeight - 2 * inset, 0);
+      const r = Math.min(Math.max(radius - inset, 0), w / 2, h / 2);
+      const straightX = Math.max(w - 2 * r, 0);
+      const straightY = Math.max(h - 2 * r, 0);
+      const arc = (Math.PI * r) / 2;
+      const perimeter = 2 * straightX + 2 * straightY + 4 * arc;
+      return { inset, w, h, r, straightX, straightY, arc, perimeter };
+    };
+
     const drawBeam = (progress: number) => {
-      const width = canvas.width;
-      const height = canvas.height;
-      const perimeter = 2 * (width + height);
+      const { perimeter } = getGeometry();
+      if (perimeter === 0) return;
       const beamLength = perimeter * 0.05;
 
-      // Calculate start and end positions
-      let positionStart = progress * perimeter;
-      let positionEnd = (positionStart + beamLength) % perimeter;
+      const positionStart = progress * perimeter;
+      const positionEnd = (positionStart + beamLength) % perimeter;
 
-      // Create gradient for the beam
       const gradient = createBeamGradient(positionStart, positionEnd);
       ctx.strokeStyle = gradient;
       ctx.lineWidth = size;
+      ctx.lineCap = 'round';
 
-      // Draw the beam along the border
       ctx.beginPath();
       drawPath(positionStart, positionEnd);
       ctx.stroke();
     };
 
     const createBeamGradient = (start: number, end: number) => {
-      const width = canvas.width;
-      const height = canvas.height;
-      const perimeter = 2 * (width + height);
-
-      // Get coordinates for gradient
       const startCoord = getCoordinatesFromDistance(start);
       const endCoord = getCoordinatesFromDistance(end);
 
@@ -92,48 +116,76 @@ const BorderBeam: React.FC<BorderBeamProps> = ({
         endCoord.y,
       );
 
-      // Updated gradient with teal head and red body that fades to transparent at the tail
-      gradient.addColorStop(0, 'transparent'); // Tail starts transparent
-      gradient.addColorStop(0.2, 'rgba(255, 53, 26, 0.3)'); // Red body starts faded
-      gradient.addColorStop(0.5, '#ff351a'); // Full red in middle of body
-      gradient.addColorStop(0.8, '#ff351a'); // Red continues
-      gradient.addColorStop(0.9, '#12e5e5'); // Teal head starts (slightly longer)
-      gradient.addColorStop(1, 'transparent'); // Fade to transparent at the leading edge
+      // Teal head + red body fading to transparent at the tail.
+      gradient.addColorStop(0, 'transparent');
+      gradient.addColorStop(0.2, 'rgba(255, 53, 26, 0.3)');
+      gradient.addColorStop(0.5, '#ff351a');
+      gradient.addColorStop(0.8, '#ff351a');
+      gradient.addColorStop(0.9, '#12e5e5');
+      gradient.addColorStop(1, 'transparent');
 
       return gradient;
     };
 
+    // Map a perimeter distance to a point on the inset rounded rectangle.
+    // Path order: top edge → top-right arc → right edge → bottom-right arc →
+    // bottom edge → bottom-left arc → left edge → top-left arc.
     const getCoordinatesFromDistance = (distance: number) => {
-      const width = canvas.width;
-      const height = canvas.height;
-      const perimeter = 2 * (width + height);
+      const { inset, w, h, r, straightX, straightY, arc, perimeter } =
+        getGeometry();
+      if (perimeter === 0) return { x: inset, y: inset };
 
-      // Normalize distance
-      distance = distance % perimeter;
+      let d = ((distance % perimeter) + perimeter) % perimeter;
 
-      // Top edge
-      if (distance < width) {
-        return { x: distance, y: 0 };
+      // 1. Top edge: (r, 0) → (w - r, 0)
+      if (d < straightX) return { x: inset + r + d, y: inset };
+      d -= straightX;
+      // 2. Top-right arc, center (w - r, r), angle -π/2 → 0
+      if (d < arc) {
+        const a = -Math.PI / 2 + (d / arc) * (Math.PI / 2);
+        return {
+          x: inset + (w - r) + r * Math.cos(a),
+          y: inset + r + r * Math.sin(a),
+        };
       }
-      // Right edge
-      else if (distance < width + height) {
-        return { x: width, y: distance - width };
+      d -= arc;
+      // 3. Right edge: (w, r) → (w, h - r)
+      if (d < straightY) return { x: inset + w, y: inset + r + d };
+      d -= straightY;
+      // 4. Bottom-right arc, center (w - r, h - r), angle 0 → π/2
+      if (d < arc) {
+        const a = (d / arc) * (Math.PI / 2);
+        return {
+          x: inset + (w - r) + r * Math.cos(a),
+          y: inset + (h - r) + r * Math.sin(a),
+        };
       }
-      // Bottom edge
-      else if (distance < 2 * width + height) {
-        return { x: width - (distance - (width + height)), y: height };
+      d -= arc;
+      // 5. Bottom edge: (w - r, h) → (r, h)
+      if (d < straightX) return { x: inset + (w - r) - d, y: inset + h };
+      d -= straightX;
+      // 6. Bottom-left arc, center (r, h - r), angle π/2 → π
+      if (d < arc) {
+        const a = Math.PI / 2 + (d / arc) * (Math.PI / 2);
+        return {
+          x: inset + r + r * Math.cos(a),
+          y: inset + (h - r) + r * Math.sin(a),
+        };
       }
-      // Left edge
-      else {
-        return { x: 0, y: height - (distance - (2 * width + height)) };
-      }
+      d -= arc;
+      // 7. Left edge: (0, h - r) → (0, r)
+      if (d < straightY) return { x: inset, y: inset + (h - r) - d };
+      d -= straightY;
+      // 8. Top-left arc, center (r, r), angle π → 3π/2
+      const a = Math.PI + (d / arc) * (Math.PI / 2);
+      return {
+        x: inset + r + r * Math.cos(a),
+        y: inset + r + r * Math.sin(a),
+      };
     };
 
     const drawPath = (start: number, end: number) => {
-      const width = canvas.width;
-      const height = canvas.height;
-      const perimeter = 2 * (width + height);
-
+      const { perimeter } = getGeometry();
       if (end < start) {
         drawPathSegment(start, perimeter);
         drawPathSegment(0, end);
@@ -143,18 +195,15 @@ const BorderBeam: React.FC<BorderBeamProps> = ({
     };
 
     const drawPathSegment = (start: number, end: number) => {
-      const width = canvas.width;
-      const height = canvas.height;
+      const current = getCoordinatesFromDistance(start);
+      ctx.moveTo(current.x, current.y);
 
-      let current = start;
-      let currentPoint = getCoordinatesFromDistance(current);
-      ctx.moveTo(currentPoint.x, currentPoint.y);
-
-      // Draw the segment by moving at small intervals
+      // 1 CSS-pixel step is fine for the smoothing the arcs need.
       const step = 1;
-      while (current < end) {
-        current += step;
-        const point = getCoordinatesFromDistance(current);
+      let d = start;
+      while (d < end) {
+        d += step;
+        const point = getCoordinatesFromDistance(d);
         ctx.lineTo(point.x, point.y);
       }
     };


### PR DESCRIPTION
## Summary

- `BorderBeam` hardcoded `border-radius: 24px` on its frame, while the active card hosts (`.choice-tabs__card--active`, `.shared-tabs__card--active`, used by ChoiceTabs / PlatformTabs / TutorialTabs) use `14px`. The frame's `overflow: hidden` therefore clipped at a different curve than the visible card, and the rectangular canvas stroke bled past the rounded corners.
- Symptom: a stray red/teal gradient streak orbiting just outside the active ChoiceTab card (most visible on `/next/guide/start/quick-start.html`), and the same on PlatformTabs.
- Fix: change the frame to `border-radius: inherit` so the clip always matches whatever host renders the beam.

## Before / after

The beam orbits the perimeter every 3s. In the buggy state, the beam visibly poked outside the active card at each corner. After the fix, the beam stays inside the rounded card on both ChoiceTabs and PlatformTabs (verified via 3 sequential frame captures per page).

Computed `border-radius` on `.border-beam-frame` after the fix:
- `.choice-tabs__card--active` host → 14px (was 24px)
- `.shared-tabs__card--active` host → 14px (was 24px)

## Test plan

- [ ] Hit `/next/guide/start/quick-start.html`, look at the "Try with Explorer" active card across one full 3s animation cycle: no colored streak outside the card
- [ ] Hit `/next/guide/use-data-from-host-platform.html`, same check on the active PlatformTab
- [ ] Spot-check homepage feature cards (other BorderBeam consumers) — they already used 14-ish radii via design tokens, so no regression expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Inherit host border-radius in BorderBeam to prevent beam leakage

- Set border-radius: inherit on .border-beam-frame so the canvas clip matches the host card corners and prevents the beam from bleeding past rounded edges.
- Scale canvas by devicePixelRatio and use CSS-pixel dimensions to avoid HiDPI subpixel artifacts when drawing.
- Read the corner radius from the frame’s computed style so the beam path follows the host’s actual radius.
- Trace an inset rounded-rectangle path (four edges + four quarter-circle arcs) and inset by lineWidth/2 so the stroke sits fully inside the clipped area.
- Map perimeter distance to coordinates with a segment/arc approach and draw the beam by sampling along that path to produce a continuous stroke around the inset rounded rect.
- Replace previous gradient with a defined sequence of color stops to produce a teal head and red body that fade to transparent at both ends.
- Remove remaining 1–2px streaks where straight strokes met clipped corners by aligning stroke geometry with the host clipping and HiDPI scaling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->