### PR TITLE
feat(theme): show GitHub star count in nav

### DIFF
--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -147,11 +147,6 @@ export default defineConfig({
     ],
     socialLinks: [
       {
-        icon: 'github',
-        mode: 'link',
-        content: 'https://github.com/lynx-family',
-      },
-      {
         icon: 'discord',
         mode: 'link',
         content: 'https://discord.gg/mXk7jqdDXk',

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -146,6 +146,15 @@ export default defineConfig({
       },
     ],
     socialLinks: [
+      // GitHub also renders as <GithubStars> via the afterNavMenu slot above
+      // 1280px. Below 1280px, the inline button is hidden and this entry
+      // surfaces the icon inside the hamburger dropdown / mobile drawer.
+      // The desktop duplicate is suppressed by CSS in `theme/index.scss`.
+      {
+        icon: 'github',
+        mode: 'link',
+        content: 'https://github.com/lynx-family/lynx',
+      },
       {
         icon: 'discord',
         mode: 'link',

--- a/theme/GithubStars.module.scss
+++ b/theme/GithubStars.module.scss
@@ -29,12 +29,11 @@
   font-variant-numeric: tabular-nums;
 }
 
-@media (max-width: 768px) {
+// Hide the inline button when the hamburger takes over. The github icon
+// is provided via socialLinks below 1281px so it still appears inside the
+// hamburger dropdown / mobile drawer.
+@media (max-width: 1280px) {
   .githubStars {
-    padding: 0 6px;
-
-    .count {
-      display: none;
-    }
+    display: none;
   }
 }

--- a/theme/GithubStars.module.scss
+++ b/theme/GithubStars.module.scss
@@ -1,0 +1,40 @@
+.githubStars {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 28px;
+  padding: 0 8px;
+  margin-right: 4px;
+  border-radius: 6px;
+  color: var(--rp-c-text-2);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1;
+  text-decoration: none;
+  transition:
+    color 0.2s ease,
+    background-color 0.2s ease;
+
+  svg {
+    fill: currentColor;
+  }
+
+  &:hover {
+    color: var(--rp-c-text-1);
+    background-color: var(--rp-c-bg-soft);
+  }
+}
+
+.count {
+  font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 768px) {
+  .githubStars {
+    padding: 0 6px;
+
+    .count {
+      display: none;
+    }
+  }
+}

--- a/theme/GithubStars.tsx
+++ b/theme/GithubStars.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useState } from 'react';
+import styles from './GithubStars.module.scss';
+
+const REPO = 'lynx-family/lynx';
+const HREF = `https://github.com/${REPO}`;
+const STORAGE_KEY = `rspress-github-stars:${REPO}`;
+const TTL_MS = 60 * 60 * 1000;
+
+type Cached = { count: number; fetchedAt: number };
+
+function readCache(): Cached | null {
+  if (typeof localStorage === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Cached;
+    if (
+      typeof parsed?.count !== 'number' ||
+      typeof parsed?.fetchedAt !== 'number'
+    ) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(count: number) {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ count, fetchedAt: Date.now() }),
+    );
+  } catch {
+    // Ignore storage errors (quota, private mode, etc.).
+  }
+}
+
+function formatCount(count: number): string {
+  if (count >= 1000) {
+    return `${(count / 1000).toFixed(1)}K`;
+  }
+  return String(count);
+}
+
+export function GithubStars() {
+  const [count, setCount] = useState<number | null>(() => {
+    const cached = readCache();
+    return cached ? cached.count : null;
+  });
+
+  useEffect(() => {
+    const cached = readCache();
+    if (cached && Date.now() - cached.fetchedAt < TTL_MS) return;
+
+    let cancelled = false;
+    fetch(`https://api.github.com/repos/${REPO}`)
+      .then((res) => (res.ok ? res.json() : Promise.reject(res.status)))
+      .then((data: { stargazers_count: number }) => {
+        if (cancelled) return;
+        const next = data.stargazers_count;
+        if (typeof next === 'number') {
+          setCount(next);
+          writeCache(next);
+        }
+      })
+      .catch(() => {
+        // Network or rate-limit errors: keep last known value or icon-only.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <a
+      href={HREF}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={styles.githubStars}
+      aria-label={
+        count == null
+          ? 'Lynx on GitHub'
+          : `Lynx on GitHub, ${count.toLocaleString()} stars`
+      }
+    >
+      <svg
+        role="img"
+        viewBox="0 0 24 24"
+        width="20"
+        height="20"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <path
+          fill="currentColor"
+          d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"
+        />
+      </svg>
+      {count != null && (
+        <span className={styles.count}>{formatCount(count)}</span>
+      )}
+    </a>
+  );
+}

--- a/theme/index.scss
+++ b/theme/index.scss
@@ -261,3 +261,15 @@ $link-color-dark: rgba(84, 169, 255, 1);
   word-break: break-all;
 }
 // #endregion ======== overview =========
+
+// #region ======== github-stars =========
+// On desktop the GitHub link is rendered as <GithubStars> via afterNavMenu.
+// Suppress the duplicate icon coming from socialLinks in .rp-nav__others.
+// Below 1280px .rp-nav__others is hidden by rspress, so the rule only fires
+// on desktop where the conflict exists.
+@media (min-width: 1281px) {
+  .rp-nav__others .rp-social-links__item[href*='github.com/lynx-family'] {
+    display: none;
+  }
+}
+// #endregion ======== github-stars =========

--- a/theme/index.tsx
+++ b/theme/index.tsx
@@ -37,6 +37,7 @@ import {
 import { SUBSITES_CONFIG } from '@site/shared-route-config';
 import AfterNavTitle from './AfterNavTitle';
 import BeforeSidebar from './BeforeSidebar';
+import { GithubStars } from './GithubStars';
 import { useBlogBtnDom } from './hooks/use-blog-btn-dom';
 
 // Match subsite by checking if any path segment exactly equals the subsite value
@@ -76,6 +77,7 @@ function Layout({
       <BaseLayout
         {...props}
         afterNavTitle={afterNavTitle}
+        afterNavMenu={<GithubStars />}
         beforeSidebar={<BeforeSidebar />}
         bottom={<Footer />}
       />


### PR DESCRIPTION
## Summary

Replaces the plain GitHub icon in `socialLinks` with a `<GithubStars>` component that fetches the `lynx-family/lynx` star count from the GitHub REST API and renders it inline next to the icon — same pattern many docs sites use (Rsbuild, Tailwind, etc.).

Currently rendering as: GitHub icon + **`14.9K`** (will update with the real number at the time the page loads).

### How it works

- Fetches `https://api.github.com/repos/lynx-family/lynx` on mount, caches in `localStorage` for **1 hour** to avoid the unauthenticated rate limit (60 req/hr/IP).
- SSR-safe: server renders icon-only, the count hydrates after mount.
- On request failure (offline, rate-limited), falls back to icon-only — never a broken state.
- Hidden below `768px` so mobile nav stays uncluttered; icon stays clickable.
- Wired through the theme's `afterNavMenu` slot, so the existing nav layout is untouched.

The original `{ icon: 'github', mode: 'link', ... }` entry in `socialLinks` is removed to avoid showing the icon twice.

### Follow-up

This is a temporary local component. I've also opened an upstream PR — [web-infra-dev/rspress#3433](https://github.com/web-infra-dev/rspress/pull/3433) — adding a `mode: 'github-stars'` to `SocialLink`. Once that lands and we bump `@rspress/core`, this component and the `afterNavMenu` wiring can be deleted and replaced with a single config entry:

```ts
socialLinks: [
  { icon: 'github', mode: 'github-stars', content: 'https://github.com/lynx-family/lynx' },
  // ...
]
```

## Test plan

- [x] Dev server (`pnpm dev`) compiles clean, no console errors.
- [x] Verified in a headless browser at `http://localhost:3000/next/`: exactly one `a[href*="github.com"]` in nav, text reads `14.9K`, link points to `https://github.com/lynx-family/lynx`.
- [ ] Spot-check mobile width — count should be hidden, icon should remain clickable.
- [ ] Spot-check dark mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## feat(theme): show GitHub star count in nav

- Remove GitHub social link from `themeConfig.socialLinks` in rspress.config.ts
- Add `GithubStars` component with GitHub REST API integration to fetch and display repository star count
- Cache star count in localStorage with 1-hour TTL to minimize API requests and avoid rate-limiting
- Render icon-only on server; hydrate star count client-side after mount for SSR compatibility
- Hide count display on screens below 768px while keeping icon clickable
- Gracefully fall back to icon-only display on fetch errors (network issues or rate limits)
- Integrate `GithubStars` component into theme layout via the `afterNavMenu` slot
- Add SCSS module with styling for GitHub stars button, count display, and responsive behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->