### PR TITLE
feat(sidebar): motion.dev-style subsite icon row + brand-themed nav header + single canonical Quick Start

### DIFF
--- a/docs/en/help/subsite.mdx
+++ b/docs/en/help/subsite.mdx
@@ -47,32 +47,23 @@ To add a new subsite (e.g., `my-framework`):
     ```
 3.  **Configure Sidebar**: Create `docs/en/my-framework/_meta.json` to define its specific sidebar structure.
 
-## Shared Documentation
+## The shared entry: Quick Start
 
-To avoid duplicating content (like "Quick Start" guides) across multiple subsites, we use a shared documentation system.
+`SHARED_DOC_TITLES` historically held several cross-subsite docs (tutorials, integration guides, …) and the build mapped them to virtual `/<subsite>/start/<filename>` routes. Those docs have since either been folded into ChoiceTabs or lifted out to top-level `/learn/*`. Quick Start is the only one that still genuinely belongs to "everyone's first-run experience."
 
-### How it Works
+Its canonical URL is pinned in `shared-route-config.ts` as `QUICK_START_PATH` (= `/guide/start/quick-start`). We park it under `/guide/` because Lynx is the runtime substrate every other subsite is defined relative to (Rspeedy = build tool for Lynx, ReactLynx = React on Lynx, …), so routing the platform's onboarding doorway under the platform is the honest framing — the page's job is to _send_ you into a framework, not to _belong_ to one.
 
-1.  **Source of Truth**: Shared files are physically located in `docs/en/guide/start/`.
-2.  **Virtual Routes**: The `sharedSidebarPlugin` in `rspress.config.ts` dynamically creates virtual pages for other subsites (e.g., `react/start/quick-start`) that point to the same content.
-3.  **Unified Sidebar**: The `BeforeSidebar` component (in `theme/BeforeSidebar.tsx`) automatically injects the shared "Start" section into the sidebar of every subsite.
+### How it works
 
-### Managing Shared Content
-
-To modify which files are shared, update `SHARED_DOC_TITLES` in `shared-route-config.ts`.
-
-```typescript
-const SHARED_DOC_TITLES = {
-  'quick-start': { en: 'Quick Start', zh: '快速上手' },
-  // ...
-};
-```
+1.  **Source of truth**: the file lives at `docs/{en,zh}/guide/start/quick-start.mdx`.
+2.  **Sidebar entry**: `BeforeSidebar`'s Get Started link always points to `QUICK_START_PATH` regardless of which subsite the reader is currently in.
+3.  **Historical-URL compatibility**: legacy `/<ai|react|rspeedy|lynx-ui>/start/*` URLs are 301'd to `/guide/start/*` in `netlify.toml`, so bookmarks and LLM-cached references keep resolving.
 
 ## Subsite UI
 
-The subsite navigation and identity are handled by custom theme components:
+Subsite navigation and identity are handled by custom theme components:
 
-- **`SubsiteSelect`** (`theme/BeforeSidebar.tsx`): The dropdown menu at the top of the sidebar allows users to switch between subsites.
-- **`SubsiteLogo`** (`theme/subsite-ui.tsx`): Renders the correct logo for the current subsite and theme mode.
+- **`SubsiteRow`** (`theme/SubsiteRow.tsx`): horizontal row of all subsite icons at the top of the sidebar; the active subsite gets a brand-themed border.
+- **`SubsiteLogo`** (`theme/subsite-ui.tsx`): renders the correct logo for the current subsite and theme mode.
 
 These components read directly from `SUBSITES_CONFIG`, so any changes there are immediately reflected in the UI.

--- a/docs/en/help/subsite.mdx
+++ b/docs/en/help/subsite.mdx
@@ -56,7 +56,7 @@ Its canonical URL is pinned in `shared-route-config.ts` as `QUICK_START_PATH` (=
 ### How it works
 
 1.  **Source of truth**: the file lives at `docs/{en,zh}/guide/start/quick-start.mdx`.
-2.  **Sidebar entry**: `BeforeSidebar`'s Get Started link always points to `QUICK_START_PATH` regardless of which subsite the reader is currently in.
+2.  **Sidebar entry**: clicking the Lynx icon in `SubsiteRow` routes to `QUICK_START_PATH` instead of the Lynx subsite's `url`. The other icons keep navigating to their respective subsite landings.
 3.  **Historical-URL compatibility**: legacy `/<ai|react|rspeedy|lynx-ui>/start/*` URLs are 301'd to `/guide/start/*` in `netlify.toml`, so bookmarks and LLM-cached references keep resolving.
 
 ## Subsite UI

--- a/docs/en/react/index.mdx
+++ b/docs/en/react/index.mdx
@@ -11,5 +11,5 @@ hero:
       link: /react/introduction.html
     - theme: alt
       text: Quick Start
-      link: /react/start/quick-start.html
+      link: /guide/start/quick-start.html
 ---

--- a/docs/en/rspeedy/index.md
+++ b/docs/en/rspeedy/index.md
@@ -8,7 +8,7 @@ hero:
   actions:
     - theme: brand
       text: Get Started
-      link: /rspeedy/start/quick-start.html
+      link: /guide/start/quick-start.html
     - theme: alt
       text: API
       link: /api/rspeedy.html

--- a/docs/public/AGENTS.md
+++ b/docs/public/AGENTS.md
@@ -154,8 +154,8 @@ Common APIs:
 
 ## 15. Engineering Practices and Tooling
 
-- **Project initialization**: `pnpm create rspeedy` scaffolds a ReactLynx project with Rspeedy configuration and sample code. (See [Quick Start](/rspeedy/start/quick-start.md))
-- **Development and debugging**: `pnpm dev` starts the Rspeedy dev server. The terminal prints a QR code—scan it with the LynxExample app (iOS/Android/Harmony emulator) for hot-update previews. (See [Quick Start](/rspeedy/start/quick-start.md))
+- **Project initialization**: `pnpm create rspeedy` scaffolds a ReactLynx project with Rspeedy configuration and sample code. (See [Quick Start](/guide/start/quick-start.md))
+- **Development and debugging**: `pnpm dev` starts the Rspeedy dev server. The terminal prints a QR code—scan it with the LynxExample app (iOS/Android/Harmony emulator) for hot-update previews. (See [Quick Start](/guide/start/quick-start.md))
 - **DevTool debugging**: After connecting a device, use the desktop Lynx DevTool to debug JS, inspect nodes, and record performance. (See [Lynx DevTool](/guide/devtool.md))
 - **Build artifacts**: Rspeedy outputs a bundle that includes the background-thread script (text), main-thread bytecode, styles, and other assets. Set `DEBUG=rspeedy` to dump intermediate artifacts (background script, main-thread bytecode, styles, source maps, etc.) into `dist/.rspeedy`; otherwise only the final bundle is produced. (See [Output Files](/rspeedy/output.md))
 - **Docs asset references**: In MDX, prefer the `@assets` alias for local assets (for example `import demoImg from '@assets/foo.png?url'`) and pass the imported variable to components such as `<Go img={demoImg} />`. Do not hardcode `/assets/...` paths in MDX props.

--- a/docs/public/zh/AGENTS.md
+++ b/docs/public/zh/AGENTS.md
@@ -154,8 +154,8 @@
 
 ## 15. 工程实践与工具链
 
-- **项目初始化**：`pnpm create rspeedy` 一键生成 ReactLynx 工程，自动带上 Rspeedy 配置、脚手架示例。（参考：[Quick Start](/zh/rspeedy/start/quick-start.md)）
-- **开发调试**：`pnpm dev` 启动 Rspeedy Dev Server，终端输出二维码，使用 LynxExample App（iOS/Android/Harmony 模拟器）扫描即可热更新预览。（参考：[Quick Start](/zh/rspeedy/start/quick-start.md)）
+- **项目初始化**：`pnpm create rspeedy` 一键生成 ReactLynx 工程，自动带上 Rspeedy 配置、脚手架示例。（参考：[Quick Start](/zh/guide/start/quick-start.md)）
+- **开发调试**：`pnpm dev` 启动 Rspeedy Dev Server，终端输出二维码，使用 LynxExample App（iOS/Android/Harmony 模拟器）扫描即可热更新预览。（参考：[Quick Start](/zh/guide/start/quick-start.md)）
 - **DevTool 调试**：连接设备后使用 Lynx DevTool 桌面端调试 JS、查看节点、性能记录。（参考：[Lynx DevTool](/zh/guide/devtool.md)）
 - **构建产物**：Rspeedy 输出的 Bundle 包含后台线程脚本（文本）、主线程字节码、样式等资源；需要 `DEBUG=rspeedy` 环境变量以输出中间产物（组成Lynx Bundle 的后台线程脚本（文本）、主线程字节码、样式、SourceMap 等）到 `dist/.rspeedy` 目录，否则只会输出最终的 Lynx Bundle 文件。（参考：[Output Files](/zh/rspeedy/output.md)）
 - **文档资源引用**：在 MDX 中引用本地图片或文件时，优先使用 `@assets` alias（例如 `import demoImg from '@assets/foo.png?url'`），再传给 `<Go img={demoImg} />` 这类组件。不要在 MDX 的组件参数里直接硬编码 `/assets/...` 路径。

--- a/docs/zh/help/subsite.mdx
+++ b/docs/zh/help/subsite.mdx
@@ -56,7 +56,7 @@ export type SubsiteConfig = {
 ### 工作原理
 
 1.  **事实来源**：物理文件位于 `docs/{en,zh}/guide/start/quick-start.mdx`。
-2.  **侧边栏入口**：`BeforeSidebar` 渲染的 Get Started 链接总是指向 `QUICK_START_PATH`，不论用户当前所处的子站点。
+2.  **侧边栏入口**：在 `SubsiteRow` 中点击 Lynx 图标会跳转到 `QUICK_START_PATH`，而不是 Lynx 子站点的 `url`；其他图标仍跳转到各自子站点的入口页。
 3.  **历史 URL 兼容**：旧的 `/<ai|react|rspeedy|lynx-ui>/start/*` URL 通过 `netlify.toml` 中的 301 重定向跳转到 `/guide/start/*`，确保旧书签与已被 LLM 爬取的引用仍可访问。
 
 ## 子站点 UI

--- a/docs/zh/help/subsite.mdx
+++ b/docs/zh/help/subsite.mdx
@@ -47,32 +47,23 @@ export type SubsiteConfig = {
     ```
 3.  **配置侧边栏**：创建 `docs/en/my-framework/_meta.json` 以定义其特定的侧边栏结构。
 
-## 共享文档
+## 共享入口：Quick Start
 
-为了避免在多个子站点之间重复内容（如“快速上手”指南），我们使用共享文档系统。
+历史上 `SHARED_DOC_TITLES` 曾收纳过多份跨子站点共享的文档（教程、集成指南等），并通过虚拟路由把它们映射到 `/<subsite>/start/<filename>` 下。今天这些文档要么已被合并进 ChoiceTabs，要么已迁出至顶层 `/learn/*`，只剩 Quick Start 一篇真正属于"所有子站点共享的入口"。
+
+我们把它的规范 URL 固定在 `shared-route-config.ts` 中的 `QUICK_START_PATH`（=`/guide/start/quick-start`）。之所以放在 `/guide/` 之下，是因为 Lynx 是所有其他子站点的运行时底座（Rspeedy = Lynx 构建工具，ReactLynx = React on Lynx，等等），把 Quick Start 安放在平台根目录下是诚实的做法——它的工作就是把读者分流到具体框架的入口。
 
 ### 工作原理
 
-1.  **事实来源**：共享文件物理位置在 `docs/en/guide/start/`。
-2.  **虚拟路由**：`rspress.config.ts` 中的 `sharedSidebarPlugin` 动态地为其他子站点创建虚拟页面（例如 `react/start/quick-start`），指向相同的内容。
-3.  **统一侧边栏**：`BeforeSidebar` 组件（在 `theme/BeforeSidebar.tsx` 中）自动将共享的“开始”部分注入每个子站点的侧边栏。
-
-### 管理共享内容
-
-要修改哪些文件被共享，请更新 `shared-route-config.ts` 中的 `SHARED_DOC_TITLES`。
-
-```typescript
-const SHARED_DOC_TITLES = {
-  'quick-start': { en: 'Quick Start', zh: '快速上手' },
-  // ...
-};
-```
+1.  **事实来源**：物理文件位于 `docs/{en,zh}/guide/start/quick-start.mdx`。
+2.  **侧边栏入口**：`BeforeSidebar` 渲染的 Get Started 链接总是指向 `QUICK_START_PATH`，不论用户当前所处的子站点。
+3.  **历史 URL 兼容**：旧的 `/<ai|react|rspeedy|lynx-ui>/start/*` URL 通过 `netlify.toml` 中的 301 重定向跳转到 `/guide/start/*`，确保旧书签与已被 LLM 爬取的引用仍可访问。
 
 ## 子站点 UI
 
 子站点导航和身份由自定义主题组件处理：
 
-- **`SubsiteSelect`** (`theme/BeforeSidebar.tsx`)：侧边栏顶部的下拉菜单允许用户在子站点之间切换。
+- **`SubsiteRow`** (`theme/SubsiteRow.tsx`)：侧边栏顶部的横向图标行，展示所有子站点，活动子站点以品牌色描边高亮。
 - **`SubsiteLogo`** (`theme/subsite-ui.tsx`)：渲染当前子站点和主题模式的正确 Logo。
 
 这些组件直接从 `SUBSITES_CONFIG` 读取，因此其中的任何更改都会立即反映在 UI 中。

--- a/docs/zh/react/index.mdx
+++ b/docs/zh/react/index.mdx
@@ -11,5 +11,5 @@ hero:
       link: /zh/react/introduction.html
     - theme: alt
       text: 快速开始
-      link: /zh/react/start/quick-start.html
+      link: /zh/guide/start/quick-start.html
 ---

--- a/docs/zh/rspeedy/index.md
+++ b/docs/zh/rspeedy/index.md
@@ -8,7 +8,7 @@ hero:
   actions:
     - theme: brand
       text: 开始
-      link: /zh/rspeedy/start/quick-start.html
+      link: /zh/guide/start/quick-start.html
     - theme: alt
       text: API
       link: /api/rspeedy.html

--- a/netlify.toml
+++ b/netlify.toml
@@ -62,6 +62,58 @@
   status = 301
   force = true
 
+# Quick Start lived at /<subsite>/start/quick-start for every subsite while
+# we had multiple shared docs (see shared-route-config.ts history). Today
+# the canonical is /guide/start/quick-start; redirect historical alternates
+# so bookmarks and crawler-cached URLs still resolve.
+[[redirects]]
+  from = "/ai/start/*"
+  to = "/guide/start/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/zh/ai/start/*"
+  to = "/zh/guide/start/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/react/start/*"
+  to = "/guide/start/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/zh/react/start/*"
+  to = "/zh/guide/start/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/rspeedy/start/*"
+  to = "/guide/start/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/zh/rspeedy/start/*"
+  to = "/zh/guide/start/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/lynx-ui/start/*"
+  to = "/guide/start/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/zh/lynx-ui/start/*"
+  to = "/zh/guide/start/:splat"
+  status = 301
+  force = true
+
 # Serve everything under /next/ from the site root.
 [[redirects]]
   from = "/next/*"

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -19,10 +19,6 @@ import versionJson from './docs/public/version.json';
 import { visit } from 'unist-util-visit';
 import { pluginGoogleAnalytics } from 'rsbuild-plugin-google-analytics';
 import { pluginOpenGraph } from 'rsbuild-plugin-open-graph';
-import {
-  SHARED_DOC_FILES,
-  SHARED_SIDEBAR_PATHS,
-} from './shared-route-config.js';
 
 const PUBLISH_URL = 'https://lynxjs.org/';
 const NETLIFY_CONTEXT = process.env.CONTEXT ?? '';
@@ -189,7 +185,6 @@ export default defineConfig({
         },
       ],
     }),
-    sharedSidebarPlugin(),
     ...(!IS_LIGHTWEIGHT_BUILD
       ? [
           pluginSitemap({
@@ -276,38 +271,5 @@ function remarkReplaceVersionJsonPlaceholders() {
         node.value = applyReplacements(node.value);
       }
     });
-  };
-}
-
-function mapNonGuideSharedSectionsToGuide(
-  lang: string,
-  routes: string[],
-  filenames: string[],
-) {
-  return routes
-    .filter((route) => route !== 'guide')
-    .flatMap((route) =>
-      filenames.map((filename) => ({
-        routePath: `/${lang}/${route}/${filename}`,
-        filepath: path.join(__dirname, `docs/${lang}/guide`, `${filename}.mdx`),
-      })),
-    );
-}
-
-function sharedSidebarPlugin(): RspressPlugin {
-  return {
-    name: 'rspeedy:shared-sidebar',
-    addPages(config, isProd) {
-      const pages =
-        config.themeConfig?.locales?.flatMap(({ lang }) =>
-          mapNonGuideSharedSectionsToGuide(
-            lang,
-            SHARED_SIDEBAR_PATHS,
-            SHARED_DOC_FILES,
-          ),
-        ) || [];
-
-      return pages;
-    },
   };
 }

--- a/shared-route-config.ts
+++ b/shared-route-config.ts
@@ -2,8 +2,6 @@
  * Sub-sites and shared docs configuration
  */
 
-import type { SidebarData } from '@rspress/core/theme';
-
 /**
  * Metadata for each subsites. This is used to
  * - generate the sidebar subsite selector dropdown UI.
@@ -183,9 +181,9 @@ export const CORE_SUBSITES = SUBSITES_CONFIG.filter(
  * tracks — its job is to send you somewhere, not to belong somewhere — so
  * routing it under the platform is the honest framing.
  *
- * Every subsite's "Get Started" sidebar link and home-page CTA points here.
- * Historical `/{ai,react,rspeedy,lynx-ui}/start/quick-start` URLs are 301'd
- * to this canonical in netlify.toml.
+ * Clicking the Lynx icon in SubsiteRow and every subsite home-page CTA
+ * land here. Historical `/{ai,react,rspeedy,lynx-ui}/start/quick-start`
+ * URLs are 301'd to this canonical in netlify.toml.
  */
 export const QUICK_START_PATH = '/guide/start/quick-start';
 
@@ -207,7 +205,7 @@ export const DROPDOWN_NATIVE_FRAMEWORK = topLevel('native-framework');
 
 /**
  * First-segment values that count as a "subsite" — used by BeforeSidebar to
- * decide whether to render the SubsiteRow + Get Started header.
+ * decide whether to render the SubsiteRow nav header.
  */
 export const SHARED_SIDEBAR_PATHS = CORE_SUBSITES.map((config) => config.value);
 
@@ -253,30 +251,3 @@ export function getLangPrefix(lang: string) {
   // The constant here must match the configured lang in rspress.config.ts.
   return lang === 'en' ? '' : `/${lang}`;
 }
-
-const GET_STARTED_LABEL = {
-  en: 'Get Started',
-  zh: '起步',
-} as const;
-
-/**
- * Sidebar entries shown above the SubsiteRow in every subsite's sidebar.
- * Today this is just one link — Get Started — pointing at the canonical
- * Quick Start URL regardless of which subsite the user is currently in.
- * The trailing divider is rendered separately by BeforeSidebar so the
- * "Get Started + SubsiteRow" header reads as one unit above the divider.
- */
-export const createSharedRouteSidebar = (
-  lang: string,
-  pathname: string,
-): SidebarData => {
-  const pathPrefix = getUrlPathPrefix(pathname, SHARED_SIDEBAR_PATHS);
-  if (!pathPrefix) return [];
-
-  return [
-    {
-      text: GET_STARTED_LABEL[lang === 'zh' ? 'zh' : 'en'],
-      link: `${getLangPrefix(lang)}${QUICK_START_PATH}`,
-    },
-  ];
-};

--- a/shared-route-config.ts
+++ b/shared-route-config.ts
@@ -173,6 +173,22 @@ export const CORE_SUBSITES = SUBSITES_CONFIG.filter(
   (s) => !s.external && !s.disabled,
 );
 
+/**
+ * Canonical Quick Start URL.
+ *
+ * The page lives under `/guide/` because Lynx is the platform every other
+ * subsite is defined relative to (Rspeedy = build tool for Lynx, ReactLynx
+ * = React on Lynx, lynx-ui = UI for ReactLynx, …). The page itself is a
+ * branching switcher (ChoiceTabs) that fans *out* into framework-specific
+ * tracks — its job is to send you somewhere, not to belong somewhere — so
+ * routing it under the platform is the honest framing.
+ *
+ * Every subsite's "Get Started" sidebar link and home-page CTA points here.
+ * Historical `/{ai,react,rspeedy,lynx-ui}/start/quick-start` URLs are 301'd
+ * to this canonical in netlify.toml.
+ */
+export const QUICK_START_PATH = '/guide/start/quick-start';
+
 /** Subsites that link to external sites. */
 export const ECOSYSTEM_SUBSITES = SUBSITES_CONFIG.filter((s) => s.external);
 
@@ -190,32 +206,10 @@ export const DROPDOWN_JS_FRAMEWORK = topLevel('js-framework');
 export const DROPDOWN_NATIVE_FRAMEWORK = topLevel('native-framework');
 
 /**
- * URL paths that share common documentation files.
- * For example, "start/quick-start" will be accessible at both
- * "guide/start/quick-start" and "react/start/quick-start".
+ * First-segment values that count as a "subsite" — used by BeforeSidebar to
+ * decide whether to render the SubsiteRow + Get Started header.
  */
 export const SHARED_SIDEBAR_PATHS = CORE_SUBSITES.map((config) => config.value);
-
-const SHARED_DOC_ROOT = 'start';
-
-// Map of localized titles for shared documentation files
-const SHARED_DOC_TITLES = {
-  'quick-start': {
-    en: 'Get Started',
-    zh: '起步',
-  },
-} as const;
-
-/**
- * List of documentation files that are shared between URL paths.
- * Each file exists once but is accessible from multiple paths.
- * For example, "start/quick-start" can be accessed at both:
- * - /guide/start/quick-start
- * - /react/start/quick-start
- */
-export const SHARED_DOC_FILES = Object.keys(SHARED_DOC_TITLES).map(
-  (filename) => `${SHARED_DOC_ROOT}/${filename}`,
-);
 
 /**
  * Gets the current URL path prefix from the pathname.
@@ -260,13 +254,17 @@ export function getLangPrefix(lang: string) {
   return lang === 'en' ? '' : `/${lang}`;
 }
 
+const GET_STARTED_LABEL = {
+  en: 'Get Started',
+  zh: '起步',
+} as const;
+
 /**
- * Creates sidebar data structure for shared documentation files.
- * Handles both internationalization and dynamic route generation.
- *
- * @param lang - Current language code
- * @param pathname - Current URL pathname
- * @returns Sidebar configuration for shared documentation sections
+ * Sidebar entries shown above the SubsiteRow in every subsite's sidebar.
+ * Today this is just one link — Get Started — pointing at the canonical
+ * Quick Start URL regardless of which subsite the user is currently in.
+ * The trailing divider is rendered separately by BeforeSidebar so the
+ * "Get Started + SubsiteRow" header reads as one unit above the divider.
  */
 export const createSharedRouteSidebar = (
   lang: string,
@@ -275,22 +273,10 @@ export const createSharedRouteSidebar = (
   const pathPrefix = getUrlPathPrefix(pathname, SHARED_SIDEBAR_PATHS);
   if (!pathPrefix) return [];
 
-  const fullPrefix = `${getLangPrefix(lang)}${pathPrefix}/${SHARED_DOC_ROOT}`;
-
-  // Render shared docs as flat top-level entries (one per file).
-  // After collapsing Get Started to a single Quick Start page, there is no
-  // longer a section-with-sub-items layer; each shared doc renders directly.
-  const flatItems: SidebarData = Object.entries(SHARED_DOC_TITLES).map(
-    ([filename, texts]) => ({
-      text: texts[lang === 'zh' ? 'zh' : 'en'],
-      link: `${fullPrefix}/${filename}`,
-    }),
-  );
-
   return [
-    ...flatItems,
     {
-      dividerType: 'solid',
+      text: GET_STARTED_LABEL[lang === 'zh' ? 'zh' : 'en'],
+      link: `${getLangPrefix(lang)}${QUICK_START_PATH}`,
     },
   ];
 };

--- a/theme/BeforeSidebar.tsx
+++ b/theme/BeforeSidebar.tsx
@@ -1,97 +1,14 @@
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-} from '@/components/ui/select';
 import { useEffect, useState } from 'react';
-import { useLang, useLocation, useNavigate } from '@rspress/core/runtime';
+import { useLang, useLocation } from '@rspress/core/runtime';
 import { type SidebarData, SidebarList } from '@rspress/core/theme-original';
 import {
-  CORE_SUBSITES,
   SHARED_SIDEBAR_PATHS,
   createSharedRouteSidebar,
   getLangPrefix,
 } from '@site/shared-route-config';
 import './index.scss';
 
-import type { SubsiteConfig } from '@site/shared-route-config';
-
-import { SubsiteView } from './subsite-ui';
-
-function findSubsiteFromPathname(
-  pathname: string,
-  lang: string,
-): SubsiteConfig {
-  const langPrefix = getLangPrefix(lang);
-  let path = pathname;
-
-  if (langPrefix && path.startsWith(`${langPrefix}/`)) {
-    path = path.slice(langPrefix.length + 1);
-  } else if (!langPrefix && path.startsWith('/')) {
-    path = path.slice(1);
-  }
-
-  if (!path) {
-    return CORE_SUBSITES[0];
-  }
-
-  const [firstSegment] = path.split('/');
-  const normalizedSegment = firstSegment.replace(/\.html$/, '');
-
-  const subsite =
-    CORE_SUBSITES.find((s) => s.value === normalizedSegment) ||
-    CORE_SUBSITES[0];
-
-  return subsite;
-}
-
-function SubsiteSelect() {
-  const { pathname } = useLocation();
-  const navigate = useNavigate();
-  const lang = useLang();
-  const [selectedSubsite, setSelectedSubsite] = useState<SubsiteConfig>(() =>
-    findSubsiteFromPathname(pathname, lang),
-  );
-
-  useEffect(() => {
-    const subsite = findSubsiteFromPathname(pathname, lang);
-    if (subsite.value !== selectedSubsite.value) {
-      setSelectedSubsite(subsite);
-    }
-  }, [lang, pathname, selectedSubsite.value]);
-
-  const handleValueChange = (value: string) => {
-    const newSubsite = CORE_SUBSITES.find((s) => s.value === value);
-    if (newSubsite) {
-      setSelectedSubsite(newSubsite);
-      navigate(`${getLangPrefix(lang)}${newSubsite.url}`);
-    }
-  };
-
-  return (
-    <div className="w-full">
-      <Select onValueChange={handleValueChange} value={selectedSubsite.value}>
-        <SelectTrigger className="h-auto border-0 bg-transparent px-4 py-2 shadow-none [&>span]:flex [&>span]:flex-1 relative before:pointer-events-none before:absolute before:inset-0 before:size-full before:rounded-md before:p-[1px] before:will-change-[background-position] before:content-[''] before:[-webkit-mask-composite:xor] before:[mask-composite:exclude] before:bg-shine before:bg-[length:300%_300%] before:[mask:linear-gradient(white_0_0)_content-box,linear-gradient(white_0_0)] before:opacity-0 hover:before:opacity-100 before:transition-opacity before:duration-300 hover:motion-safe:before:animate-shine transition-all hover:shadow-[0_0_12px_-3px_var(--rp-c-brand)] hover:translate-y-[-1px]">
-          <div className="flex w-full items-center gap-2 relative">
-            <SubsiteView subsite={selectedSubsite} lang={lang} size="minimal" />
-          </div>
-        </SelectTrigger>
-        <SelectContent className="min-w-[240px] z-[100]">
-          {CORE_SUBSITES.map((subsite) => (
-            <SelectItem
-              key={subsite.value}
-              value={subsite.value}
-              className="!pl-3 py-2 [&>span:first-child]:hidden"
-            >
-              <SubsiteView subsite={subsite} lang={lang} />
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
-  );
-}
+import { SubsiteRow } from './SubsiteRow';
 
 export default function BeforeSidebar() {
   const lang = useLang();
@@ -129,7 +46,7 @@ export default function BeforeSidebar() {
   return (
     <div id="before-sidebar">
       <SidebarList sidebarData={sidebarData} setSidebarData={setSidebarData} />
-      <SubsiteSelect />
+      <SubsiteRow />
     </div>
   );
 }

--- a/theme/BeforeSidebar.tsx
+++ b/theme/BeforeSidebar.tsx
@@ -1,63 +1,30 @@
-import { useEffect, useState } from 'react';
 import { useLang, useLocation } from '@rspress/core/runtime';
 import { type SidebarData, SidebarList } from '@rspress/core/theme-original';
-import {
-  SHARED_SIDEBAR_PATHS,
-  createSharedRouteSidebar,
-  getLangPrefix,
-} from '@site/shared-route-config';
+import { SHARED_SIDEBAR_PATHS, getLangPrefix } from '@site/shared-route-config';
 import './index.scss';
 import './SubsiteRow.scss';
 
 import { SubsiteRow } from './SubsiteRow';
 
+// Render the divider through SidebarList so its geometry (border, margin)
+// is byte-identical to every other rp-sidebar-divider rspress emits in
+// the sidebar — instead of a hand-rolled <div> whose spacing we'd have to
+// keep in sync as rspress evolves.
+const HEADER_DIVIDER: SidebarData = [{ dividerType: 'solid' }];
+
 export default function BeforeSidebar() {
   const lang = useLang();
   const { pathname } = useLocation();
 
-  // Initialize sidebar data based on current path and language
-  const [sidebarData, setSidebarData] = useState<SidebarData>(() =>
-    createSharedRouteSidebar(lang, pathname),
+  const isSharedPath = SHARED_SIDEBAR_PATHS.some((prefix) =>
+    pathname.startsWith(`${getLangPrefix(lang)}/${prefix}`),
   );
-
-  useEffect(() => {
-    // Check if current path should show shared sidebar
-    const isSharedPath = SHARED_SIDEBAR_PATHS.some((prefix) =>
-      pathname.startsWith(`${getLangPrefix(lang)}/${prefix}`),
-    );
-
-    // Update sidebar data based on path:
-    // - For shared paths: generate new sidebar data
-    // - For non-shared paths: set to empty to hide sidebar
-    //
-    // Since the container component (Sidebar) re-renders in useEffect (next tick),
-    // we need to reset here to ensure both components update in the same tick.
-    // This avoids UI jump when switching in/out of shared paths.
-    const newSidebarData = isSharedPath
-      ? createSharedRouteSidebar(lang, pathname)
-      : [];
-    setSidebarData(newSidebarData);
-  }, [lang, pathname]);
-
-  // Only render if we have sidebar data and it's not empty
-  if (!sidebarData || sidebarData.length === 0) {
-    return null;
-  }
-
-  // Drop the trailing divider that createSharedRouteSidebar appends — we
-  // group Get Started + SubsiteRow as a single "nav header" unit and place
-  // the divider *under* the unit instead of between its two halves.
-  const navLinks = sidebarData.filter(
-    (item) => !('dividerType' in item),
-  ) as SidebarData;
+  if (!isSharedPath) return null;
 
   return (
     <div id="before-sidebar">
-      <div className="sidebar-nav-header">
-        <SidebarList sidebarData={navLinks} setSidebarData={setSidebarData} />
-        <SubsiteRow />
-      </div>
-      <div className="rp-sidebar-divider sidebar-nav-header__divider" />
+      <SubsiteRow />
+      <SidebarList sidebarData={HEADER_DIVIDER} setSidebarData={() => {}} />
     </div>
   );
 }

--- a/theme/BeforeSidebar.tsx
+++ b/theme/BeforeSidebar.tsx
@@ -7,6 +7,7 @@ import {
   getLangPrefix,
 } from '@site/shared-route-config';
 import './index.scss';
+import './SubsiteRow.scss';
 
 import { SubsiteRow } from './SubsiteRow';
 
@@ -43,10 +44,20 @@ export default function BeforeSidebar() {
     return null;
   }
 
+  // Drop the trailing divider that createSharedRouteSidebar appends — we
+  // group Get Started + SubsiteRow as a single "nav header" unit and place
+  // the divider *under* the unit instead of between its two halves.
+  const navLinks = sidebarData.filter(
+    (item) => !('dividerType' in item),
+  ) as SidebarData;
+
   return (
     <div id="before-sidebar">
-      <SidebarList sidebarData={sidebarData} setSidebarData={setSidebarData} />
-      <SubsiteRow />
+      <div className="sidebar-nav-header">
+        <SidebarList sidebarData={navLinks} setSidebarData={setSidebarData} />
+        <SubsiteRow />
+      </div>
+      <div className="rp-sidebar-divider sidebar-nav-header__divider" />
     </div>
   );
 }

--- a/theme/SubsiteRow.scss
+++ b/theme/SubsiteRow.scss
@@ -63,60 +63,6 @@
   }
 }
 
-// ─── Sidebar nav header ──────────────────────────────────────────────────
-// Get Started + SubsiteRow form a single header unit. The Get Started link
-// (rendered by rspress's <SidebarList>) inherits the active brand color via
-// `rp-sidebar-item--active`; we re-skin its active state with the same
-// recipe the SubsiteRow active icon uses so the two read as one block.
-// Inactive Get Started stays a plain link.
-
-.sidebar-nav-header {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  padding-top: 4px;
-
-  // Anchor Get Started's horizontal padding to the SubsiteRow gutter so
-  // their left edges line up.
-  > .rp-sidebar-item {
-    margin: 0 8px;
-    padding-left: 12px;
-    padding-right: 12px;
-    border: 1px solid transparent;
-    border-radius: 8px;
-    font-weight: 500;
-    transition:
-      background-color 0.15s ease-out,
-      border-color 0.15s ease-out,
-      box-shadow 0.15s ease-out;
-  }
-
-  > .rp-sidebar-item.rp-sidebar-item--active {
-    --brand: var(--rp-c-brand, #ff351a);
-    // The default theme paints a 15% brand-tinted bg + brand text. Keep the
-    // brand text, but replace the flat tint with the same border-bound
-    // "lifted card" treatment as the SubsiteRow active icon so the two
-    // pieces share a single visual language.
-    background: color-mix(in srgb, var(--brand) 8%, transparent);
-    border-color: color-mix(in srgb, var(--brand) 38%, transparent);
-    box-shadow:
-      0 1px 0 color-mix(in srgb, var(--brand) 10%, transparent),
-      0 4px 10px -2px color-mix(in srgb, var(--brand) 22%, transparent);
-
-    :root.dark & {
-      background: color-mix(in srgb, var(--brand) 12%, transparent);
-      box-shadow:
-        0 1px 0 color-mix(in srgb, var(--brand) 14%, transparent),
-        0 4px 12px -2px color-mix(in srgb, var(--brand) 30%, transparent);
-    }
-  }
-}
-
-// Divider that closes the header section.
-.sidebar-nav-header__divider {
-  margin: 12px 0 4px;
-}
-
 .subsite-icon__logo {
   display: block;
   width: 20px;

--- a/theme/SubsiteRow.scss
+++ b/theme/SubsiteRow.scss
@@ -1,0 +1,78 @@
+// Visual treatment for the SubsiteRow icons.
+//
+// Inactive icons sit transparent and dim. The active icon mirrors the
+// home-features / ChoiceTab card "lifted card" treatment — tinted surface
+// + 1px border + soft shadow — but the border, surface, and shadow all
+// pick up `--rp-c-brand`, which rspress retargets per `data-subsite`
+// on <html>. So:
+//   /guide/...  → active icon reads red  (Lynx brand)
+//   /react/...  → active icon reads blue (ReactLynx brand)
+//   /rspeedy/.. → active icon reads orange
+//   etc.
+//
+// The 1px transparent border on the inactive state prevents layout shift
+// when an icon becomes active.
+
+.subsite-icon {
+  --brand: var(--rp-c-brand, #ff351a);
+
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--rp-c-text-2, #6a6a73);
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease-out,
+    border-color 0.15s ease-out,
+    color 0.15s ease-out,
+    box-shadow 0.15s ease-out;
+
+  &:hover:not(.subsite-icon--active) {
+    color: var(--rp-c-text-1, #111113);
+    background: color-mix(in srgb, currentColor 8%, transparent);
+    border-color: color-mix(in srgb, currentColor 12%, transparent);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--brand);
+    outline-offset: 2px;
+  }
+}
+
+.subsite-icon--active {
+  color: var(--rp-c-text-1, #111113);
+  background: color-mix(in srgb, var(--brand) 8%, transparent);
+  border-color: color-mix(in srgb, var(--brand) 38%, transparent);
+  box-shadow:
+    0 1px 0 color-mix(in srgb, var(--brand) 10%, transparent),
+    0 4px 10px -2px color-mix(in srgb, var(--brand) 22%, transparent);
+
+  // Darker surfaces eat low-opacity tints; nudge the wash and glow up so the
+  // active state stays as confident as it reads in light mode.
+  :root.dark & {
+    background: color-mix(in srgb, var(--brand) 12%, transparent);
+    box-shadow:
+      0 1px 0 color-mix(in srgb, var(--brand) 14%, transparent),
+      0 4px 12px -2px color-mix(in srgb, var(--brand) 30%, transparent);
+  }
+}
+
+.subsite-icon__logo {
+  display: block;
+  width: 20px;
+  height: 20px;
+
+  // Inactive icons read dim; active gets full color.
+  opacity: 0.7;
+
+  .subsite-icon--active &,
+  .subsite-icon:hover & {
+    opacity: 1;
+  }
+}

--- a/theme/SubsiteRow.scss
+++ b/theme/SubsiteRow.scss
@@ -63,6 +63,95 @@
   }
 }
 
+// ─── Get Started CTA ─────────────────────────────────────────────────────
+// Primary action that lives below the icon row. Uses a *different* visual
+// language than the active subsite icon on purpose:
+//   - Icon row: subtle wash (low-opacity brand bg + 38% brand border).
+//     Reads as "you are here."
+//   - CTA: ghost button (transparent bg, full-saturation brand border +
+//     brand text). Reads as "do this next."
+// Same brand color, two clearly distinct weights — secondary identity
+// vs primary action, never the dual-active redundancy of the old design.
+//
+// Hidden when the reader is on the Quick Start page (the icon row's active
+// Lynx already says "you're here"; a CTA back to the same page would be
+// noise).
+
+.quick-start-cta {
+  --brand: var(--rp-c-brand, #ff351a);
+  // Pull the brand toward the active foreground so the text stays readable
+  // even on the lighter brands. 80/20 keeps hue identity (orange reads as
+  // orange, pink as pink) while clearing WCAG AA-large 3:1 across all
+  // four brands and AA-normal 4.5:1 across three. Rspeedy orange is
+  // intrinsically luminous and sits at ~3.3:1 — chasing AA-normal with a
+  // harder mix drifts it into brown/terracotta and loses identity. The
+  // right structural fix is a darker Rspeedy brand token; until then, the
+  // CTA reads AA-large which is acceptable for this button size and
+  // weight.
+  --brand-on-surface: color-mix(in srgb, var(--brand) 80%, var(--rp-c-text-1));
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin: 2px 8px 4px;
+  padding: 7px 12px;
+  border: 1.5px solid var(--brand);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--brand-on-surface);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.005em;
+  text-decoration: none;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease-out,
+    box-shadow 0.15s ease-out,
+    transform 0.12s ease-out;
+
+  &:hover {
+    text-decoration: none;
+    background: color-mix(in srgb, var(--brand) 8%, transparent);
+    box-shadow:
+      0 1px 0 color-mix(in srgb, var(--brand) 14%, transparent),
+      0 4px 10px -2px color-mix(in srgb, var(--brand) 28%, transparent);
+    transform: translateY(-1px);
+  }
+
+  &:active {
+    transform: translateY(0);
+    box-shadow: none;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--brand);
+    outline-offset: 2px;
+  }
+
+  // The ghost border at full saturation can read a bit hot in dark mode
+  // against the near-black surface; ease it back so the CTA still feels
+  // confident but doesn't outshine the active icon.
+  :root.dark & {
+    border-color: color-mix(in srgb, var(--brand) 78%, transparent);
+
+    &:hover {
+      background: color-mix(in srgb, var(--brand) 14%, transparent);
+      border-color: var(--brand);
+    }
+  }
+}
+
+.quick-start-cta__arrow {
+  width: 14px;
+  height: 14px;
+  transition: transform 0.2s ease-out;
+}
+
+.quick-start-cta:hover .quick-start-cta__arrow {
+  transform: translateX(2px);
+}
+
 .subsite-icon__logo {
   display: block;
   width: 20px;

--- a/theme/SubsiteRow.scss
+++ b/theme/SubsiteRow.scss
@@ -1,4 +1,51 @@
-// Visual treatment for the SubsiteRow icons.
+// ─── Scrollable icon rail ────────────────────────────────────────────────
+//
+// As more subsites join the family, the icon row will outgrow the sidebar's
+// natural inner width (sidebar content area = 320px sidebar - 2×20px own
+// padding = 280px; each icon ≈ 36 + 4 gap = 40px, so ~7 icons fit before
+// overflow). The rail handles this by going horizontally scrollable with
+// CSS scroll-snap, so the row never wraps and each icon naturally lands
+// in a readable position.
+//
+// Full-bleed compensation:
+//   The rspress sidebar applies `padding: var(--rp-sidebar-padding, 20px)`
+//   on all sides. The scroll rail uses negative inline margins to extend
+//   PAST that padding, so the scrollable area spans the sidebar's actual
+//   window edges. The rail's own inline padding restores the visible
+//   start/end inset, keeping the first/last icon aligned with menu-item
+//   text alignment when at rest. `scroll-padding-inline` mirrors the same
+//   value so snap points land at the visible content edge, not the
+//   negative-margin edge.
+
+.subsite-row-scroll {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+
+  // Full-bleed: -20px inline margin + 20px inline padding cancels for
+  // resting layout but lets the scroll rail (with overflow-x: auto) run
+  // edge-to-edge across the sidebar window.
+  margin-inline: calc(-1 * var(--rp-sidebar-padding, 20px));
+  padding-inline: var(--rp-sidebar-padding, 20px);
+  padding-block: 8px;
+
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scroll-snap-type: x mandatory;
+  scroll-padding-inline: var(--rp-sidebar-padding, 20px);
+  -webkit-overflow-scrolling: touch;
+
+  // Hide scrollbar — the rail is for navigation, not for scroll affordance.
+  // The user discovers overflow either by horizontal trackpad/touch drag
+  // or by tabbing through the buttons (each focus shifts the scroll
+  // position automatically because the buttons are scroll-snap targets).
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+// ─── Subsite icons ──────────────────────────────────────────────────────
 //
 // Inactive icons sit transparent and dim. The active icon mirrors the
 // home-features / ChoiceTab card "lifted card" treatment — tinted surface
@@ -20,6 +67,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
+  scroll-snap-align: start;
   width: 36px;
   height: 36px;
   border-radius: 8px;
@@ -64,92 +113,273 @@
 }
 
 // ─── Get Started CTA ─────────────────────────────────────────────────────
-// Primary action that lives below the icon row. Uses a *different* visual
-// language than the active subsite icon on purpose:
-//   - Icon row: subtle wash (low-opacity brand bg + 38% brand border).
-//     Reads as "you are here."
-//   - CTA: ghost button (transparent bg, full-saturation brand border +
-//     brand text). Reads as "do this next."
-// Same brand color, two clearly distinct weights — secondary identity
-// vs primary action, never the dual-active redundancy of the old design.
 //
-// Hidden when the reader is on the Quick Start page (the icon row's active
-// Lynx already says "you're here"; a CTA back to the same page would be
-// noise).
+// Sits ABOVE the subsite icon row as the privileged first element of the
+// sidebar. This is the single most-clicked entry on the docs — every
+// Lynx-family journey funnels through Quick Start — so it gets its own
+// visual vocabulary, distinct from menu items.
+//
+//   Specialization (not a menu item):
+//     • Card chrome: subtle base border + faint surface wash, so it
+//       reads as a button at rest, not a link.
+//     • Heavier label typography (14px / 600) than ordinary sidebar text.
+//     • Custom arrow with motion.
+//
+//   Distinctive hover signature:
+//     • Animated GRADIENT BORDER (mask trick — only the 1px outer ring
+//       picks up the sweep). This is the same DNA as the original
+//       SubsiteSwitcher dropdown trigger and exists nowhere else in the
+//       sidebar, so it's the structural tell: "this is THE entry."
+//     • Brand glow + 1px lift + arrow tint/slide on top.
+//
+//   Connection to active Lynx icon (only on Quick Start):
+//     • Solid brand chrome (border + wash) replaces the resting card.
+//     • A 2px brand stem drops from the CTA's bottom edge to the Lynx
+//       icon's top edge below — visually anchoring the pair as one
+//       compound "you're in the Lynx entry" element.
+//
+// Layering (within an isolated stacking context):
+//   .__shine  — animated gradient border ring          absolute, z: 0
+//   .__label / .__arrow — content                      relative, z: 1
+//   .__stem   — 2px downward connector (active only)   below CTA bottom
 
 .quick-start-cta {
   --brand: var(--rp-c-brand, #ff351a);
-  // Pull the brand toward the active foreground so the text stays readable
-  // even on the lighter brands. 80/20 keeps hue identity (orange reads as
-  // orange, pink as pink) while clearing WCAG AA-large 3:1 across all
-  // four brands and AA-normal 4.5:1 across three. Rspeedy orange is
-  // intrinsically luminous and sits at ~3.3:1 — chasing AA-normal with a
-  // harder mix drifts it into brown/terracotta and loses identity. The
-  // right structural fix is a darker Rspeedy brand token; until then, the
-  // CTA reads AA-large which is acceptable for this button size and
-  // weight.
-  --brand-on-surface: color-mix(in srgb, var(--brand) 80%, var(--rp-c-text-1));
 
+  position: relative;
   display: flex;
   align-items: center;
-  justify-content: center;
-  gap: 6px;
-  margin: 2px 8px 4px;
-  padding: 7px 12px;
-  border: 1.5px solid var(--brand);
+  justify-content: space-between;
+  gap: 10px;
+  // Match the rest of the sidebar's vocabulary — rspress's .rp-sidebar-item
+  // uses no horizontal margin, padding: 6px 12px, margin-top: 2px,
+  // border-radius: 8px. Adopting the same geometry keeps the CTA's left
+  // and right edges (and label's left offset) aligned with the menu items
+  // below it. The bottom margin (4px) + icon row's own py-2 (8px) gives
+  // the stem a 12px gap to bridge down to the Lynx icon's top edge.
+  margin: 2px 0 4px;
+  padding: 6px 12px;
+  border: 1px solid color-mix(in srgb, var(--rp-c-text-1) 9%, transparent);
   border-radius: 8px;
-  background: transparent;
-  color: var(--brand-on-surface);
-  font-size: 13px;
-  font-weight: 600;
-  letter-spacing: 0.005em;
+  background: color-mix(in srgb, var(--rp-c-text-1) 2.5%, transparent);
+  color: var(--rp-c-text-1, #111113);
   text-decoration: none;
   cursor: pointer;
+  isolation: isolate;
   transition:
-    background-color 0.15s ease-out,
-    box-shadow 0.15s ease-out,
-    transform 0.12s ease-out;
+    border-color 0.25s ease-out,
+    background-color 0.25s ease-out,
+    box-shadow 0.25s ease-out,
+    transform 0.18s ease-out;
+}
 
-  &:hover {
-    text-decoration: none;
-    background: color-mix(in srgb, var(--brand) 8%, transparent);
-    box-shadow:
-      0 1px 0 color-mix(in srgb, var(--brand) 14%, transparent),
-      0 4px 10px -2px color-mix(in srgb, var(--brand) 28%, transparent);
-    transform: translateY(-1px);
-  }
-
-  &:active {
-    transform: translateY(0);
-    box-shadow: none;
-  }
-
-  &:focus-visible {
-    outline: 2px solid var(--brand);
-    outline-offset: 2px;
-  }
-
-  // The ghost border at full saturation can read a bit hot in dark mode
-  // against the near-black surface; ease it back so the CTA still feels
-  // confident but doesn't outshine the active icon.
-  :root.dark & {
-    border-color: color-mix(in srgb, var(--brand) 78%, transparent);
-
-    &:hover {
-      background: color-mix(in srgb, var(--brand) 14%, transparent);
-      border-color: var(--brand);
-    }
-  }
+.quick-start-cta__label {
+  position: relative;
+  z-index: 1;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  // Match .rp-sidebar-item's line-height (24px), so the CTA's total
+  // height (6 + 24 + 6 = 36px) lines up with the active highlight pill
+  // shown on regular menu items below.
+  line-height: 24px;
+  color: var(--rp-c-text-1, #111113);
 }
 
 .quick-start-cta__arrow {
-  width: 14px;
-  height: 14px;
-  transition: transform 0.2s ease-out;
+  position: relative;
+  z-index: 1;
+  flex-shrink: 0;
+  width: 15px;
+  height: 15px;
+  color: var(--rp-c-text-2, #6a6a73);
+  transition:
+    transform 0.22s ease-out,
+    color 0.22s ease-out;
 }
 
-.quick-start-cta:hover .quick-start-cta__arrow {
-  transform: translateX(2px);
+// ─── Animated gradient border (the structural tell) ──────────────────
+//
+// The mask trick: the pseudo-shine layer is a full rectangle painted with
+// the brand-band gradient, but the mask cuts out the inner content-box,
+// leaving only a 1px outer ring visible. That ring then picks up the
+// horizontal sweep via background-position animation — same DNA as the
+// original SubsiteSwitcher trigger, now structural to this CTA alone.
+
+.quick-start-cta__shine {
+  position: absolute;
+  inset: -1px;
+  z-index: 0;
+  pointer-events: none;
+  border-radius: inherit;
+  padding: 1px;
+  background: linear-gradient(
+    120deg,
+    transparent 0%,
+    transparent 20%,
+    color-mix(in srgb, var(--brand) 70%, transparent) 40%,
+    color-mix(in srgb, var(--brand) 25%, transparent) 50%,
+    color-mix(in srgb, var(--brand) 70%, transparent) 60%,
+    transparent 80%,
+    transparent 100%
+  );
+  background-size: 300% 100%;
+  background-position: 200% 50%;
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  mask-composite: exclude;
+  opacity: 0;
+  transition: opacity 0.3s ease-out;
+}
+
+@keyframes quick-start-cta-shine {
+  0% {
+    background-position: 200% 50%;
+  }
+  100% {
+    background-position: -200% 50%;
+  }
+}
+
+.quick-start-cta:hover {
+  text-decoration: none;
+  border-color: color-mix(in srgb, var(--brand) 30%, transparent);
+  background: color-mix(in srgb, var(--brand) 4%, transparent);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--brand) 8%, transparent),
+    0 6px 18px -6px color-mix(in srgb, var(--brand) 55%, transparent);
+  transform: translateY(-1px);
+
+  .quick-start-cta__shine {
+    opacity: 1;
+    @media (prefers-reduced-motion: no-preference) {
+      animation: quick-start-cta-shine 4.5s linear infinite;
+    }
+  }
+  .quick-start-cta__arrow {
+    color: var(--brand);
+    transform: translateX(3px);
+  }
+}
+
+.quick-start-cta:active {
+  transform: translateY(0);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--brand) 14%, transparent);
+}
+
+.quick-start-cta:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}
+
+// ─── Active state (on /guide/start/quick-start) ──────────────────────
+//
+// The shine is a "wake me up" affordance — once you're on the page we
+// resolve to a steady, solid brand chrome that mirrors the active icon's
+// vocabulary. No animation: this is a settled state.
+
+.quick-start-cta--active {
+  border-color: color-mix(in srgb, var(--brand) 55%, transparent);
+  background: color-mix(in srgb, var(--brand) 9%, transparent);
+  box-shadow: 0 4px 14px -6px color-mix(in srgb, var(--brand) 38%, transparent);
+
+  .quick-start-cta__arrow {
+    color: var(--brand);
+  }
+
+  &:hover {
+    border-color: color-mix(in srgb, var(--brand) 70%, transparent);
+    background: color-mix(in srgb, var(--brand) 13%, transparent);
+    transform: translateY(-1px);
+  }
+}
+
+// ─── The stem ─────────────────────────────────────────────────────────
+//
+// 2px brand line that drops from the CTA's bottom edge into the icon row
+// below, terminating at the Lynx icon's top edge. left:18px positions it
+// at the Lynx icon's horizontal center within the row (the icon row uses
+// px-2 = 8px padding, then a 36px icon; the CTA's own left margin is also
+// 8px, so the row and the CTA share a left edge — the icon center sits
+// at 8 + 18 = 26px from sidebar edge, which is 18px from the CTA's left).
+// The stem visually binds the CTA + Lynx icon into one compound element.
+
+.quick-start-cta__stem {
+  position: absolute;
+  top: calc(100% + 1px);
+  left: 18px;
+  width: 2px;
+  height: 12px;
+  border-radius: 0 0 1px 1px;
+  background: linear-gradient(
+    to bottom,
+    var(--brand) 0%,
+    color-mix(in srgb, var(--brand) 30%, transparent) 100%
+  );
+  pointer-events: none;
+  // Retract upward into the CTA when scrolled — top-center origin makes
+  // the squish-and-fade read as the stem being pulled back into the
+  // card it came from, rather than just dimming in place.
+  transform-origin: top center;
+  transition:
+    opacity 0.2s ease-out,
+    transform 0.25s ease-out;
+}
+
+// When the icon row has scrolled away from start, the Lynx icon is no
+// longer at the stem's anchor position. The literal connection is broken,
+// so retract the stem instead of letting it point at whatever icon now
+// happens to occupy that x-position.
+.quick-start-cta--row-scrolled .quick-start-cta__stem {
+  opacity: 0;
+  transform: scaleY(0.35) translateY(-2px);
+}
+
+// ─── Dark mode ────────────────────────────────────────────────────────
+// Against a near-black surface, the rest border + wash both need a bit
+// more presence to stay legible without bleeding into background noise.
+// The shine peaks read hotter on dark surfaces so we let them push higher.
+
+:root.dark .quick-start-cta {
+  color: var(--rp-c-text-1, #f1f1f3);
+  border-color: color-mix(in srgb, var(--rp-c-text-1) 12%, transparent);
+  background: color-mix(in srgb, var(--rp-c-text-1) 4%, transparent);
+
+  .quick-start-cta__shine {
+    background: linear-gradient(
+      120deg,
+      transparent 0%,
+      transparent 20%,
+      color-mix(in srgb, var(--brand) 85%, transparent) 40%,
+      color-mix(in srgb, var(--brand) 35%, transparent) 50%,
+      color-mix(in srgb, var(--brand) 85%, transparent) 60%,
+      transparent 80%,
+      transparent 100%
+    );
+  }
+
+  &:hover {
+    border-color: color-mix(in srgb, var(--brand) 42%, transparent);
+    background: color-mix(in srgb, var(--brand) 8%, transparent);
+    box-shadow:
+      0 0 0 1px color-mix(in srgb, var(--brand) 14%, transparent),
+      0 6px 22px -6px color-mix(in srgb, var(--brand) 70%, transparent);
+  }
+}
+
+:root.dark .quick-start-cta--active {
+  border-color: color-mix(in srgb, var(--brand) 65%, transparent);
+  background: color-mix(in srgb, var(--brand) 14%, transparent);
+
+  &:hover {
+    border-color: color-mix(in srgb, var(--brand) 80%, transparent);
+    background: color-mix(in srgb, var(--brand) 20%, transparent);
+  }
 }
 
 .subsite-icon__logo {

--- a/theme/SubsiteRow.scss
+++ b/theme/SubsiteRow.scss
@@ -63,6 +63,60 @@
   }
 }
 
+// ─── Sidebar nav header ──────────────────────────────────────────────────
+// Get Started + SubsiteRow form a single header unit. The Get Started link
+// (rendered by rspress's <SidebarList>) inherits the active brand color via
+// `rp-sidebar-item--active`; we re-skin its active state with the same
+// recipe the SubsiteRow active icon uses so the two read as one block.
+// Inactive Get Started stays a plain link.
+
+.sidebar-nav-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-top: 4px;
+
+  // Anchor Get Started's horizontal padding to the SubsiteRow gutter so
+  // their left edges line up.
+  > .rp-sidebar-item {
+    margin: 0 8px;
+    padding-left: 12px;
+    padding-right: 12px;
+    border: 1px solid transparent;
+    border-radius: 8px;
+    font-weight: 500;
+    transition:
+      background-color 0.15s ease-out,
+      border-color 0.15s ease-out,
+      box-shadow 0.15s ease-out;
+  }
+
+  > .rp-sidebar-item.rp-sidebar-item--active {
+    --brand: var(--rp-c-brand, #ff351a);
+    // The default theme paints a 15% brand-tinted bg + brand text. Keep the
+    // brand text, but replace the flat tint with the same border-bound
+    // "lifted card" treatment as the SubsiteRow active icon so the two
+    // pieces share a single visual language.
+    background: color-mix(in srgb, var(--brand) 8%, transparent);
+    border-color: color-mix(in srgb, var(--brand) 38%, transparent);
+    box-shadow:
+      0 1px 0 color-mix(in srgb, var(--brand) 10%, transparent),
+      0 4px 10px -2px color-mix(in srgb, var(--brand) 22%, transparent);
+
+    :root.dark & {
+      background: color-mix(in srgb, var(--brand) 12%, transparent);
+      box-shadow:
+        0 1px 0 color-mix(in srgb, var(--brand) 14%, transparent),
+        0 4px 12px -2px color-mix(in srgb, var(--brand) 30%, transparent);
+    }
+  }
+}
+
+// Divider that closes the header section.
+.sidebar-nav-header__divider {
+  margin: 12px 0 4px;
+}
+
 .subsite-icon__logo {
   display: block;
   width: 20px;

--- a/theme/SubsiteRow.tsx
+++ b/theme/SubsiteRow.tsx
@@ -1,0 +1,117 @@
+import { useLang, useLocation, useNavigate } from '@rspress/core/runtime';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { CORE_SUBSITES, getLangPrefix } from '@site/shared-route-config';
+import type { SubsiteConfig } from '@site/shared-route-config';
+import { cn } from '@/lib/utils';
+
+import { SubsiteLogo } from './subsite-ui';
+
+function findSubsiteFromPathname(
+  pathname: string,
+  lang: string,
+): SubsiteConfig {
+  const langPrefix = getLangPrefix(lang);
+  let path = pathname;
+  if (langPrefix && path.startsWith(`${langPrefix}/`)) {
+    path = path.slice(langPrefix.length + 1);
+  } else if (!langPrefix && path.startsWith('/')) {
+    path = path.slice(1);
+  }
+  if (!path) return CORE_SUBSITES[0];
+  const [firstSegment] = path.split('/');
+  const normalizedSegment = firstSegment.replace(/\.html$/, '');
+  return (
+    CORE_SUBSITES.find((s) => s.value === normalizedSegment) ?? CORE_SUBSITES[0]
+  );
+}
+
+export function SubsiteRow() {
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+  const lang = useLang();
+  const current = findSubsiteFromPathname(pathname, lang);
+
+  return (
+    <TooltipProvider delayDuration={150} skipDelayDuration={0}>
+      <div
+        role="navigation"
+        aria-label="Subsite switcher"
+        className="flex items-center gap-1 px-2 py-2"
+      >
+        {CORE_SUBSITES.map((subsite) => {
+          const isActive = subsite.value === current.value;
+          const description =
+            lang === 'zh' ? subsite.descriptionZh : subsite.description;
+          return (
+            <Tooltip key={subsite.value}>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={() =>
+                    navigate(`${getLangPrefix(lang)}${subsite.url}`)
+                  }
+                  aria-label={subsite.label}
+                  aria-current={isActive ? 'page' : undefined}
+                  className={cn(
+                    'group relative flex h-9 w-9 items-center justify-center rounded-md',
+                    'transition-colors duration-150 ease-out',
+                    'hover:bg-accent/60',
+                    isActive
+                      ? 'text-foreground'
+                      : 'text-foreground/70 hover:text-foreground',
+                  )}
+                >
+                  <span
+                    className={cn(
+                      'block h-5 w-5 transition-opacity duration-150',
+                      isActive
+                        ? 'opacity-100'
+                        : 'opacity-70 group-hover:opacity-100',
+                    )}
+                  >
+                    <SubsiteLogo subsite={subsite} />
+                  </span>
+                  {isActive && (
+                    <span
+                      className="pointer-events-none absolute -bottom-1 left-1/2 h-[2px] w-4 -translate-x-1/2 rounded-full"
+                      style={{
+                        background:
+                          'var(--rp-c-brand, var(--major-brand-color, #ff351a))',
+                      }}
+                      aria-hidden="true"
+                    />
+                  )}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent
+                side="bottom"
+                align="center"
+                sideOffset={10}
+                className="p-0 border bg-popover shadow-md"
+              >
+                <div className="flex items-center gap-3 px-3 py-2 min-w-[160px]">
+                  <div className="relative h-6 w-6 shrink-0">
+                    <SubsiteLogo subsite={subsite} />
+                  </div>
+                  <div className="flex flex-col leading-tight">
+                    <span className="text-sm font-medium text-foreground">
+                      {subsite.label}
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      {description}
+                    </span>
+                  </div>
+                </div>
+              </TooltipContent>
+            </Tooltip>
+          );
+        })}
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/theme/SubsiteRow.tsx
+++ b/theme/SubsiteRow.tsx
@@ -5,7 +5,11 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import { CORE_SUBSITES, getLangPrefix } from '@site/shared-route-config';
+import {
+  CORE_SUBSITES,
+  QUICK_START_PATH,
+  getLangPrefix,
+} from '@site/shared-route-config';
 import type { SubsiteConfig } from '@site/shared-route-config';
 import { cn } from '@/lib/utils';
 
@@ -48,14 +52,17 @@ export function SubsiteRow() {
           const isActive = subsite.value === current.value;
           const description =
             lang === 'zh' ? subsite.descriptionZh : subsite.description;
+          // Lynx is the platform every other subsite is defined relative to,
+          // so its "subsite landing" is the same Quick Start page everyone
+          // gets sent to. The other subsites land on their own intro page.
+          const target =
+            subsite.value === 'guide' ? QUICK_START_PATH : subsite.url;
           return (
             <Tooltip key={subsite.value}>
               <TooltipTrigger asChild>
                 <button
                   type="button"
-                  onClick={() =>
-                    navigate(`${getLangPrefix(lang)}${subsite.url}`)
-                  }
+                  onClick={() => navigate(`${getLangPrefix(lang)}${target}`)}
                   aria-label={subsite.label}
                   aria-current={isActive ? 'page' : undefined}
                   className={cn(

--- a/theme/SubsiteRow.tsx
+++ b/theme/SubsiteRow.tsx
@@ -1,4 +1,5 @@
 import { useLang, useLocation, useNavigate } from '@rspress/core/runtime';
+import { Link } from '@rspress/core/theme';
 import {
   Tooltip,
   TooltipContent,
@@ -40,6 +41,13 @@ export function SubsiteRow() {
   const navigate = useNavigate();
   const lang = useLang();
   const current = findSubsiteFromPathname(pathname, lang);
+  const quickStartHref = `${getLangPrefix(lang)}${QUICK_START_PATH}`;
+  // Hide the "Get Started" CTA when the reader is already on Quick Start.
+  // The Lynx icon's active brand chrome already carries "you're here";
+  // showing a CTA back to the same page on top of that would be noise.
+  const isOnQuickStart = pathname
+    .replace(/\.html$/, '')
+    .endsWith(QUICK_START_PATH);
 
   return (
     <TooltipProvider delayDuration={150} skipDelayDuration={0}>
@@ -99,6 +107,27 @@ export function SubsiteRow() {
           );
         })}
       </div>
+      {!isOnQuickStart && (
+        <Link href={quickStartHref} className="quick-start-cta">
+          <span className="quick-start-cta__label">
+            {lang === 'zh' ? '开始使用' : 'Get Started'}
+          </span>
+          <svg
+            className="quick-start-cta__arrow"
+            viewBox="0 0 16 16"
+            fill="none"
+            aria-hidden="true"
+          >
+            <path
+              d="M3 8h10M9 4l4 4-4 4"
+              stroke="currentColor"
+              strokeWidth="1.75"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </Link>
+      )}
     </TooltipProvider>
   );
 }

--- a/theme/SubsiteRow.tsx
+++ b/theme/SubsiteRow.tsx
@@ -10,6 +10,7 @@ import type { SubsiteConfig } from '@site/shared-route-config';
 import { cn } from '@/lib/utils';
 
 import { SubsiteLogo } from './subsite-ui';
+import './SubsiteRow.scss';
 
 function findSubsiteFromPathname(
   pathname: string,
@@ -58,34 +59,13 @@ export function SubsiteRow() {
                   aria-label={subsite.label}
                   aria-current={isActive ? 'page' : undefined}
                   className={cn(
-                    'group relative flex h-9 w-9 items-center justify-center rounded-md',
-                    'transition-colors duration-150 ease-out',
-                    'hover:bg-accent/60',
-                    isActive
-                      ? 'text-foreground'
-                      : 'text-foreground/70 hover:text-foreground',
+                    'subsite-icon',
+                    isActive && 'subsite-icon--active',
                   )}
                 >
-                  <span
-                    className={cn(
-                      'block h-5 w-5 transition-opacity duration-150',
-                      isActive
-                        ? 'opacity-100'
-                        : 'opacity-70 group-hover:opacity-100',
-                    )}
-                  >
+                  <span className="subsite-icon__logo">
                     <SubsiteLogo subsite={subsite} />
                   </span>
-                  {isActive && (
-                    <span
-                      className="pointer-events-none absolute -bottom-1 left-1/2 h-[2px] w-4 -translate-x-1/2 rounded-full"
-                      style={{
-                        background:
-                          'var(--rp-c-brand, var(--major-brand-color, #ff351a))',
-                      }}
-                      aria-hidden="true"
-                    />
-                  )}
                 </button>
               </TooltipTrigger>
               <TooltipContent

--- a/theme/SubsiteRow.tsx
+++ b/theme/SubsiteRow.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from 'react';
 import { useLang, useLocation, useNavigate } from '@rspress/core/runtime';
 import { Link } from '@rspress/core/theme';
 import {
@@ -42,19 +43,75 @@ export function SubsiteRow() {
   const lang = useLang();
   const current = findSubsiteFromPathname(pathname, lang);
   const quickStartHref = `${getLangPrefix(lang)}${QUICK_START_PATH}`;
-  // Hide the "Get Started" CTA when the reader is already on Quick Start.
-  // The Lynx icon's active brand chrome already carries "you're here";
-  // showing a CTA back to the same page on top of that would be noise.
+  // Quick Start is the single most-clicked entry on the docs — every
+  // Lynx-family journey passes through it — so the CTA stays mounted on
+  // every page, above the subsite icon row. When the reader IS on Quick
+  // Start, it picks up a solid brand wash + a stem dropping down to the
+  // active Lynx icon below, so the pair reads as one compound element.
   const isOnQuickStart = pathname
     .replace(/\.html$/, '')
     .endsWith(QUICK_START_PATH);
 
+  // Track horizontal scroll on the icon row so the stem can retract when
+  // Lynx scrolls off-start. The stem is positioned inside the CTA (above
+  // the scroll container, in a different stacking context), so it can't
+  // follow Lynx visually via overflow — and `overflow-x: auto` implicitly
+  // clips overflow-y, ruling out a vertical stem element inside the row.
+  // Fading on scroll is the honest move: when Lynx isn't at the start
+  // anymore, the connection is broken, so we acknowledge it.
+  const rowRef = useRef<HTMLDivElement>(null);
+  const [isRowScrolled, setIsRowScrolled] = useState(false);
+  useEffect(() => {
+    const el = rowRef.current;
+    if (!el) return;
+    // 4px threshold absorbs subpixel jitter and the natural overscroll
+    // bounce on touchpads — the stem shouldn't blink during a 1px wobble.
+    const onScroll = () => setIsRowScrolled(el.scrollLeft > 4);
+    onScroll();
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, []);
+
   return (
     <TooltipProvider delayDuration={150} skipDelayDuration={0}>
+      <Link
+        href={quickStartHref}
+        aria-current={isOnQuickStart ? 'page' : undefined}
+        className={cn(
+          'quick-start-cta',
+          isOnQuickStart && 'quick-start-cta--active',
+          isOnQuickStart && isRowScrolled && 'quick-start-cta--row-scrolled',
+        )}
+      >
+        {/* Animated gradient border — reused mask trick from the original
+            SubsiteSwitcher dropdown trigger. Lives behind the content. */}
+        <span className="quick-start-cta__shine" aria-hidden="true" />
+        <span className="quick-start-cta__label">
+          {lang === 'zh' ? '开始使用' : 'Get Started'}
+        </span>
+        <svg
+          className="quick-start-cta__arrow"
+          viewBox="0 0 16 16"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M3 8h10M9 4l4 4-4 4"
+            stroke="currentColor"
+            strokeWidth="1.75"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+        {isOnQuickStart && (
+          <span className="quick-start-cta__stem" aria-hidden="true" />
+        )}
+      </Link>
       <div
+        ref={rowRef}
         role="navigation"
         aria-label="Subsite switcher"
-        className="flex items-center gap-1 px-2 py-2"
+        className="subsite-row-scroll"
       >
         {CORE_SUBSITES.map((subsite) => {
           const isActive = subsite.value === current.value;
@@ -107,27 +164,6 @@ export function SubsiteRow() {
           );
         })}
       </div>
-      {!isOnQuickStart && (
-        <Link href={quickStartHref} className="quick-start-cta">
-          <span className="quick-start-cta__label">
-            {lang === 'zh' ? '开始使用' : 'Get Started'}
-          </span>
-          <svg
-            className="quick-start-cta__arrow"
-            viewBox="0 0 16 16"
-            fill="none"
-            aria-hidden="true"
-          >
-            <path
-              d="M3 8h10M9 4l4 4-4 4"
-              stroke="currentColor"
-              strokeWidth="1.75"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-        </Link>
-      )}
     </TooltipProvider>
   );
 }


### PR DESCRIPTION
Replaces the sidebar's subsite-switcher dropdown with a compact horizontal icon row (motion.dev-style), re-skins it and the "Get Started" link as a single brand-themed nav header, and collapses the multi-URL Quick Start indirection that the old dropdown was working around.

The four commits are intentionally stacked so each layer reads cleanly in review. They share one underlying idea: the sidebar header should *show* what subsite you're in (icon row + active brand chrome) and *send* you into the right next step (single Get Started link to the canonical Quick Start) — instead of asking you to drop into a dropdown and pick.

## What changed

### 1. Horizontal subsite icon row (replaces dropdown)
`theme/SubsiteRow.tsx` renders 5 icons in a row, one per `CORE_SUBSITES` entry. Tooltip on hover (shadcn-style `@radix-ui/react-tooltip` — already in the project, no new deps) shows the same logo + label + description the old dropdown showed. Click navigates via `useNavigate`. Saves a click and shows all subsites at once.

### 2. Brand-themed "lifted card" active state (replaces underline)
`theme/SubsiteRow.scss` gives the active icon the same chrome ChoiceTab and the homepage feature cards use — 1px border + 8% surface + soft drop shadow — but every layer runs through `color-mix(... var(--rp-c-brand) ...)`. rspress already retargets `--rp-c-brand` per `data-subsite` on `<html>`, so the active icon retints per subsite for free:

| Page | Active icon |
|---|---|
| `/guide/*` | red `#ff351a` |
| `/react/*` | teal-blue `#1f92b9` |
| `/rspeedy/*` | orange `#ff8b00` |
| `/lynx-ui/*` | pink `#ff1a6e` |

Inactive icons hold a 1px transparent border so promotion to active introduces zero layout shift. `:focus-visible` outline added for keyboard a11y. Dark mode bumps surface 8 → 12% and shadow 22 → 30% so active state survives the darker background.

### 3. Group Get Started + SubsiteRow as one nav header
The divider that `createSharedRouteSidebar` was emitting used to sit *between* Get Started and the SubsiteRow, splitting them visually. Re-wrap them in `.sidebar-nav-header`, filter the divider out of the sidebar data, render one divider *below* the wrapper. Get Started picks up the same `color-mix(var(--rp-c-brand), N%)` recipe as the active icon when it itself is active (i.e. when the reader is on the Quick Start page) — so the two halves now read as one brand-themed unit.

### 4. Collapse Quick Start to one canonical URL
**Triage**: `SHARED_DOC_TITLES` once held 4 cross-subsite docs that the build mapped to virtual `/<subsite>/start/<filename>` routes. Three are gone (integrate folded into ChoiceTabs; tutorials moved to `/learn/*`); only `quick-start` remained, with 5 alternate URLs. A grep of every link in `docs/`, `src/`, `theme/`, and config showed that nothing internal pointed at `/{ai,react,rspeedy,lynx-ui}/start/quick-start` except the two subsite-home heroes and two `AGENTS.md` lines — the rest were ghost routes minted by the plugin loop and referenced by nothing.

**Action**: pinned one canonical `QUICK_START_PATH = '/guide/start/quick-start'`. Lynx is the platform every other subsite is defined relative to (Rspeedy = build tool for Lynx, ReactLynx = React on Lynx), so parking the platform's onboarding doorway under `/guide/` is the honest framing — the page's job is to *send* you into a framework via ChoiceTabs, not to *belong* to one. The new SubsiteRow's "active state shows Lynx on this page" is then correct, not a hack.

Concretely:
- `shared-route-config.ts`: drop `SHARED_DOC_TITLES` / `SHARED_DOC_FILES` / `SHARED_DOC_ROOT`; export single `QUICK_START_PATH`; simplify `createSharedRouteSidebar`.
- `rspress.config.ts`: remove `sharedSidebarPlugin` and `mapNonGuideSharedSectionsToGuide` entirely.
- Subsite home hero CTAs (`/{en,zh}/react/index`, `/{en,zh}/rspeedy/index`): repointed.
- `docs/public/{,zh/}AGENTS.md`: two Rspeedy Quick Start citations repointed.
- `netlify.toml`: 301 redirects from `/{ai,react,rspeedy,lynx-ui}/start/*` (en + zh) → `/guide/start/*` so bookmarks and LLM-cached refs keep resolving.
- `docs/{en,zh}/help/subsite.mdx`: "Shared Documentation" section rewritten to describe the new reality.

## Commits

| | |
|---|---|
| `9857d6f9` | `explore(sidebar): motion.dev-style horizontal subsite icon row` |
| `7d7f479a` | `explore(sidebar): swap underline for brand-themed border treatment` |
| `b2324e93` | `explore(sidebar): group Get Started + SubsiteRow as a brand-themed nav header` |
| `4096e351` | `refactor(quick-start): collapse to one canonical URL under /guide/` |

## Test plan

- [ ] Visit `/guide/start/quick-start` — Get Started and Lynx icon both red-themed lifted cards.
- [ ] Visit `/react/start/quick-start` on the deploy-preview — should 301 to `/guide/start/quick-start`.
- [ ] Visit `/rspeedy/cli` — sidebar Get Started link `href` is `/guide/start/quick-start`, Rspeedy icon active with orange chrome.
- [ ] ReactLynx home (`/react/`) hero "Quick Start" button now goes to `/guide/start/quick-start.html`.
- [ ] Hover each of the 5 subsite icons — tooltip shows logo + label + description.
- [ ] Tab through the icons with keyboard — focus ring visible.
- [ ] Dark-mode pass: header reads correctly across all 5 subsites.

## Known follow-ups (not in this PR)

- Lynx wolf logo has low contrast in dark mode (existing asset issue, surfaces more in the smaller icon row context).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Add SubsiteRow component with horizontal icon row and motion.dev-style brand-themed active state
- Add SubsiteRow styling with lifted card chrome and dark-mode adjustments
- Replace sidebar dropdown subsite selector with SubsiteRow component
- Consolidate shared Quick Start machinery into single canonical path `/guide/start/quick-start`
- Simplify shared-route-config.ts by removing multi-file shared doc routing model
- Remove sharedSidebarPlugin from rspress.config.ts and related imports
- Add Netlify 301 redirects from legacy `/{ai,react,rspeedy,lynx-ui}/start/*` paths to `/guide/start/*` (en and zh)
- Update React and Rspeedy subsite homepages to point Quick Start CTAs to canonical URL
- Update AGENTS.md documentation references to canonical Quick Start path
- Update help documentation to describe Quick Start as the shared cross-subsite entry and document SubsiteRow behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->