### PR TITLE
chore: upgrade pnpm to 11.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,5 +111,5 @@
     "unist-util-visit": "^5.0.0",
     "zhlint": "^0.8.2"
   },
-  "packageManager": "pnpm@9.15.2+sha512.93e57b0126f0df74ce6bff29680394c0ba54ec47246b9cf321f0121d8d9bb03f750a705f24edc3c1180853afd7c2c3b94196d0a3d53d3e069d9e2793ef11f321"
+  "packageManager": "pnpm@11.5.1"
 }

--- a/package.json
+++ b/package.json
@@ -111,5 +111,5 @@
     "unist-util-visit": "^5.0.0",
     "zhlint": "^0.8.2"
   },
-  "packageManager": "pnpm@11.5.1+sha512.93f7b57422ea7068257235b4c16eb60762eb68e1dc23723199cc739043ea9be2c4143274a399d8c6defa2b1176226d9ca1c4b63482d6200c1a8fbaa78c1d1485"
+  "packageManager": "pnpm@11.5.0+sha512.dbfcc4f81cf48597afd4bc391ffdf12c11f1a9fb83a395bfa6b0a2d9cc2fd8ffebafdb1ccbd529632153f793904c2615b7f09fe1a345473fd1c35845172a8eb1"
 }

--- a/package.json
+++ b/package.json
@@ -111,5 +111,5 @@
     "unist-util-visit": "^5.0.0",
     "zhlint": "^0.8.2"
   },
-  "packageManager": "pnpm@11.5.1"
+  "packageManager": "pnpm@11.5.1+sha512.93f7b57422ea7068257235b4c16eb60762eb68e1dc23723199cc739043ea9be2c4143274a399d8c6defa2b1176226d9ca1c4b63482d6200c1a8fbaa78c1d1485"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,3 +8,9 @@ packages:
 minimumReleaseAgeExclude:
   - '@lynx-example/*'
   - '@lynx-js/*'
+
+# pnpm 10+/11 no longer runs dependency build scripts unless allowlisted.
+# Allow the trusted deps that legitimately need a postinstall/build step.
+onlyBuiltDependencies:
+  - core-js
+  - esbuild

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,10 @@
 packages:
   - 'packages/*'
   - 'plugins/*'
+
+# pnpm 11's minimumReleaseAge supply-chain policy rejects very recently published
+# packages. The Lynx example/runtime packages are first-party and published
+# frequently, so exempt our own OSS scopes to avoid blocking fresh releases.
+minimumReleaseAgeExclude:
+  - '@lynx-example/*'
+  - '@lynx-js/*'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,8 +9,8 @@ minimumReleaseAgeExclude:
   - '@lynx-example/*'
   - '@lynx-js/*'
 
-# pnpm 10+/11 no longer runs dependency build scripts unless allowlisted.
-# Allow the trusted deps that legitimately need a postinstall/build step.
-onlyBuiltDependencies:
-  - core-js
-  - esbuild
+# pnpm 11 no longer runs dependency build scripts unless explicitly allowed
+# (else ERR_PNPM_IGNORED_BUILDS). Allow the trusted deps that need a build step.
+allowBuilds:
+  core-js: true
+  esbuild: true


### PR DESCRIPTION
Bumps `packageManager` from `pnpm@9.15.2` to the latest `pnpm@11.5.1`.

### Notes
- pnpm 11 gates **git-hosted dependency prepare scripts** behind `pnpm.onlyBuiltDependencies` (they no longer run automatically), and uses a newer lockfile format.
- If CI installs with `--frozen-lockfile`, the lockfile likely needs regenerating with `pnpm install` on pnpm 11 — opening as **draft** to check CI first.

Draft for review before regenerating the lockfile / rolling out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Upgrade pnpm to 11.5.0 with updated integrity hash and supply-chain policy configurations.

- Upgrade `packageManager` in `package.json` from pnpm@9.15.2 to pnpm@11.5.0 with new SHA512 integrity hash
- Exempt `@lynx-example/*` and `@lynx-js/*` scopes from `minimumReleaseAgeExclude` to prevent supply-chain policy rejection of internal packages
- Allow build scripts for `core-js` and `esbuild` dependencies via `allowBuilds` configuration, as pnpm 10+/11 requires explicit allowlisting (migration from `pnpm.onlyBuiltDependencies`)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->