### PR TITLE
docs(frame): Update frame element docs

### DIFF
--- a/docs/en/api/elements/built-in/frame.mdx
+++ b/docs/en/api/elements/built-in/frame.mdx
@@ -21,8 +21,8 @@ A page element similar to HTML's `<iframe>`, which can embed a Lynx page into th
 
 The following is an example of a main page loading an embedded page via the `<frame>` element.
 
-- The main page passes `initData` and `globalProps` to the embedded page through the `data` and `globalProps` attributes.
-- The main page listens for the embedded page loading status via the `bindload` event.
+- The main page passes `initData` and `globalProps` to the embedded page through the `data` and `global-props` attributes.
+- The main page listens for the embedded page loading status via the `bindload` event, and can use `bindloadmetrics` to receive loading metrics.
 
 ### Main Page
 
@@ -45,8 +45,8 @@ The following is an example of a main page loading an embedded page via the `<fr
 The `<frame>` element was introduced in <VersionBadge v={3.4} />. To use this element, the Lynx dependency version must be upgraded to <VersionBadge v={3.4} /> or higher.
 :::
 
-:::caution
-`<frame>` does not currently support automatic height adjustment. You need to manually set the width and height of the frame.
+:::tip
+Starting from <VersionBadge v={3.8} />, `auto-width` and `auto-height` can make `<frame>` follow the embedded page's content size. If automatic sizing is disabled, or if you are using an earlier version, you still need to manually set the frame width and height. Before the first content size is initialized, <VersionBadge v={3.9} /> and later can use `preset-width` and `preset-height` to set the preset size.
 :::
 
 import APIReference from './frame-API.mdx';

--- a/docs/zh/api/elements/built-in/frame.mdx
+++ b/docs/zh/api/elements/built-in/frame.mdx
@@ -19,10 +19,10 @@ import {
 
 ## 使用指南
 
-以下为主页面通过`<frame>`元素加载 frame 内嵌页面的示例
+以下为主页面通过 `<frame>` 元素加载 frame 内嵌页面的示例
 
-- 主页面通过 `data`,`globalProps` 属性值内嵌页面传递 `initData`,`globalProps` 数据
-- 主页面通过 `bindload` 事件监听内嵌页面加载情况
+- 主页面通过 `data`、`global-props` 属性向内嵌页面传递 `initData`、`globalProps` 数据
+- 主页面通过 `bindload` 事件监听内嵌页面加载情况，也可以通过 `bindloadmetrics` 获取加载指标
 
 ### 主页面
 
@@ -45,8 +45,8 @@ import {
 `<frame>` 元件于 <VersionBadge v={3.4} /> 引入，需要使用该元件的场景，需将依赖的 Lynx 版本升级至 <VersionBadge v={3.4} /> 及以上。
 :::
 
-:::caution
-`<frame>` 暂不支持自动撑高，需要手动设置 frame 的宽高。
+:::tip
+从 <VersionBadge v={3.8} /> 开始，可以通过 `auto-width` 和 `auto-height` 让 `<frame>` 跟随内嵌页面内容尺寸。未开启自动尺寸或低于该版本时，仍需要手动设置 frame 的宽高。首次内容尺寸未初始化前，可在 <VersionBadge v={3.9} /> 及以上通过 `preset-width` 和 `preset-height` 设置预设尺寸。
 :::
 
 import APIReference from './frame-API.mdx';

--- a/packages/lynx-compat-data/elements/frame.json
+++ b/packages/lynx-compat-data/elements/frame.json
@@ -3,6 +3,10 @@
     "frame": {
       "__compat": {
         "description": "frame",
+        "status": {
+          "deprecated": false,
+          "experimental": false
+        },
         "support": {
           "android": {
             "version_added": "3.4"
@@ -33,6 +37,10 @@
       "src": {
         "__compat": {
           "description": "",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": "3.4"
@@ -64,6 +72,10 @@
       "data": {
         "__compat": {
           "description": "",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": "3.4"
@@ -92,15 +104,194 @@
           }
         }
       },
-      "globalProps": {
+      "global-props": {
         "__compat": {
           "description": "",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": "3.6"
             },
             "ios": {
               "version_added": "3.6"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "auto-width": {
+        "__compat": {
+          "description": "",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "3.8"
+            },
+            "ios": {
+              "version_added": "3.8"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "auto-height": {
+        "__compat": {
+          "description": "",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "3.8"
+            },
+            "ios": {
+              "version_added": "3.8"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "preset-width": {
+        "__compat": {
+          "description": "",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "3.9"
+            },
+            "ios": {
+              "version_added": "3.9"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "preset-height": {
+        "__compat": {
+          "description": "",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "3.9"
+            },
+            "ios": {
+              "version_added": "3.9"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "enable-multi-async-thread": {
+        "__compat": {
+          "description": "",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "3.9"
+            },
+            "ios": {
+              "version_added": "3.9"
             },
             "harmony": {
               "version_added": false
@@ -126,12 +317,51 @@
       "bindload": {
         "__compat": {
           "description": "",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": "3.6"
             },
             "ios": {
               "version_added": "3.6"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "bindloadmetrics": {
+        "__compat": {
+          "description": "",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "3.9"
+            },
+            "ios": {
+              "version_added": "3.9"
             },
             "harmony": {
               "version_added": false


### PR DESCRIPTION
## Summary

- Update the Chinese and English `<frame>` docs to reference `global-props`, `bindloadmetrics`, and the newer automatic/preset sizing APIs.
- Update frame compatibility data to use `global-props`, include the new attributes/events, and add schema status fields for frame entries.

## Why

The frame documentation lagged behind the TypeScript definitions in `lynx/js_libraries/types/types/common/element/frame.d.ts`, so newer frame sizing, preset sizing, async-thread, and load-metrics APIs were missing from the visible docs and compatibility data.

## Validation

- `pnpm exec prettier --check docs/zh/api/elements/built-in/frame.mdx docs/en/api/elements/built-in/frame.mdx packages/lynx-compat-data/elements/frame.json`
- `pnpm exec cspell lint -c cspell.json docs/zh/api/elements/built-in/frame.mdx docs/en/api/elements/built-in/frame.mdx`
- `pnpm exec zhlint docs/zh/api/elements/built-in/frame.mdx`
- `pnpm --filter @lynx-js/lynx-compat-data run lint:keys`
- `git diff --check HEAD^`
- `frame.json` single-file schema validation

Note: full `pnpm run check-docs` previously reported pre-existing missing `APISummary` imports in `docs/en/api/elements/built-in/svg.mdx` and `docs/zh/api/elements/built-in/svg.mdx`, unrelated to this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Update frame element API documentation and compatibility data

- Update English and Chinese frame element API documentation to clarify data passing through `data` and `global-props` attributes to embedded pages
- Add documentation for missing frame sizing attributes with version gates: `auto-width` and `auto-height` (v3.8+), `preset-width` and `preset-height` (v3.9+)
- Document `enable-multi-async-thread` attribute for frame elements
- Add `bindloadmetrics` event documentation and its event.detail fields to both language versions
- Update frame compatibility data in `packages/lynx-compat-data/elements/frame.json` to include per-platform version support for new attributes and events
- Normalize compatibility property naming from `globalProps` to `global-props` in compat data
- Add schema status fields to frame compatibility entries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->