### PR TITLE
feat(badge): use Rspress icons for Experimental and Deprecated, dedup on react-compiler

### DIFF
--- a/docs/en/react/react-compiler.mdx
+++ b/docs/en/react/react-compiler.mdx
@@ -4,9 +4,8 @@ description: 'Use React Compiler to auto-optimize components in ReactLynx.'
 ---
 
 import { PackageManagerTabs } from '@theme';
-import { Experimental } from '@lynx';
 
-# React Compiler <Experimental />
+# React Compiler
 
 [React Compiler](https://react.dev/learn/react-compiler) can optimize components at compile time, eliminating the need to manually use `useMemo`, `useCallback`, and `memo`. You can use React Compiler in ReactLynx to enhance your application's performance.
 

--- a/docs/zh/react/react-compiler.mdx
+++ b/docs/zh/react/react-compiler.mdx
@@ -4,9 +4,8 @@ description: '用 React Compiler 自动优化组件。'
 ---
 
 import { PackageManagerTabs } from '@theme';
-import { Experimental } from '@lynx';
 
-# React Compiler <Experimental />
+# React Compiler
 
 [React Compiler](https://react.dev/learn/react-compiler) 可以在编译期对组件进行优化，从而无需手动使用 `useMemo`、`useCallback` 和 `memo`。你可以在 ReactLynx 中使用 React Compiler 来对你的应用性能进行优化。
 

--- a/src/components/api-badge/StatusBadge.tsx
+++ b/src/components/api-badge/StatusBadge.tsx
@@ -1,34 +1,29 @@
-import { Badge } from '@rspress/core/theme';
+import { Badge, Tag } from '@rspress/core/theme';
 
 /**
  * Renders a badge indicating that a feature is deprecated.
- * @param {Object} props - The component props.
- * @param {string} [props.since] - The version since which the feature was deprecated.
- * @returns {JSX.Element} A Badge component with "Deprecated" text.
- * @example
- * // Render a deprecated badge without version
- * <Deprecated />
  *
- * // Render a deprecated badge with version
- * <Deprecated since="2.0.0" />
+ * Delegates to Rspress's built-in `Tag` so the badge picks up Rspress's
+ * deprecated icon and stays in lockstep with the frontmatter
+ * `tag: deprecated` rendering.
+ * @example
+ * <Deprecated />
  */
-export function Deprecated({ since }: { since?: string }) {
-  return (
-    <Badge
-      text={since ? `Deprecated in ${since}` : 'Deprecated'}
-      type="danger"
-    />
-  );
+export function Deprecated() {
+  return <Tag tag="deprecated" />;
 }
 
 /**
  * Renders a badge indicating that a feature is experimental.
- * @returns {JSX.Element} A Badge component with "Experimental" text.
+ *
+ * Delegates to Rspress's built-in `Tag` so the badge picks up the
+ * Rspress experimental flask icon and stays in lockstep with the
+ * frontmatter `tag: experimental` rendering.
  * @example
  * <Experimental />
  */
 export function Experimental() {
-  return <Badge text={'Experimental'} type="warning" />;
+  return <Tag tag="experimental" />;
 }
 
 /**


### PR DESCRIPTION
## Summary

Two related changes to make the experimental/deprecated badges consistent across the site.

### 1. `<Experimental />` and `<Deprecated />` now use Rspress's `Tag`

`src/components/api-badge/StatusBadge.tsx` previously rendered raw `<Badge text="..." type="...">` chips with no icon. Rspress's built-in `<Tag>` already renders "experimental" and "deprecated" with the flask / deprecated icon and is what fires when you set `tag: experimental` in frontmatter. Delegating our wrappers to `<Tag>` means every inline `<Experimental />` and `<Deprecated />` picks up the same icons for free, and the chip looks identical whether the marker came from frontmatter or from MDX.

Side effect: the label lowercases ("experimental", "deprecated") to match Rspress's convention. The unused `since` prop on `<Deprecated />` is dropped (zero call sites in docs).

### 2. Drop the duplicated badge on react-compiler

`docs/{en,zh}/react/react-compiler.mdx` had both `tag: experimental` frontmatter AND an inline `<Experimental />` on the H1, so the heading was rendering two chips side-by-side. Removed the inline component and its import — the frontmatter tag alone covers heading + sidebar.

## What this does NOT change

`<Experimental />` stays exported and is still used inline by:
- `docs/{en,zh}/blog/lynx-3-5.mdx` — section-level annotation on a release-notes section
- `docs/{en,zh}/help/components.mdx`, `docs/zh/internal/docs-contribution-guide/doc-components.mdx` — demo / reference uses

Those are not page-level experimental markers, so frontmatter would be wrong for them. They still work and now render with the Rspress icon.

## Test plan

- [ ] Netlify deploy preview: `/react/react-compiler` (en + zh) shows one experimental chip in the H1 area and one in the sidebar nav
- [ ] Every inline `<Experimental />` and `<Deprecated />` on other pages renders with the Rspress flask / deprecated icon
- [ ] Sidebar still shows the flask next to "React Compiler"