### PR TITLE
docs: replace erroneous `<x-webview>` with `<webview>` in webview docs

### DIFF
--- a/docs/en/api/elements/built-in/webview.mdx
+++ b/docs/en/api/elements/built-in/webview.mdx
@@ -23,9 +23,9 @@ Used to embed web pages in Lynx, providing a flexible way to integrate existing 
 - `<webview>` acts as a viewport on the element side and must have a fixed width.
 - `<webview>` acts as a viewport on the element side and requires a fixed height.
 - After the web resource finishes rendering, use `document.getElementById` to obtain its height, then notify `<webview>` to adjust the height via message.
-- Unless `<x-webview native-interaction-enabled={false} />` is set, interaction events of `<webview>` cannot pass through to other elements.
+- Unless `native-interaction-enabled={false}` is set on `<webview />`, interaction events of `<webview>` cannot pass through to other elements.
 - `<webview>` cannot be nested with other scrollable elements; if needed, wrap it with `<scroll-view>`.
-- To intercept click events, manually add `<x-webview catchtap={() => {}} />`.
+- To intercept click events, manually add `catchtap={() => {}}` to `<webview />`.
 
 ## Usage
 

--- a/docs/zh/api/elements/built-in/webview.mdx
+++ b/docs/zh/api/elements/built-in/webview.mdx
@@ -22,9 +22,9 @@ import {
 - `<webview>` 在元素侧作为视口，必须有确定的宽度。
 - `<webview>` 在元素侧作为视口，必须有确定的高度。
 - Web 资源渲染完成后，可使用 `document.getElementById` 获取自身高度，通过 message 通知 `<webview>` 修改高度。
-- 除非设置了 `<x-webview native-interaction-enabled={false} />`，否则 `<webview>` 的交互事件无法穿透到其他元素。
+- 除非在 `<webview />` 上设置 `native-interaction-enabled={false}`，否则 `<webview>` 的交互事件无法穿透到其他元素。
 - `<webview>` 不能与其他可滚动元素嵌套使用，如有需要请使用 `<scroll-view>` 进行包裹。
-- 若需拦截点击事件，需手动添加 `<x-webview catchtap={() => {}} />`。
+- 若需拦截点击事件，需在 `<webview />` 上手动添加 `catchtap={() => {}}`。
 
 ## 使用指南
 


### PR DESCRIPTION
### Motivation
- Correct mistaken examples that used the non-existent `<x-webview>` tag so documentation reflects the actual `<webview>` element usage and attributes.

### Description
- Replaced `<x-webview native-interaction-enabled={false} />` with `<webview native-interaction-enabled={false} />` in `docs/en/api/elements/built-in/webview.mdx` and `docs/zh/api/elements/built-in/webview.mdx`.
- Replaced `<x-webview catchtap={() => {}} />` with `<webview catchtap={() => {}} />` in the same two MDX files.
- Created a PR with the updated MDX files; an unrelated local modification to `packages/lynx-compat-data/api-stats.json` was observed but not staged or included in this change.

### Testing
- Ran `pnpm exec prettier --check docs/en/api/elements/built-in/webview.mdx docs/zh/api/elements/built-in/webview.mdx` and it passed.
- Ran `pnpm exec cspell lint -c cspell.json docs/en/api/elements/built-in/webview.mdx docs/zh/api/elements/built-in/webview.mdx --no-must-find-files` and it passed.
- Commit hooks ran `prettier --write`, `cspell lint`, `node scripts/ci/check-api-summary.mjs`, and `node scripts/ci/check-asset-urls.mjs` on the staged files and all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2270b921588331885022eb8366df75)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Replace `<x-webview>` with `<webview>` in webview API documentation

- Replace erroneous `<x-webview>` tag references with the correct `<webview>` element in docs/en/api/elements/built-in/webview.mdx
- Replace erroneous `<x-webview>` tag references with the correct `<webview>` element in docs/zh/api/elements/built-in/webview.mdx
<!-- end of auto-generated comment: release notes by coderabbit.ai -->