### PR TITLE
docs: complete frame API reference

### DIFF
--- a/docs/en/api/elements/built-in/frame-API.mdx
+++ b/docs/en/api/elements/built-in/frame-API.mdx
@@ -38,6 +38,18 @@ data?: Record<string, unknown>;
 Passes data to the nested Lynx page within the frame.
 
 
+### `enable-multi-async-thread`
+
+ <AndroidOnly /> <IOSOnly /> <VersionBadge>3.9</VersionBadge>
+
+```tsx
+// @defaultValue: false
+'enable-multi-async-thread'?: boolean;
+```
+
+Overrides whether the embedded Lynx page uses multiple asynchronous threads. When omitted, the frame inherits the host setting.
+
+
 ### `global-props`
 
  <AndroidOnly /> <IOSOnly /> <VersionBadge>3.6</VersionBadge>
@@ -51,6 +63,28 @@ Passes
  to the Lynx page embedded in the frame. The embedded page can read it via 
 `lynx.__globalProps`
 .
+
+
+### `preset-height`
+
+ <AndroidOnly /> <IOSOnly /> <VersionBadge>3.9</VersionBadge>
+
+```tsx
+'preset-height'?: `${number}px` | `${number}rpx`;
+```
+
+Sets the preset height used before the embedded Lynx page receives an initialized content rect.
+
+
+### `preset-width`
+
+ <AndroidOnly /> <IOSOnly /> <VersionBadge>3.9</VersionBadge>
+
+```tsx
+'preset-width'?: `${number}px` | `${number}rpx`;
+```
+
+Sets the preset width used before the embedded Lynx page receives an initialized content rect.
 
 
 ### `src`
@@ -84,3 +118,19 @@ bindload = (e: FrameLoadEvent) => {};
 
 Bind frame load event callback.
 
+
+### `bindloadmetrics`
+ <AndroidOnly /> <IOSOnly /> <VersionBadge>3.9</VersionBadge>
+
+```tsx
+bindloadmetrics = (e: FrameLoadMetricsEvent) => {};
+```
+
+| Field | Type | Optional | Default | Platforms | Since | Description |
+| --- | --- | --- | --- | --- | --- | --- |
+| entry | FrameLoadMetricsEntry | No | – |  <AndroidOnly /> <IOSOnly /> <VersionBadge>3.9</VersionBadge> | 3.9 | The raw `loadBundle` performance entry emitted by the embedded Lynx page. |
+| mode | string | No | – |  <AndroidOnly /> <IOSOnly /> <VersionBadge>3.9</VersionBadge> | 3.9 | The frame loading mode. |
+| url | string | No | – |  <AndroidOnly /> <IOSOnly /> <VersionBadge>3.9</VersionBadge> | 3.9 | The loaded url of the frame. |
+
+
+Bind frame load metrics event callback.

--- a/docs/zh/api/elements/built-in/frame-API.mdx
+++ b/docs/zh/api/elements/built-in/frame-API.mdx
@@ -35,6 +35,17 @@ data?: Record<string, unknown>;
 
 将数据传递给框架内嵌套的 Lynx 页面。
 
+### `enable-multi-async-thread`
+
+ <AndroidOnly /> <IOSOnly /> <VersionBadge>3.9</VersionBadge>
+
+```tsx
+// @默认值: false
+'enable-multi-async-thread'?: boolean;
+```
+
+覆盖内嵌 Lynx 页面是否使用多个异步线程。未设置时，frame 会继承宿主页面的配置。
+
 ### `global-props`
 
  <AndroidOnly /> <IOSOnly /> <VersionBadge>3.6</VersionBadge>
@@ -48,6 +59,26 @@ data?: Record<string, unknown>;
  传递给框架中嵌入的 Lynx 页面。嵌入的页面可以通过 
 `lynx.__globalProps`
  读取它。
+
+### `preset-height`
+
+ <AndroidOnly /> <IOSOnly /> <VersionBadge>3.9</VersionBadge>
+
+```tsx
+'preset-height'?: `${number}px` | `${number}rpx`;
+```
+
+设置内嵌 Lynx 页面收到初始化内容区域前使用的预设高度。
+
+### `preset-width`
+
+ <AndroidOnly /> <IOSOnly /> <VersionBadge>3.9</VersionBadge>
+
+```tsx
+'preset-width'?: `${number}px` | `${number}rpx`;
+```
+
+设置内嵌 Lynx 页面收到初始化内容区域前使用的预设宽度。
 
 ### `src`
 
@@ -78,3 +109,17 @@ bindload = (e: FrameLoadEvent) => {};
 
 绑定框架加载事件回调。
 
+### `bindloadmetrics`
+ <AndroidOnly /> <IOSOnly /> <VersionBadge>3.9</VersionBadge>
+
+```tsx
+bindloadmetrics = (e: FrameLoadMetricsEvent) => {};
+```
+
+| 字段 | 类型 | 是否可选 | 默认值 | 平台 | 版本 | 描述 |
+| --- | --- | --- | --- | --- | --- | --- |
+| entry | FrameLoadMetricsEntry | 否 | – |  <AndroidOnly /> <IOSOnly /> <VersionBadge>3.9</VersionBadge> | 3.9 | 内嵌 Lynx 页面发出的原始 `loadBundle` 性能条目。 |
+| mode | 字符串 | 否 | – |  <AndroidOnly /> <IOSOnly /> <VersionBadge>3.9</VersionBadge> | 3.9 | frame 的加载模式。 |
+| url | 字符串 | 否 | – |  <AndroidOnly /> <IOSOnly /> <VersionBadge>3.9</VersionBadge> | 3.9 | frame 加载的 URL。 |
+
+绑定 frame 加载指标事件回调。


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Add frame API documentation for async threading and layout configuration attributes

Document new frame element attributes and event binding:
- Add `enable-multi-async-thread` boolean attribute to control multiple async thread usage in embedded Lynx pages
- Add `preset-height` and `preset-width` layout attributes for specifying dimensions prior to content initialization
- Add `bindloadmetrics` event binding with `FrameLoadMetricsEvent` signature for performance/load metrics tracking

Update documentation in both English and Chinese language versions to reflect frame API enhancements introduced in version 3.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->