### PR TITLE
[codex] disable Rsbuild file size report

### DIFF
--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -2,7 +2,6 @@ import { pluginLLMsPostprocess } from '@lynx-js/rspress-plugin-llms-postprocess'
 import { pluginLess } from '@rsbuild/plugin-less';
 import { pluginSass } from '@rsbuild/plugin-sass';
 import { pluginSvgr } from '@rsbuild/plugin-svgr';
-import type { RspressPlugin } from '@rspress/core';
 import { defineConfig } from '@rspress/core';
 import { transformerCompatibleMetaHighlight } from '@rspress/core/shiki-transformers';
 import { pluginAlgolia } from '@rspress/plugin-algolia';
@@ -53,6 +52,7 @@ export default defineConfig({
       printFileSize: false,
     },
     plugins: [
+      rsbuildPluginDisableFileSizeReport(),
       pluginGoogleAnalytics({ id: 'G-WGP37JWP9M' }),
       // Open Graph / Twitter Card meta is injected per-page by the theme
       // (theme/OgHead.tsx) so each route gets its build-time OG image and
@@ -244,6 +244,31 @@ export default defineConfig({
   },
   llms: !IS_LIGHTWEIGHT_BUILD,
 });
+
+function rsbuildPluginDisableFileSizeReport() {
+  return {
+    name: 'disable-file-size-report',
+    setup(api: RsbuildPluginApi) {
+      api.modifyEnvironmentConfig((config) => {
+        config.performance ??= {};
+        config.performance.printFileSize = false;
+        return config;
+      });
+    },
+  };
+}
+
+type RsbuildEnvironmentConfig = {
+  performance?: {
+    printFileSize?: boolean;
+  };
+};
+
+type RsbuildPluginApi = {
+  modifyEnvironmentConfig: (
+    modify: (config: RsbuildEnvironmentConfig) => RsbuildEnvironmentConfig,
+  ) => void;
+};
 
 function remarkReplaceVersionJsonPlaceholders() {
   const replacements: Array<[string, string]> = [


### PR DESCRIPTION
## Summary
- Disable Rsbuild file-size reporting across Rspress-created build environments.
- Preserve full API SSG while avoiding the late-build asset scan/gzip memory spike.
- Remove the now-unused RspressPlugin type import.

## Root Cause
Rspress creates multiple Rsbuild environments. The existing top-level `performance.printFileSize = false` did not suppress file-size reporting in those environment configs, so Rsbuild still walked and gzipped the emitted assets. With the full docs build, that includes about 1.1 GB of API HTML and can spike memory near the end of the build.

## Validation
- `CONTEXT=deploy-preview RSPRESS_LIGHTWEIGHT_BUILD=true NODE_OPTIONS=--max-old-space-size=3072 RSPRESS_SSG_WORKER_THREAD_COUNT=1 pnpm gen:og && pnpm exec rspress build`
  - passed, 3308 API HTML files emitted, peak RSS 5352374272 bytes, doc_build 1.4G
- `NODE_OPTIONS=--max-old-space-size=3072 RSPRESS_SSG_WORKER_THREAD_COUNT=1 pnpm gen:og && pnpm exec rspress build`
  - passed, 3308 API HTML files emitted, peak RSS 6370148352 bytes, doc_build 1.5G
- `pnpm exec prettier --check rspress.config.ts`
- `git diff --check -- rspress.config.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Introduce custom Rsbuild plugin to disable file-size reporting across all environments
- Add `rsbuildPluginDisableFileSizeReport()` function that configures each Rsbuild environment to skip file-size reporting, preventing late-build asset scanning and gzip processing
- Include the new plugin in the builder configuration plugins list
- Remove unused `RspressPlugin` type import from `@rspress/core`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->