### PR TITLE
feat(theme): refine Copy Markdown / view-options buttons

### DIFF
--- a/theme/index.scss
+++ b/theme/index.scss
@@ -4,6 +4,7 @@
 @use './home-layout-var';
 @use './hero-text';
 @use './semi';
+@use './llms-button';
 
 .rspress-doc {
   @include external-links.external-links;

--- a/theme/llms-button.scss
+++ b/theme/llms-button.scss
@@ -1,0 +1,168 @@
+// ─── LLM tool buttons (Copy Markdown + view-options trigger) ──────────────
+//
+// Rspress ships `.rp-llms-button` (Copy Markdown) and
+// `.rp-llms-view-options__trigger` (caret) as 36px-tall pills with the
+// generic divider-light border + plain bg + ambient shadow on hover.
+// On a doc page that lands right under the H1, and on the blog page where
+// the surrounding type scale is small, they feel oversized and templated.
+//
+// Restyle them as a sibling of the SubsiteRow icon rail:
+//   • 30px geometry (~83% of the original), 7px radius matches subsite-icon
+//   • color-mix tints sourced from `--rp-c-text-1` and `--rp-c-brand` so
+//     the family rides whatever subsite theme is active
+//   • caret becomes a square 30×30 dim icon button (subsite-icon vocab)
+//   • container gap 8 → 4, so the pair reads as one compound object
+//   • the success state stays green for unambiguous feedback, but slim
+//
+// Specificity notes: rspress uses `.rp-llms-copy-button--success.rp-llms-copy-button`
+// for the success treatment, so the same chained form is used here to win.
+
+.rp-llms-container {
+  gap: 4px;
+}
+
+.rp-llms-button {
+  height: 30px;
+  padding: 0 10px;
+  gap: 5px;
+
+  border-radius: 7px;
+  border: 1px solid color-mix(in srgb, var(--rp-c-text-1) 9%, transparent);
+  background: color-mix(in srgb, var(--rp-c-text-1) 2.5%, transparent);
+  color: var(--rp-c-text-2);
+
+  font-size: 12.5px;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+
+  // Tighter, springier ease — matches the subsite-icon rail's 0.15s out
+  transition:
+    background-color 0.18s ease-out,
+    border-color 0.18s ease-out,
+    color 0.18s ease-out,
+    box-shadow 0.2s ease-out,
+    transform 0.15s ease-out;
+
+  &:hover {
+    color: var(--rp-c-text-1);
+    border-color: color-mix(in srgb, var(--rp-c-brand) 28%, transparent);
+    background: color-mix(in srgb, var(--rp-c-brand) 4%, transparent);
+    // Replace the generic ambient shadow with a brand-tinted glow —
+    // same DNA as `.subsite-icon--active`'s lifted-card treatment.
+    box-shadow:
+      0 1px 0 color-mix(in srgb, var(--rp-c-brand) 6%, transparent),
+      0 4px 10px -3px color-mix(in srgb, var(--rp-c-brand) 22%, transparent);
+  }
+
+  &:active {
+    background: color-mix(in srgb, var(--rp-c-brand) 7%, transparent);
+    box-shadow: none;
+    transform: translateY(0.5px);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--rp-c-brand);
+    outline-offset: 2px;
+  }
+}
+
+// Icon wrappers + svg ride down to 14px to keep optical balance with the
+// 12.5px label and the tighter 30px chrome.
+.rp-llms-copy-button__icon-wrapper,
+.rp-llms-copy-button__icon-copy,
+.rp-llms-copy-button__icon-success {
+  width: 14px;
+  height: 14px;
+}
+
+// Caret trigger: a square icon-button (no label), mirroring `.subsite-icon`
+.rp-llms-view-options__trigger {
+  width: 30px;
+  padding: 0;
+  justify-content: center;
+
+  // The arrow svg sits at 16px in the rspress default — bring it down so
+  // the caret reads as a dim affordance, not a chunky chevron.
+  .rp-llms-view-options__arrow {
+    width: 13px;
+    height: 13px;
+  }
+
+  &--active {
+    color: var(--rp-c-text-1);
+    border-color: color-mix(in srgb, var(--rp-c-brand) 32%, transparent);
+    background: color-mix(in srgb, var(--rp-c-brand) 6%, transparent);
+  }
+}
+
+// Success state: keep the green semantic but with the new slim chrome.
+// The chained class form matches rspress's own specificity.
+.rp-llms-copy-button--success.rp-llms-copy-button {
+  color: var(--rp-c-green-1, #10b981);
+  border-color: color-mix(
+    in srgb,
+    var(--rp-c-green-1, #10b981) 38%,
+    transparent
+  );
+  background: color-mix(in srgb, var(--rp-c-green-1, #10b981) 6%, transparent);
+  box-shadow: none;
+}
+
+// ─── Dropdown menu refinements ────────────────────────────────────────────
+//
+// Tighten the menu to match the new trigger size: narrower min-width, a
+// tighter offset under the caret, and a brand-aware hover state on items
+// so the menu reads as part of the same family, not a generic popover.
+
+.rp-llms-view-options__menu {
+  min-width: 200px;
+  top: calc(100% + 5px);
+  padding: 5px;
+  border-radius: 9px;
+  border-color: color-mix(in srgb, var(--rp-c-text-1) 10%, transparent);
+}
+
+.rp-llms-view-options__menu-item {
+  padding: 7px 9px;
+  font-size: 13px;
+  border-radius: 6px;
+
+  &:hover {
+    color: var(--rp-c-brand);
+    background: color-mix(in srgb, var(--rp-c-brand) 7%, transparent);
+  }
+
+  &:active {
+    background: color-mix(in srgb, var(--rp-c-brand) 11%, transparent);
+  }
+}
+
+// External-link affordance — dim it; it's a signal, not a button.
+.rp-llms-view-options__external-icon {
+  opacity: 0.5;
+  width: 13px;
+  height: 13px;
+}
+
+// ─── Dark mode ───────────────────────────────────────────────────────────
+// On a near-black surface the rest border + wash both need a bit more
+// presence to read; mirrors the SubsiteRow dark-mode bump.
+
+:root.dark {
+  .rp-llms-button {
+    border-color: color-mix(in srgb, var(--rp-c-text-1) 14%, transparent);
+    background: color-mix(in srgb, var(--rp-c-text-1) 4%, transparent);
+
+    &:hover {
+      border-color: color-mix(in srgb, var(--rp-c-brand) 42%, transparent);
+      background: color-mix(in srgb, var(--rp-c-brand) 8%, transparent);
+      box-shadow:
+        0 1px 0 color-mix(in srgb, var(--rp-c-brand) 10%, transparent),
+        0 4px 12px -3px color-mix(in srgb, var(--rp-c-brand) 32%, transparent);
+    }
+  }
+
+  .rp-llms-view-options__menu {
+    border-color: color-mix(in srgb, var(--rp-c-text-1) 16%, transparent);
+  }
+}

--- a/theme/llms-button.scss
+++ b/theme/llms-button.scss
@@ -147,8 +147,12 @@
 // ─── Dark mode ───────────────────────────────────────────────────────────
 // On a near-black surface the rest border + wash both need a bit more
 // presence to read; mirrors the SubsiteRow dark-mode bump.
+//
+// `:where(.dark, .rp-dark)` is the defensive pattern documented in
+// `tailwind.config.js`: rspress may apply either class on `<html>`
+// depending on the theme pipeline.
 
-:root.dark {
+:root:where(.dark, .rp-dark) {
   .rp-llms-button {
     border-color: color-mix(in srgb, var(--rp-c-text-1) 14%, transparent);
     background: color-mix(in srgb, var(--rp-c-text-1) 4%, transparent);


### PR DESCRIPTION
## Summary

Restyle rspress's auto-injected `.rp-llms-*` button family — **Copy Markdown** + the **view-options caret** — to feel like a sibling of the SubsiteRow icon rail instead of a generic 36px CTA pill. Most visible on the blog header, where the original buttons dominated the slim author row and date.

### Before / after

| | Before | After |
|---|---|---|
| Height | 36px | 30px |
| Radius | 8px | 7px (matches `.subsite-icon`) |
| Font | 14px / 500 | 12.5px / 500 / -0.005em tracking |
| Icon | 16px | 14px |
| Container gap | 8px | 4px (reads as one compound object) |
| Caret button | 36×36 with chunky chevron | 30×30 dim icon button |
| Hover | generic ambient shadow | brand-tinted glow (`--rp-c-brand` color-mix) |

### Design notes

- **Color-mix tints sourced from `--rp-c-text-1` and `--rp-c-brand`** — so the button family rides whatever subsite theme is active. Hover on `/react/...` reads blue, `/rspeedy/...` reads orange, etc.
- **Caret becomes a square 30×30 dim icon button**, mirroring `.subsite-icon`'s vocabulary. The two now read as a coordinated pair, not two unrelated pills.
- **Dropdown menu**: tighter padding, 9px radius, brand-aware item hover. External-link affordance dimmed — it's a signal, not a button.
- **Dark-mode pass** mirrors the SubsiteRow's confidence bump on near-black surfaces.

Specificity matches rspress's own (chained-class form for `--success`).

## Test plan

- [ ] Visit a blog post (`/zh/blog/lynx-3-8`) — the Copy Markdown + caret pair sits comfortably under the author avatars
- [ ] Visit a regular doc page — buttons feel tucked, not dominant
- [ ] Hover the Copy Markdown button — brand-tinted border + faint wash + soft lift; arrow color picks up on the caret variant
- [ ] Click Copy Markdown — success state stays green for clear semantic feedback
- [ ] Open the caret dropdown — tighter menu, item hover picks up brand tint, external-link arrow dimmed
- [ ] Switch subsite (`/react/`, `/rspeedy/`) — hover color picks up the subsite's brand on each
- [ ] Toggle dark mode — borders/wash stay legible without bleeding into background

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Refine Copy Markdown and view-options buttons to match SubsiteRow icon rail styling

- Add llms-button.scss module to restyle Rspress LLMS tool buttons to align with SubsiteRow design language
- Reduce button height from 36px to 30px and set border-radius to 7px to match .subsite-icon
- Decrease font size to 12.5px/500 with -0.005em tracking
- Reduce icon size from 16px to 14px and constrain icon wrappers to 14×14
- Tighten container gap from 8px to 4px for denser spacing
- Convert view-options caret into a 30×30 dim square icon button with adjusted arrow sizing and active state
- Apply brand-aware color-mix hover/active/focus treatments using --rp-c-text-1 and --rp-c-brand, including a subtle brand-tinted glow
- Update .rp-llms-copy-button--success to use slim green chrome via color-mix and remove success box-shadow
- Refine view-options dropdown: adjust min-width, top offset, padding, 9px border-radius, border color, and tighter menu-item padding/typography
- Add brand-tinted hover/active backgrounds for menu items and dim the external-link icon to 13×13 with reduced opacity
- Mirror SubsiteRow adjustments in dark mode using :root:where(.dark, .rp-dark) to ensure consistent dark-theme styling
- Import llms-button into theme/index.scss
<!-- end of auto-generated comment: release notes by coderabbit.ai -->