### PR TITLE
feat(NextSteps): refine Step card chrome and hover affordance

### DIFF
--- a/src/components/NextSteps/Step.module.scss
+++ b/src/components/NextSteps/Step.module.scss
@@ -114,8 +114,12 @@
 // ─── Dark mode ───────────────────────────────────────────────────────
 // Mirrors the SubsiteRow/Quick-Start-CTA pattern: bump the rest border +
 // wash and let the hover glow push harder against a near-black surface.
+//
+// `:where(.dark, .rp-dark)` is the defensive pattern documented in
+// `tailwind.config.js`: rspress may apply either class on `<html>`
+// depending on the theme pipeline.
 
-:root.dark {
+:root:where(.dark, .rp-dark) {
   .step {
     border-color: color-mix(in srgb, var(--rp-c-text-1) 12%, transparent);
     background: color-mix(in srgb, var(--rp-c-text-1) 4%, transparent);

--- a/src/components/NextSteps/Step.module.scss
+++ b/src/components/NextSteps/Step.module.scss
@@ -1,33 +1,131 @@
+// NextSteps Step — refined "next step" card.
+//
+// The old chrome was a flat gray block with the border the same color as
+// the surface (invisible until hover) and a blue link title. That reads
+// as a bland, templated card with a title competing with itself for
+// "clickability." Restyle it as a sibling of `.choice-tabs__card` and
+// the `.quick-start-cta`: color-mix tints from `--rp-c-text-1`, a soft
+// brand-aware hover with a lifted-card shadow, and a single arrow
+// affordance that owns the "this card is interactive" signal.
+//
+// Geometry borrowed from ChoiceTabs (18px/22px padding, 12px radius) so
+// the two card families read as the same vocabulary.
+
 .step {
-  border: 1px solid var(--rp-c-bg-soft);
-  background-color: var(--rp-c-bg-soft);
-  transition:
-    color 0.5s,
-    background-color 0.5s;
-  padding: 28px 36px;
-  border-radius: 8px;
+  --brand: var(--rp-c-brand);
+
+  position: relative;
+  display: block;
   flex: auto;
   width: 15rem;
-  font-size: 14px;
-  font-weight: 500;
+  padding: 18px 22px;
+  border: 1px solid color-mix(in srgb, var(--rp-c-text-1) 8%, transparent);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--rp-c-text-1) 2%, transparent);
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+  overflow: hidden;
+  isolation: isolate;
 
-  &:hover {
-    border-color: var(--rp-c-brand);
-    transition: border-color 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+  transition:
+    border-color 0.25s ease-out,
+    background-color 0.25s ease-out,
+    box-shadow 0.25s ease-out,
+    transform 0.18s ease-out;
+
+  &:hover,
+  &:hover:visited {
+    text-decoration: none;
+    border-color: color-mix(in srgb, var(--brand) 30%, transparent);
+    background: color-mix(in srgb, var(--brand) 4%, transparent);
+    // Brand-tinted lifted-card shadow — same DNA as `.subsite-icon--active`
+    // and `.quick-start-cta:hover`.
+    box-shadow:
+      0 1px 0 color-mix(in srgb, var(--brand) 8%, transparent),
+      0 8px 22px -8px color-mix(in srgb, var(--brand) 32%, transparent);
+    transform: translateY(-1px);
+
+    .title {
+      color: var(--brand);
+    }
+    .arrow {
+      opacity: 1;
+      transform: translateX(2px);
+      color: var(--brand);
+    }
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--brand);
+    outline-offset: 2px;
   }
 }
 
+// ─── Title row: label + animated arrow ───────────────────────────────
+//
+// The whole card is the link, so the title doesn't need to inherit the
+// blue anchor color — making it `--rp-c-text-1` removes the "title looks
+// like a separate link" effect and lets the card own its clickability.
+// The arrow is the new affordance: dim at rest, animates in on hover.
+//
+// `!important` on margin matches the old rule, which exists because
+// rspress's doc styles add tight margins to inline `<p>` children.
+
 .title {
-  font-size: 20px;
-  line-height: 1.4;
-  letter-spacing: -0.02em;
-  margin: 0 0 0.75em !important;
-  display: block;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 6px !important;
+  font-size: 1rem; // 16px — refined heading, down from 20px
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1.3;
+  color: var(--rp-c-text-1);
+  transition: color 0.2s ease-out;
+
+  // `<span>` wrapper keeps the label intrinsically sized so the arrow
+  // can sit tight to it instead of being pushed to the row's edge.
+  > span {
+    min-width: 0;
+  }
+}
+
+.arrow {
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+  color: var(--rp-c-text-2);
+  opacity: 0;
+  transform: translateX(0);
+  transition:
+    color 0.22s ease-out,
+    opacity 0.22s ease-out,
+    transform 0.22s ease-out;
 }
 
 .description {
   margin: 0 !important;
-  line-height: 1.7 !important;
+  font-size: 0.875rem; // 14px
+  line-height: 1.55 !important;
   color: var(--rp-c-text-2);
-  transition: color 0.5s;
+}
+
+// ─── Dark mode ───────────────────────────────────────────────────────
+// Mirrors the SubsiteRow/Quick-Start-CTA pattern: bump the rest border +
+// wash and let the hover glow push harder against a near-black surface.
+
+:root.dark {
+  .step {
+    border-color: color-mix(in srgb, var(--rp-c-text-1) 12%, transparent);
+    background: color-mix(in srgb, var(--rp-c-text-1) 4%, transparent);
+
+    &:hover {
+      border-color: color-mix(in srgb, var(--brand) 45%, transparent);
+      background: color-mix(in srgb, var(--brand) 8%, transparent);
+      box-shadow:
+        0 1px 0 color-mix(in srgb, var(--brand) 14%, transparent),
+        0 8px 26px -8px color-mix(in srgb, var(--brand) 48%, transparent);
+    }
+  }
 }

--- a/src/components/NextSteps/Step.tsx
+++ b/src/components/NextSteps/Step.tsx
@@ -6,7 +6,23 @@ import { getLangPrefix } from '../../../shared-route-config';
 const Step = (props: { href: string; title: string; description: string }) => {
   return (
     <Link className={styles.step} href={useUrl(props.href)}>
-      <p className={styles.title}>{props.title}</p>
+      <p className={styles.title}>
+        <span>{props.title}</span>
+        <svg
+          className={styles.arrow}
+          viewBox="0 0 16 16"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M3 8h10M9 4l4 4-4 4"
+            stroke="currentColor"
+            strokeWidth="1.75"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </p>
       <p className={styles.description}>{props.description}</p>
     </Link>
   );


### PR DESCRIPTION
## Summary

Restyle the "next step" card family — used at the bottom of guide articles via `<NextSteps.Root>` + `<NextSteps.Step>` — to share visual vocabulary with the SubsiteRow icon rail and ChoiceTabs cards (`color-mix` brand-aware tints, lifted-card hover shadow, refined typography).

The old chrome was a flat gray fill with the border the same color as the surface — invisible at rest — and a blue link title. That read as a templated card with the title competing for "clickability."

### Before / after

| | Before | After |
|---|---|---|
| Padding | 28 / 36px | 18 / 22px |
| Radius | 8px | 12px (matches ChoiceTabs) |
| Title size | 20px | 16px / 600 / -0.01em tracking |
| Title color | Inherited link blue | `--rp-c-text-1` (full strength) |
| Rest border | Same as bg (invisible) | `color-mix(text-1 8%)` — visible |
| Hover | Border → brand color only | Brand-tinted border + faint wash + lifted-card shadow + 1px lift |
| Affordance | None at rest | Arrow reveals on hover with brand tint + translate |

### Design notes

- **`color-mix` tints sourced from `--rp-c-text-1` and `--rp-c-brand`** — the family rides the active subsite's brand: hovering on `/react/...` reads blue, `/rspeedy/...` reads orange, etc.
- **Title becomes `--rp-c-text-1`** instead of inheriting the anchor's link blue. The whole card is the link target, so the title shouldn't compete with itself.
- **Arrow affordance** owns the "this is interactive" signal — same DNA as the Quick Start CTA arrow that picks up brand on hover and slides.
- **Lifted-card shadow on hover** mirrors `.subsite-icon--active` and `.quick-start-cta:hover` — a brand-tinted soft glow + 1px lift.
- **Dark-mode pass** bumps rest + hover so the chrome stays confident against near-black surfaces.

Sibling to #1103 (LLMs button redesign) — both adopt the SubsiteRow / ChoiceTabs vocabulary.

## Test plan

- [ ] Visit `/zh/react/introduction#下一步` — cards under "进一步学习 ReactLynx", "学习 Lynx 基础" sit tighter and the titles read as the actual heading color
- [ ] Hover a card — border picks up brand tint, faint wash appears, card lifts 1px, arrow slides in
- [ ] Switch subsite (browse `/react/...` then a `/rspeedy/...` page that uses NextSteps) — hover color picks up each subsite's brand
- [ ] Toggle dark mode — chrome stays legible at rest; hover glow reads confidently
- [ ] Keyboard-tab to a card — focus ring visible