### PR TITLE
fix(tutorial-tabs): scroll-snap carousel on narrow viewports

### DIFF
--- a/src/components/tutorial-tabs/TutorialTabs.scss
+++ b/src/components/tutorial-tabs/TutorialTabs.scss
@@ -1,3 +1,14 @@
+// ─── TutorialTabs ────────────────────────────────────────────────────────
+//
+// The track is `inline-flex` so the rounded container hugs its tabs at
+// rest. On narrow viewports the labels ("Tutorial: Product Gallery") run
+// wider than the doc body — without scroll the second tab clips off the
+// right edge and reads as broken. Below 720px we cap the track at the
+// parent width, allow horizontal scroll, and snap each tab into view.
+// The container chrome (rounded bg + border) survives because the track
+// itself does the scrolling; the active tab's BorderBeam still renders
+// because we don't clip vertically.
+
 .tutorial-tabs {
   width: 100%;
   margin: 0.5rem 0 1.5rem;
@@ -5,6 +16,10 @@
 
 .tutorial-tabs__track {
   display: inline-flex;
+  // `max-width: 100%` lets the inline-flex track shrink to fit the parent
+  // when the natural content width would exceed it. Without this, inline-
+  // flex sizes to its intrinsic content and just overflows the page.
+  max-width: 100%;
   gap: 8px;
   padding: 4px;
   border-radius: 12px;
@@ -16,6 +31,9 @@
   position: relative;
   display: inline-flex;
   align-items: center;
+  // Tabs must not shrink — they should keep their natural width and the
+  // overflowing tabs scroll into view via the snap carousel below.
+  flex-shrink: 0;
   padding: 8px 16px;
   border-radius: 8px;
   font-size: 14px;
@@ -57,4 +75,28 @@
   position: relative;
   z-index: 1;
   white-space: nowrap;
+}
+
+// ─── Narrow viewport: scroll-snap carousel ───────────────────────────────
+//
+// Below 720px the two "Tutorial: …" labels exceed the doc body width on
+// most phones. Switch the track into a horizontally scrollable snap rail
+// so each tab snaps into view. The scrollbar is hidden — the snap stops
+// + the visible second-tab edge convey scrollability.
+
+@media (max-width: 720px) {
+  .tutorial-tabs__track {
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  .tutorial-tabs__tab {
+    scroll-snap-align: start;
+  }
 }

--- a/src/components/tutorial-tabs/TutorialTabs.tsx
+++ b/src/components/tutorial-tabs/TutorialTabs.tsx
@@ -1,6 +1,7 @@
 import { cn } from '@/lib/utils';
 import { Link } from '@rspress/core/theme';
 import { useI18n, useLang, withBase } from '@rspress/core/runtime';
+import { useEffect, useRef } from 'react';
 import { BorderBeam } from '@/components/home-comps/border-beam';
 import { getLangPrefix } from '../../../shared-route-config';
 import './TutorialTabs.scss';
@@ -24,9 +25,25 @@ export const TutorialTabs = ({
   active,
   className,
 }: TutorialTabsProps) => {
+  // On narrow viewports the track scrolls horizontally (see SCSS). If the
+  // active tab lives past the right edge — e.g. user lands on /product-detail
+  // on a phone — center it into view so the selected state is visible on
+  // arrival. Only runs when the track actually overflows; on desktop the
+  // track fits all tabs and this is a no-op.
+  const trackRef = useRef<HTMLDivElement>(null);
+  const activeRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const track = trackRef.current;
+    const card = activeRef.current;
+    if (!track || !card) return;
+    if (track.scrollWidth <= track.clientWidth) return;
+    track.scrollLeft =
+      card.offsetLeft - (track.clientWidth - card.offsetWidth) / 2;
+  }, [active]);
+
   return (
     <div className={cn('tutorial-tabs', className)}>
-      <div className="tutorial-tabs__track">
+      <div className="tutorial-tabs__track" ref={trackRef}>
         {tabs.map((tab) => {
           const isActive = tab.slug === active;
           const cls = cn(
@@ -35,7 +52,12 @@ export const TutorialTabs = ({
           );
           if (isActive) {
             return (
-              <div key={tab.slug} className={cls} aria-current="page">
+              <div
+                key={tab.slug}
+                ref={activeRef}
+                className={cls}
+                aria-current="page"
+              >
                 <BorderBeam duration={3} size={2} />
                 <span className="tutorial-tabs__label">{tab.label}</span>
               </div>


### PR DESCRIPTION
## Summary

The Learn tutorial switcher (`<LearnTutorialTabs />` on `/learn/gallery` and `/learn/product-detail`) uses an `inline-flex` track that sizes to its content. On phones the two `Tutorial: Product Gallery` / `Tutorial: Product Detail` labels run wider than the doc body and the second tab clips off the right edge with no scroll affordance — reads as broken.

### Before

The second tab is cut off at the viewport edge with no way to reach it:

```
| Tutorial: Product Gallery | Tutorial: Product De…
                                                  ↑ clipped
```

### After

Below 720px the track becomes a horizontal scroll-snap rail. On mount, the active tab is scrolled into view (centered), so landing on `/learn/product-detail` on a phone shows the active state immediately instead of leaving it offscreen.

## Changes

- `TutorialTabs.scss`: cap track at `max-width: 100%`, add `flex-shrink: 0` to tabs so they keep their natural width, switch the track to a horizontal scroll-snap rail below 720px
- `TutorialTabs.tsx`: scroll the active tab into view on mount when the track overflows (mirrors the existing `ChoiceTabs` behavior); no-op on desktop where everything fits

The container chrome (rounded background + border) survives because the track itself does the scrolling, and the active tab's `BorderBeam` still renders since we don't clip vertically.

## Test plan

- [ ] On desktop, both `/learn/gallery` and `/learn/product-detail` show both tabs side by side, no scroll
- [ ] On mobile (~390px viewport): tabs scroll horizontally with snap; scrollbar hidden
- [ ] Landing on `/learn/product-detail` on mobile: the "Product Detail" tab is centered in view on first paint
- [ ] Landing on `/learn/gallery` on mobile: the "Product Gallery" tab is at the start, with the next tab partially visible as scrollability cue
- [ ] Active tab's BorderBeam still animates correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## fix(tutorial-tabs): scroll-snap carousel on narrow viewports

- Cap track width to parent with `max-width: 100%` to prevent overflow on narrow viewports
- Prevent tab compression with `flex-shrink: 0` to maintain natural widths for scrolling
- Add responsive scroll-snap carousel below 720px: enable `overflow-x: auto` with `scroll-snap-type: x mandatory` and hide scrollbars via `scrollbar-width: none` and webkit scrollbar rules
- Set tabs to `scroll-snap-align: start` for snapping behavior on mobile
- Auto-center active tab into view on mount when track overflows by calculating scroll position based on active tab's position and dimensions
- Render active tab as regular `div` with ref to enable scroll-into-view logic while preserving BorderBeam animation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->