### PR TITLE
fix(lynx-compat-data): clean output dir before CSS property generation

### DIFF
--- a/packages/lynx-compat-data/scripts/generate-css-from-defines.ts
+++ b/packages/lynx-compat-data/scripts/generate-css-from-defines.ts
@@ -50,7 +50,9 @@ const manualDir = path.join(__dirname, '..', 'css', 'properties-manual');
  * Generate CSS property compat data files from @lynx-js/css-defines.
  */
 async function generateCssProperties(): Promise<void> {
-  // Ensure output directory exists
+  // Clean output directory to avoid stale files from previous runs
+  // colliding with the manual copy collision check below.
+  await fs.rm(outputDir, { recursive: true, force: true });
   await fs.mkdir(outputDir, { recursive: true });
 
   // Read all definition files from css-defines


### PR DESCRIPTION
Prevent stale files from previous gen-css runs from colliding with the manual copy collision check. Previously, a css/properties/ file left over from a prior run's manual copy would trigger a false collision on the next run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Remove generated CSS properties output directory before generation to prevent stale files from previous runs from triggering false collision detections during manual file copying

<!-- end of auto-generated comment: release notes by coderabbit.ai -->