### PR TITLE
fix(lynx-compat-data): fix styling error and pnpm 11 build error

### DIFF
--- a/packages/lynx-compat-data/scripts/generate-css-from-defines.ts
+++ b/packages/lynx-compat-data/scripts/generate-css-from-defines.ts
@@ -24,17 +24,31 @@ const __dirname = path.dirname(__filename);
 
 function findCssDefinesDir(): string {
   const candidates = [
-    path.join(__dirname, '..', 'node_modules', '@lynx-js', 'css-defines', 'css_defines'),
-    path.join(__dirname, '..', '..', '..', 'node_modules', '@lynx-js', 'css-defines', 'css_defines'),
+    path.join(
+      __dirname,
+      '..',
+      'node_modules',
+      '@lynx-js',
+      'css-defines',
+      'css_defines',
+    ),
+    path.join(
+      __dirname,
+      '..',
+      '..',
+      '..',
+      'node_modules',
+      '@lynx-js',
+      'css-defines',
+      'css_defines',
+    ),
   ];
   for (const candidate of candidates) {
     if (existsSync(candidate)) {
       return candidate;
     }
   }
-  throw new Error(
-    'Could not find @lynx-js/css-defines/css_defines directory',
-  );
+  throw new Error('Could not find @lynx-js/css-defines/css_defines directory');
 }
 
 const cssDefinesDir = findCssDefinesDir();
@@ -133,7 +147,9 @@ async function generateCssProperties(): Promise<void> {
       await fs.copyFile(path.join(manualDir, file), dst);
       copied++;
     }
-    console.log(`Copied ${copied} hand-maintained files from properties-manual/`);
+    console.log(
+      `Copied ${copied} hand-maintained files from properties-manual/`,
+    );
   }
 
   console.log(`Output directory: ${outputDir}`);

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,5 +12,6 @@ minimumReleaseAgeExclude:
 # pnpm 11 no longer runs dependency build scripts unless explicitly allowed
 # (else ERR_PNPM_IGNORED_BUILDS). Allow the trusted deps that need a build step.
 allowBuilds:
+  '@parcel/watcher': true
   core-js: true
   esbuild: true


### PR DESCRIPTION
Fix the build error, @parcel/watcher should be explicitly declared in pnpm-workspace to be enabled to prevent failing by ERR_PNPM_IGNORED_BUILDS.

Fix the styling error to bypass the format check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Fix pnpm v11 build rejection and resolve styling/format issues in lynx-compat-data

- Approve `@parcel/watcher` builds in pnpm-workspace.yaml to avoid ERR_PNPM_IGNORED_BUILDS under pnpm v11
- Clear css/properties output directory before generation to prevent collisions with stale files
- Refactor packages/lynx-compat-data/scripts/generate-css-from-defines.ts to use clearer candidate path construction, multiline logging, and consistent output formatting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->