### PR TITLE
docs(api): add offset motion CSS property docs

### DIFF
--- a/docs/en/api/css/properties/offset-distance.mdx
+++ b/docs/en/api/css/properties/offset-distance.mdx
@@ -1,0 +1,79 @@
+---
+title: offset-distance
+api: css/properties/offset-distance
+---
+
+import { APISummary, APITable, Go } from '@lynx';
+
+<APISummary />
+
+## Introduction
+
+The `offset-distance` CSS property specifies the position of an element along the path defined by `offset-path`.
+
+Use `offset-distance` with `offset-path` to place an element at a specific progress point on a path, or animate it from the start of the path to the end.
+
+## Examples
+
+<Go
+  example="css-api"
+  defaultFile="src/offset-distance/App.tsx"
+  defaultEntryFile="dist/offset-distance.lynx.bundle"
+  entry="src/offset-distance"
+/>
+
+## Syntax
+
+```css
+offset-distance: 0;
+offset-distance: 1;
+offset-distance: 0%;
+offset-distance: 66%;
+offset-distance: 100%;
+```
+
+### Values
+
+- `<number>`
+
+  Specifies the element's progress along the path as a normalized value. `0` places the element at the start of the path, and `1` places it at the end of the path.
+
+- `<percentage>`
+
+  Specifies the element's progress along the path. `0%` places the element at the start of the path, and `100%` places it at the end of the path.
+
+- Default value
+
+  **0**
+
+:::info
+Lynx currently supports number values in the range `0` to `1` and percentage values in the range `0%` to `100%`.
+:::
+
+## Formal definition
+
+import { PropertyDefinition } from '@/components/PropertyDefinition';
+
+<PropertyDefinition
+  initialValue={<>0</>}
+  appliesTo={<>all elements</>}
+  inherited="no"
+  animatable="yes"
+  percentages={<>refer to the total path length</>}
+/>
+
+## Formal syntax
+
+```css
+offset-distance = <number> | <percentage>
+```
+
+## Difference from Web
+
+- [mdn:offset-distance](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/offset-distance)
+
+1. Lynx does not support `<length>` or `calc()` values.
+
+## Compatibility
+
+<APITable />

--- a/docs/en/api/css/properties/offset-path.mdx
+++ b/docs/en/api/css/properties/offset-path.mdx
@@ -1,0 +1,170 @@
+---
+title: offset-path
+api: css/properties/offset-path
+---
+
+import { APISummary, APITable, Go } from '@lynx';
+
+<APISummary />
+
+## Introduction
+
+The `offset-path` CSS property specifies the path that an element follows and determines the element's position within its parent container. The path can be a straight line, a quadratic or cubic Bézier curve, an arc, or any combination of these, along which the element will be positioned or moved.
+
+This property is typically used in combination with `offset-distance` to control the element's position along the path. You can also use `offset-rotate` to control whether the element rotates to follow the direction of that path.
+
+## Examples
+
+<Go
+  example="css-api"
+  defaultFile="src/offset-path/App.tsx"
+  defaultEntryFile="dist/offset-path.lynx.bundle"
+  entry="src/offset-path"
+/>
+
+## Syntax
+
+```css
+/* Keyword values */
+offset-path: '';
+
+/* <basic-shape> values */
+offset-path: inset(30px 50px 45px 20px round 24px 8px 32px 14px);
+offset-path: circle(50px at 0 100px);
+offset-path: path(
+  'M50,10 L90.45,34.55 L73.39,80.45 L26.61,80.45 L9.55,34.55 Z'
+);
+/* iOS: `ellipse()` is not supported */
+offset-path: ellipse(70px 45px at 90px 70px);
+```
+
+### Values
+
+The `offset-path` property is specified as one of the values listed below.
+
+`""`
+
+Specifies that the element does not follow any offset path. This is the default value.
+
+`<basic-shape>`
+
+A shape whose size and position are defined by its `border-box`. One of:
+
+- `inset()`
+
+  Defines an inset rectangle.
+
+  ```
+  inset( <length-percentage>{1, 4} [ round <border-radius> ]?)
+
+  <length-percentage> =
+    <length>
+    <percentage>
+
+  <border-radius> =
+    <length-percentage [0,∞]>{1,4} [ / <length-percentage [0,∞]>{1,4} ]?
+  ```
+
+  `<length-percentage>{1, 4}`
+
+  Represents the top, right, bottom, and left offsets from the `border-box` that define the edges of the inset rectangle. These arguments follow the syntax of the margin shorthand, allowing one, two, or four values.
+
+  `round <border-radius>`
+
+  Optional arguments that define the rounded corners of the inset rectangle. The corner radius follows the `<border-radius>` syntax.
+
+- `circle()`
+
+  Defines a circle using a radius and a position.
+
+  ```
+  circle(<length-percentage> [at <position>]?)
+
+  <length-percentage> =
+    <length [0,∞]>                |
+    <percentage [0,∞]>
+
+  <position> =
+    [ left | center | right | top | bottom | <length-percentage> ]  |
+    [ left | center | right ] && [ top | center | bottom ]  |
+    [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ]  |
+    [ [ left | right ] <length-percentage> ] && [ [ top | bottom ] <length-percentage> ]
+  ```
+
+  `<length-percentage>`
+
+  Defines the radius of the circle. It can be a `<length>` or a `<percentage>`.
+
+  `<position>`
+
+  Moves the center of the circle. It can be a `<length>`, a `<percentage>`, or a keyword such as `left`. If omitted, the position defaults to `center`.
+
+- `ellipse()`
+
+  Defines an ellipse using two radii and a position.
+
+  An ellipse is similar to a circle, but it uses two radii: one for the x-axis and one for the y-axis.
+
+  ```
+  <ellipse()> =
+    ellipse( <radial-size>? [ at <position> ]? )
+
+  <radial-size> =
+    <length-percentage [0,∞]>{2}
+
+  <position> =
+    [ left | center | right | top | bottom | <length-percentage> ]  |
+    [ left | center | right ] && [ top | center | bottom ]  |
+    [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ]  |
+    [ [ left | right ] <length-percentage> ] && [ [ top | bottom ] <length-percentage> ]
+
+  <length-percentage> =
+    <length>      |
+    <percentage>
+  ```
+
+  `<radial-size>`
+
+  Defines the two radii, in x-axis then y-axis order. Each radius can be a `<length>` or a `<percentage>`.
+
+  `<position>`
+
+  Moves the center of the ellipse. It can be a `<length>`, a `<percentage>`, or a keyword such as `left`. If omitted, the position defaults to `center`.
+
+  :::info
+  `ellipse()` is not supported on iOS.
+  :::
+
+- `path()`
+
+  Defines a shape using an SVG path definition.
+
+  ```
+  <path()> =
+    path(<string>)
+  ```
+
+  The `path()` function takes an [SVG path string](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d) as its argument.
+
+## Formal definition
+
+import { PropertyDefinition } from '@/components/PropertyDefinition';
+
+<PropertyDefinition
+  initialValue={<>""</>}
+  appliesTo={<>all elements</>}
+  inherited="no"
+  animatable="no"
+/>
+
+## Difference from Web
+
+- [mdn:offset-path](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/offset-path)
+
+1. Lynx supports `path()`, `circle()`, `ellipse()`, and `inset()`. On iOS, `ellipse()` is not supported.
+2. Lynx does not support Web values such as `polygon()`, `ray()`, and `url()`.
+3. Lynx does not support coordinate box values.
+
+## Compatibility
+
+<APITable />

--- a/docs/en/api/css/properties/offset-rotate.mdx
+++ b/docs/en/api/css/properties/offset-rotate.mdx
@@ -1,0 +1,74 @@
+---
+title: offset-rotate
+api: css/properties/offset-rotate
+---
+
+import { APISummary, APITable, Go } from '@lynx';
+
+<APISummary />
+
+## Introduction
+
+The `offset-rotate` CSS property defines the orientation of an element as it is positioned along the path defined by `offset-path`.
+
+Use `offset-rotate` with `offset-path` and `offset-distance` to decide whether the element follows the path tangent or keeps a fixed rotation while moving along the path.
+
+## Examples
+
+<Go
+  example="css-api"
+  defaultFile="src/offset-rotate/App.tsx"
+  defaultEntryFile="dist/offset-rotate.lynx.bundle"
+  entry="src/offset-rotate"
+/>
+
+## Syntax
+
+```css
+offset-rotate: auto;
+offset-rotate: 0deg;
+offset-rotate: 90deg;
+offset-rotate: 360deg;
+```
+
+### Values
+
+- `auto`
+
+  The element rotates by the angle between the path direction at its current position and the positive x-axis. This is the default value.
+
+- `<angle>`
+
+  The element keeps the specified clockwise rotation while positioned on the path. Use `0deg` when the element should not rotate with the path.
+
+:::info
+Lynx currently supports `auto` and `<angle>` values in the range `0deg` to `360deg`.
+:::
+
+## Formal definition
+
+import { PropertyDefinition } from '@/components/PropertyDefinition';
+
+<PropertyDefinition
+  initialValue={<>auto</>}
+  appliesTo={<>all elements</>}
+  inherited="no"
+  animatable="no"
+/>
+
+## Formal syntax
+
+```css
+offset-rotate = auto | <angle>
+```
+
+## Difference from Web
+
+- [mdn:offset-rotate](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/offset-rotate)
+
+1. Lynx does not support `auto <angle>`, where the specified angle is added to the automatic path direction.
+2. Lynx does not support `reverse`, which is equivalent to `auto 180deg` on the Web.
+
+## Compatibility
+
+<APITable />

--- a/docs/zh/api/css/properties/offset-distance.mdx
+++ b/docs/zh/api/css/properties/offset-distance.mdx
@@ -1,0 +1,80 @@
+---
+api: css/properties/offset-distance
+---
+
+import { APISummary, APITable, Go } from '@lynx';
+
+# offset-distance
+
+<APISummary />
+
+## 介绍
+
+`offset-distance` CSS 属性指定元件在 `offset-path` 定义的路径上的位置。
+
+可以将 `offset-distance` 与 `offset-path` 配合使用，把元件放到路径上的指定进度位置，也可以通过动画让元件从路径起点运动到终点。
+
+## 使用示例
+
+<Go
+  example="css-api"
+  defaultFile="src/offset-distance/App.tsx"
+  defaultEntryFile="dist/offset-distance.lynx.bundle"
+  entry="src/offset-distance"
+/>
+
+## 语法
+
+```css
+offset-distance: 0;
+offset-distance: 1;
+offset-distance: 0%;
+offset-distance: 66%;
+offset-distance: 100%;
+```
+
+### 取值
+
+- `<number>`
+
+  使用归一化数值指定元件沿路径的进度。`0` 表示路径起点，`1` 表示路径终点。
+
+- `<percentage>`
+
+  指定元件沿路径的进度。`0%` 表示路径起点，`100%` 表示路径终点。
+
+- 默认值
+
+  **0**
+
+:::info
+Lynx 目前支持 `0` 到 `1` 范围内的数值取值，以及 `0%` 到 `100%` 范围内的百分比取值。
+:::
+
+## 形式定义
+
+import { PropertyDefinition } from '@/components/PropertyDefinition';
+
+<PropertyDefinition
+  initialValue={<>0</>}
+  appliesTo={<>所有元件</>}
+  inherited="no"
+  animatable="yes"
+  percentages={<>参考路径总长度</>}
+/>
+
+## 形式语法
+
+```css
+offset-distance = <number> | <percentage>
+```
+
+## 与 Web 的区别
+
+- [mdn:offset-distance](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/offset-distance)
+
+1. Lynx 不支持 `<length>` 和 `calc()` 取值。
+
+## 兼容性
+
+<APITable />

--- a/docs/zh/api/css/properties/offset-path.mdx
+++ b/docs/zh/api/css/properties/offset-path.mdx
@@ -1,0 +1,169 @@
+---
+api: css/properties/offset-path
+---
+
+import { APISummary, APITable, Go } from '@lynx';
+
+# offset-path
+
+<APISummary />
+
+## 介绍
+
+`offset-path` CSS 属性指定元件要遵循的路径，并决定元件在父容器中的位置。路径可以是直线、二次或三次贝塞尔曲线、圆弧，或者这些路径命令的组合；元件会沿该路径被定位或移动。
+
+通常将 `offset-path` 与 `offset-distance` 配合使用，以控制元件沿路径的位置或运动进度。可以再配合 `offset-rotate` 控制元件是否跟随路径方向旋转。
+
+## 使用示例
+
+<Go
+  example="css-api"
+  defaultFile="src/offset-path/App.tsx"
+  defaultEntryFile="dist/offset-path.lynx.bundle"
+  entry="src/offset-path"
+/>
+
+## 语法
+
+```css
+/* 关键字取值 */
+offset-path: '';
+
+/* <basic-shape> 取值 */
+offset-path: inset(30px 50px 45px 20px round 24px 8px 32px 14px);
+offset-path: circle(50px at 0 100px);
+offset-path: path(
+  'M50,10 L90.45,34.55 L73.39,80.45 L26.61,80.45 L9.55,34.55 Z'
+);
+/* iOS 不支持 `ellipse()` */
+offset-path: ellipse(70px 45px at 90px 70px);
+```
+
+### 取值
+
+`""`
+
+表示元件不遵循任何偏移路径。这是默认值。
+
+`<basic-shape>`
+
+一种形状，其大小和位置由 `border-box` 的值作为参考框。取值可以为下值中的任意一个：
+
+- `inset()`
+
+  定义一个矩形。
+
+  ```
+  inset( <length-percentage>{1, 4} [ round <border-radius> ]?)
+
+  <length-percentage> =
+    <length>
+    <percentage>
+
+  <border-radius> =
+    <length-percentage [0,∞]>{1,4} [ / <length-percentage [0,∞]>{1,4} ]?
+  ```
+
+  `<length-percentage>{1, 4}`
+
+  为内嵌矩形框的偏移量，表示从 `border-box` 的上侧、右侧、下侧和左侧向内的偏移量，这些偏移量定义了内嵌矩形边缘的位置。这些参数遵循边间距简写的语法，它允许你定义具有一个、两个或四个值的 inset。
+
+  `round <border-radius>`
+
+  可选的圆角参数，用于定义内嵌矩形框的圆角。`<border-radius>` 使用边框半径简写语法定义内嵌矩形的圆角半径。
+
+- `circle()`
+
+  定义一个圆形（使用一个半径和一个圆心位置）。
+
+  ```
+  circle(<length-percentage> [at <position>]?)
+
+  <length-percentage> =
+    <length [0,∞]>                |
+    <percentage [0,∞]>
+
+  <position> =
+    [ left | center | right | top | bottom | <length-percentage> ]  |
+    [ left | center | right ] && [ top | center | bottom ]  |
+    [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ]  |
+    [ [ left | right ] <length-percentage> ] && [ [ top | bottom ] <length-percentage> ]
+  ```
+
+  `<length-percentage>`
+
+  这个值用于定义圆形的半径。
+
+  `<position>`
+
+  移动圆形的中心。可以是 `<length>` 或 `<percentage>`，或者类似 `left` 这样的值。如果省略 `<position>` 值，则默认为中心。
+
+- `ellipse()`
+
+  定义一个椭圆（使用两个半径和一个圆心位置）。
+
+  椭圆本质上是一个扁平的圆形，因此 `ellipse()` 的行为与 `circle()` 非常相似，只是需要指定两个半径 x 和 y。
+
+  ```
+  <ellipse()> =
+    ellipse( <radial-size>? [ at <position> ]? )
+
+  <radial-size> =
+    <length-percentage [0,∞]>{2}
+
+  <position> =
+    [ left | center | right | top | bottom | <length-percentage> ]  |
+    [ left | center | right ] && [ top | center | bottom ]  |
+    [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ]  |
+    [ [ left | right ] <length-percentage> ] && [ [ top | bottom ] <length-percentage> ]
+
+  <length-percentage> =
+    <length>      |
+    <percentage>
+  ```
+
+  `<radial-size>`
+
+  两个半径，按顺序是 x 和 y。可以是 `<length>` 或 `<percentage>`。
+
+  `<position>`
+
+  移动椭圆的中心。可以是 `<length>` 或 `<percentage>`，或者类似 `left` 这样的值。如果省略 `<position>` 值，则默认为中心。
+
+  :::info
+  iOS 不支持 `ellipse()`。
+  :::
+
+- `path()`
+
+  定义一个任意形状（使用一个 SVG 路径定义）。
+
+  ```
+  <path()> =
+    path(<string>)
+  ```
+
+  `path()` 函数接受 [SVG 路径字符串](https://developer.mozilla.org/zh-CN/docs/Web/SVG/Attribute/d) 作为参数。
+
+## 形式定义
+
+import { PropertyDefinition } from '@/components/PropertyDefinition';
+
+<PropertyDefinition
+  initialValue={<>""</>}
+  appliesTo={<>所有元件</>}
+  inherited="no"
+  animatable="no"
+/>
+
+## 与 Web 的区别
+
+- [mdn:offset-path](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/offset-path)
+
+1. Lynx 支持 `path()`、`circle()`、`ellipse()` 和 `inset()`。其中 iOS 不支持 `ellipse()`。
+2. Lynx 不支持 `polygon()`、`ray()` 和 `url()` 等 Web 取值。
+3. Lynx 不支持坐标盒取值。
+
+## 兼容性
+
+<APITable />

--- a/docs/zh/api/css/properties/offset-rotate.mdx
+++ b/docs/zh/api/css/properties/offset-rotate.mdx
@@ -1,0 +1,75 @@
+---
+api: css/properties/offset-rotate
+---
+
+import { APISummary, APITable, Go } from '@lynx';
+
+# offset-rotate
+
+<APISummary />
+
+## 介绍
+
+`offset-rotate` CSS 属性指定元件沿 `offset-path` 定义的路径定位时的方向。
+
+可以将 `offset-rotate` 与 `offset-path`、`offset-distance` 配合使用，控制元件在路径上运动时是跟随路径切线方向旋转，还是保持固定旋转角度。
+
+## 使用示例
+
+<Go
+  example="css-api"
+  defaultFile="src/offset-rotate/App.tsx"
+  defaultEntryFile="dist/offset-rotate.lynx.bundle"
+  entry="src/offset-rotate"
+/>
+
+## 语法
+
+```css
+offset-rotate: auto;
+offset-rotate: 0deg;
+offset-rotate: 90deg;
+offset-rotate: 360deg;
+```
+
+### 取值
+
+- `auto`
+
+  元件会根据当前路径位置方向与正 x 轴方向之间的角度旋转。这是默认值。
+
+- `<angle>`
+
+  元件在路径上始终保持指定的顺时针旋转角度。如果不希望元件跟随路径旋转，可以使用 `0deg`。
+
+:::info
+Lynx 目前支持 `auto` 和 `0deg` 到 `360deg` 范围内的 `<angle>` 取值。
+:::
+
+## 形式定义
+
+import { PropertyDefinition } from '@/components/PropertyDefinition';
+
+<PropertyDefinition
+  initialValue={<>auto</>}
+  appliesTo={<>所有元件</>}
+  inherited="no"
+  animatable="no"
+/>
+
+## 形式语法
+
+```css
+offset-rotate = auto | <angle>
+```
+
+## 与 Web 的区别
+
+- [mdn:offset-rotate](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/offset-rotate)
+
+1. Lynx 不支持 `auto <angle>`。在 Web 上，该语法会将指定角度叠加到自动计算的路径方向上。
+2. Lynx 不支持 `reverse`。在 Web 上，`reverse` 等价于 `auto 180deg`。
+
+## 兼容性
+
+<APITable />

--- a/packages/lynx-compat-data/api-stats.json
+++ b/packages/lynx-compat-data/api-stats.json
@@ -1,7 +1,7 @@
 {
   "summary": {
-    "total_apis": 1186,
-    "platform_api_total": 1092,
+    "total_apis": 1189,
+    "platform_api_total": 1095,
     "by_category": {
       "elements": {
         "total": 311,
@@ -40,12 +40,12 @@
         }
       },
       "css/properties": {
-        "total": 413,
+        "total": 416,
         "supported": {
-          "android": 381,
-          "ios": 381,
-          "harmony": 311,
-          "web_lynx": 333,
+          "android": 384,
+          "ios": 384,
+          "harmony": 314,
+          "web_lynx": 336,
           "clay_android": 375,
           "clay_ios": 306,
           "clay_macos": 397,
@@ -57,11 +57,11 @@
           "ios": 92,
           "harmony": 75,
           "web_lynx": 81,
-          "clay_android": 91,
+          "clay_android": 90,
           "clay_ios": 74,
-          "clay_macos": 96,
-          "clay_windows": 97,
-          "clay": 99
+          "clay_macos": 95,
+          "clay_windows": 96,
+          "clay": 98
         },
         "exclusive": {
           "android": 0,
@@ -618,28 +618,28 @@
     },
     "by_platform": {
       "android": {
-        "supported_count": 975,
+        "supported_count": 978,
         "coverage_percent": 89,
         "exclusive_count": 18
       },
       "ios": {
-        "supported_count": 977,
+        "supported_count": 980,
         "coverage_percent": 89,
         "exclusive_count": 12
       },
       "harmony": {
-        "supported_count": 848,
+        "supported_count": 851,
         "coverage_percent": 78,
         "exclusive_count": 7
       },
       "web_lynx": {
-        "supported_count": 717,
+        "supported_count": 720,
         "coverage_percent": 66,
         "exclusive_count": 30
       },
       "clay_android": {
         "supported_count": 629,
-        "coverage_percent": 58,
+        "coverage_percent": 57,
         "exclusive_count": 0
       },
       "clay_ios": {
@@ -18197,12 +18197,12 @@
     "css/properties": {
       "display_name": "CSS Properties",
       "stats": {
-        "total": 413,
+        "total": 416,
         "supported": {
-          "android": 381,
-          "ios": 381,
-          "harmony": 311,
-          "web_lynx": 333,
+          "android": 384,
+          "ios": 384,
+          "harmony": 314,
+          "web_lynx": 336,
           "clay_android": 375,
           "clay_ios": 306,
           "clay_macos": 397,
@@ -18214,11 +18214,11 @@
           "ios": 92,
           "harmony": 75,
           "web_lynx": 81,
-          "clay_android": 91,
+          "clay_android": 90,
           "clay_ios": 74,
-          "clay_macos": 96,
-          "clay_windows": 97,
-          "clay": 99
+          "clay_macos": 95,
+          "clay_windows": 96,
+          "clay": 98
         },
         "exclusive": {
           "android": 0,
@@ -18594,6 +18594,9 @@
         "css/properties/max-width",
         "css/properties/min-height",
         "css/properties/min-width",
+        "css/properties/offset-distance",
+        "css/properties/offset-path",
+        "css/properties/offset-rotate",
         "css/properties/opacity",
         "css/properties/order",
         "css/properties/overflow-x",
@@ -24468,6 +24471,54 @@
             "clay_macos": "1.0",
             "clay_windows": "1.0",
             "clay": "1.0"
+          }
+        },
+        {
+          "path": "css/properties/offset-distance",
+          "name": "offset-distance",
+          "doc_url": "api/css/properties/offset-distance",
+          "support": {
+            "android": "3.3",
+            "ios": "3.3",
+            "harmony": "3.8",
+            "web_lynx": true,
+            "clay_android": false,
+            "clay_ios": false,
+            "clay_macos": false,
+            "clay_windows": false,
+            "clay": false
+          }
+        },
+        {
+          "path": "css/properties/offset-path",
+          "name": "offset-path",
+          "doc_url": "api/css/properties/offset-path",
+          "support": {
+            "android": "3.3",
+            "ios": "3.3",
+            "harmony": "3.8",
+            "web_lynx": true,
+            "clay_android": false,
+            "clay_ios": false,
+            "clay_macos": false,
+            "clay_windows": false,
+            "clay": false
+          }
+        },
+        {
+          "path": "css/properties/offset-rotate",
+          "name": "offset-rotate",
+          "doc_url": "api/css/properties/offset-rotate",
+          "support": {
+            "android": "3.3",
+            "ios": "3.3",
+            "harmony": "3.8",
+            "web_lynx": true,
+            "clay_android": false,
+            "clay_ios": false,
+            "clay_macos": false,
+            "clay_windows": false,
+            "clay": false
           }
         },
         {
@@ -30592,6 +30643,54 @@
               "clay_windows": false,
               "clay": false
             }
+          },
+          {
+            "path": "css/properties/offset-distance",
+            "name": "offset-distance",
+            "doc_url": "api/css/properties/offset-distance",
+            "support": {
+              "android": "3.3",
+              "ios": "3.3",
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/offset-path",
+            "name": "offset-path",
+            "doc_url": "api/css/properties/offset-path",
+            "support": {
+              "android": "3.3",
+              "ios": "3.3",
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/offset-rotate",
+            "name": "offset-rotate",
+            "doc_url": "api/css/properties/offset-rotate",
+            "support": {
+              "android": "3.3",
+              "ios": "3.3",
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
           }
         ],
         "clay_ios": [
@@ -31860,6 +31959,54 @@
             }
           },
           {
+            "path": "css/properties/offset-distance",
+            "name": "offset-distance",
+            "doc_url": "api/css/properties/offset-distance",
+            "support": {
+              "android": "3.3",
+              "ios": "3.3",
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/offset-path",
+            "name": "offset-path",
+            "doc_url": "api/css/properties/offset-path",
+            "support": {
+              "android": "3.3",
+              "ios": "3.3",
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/offset-rotate",
+            "name": "offset-rotate",
+            "doc_url": "api/css/properties/offset-rotate",
+            "support": {
+              "android": "3.3",
+              "ios": "3.3",
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
             "path": "css/properties/transform.translate",
             "name": "translate",
             "doc_url": "/api/css/properties/transform",
@@ -32564,6 +32711,54 @@
               "clay_windows": false,
               "clay": false
             }
+          },
+          {
+            "path": "css/properties/offset-distance",
+            "name": "offset-distance",
+            "doc_url": "api/css/properties/offset-distance",
+            "support": {
+              "android": "3.3",
+              "ios": "3.3",
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/offset-path",
+            "name": "offset-path",
+            "doc_url": "api/css/properties/offset-path",
+            "support": {
+              "android": "3.3",
+              "ios": "3.3",
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/offset-rotate",
+            "name": "offset-rotate",
+            "doc_url": "api/css/properties/offset-rotate",
+            "support": {
+              "android": "3.3",
+              "ios": "3.3",
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
           }
         ],
         "clay_windows": [
@@ -32758,6 +32953,54 @@
               "clay_windows": false,
               "clay": false
             }
+          },
+          {
+            "path": "css/properties/offset-distance",
+            "name": "offset-distance",
+            "doc_url": "api/css/properties/offset-distance",
+            "support": {
+              "android": "3.3",
+              "ios": "3.3",
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/offset-path",
+            "name": "offset-path",
+            "doc_url": "api/css/properties/offset-path",
+            "support": {
+              "android": "3.3",
+              "ios": "3.3",
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/offset-rotate",
+            "name": "offset-rotate",
+            "doc_url": "api/css/properties/offset-rotate",
+            "support": {
+              "android": "3.3",
+              "ios": "3.3",
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
           }
         ],
         "clay": [
@@ -32849,6 +33092,54 @@
               "android": "3.4",
               "ios": "3.4",
               "harmony": false,
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/offset-distance",
+            "name": "offset-distance",
+            "doc_url": "api/css/properties/offset-distance",
+            "support": {
+              "android": "3.3",
+              "ios": "3.3",
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/offset-path",
+            "name": "offset-path",
+            "doc_url": "api/css/properties/offset-path",
+            "support": {
+              "android": "3.3",
+              "ios": "3.3",
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/offset-rotate",
+            "name": "offset-rotate",
+            "doc_url": "api/css/properties/offset-rotate",
+            "support": {
+              "android": "3.3",
+              "ios": "3.3",
+              "harmony": "3.8",
               "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
@@ -92706,6 +92997,114 @@
     },
     {
       "id": "feature-705",
+      "query": "css/properties/offset-distance",
+      "name": "offset-distance",
+      "category": "css/properties",
+      "source_file": "css/properties/offset-distance.json",
+      "support": {
+        "android": {
+          "version_added": "3.3"
+        },
+        "ios": {
+          "version_added": "3.3"
+        },
+        "harmony": {
+          "version_added": "3.8"
+        },
+        "web_lynx": {
+          "version_added": true
+        },
+        "clay_android": {
+          "version_added": false
+        },
+        "clay_ios": {
+          "version_added": false
+        },
+        "clay_macos": {
+          "version_added": false
+        },
+        "clay_windows": {
+          "version_added": false
+        },
+        "clay": {
+          "version_added": false
+        }
+      }
+    },
+    {
+      "id": "feature-706",
+      "query": "css/properties/offset-path",
+      "name": "offset-path",
+      "category": "css/properties",
+      "source_file": "css/properties/offset-path.json",
+      "support": {
+        "android": {
+          "version_added": "3.3"
+        },
+        "ios": {
+          "version_added": "3.3"
+        },
+        "harmony": {
+          "version_added": "3.8"
+        },
+        "web_lynx": {
+          "version_added": true
+        },
+        "clay_android": {
+          "version_added": false
+        },
+        "clay_ios": {
+          "version_added": false
+        },
+        "clay_macos": {
+          "version_added": false
+        },
+        "clay_windows": {
+          "version_added": false
+        },
+        "clay": {
+          "version_added": false
+        }
+      }
+    },
+    {
+      "id": "feature-707",
+      "query": "css/properties/offset-rotate",
+      "name": "offset-rotate",
+      "category": "css/properties",
+      "source_file": "css/properties/offset-rotate.json",
+      "support": {
+        "android": {
+          "version_added": "3.3"
+        },
+        "ios": {
+          "version_added": "3.3"
+        },
+        "harmony": {
+          "version_added": "3.8"
+        },
+        "web_lynx": {
+          "version_added": true
+        },
+        "clay_android": {
+          "version_added": false
+        },
+        "clay_ios": {
+          "version_added": false
+        },
+        "clay_macos": {
+          "version_added": false
+        },
+        "clay_windows": {
+          "version_added": false
+        },
+        "clay": {
+          "version_added": false
+        }
+      }
+    },
+    {
+      "id": "feature-708",
       "query": "css/properties/opacity",
       "name": "opacity",
       "category": "css/properties",
@@ -92741,7 +93140,7 @@
       }
     },
     {
-      "id": "feature-706",
+      "id": "feature-709",
       "query": "css/properties/order",
       "name": "The order CSS property sets the order to lay out an item.",
       "category": "css/properties",
@@ -92777,7 +93176,7 @@
       }
     },
     {
-      "id": "feature-707",
+      "id": "feature-710",
       "query": "css/properties/overflow-x",
       "name": "overflow-x",
       "category": "css/properties",
@@ -92813,7 +93212,7 @@
       }
     },
     {
-      "id": "feature-708",
+      "id": "feature-711",
       "query": "css/properties/overflow-y",
       "name": "overflow-y",
       "category": "css/properties",
@@ -92849,7 +93248,7 @@
       }
     },
     {
-      "id": "feature-709",
+      "id": "feature-712",
       "query": "css/properties/overflow",
       "name": "overflow",
       "category": "css/properties",
@@ -92885,7 +93284,7 @@
       }
     },
     {
-      "id": "feature-710",
+      "id": "feature-713",
       "query": "css/properties/padding-bottom",
       "name": "padding-bottom",
       "category": "css/properties",
@@ -92921,7 +93320,7 @@
       }
     },
     {
-      "id": "feature-711",
+      "id": "feature-714",
       "query": "css/properties/padding-inline-end",
       "name": "padding-inline-end",
       "category": "css/properties",
@@ -92957,7 +93356,7 @@
       }
     },
     {
-      "id": "feature-712",
+      "id": "feature-715",
       "query": "css/properties/padding-inline-start",
       "name": "padding-inline-start",
       "category": "css/properties",
@@ -92993,7 +93392,7 @@
       }
     },
     {
-      "id": "feature-713",
+      "id": "feature-716",
       "query": "css/properties/padding-left",
       "name": "padding-left",
       "category": "css/properties",
@@ -93029,7 +93428,7 @@
       }
     },
     {
-      "id": "feature-714",
+      "id": "feature-717",
       "query": "css/properties/padding-right",
       "name": "padding-right",
       "category": "css/properties",
@@ -93065,7 +93464,7 @@
       }
     },
     {
-      "id": "feature-715",
+      "id": "feature-718",
       "query": "css/properties/padding-top",
       "name": "padding-top",
       "category": "css/properties",
@@ -93101,7 +93500,7 @@
       }
     },
     {
-      "id": "feature-716",
+      "id": "feature-719",
       "query": "css/properties/padding",
       "name": "padding",
       "category": "css/properties",
@@ -93137,7 +93536,7 @@
       }
     },
     {
-      "id": "feature-717",
+      "id": "feature-720",
       "query": "css/properties/perspective",
       "name": "perspective",
       "category": "css/properties",
@@ -93173,7 +93572,7 @@
       }
     },
     {
-      "id": "feature-718",
+      "id": "feature-721",
       "query": "css/properties/pointer-events",
       "name": "pointer-events",
       "category": "css/properties",
@@ -93209,7 +93608,7 @@
       }
     },
     {
-      "id": "feature-719",
+      "id": "feature-722",
       "query": "css/properties/position",
       "name": "position",
       "category": "css/properties",
@@ -93245,7 +93644,7 @@
       }
     },
     {
-      "id": "feature-720",
+      "id": "feature-723",
       "query": "css/properties/position.relative",
       "name": "relative",
       "category": "css/properties",
@@ -93281,7 +93680,7 @@
       }
     },
     {
-      "id": "feature-721",
+      "id": "feature-724",
       "query": "css/properties/position.absolute",
       "name": "absolute",
       "category": "css/properties",
@@ -93317,7 +93716,7 @@
       }
     },
     {
-      "id": "feature-722",
+      "id": "feature-725",
       "query": "css/properties/position.fixed",
       "name": "fixed",
       "category": "css/properties",
@@ -93353,7 +93752,7 @@
       }
     },
     {
-      "id": "feature-723",
+      "id": "feature-726",
       "query": "css/properties/position.sticky",
       "name": "sticky",
       "category": "css/properties",
@@ -93389,7 +93788,7 @@
       }
     },
     {
-      "id": "feature-724",
+      "id": "feature-727",
       "query": "css/properties/position.static",
       "name": "static",
       "category": "css/properties",
@@ -93425,7 +93824,7 @@
       }
     },
     {
-      "id": "feature-725",
+      "id": "feature-728",
       "query": "css/properties/relative-align-bottom",
       "name": "Specifies that the current element is aligned with the bottom edge of the parent or sibling element corresponding to id.",
       "category": "css/properties",
@@ -93461,7 +93860,7 @@
       }
     },
     {
-      "id": "feature-726",
+      "id": "feature-729",
       "query": "css/properties/relative-align-inline-end",
       "name": "Specifies that the current element is aligned with the left/right edges of the parent or sibling element corresponding to id.",
       "category": "css/properties",
@@ -93497,7 +93896,7 @@
       }
     },
     {
-      "id": "feature-727",
+      "id": "feature-730",
       "query": "css/properties/relative-align-inline-start",
       "name": "Specifies that the current element is aligned with the left/right edges of the parent or sibling element corresponding to id.",
       "category": "css/properties",
@@ -93533,7 +93932,7 @@
       }
     },
     {
-      "id": "feature-728",
+      "id": "feature-731",
       "query": "css/properties/relative-align-left",
       "name": "Specifies that the current element is aligned with the left edge of the parent or sibling element corresponding to id.",
       "category": "css/properties",
@@ -93569,7 +93968,7 @@
       }
     },
     {
-      "id": "feature-729",
+      "id": "feature-732",
       "query": "css/properties/relative-align-right",
       "name": "Specifies that the current element is aligned with the right edge of the parent or sibling element corresponding to id.",
       "category": "css/properties",
@@ -93605,7 +94004,7 @@
       }
     },
     {
-      "id": "feature-730",
+      "id": "feature-733",
       "query": "css/properties/relative-align-top",
       "name": "Specifies that the current element is aligned with the top edge of the parent or sibling element corresponding to id.",
       "category": "css/properties",
@@ -93641,7 +94040,7 @@
       }
     },
     {
-      "id": "feature-731",
+      "id": "feature-734",
       "query": "css/properties/relative-bottom-of",
       "name": "The current element is to the bottom of the sibling element specified corresponding to id.",
       "category": "css/properties",
@@ -93677,7 +94076,7 @@
       }
     },
     {
-      "id": "feature-732",
+      "id": "feature-735",
       "query": "css/properties/relative-center",
       "name": "Specifies that the current element is aligned with the bottom edge of the parent or sibling element corresponding to id.",
       "category": "css/properties",
@@ -93713,7 +94112,7 @@
       }
     },
     {
-      "id": "feature-733",
+      "id": "feature-736",
       "query": "css/properties/relative-id",
       "name": "Used to set the number of sibling elements in the relative layout.",
       "category": "css/properties",
@@ -93749,7 +94148,7 @@
       }
     },
     {
-      "id": "feature-734",
+      "id": "feature-737",
       "query": "css/properties/relative-inline-end-of",
       "name": "The current element is to the left/right of the sibling element corresponding to the specified id.",
       "category": "css/properties",
@@ -93785,7 +94184,7 @@
       }
     },
     {
-      "id": "feature-735",
+      "id": "feature-738",
       "query": "css/properties/relative-inline-start-of",
       "name": "The current element is to the left/right of the sibling element corresponding to the specified id.",
       "category": "css/properties",
@@ -93821,7 +94220,7 @@
       }
     },
     {
-      "id": "feature-736",
+      "id": "feature-739",
       "query": "css/properties/relative-layout-once",
       "name": "Used to set typesetting acceleration. When using positioning between elements at the same level, it is recommended to enable this property, and elements at the same level will only depend upwards.",
       "category": "css/properties",
@@ -93857,7 +94256,7 @@
       }
     },
     {
-      "id": "feature-737",
+      "id": "feature-740",
       "query": "css/properties/relative-left-of",
       "name": "The current element is to the left of the sibling element specified corresponding to id.",
       "category": "css/properties",
@@ -93893,7 +94292,7 @@
       }
     },
     {
-      "id": "feature-738",
+      "id": "feature-741",
       "query": "css/properties/relative-right-of",
       "name": "The current element is to the right of the sibling element specified corresponding to id.",
       "category": "css/properties",
@@ -93929,7 +94328,7 @@
       }
     },
     {
-      "id": "feature-739",
+      "id": "feature-742",
       "query": "css/properties/relative-top-of",
       "name": "The current element is to the top of the sibling element specified corresponding to id.",
       "category": "css/properties",
@@ -93965,7 +94364,7 @@
       }
     },
     {
-      "id": "feature-740",
+      "id": "feature-743",
       "query": "css/properties/right",
       "name": "participates in setting the horizontal position of a positioned element. It has no effect on non-positioned elements.",
       "category": "css/properties",
@@ -94001,7 +94400,7 @@
       }
     },
     {
-      "id": "feature-741",
+      "id": "feature-744",
       "query": "css/properties/row-gap",
       "name": "<code>row-gap</code>",
       "category": "css/properties",
@@ -94037,7 +94436,7 @@
       }
     },
     {
-      "id": "feature-742",
+      "id": "feature-745",
       "query": "css/properties/row-gap.grid-row-gap",
       "name": "<code>grid-row-gap</code>",
       "category": "css/properties",
@@ -94073,7 +94472,7 @@
       }
     },
     {
-      "id": "feature-743",
+      "id": "feature-746",
       "query": "css/properties/row-gap.supported_in_flex_layout",
       "name": "Supported in Flexible Box Layout",
       "category": "css/properties",
@@ -94109,7 +94508,7 @@
       }
     },
     {
-      "id": "feature-744",
+      "id": "feature-747",
       "query": "css/properties/row-gap.supported_in_flex_layout.nested_value_1",
       "name": "<code>row-gap</code> and <code>grid-row-gap</code>",
       "category": "css/properties",
@@ -94145,7 +94544,7 @@
       }
     },
     {
-      "id": "feature-745",
+      "id": "feature-748",
       "query": "css/properties/row-gap.supported_in_grid_layout",
       "name": "Supported in Grid Layout",
       "category": "css/properties",
@@ -94181,7 +94580,7 @@
       }
     },
     {
-      "id": "feature-746",
+      "id": "feature-749",
       "query": "css/properties/row-gap.supported_in_grid_layout.grid-row-gap",
       "name": "<code>grid-row-gap</code>",
       "category": "css/properties",
@@ -94217,7 +94616,7 @@
       }
     },
     {
-      "id": "feature-747",
+      "id": "feature-750",
       "query": "css/properties/row-gap.supported_in_grid_layout",
       "name": "<code>row-gap</code>",
       "category": "css/properties",
@@ -94253,7 +94652,7 @@
       }
     },
     {
-      "id": "feature-748",
+      "id": "feature-751",
       "query": "css/properties/text-align",
       "name": "text-align",
       "category": "css/properties",
@@ -94289,7 +94688,7 @@
       }
     },
     {
-      "id": "feature-749",
+      "id": "feature-752",
       "query": "css/properties/text-decoration",
       "name": "text-decoration",
       "category": "css/properties",
@@ -94325,7 +94724,7 @@
       }
     },
     {
-      "id": "feature-750",
+      "id": "feature-753",
       "query": "css/properties/text-indent",
       "name": "text-indent",
       "category": "css/properties",
@@ -94361,7 +94760,7 @@
       }
     },
     {
-      "id": "feature-751",
+      "id": "feature-754",
       "query": "css/properties/text-overflow",
       "name": "text-overflow",
       "category": "css/properties",
@@ -94397,7 +94796,7 @@
       }
     },
     {
-      "id": "feature-752",
+      "id": "feature-755",
       "query": "css/properties/text-shadow",
       "name": "text-shadow",
       "category": "css/properties",
@@ -94433,7 +94832,7 @@
       }
     },
     {
-      "id": "feature-753",
+      "id": "feature-756",
       "query": "css/properties/text-stroke-color",
       "name": "text-stroke-color",
       "category": "css/properties",
@@ -94469,7 +94868,7 @@
       }
     },
     {
-      "id": "feature-754",
+      "id": "feature-757",
       "query": "css/properties/text-stroke-width",
       "name": "text-stroke-width",
       "category": "css/properties",
@@ -94505,7 +94904,7 @@
       }
     },
     {
-      "id": "feature-755",
+      "id": "feature-758",
       "query": "css/properties/text-stroke",
       "name": "text-stroke",
       "category": "css/properties",
@@ -94541,7 +94940,7 @@
       }
     },
     {
-      "id": "feature-756",
+      "id": "feature-759",
       "query": "css/properties/top",
       "name": "participates in setting the vertical position of a positioned element. It has no effect on non-positioned elements.",
       "category": "css/properties",
@@ -94577,7 +94976,7 @@
       }
     },
     {
-      "id": "feature-757",
+      "id": "feature-760",
       "query": "css/properties/transform-origin",
       "name": "transform-origin",
       "category": "css/properties",
@@ -94613,7 +95012,7 @@
       }
     },
     {
-      "id": "feature-758",
+      "id": "feature-761",
       "query": "css/properties/transform",
       "name": "transform",
       "category": "css/properties",
@@ -94649,7 +95048,7 @@
       }
     },
     {
-      "id": "feature-759",
+      "id": "feature-762",
       "query": "css/properties/transform.translate",
       "name": "translate",
       "category": "css/properties",
@@ -94685,7 +95084,7 @@
       }
     },
     {
-      "id": "feature-760",
+      "id": "feature-763",
       "query": "css/properties/transform.translateX",
       "name": "translateX",
       "category": "css/properties",
@@ -94721,7 +95120,7 @@
       }
     },
     {
-      "id": "feature-761",
+      "id": "feature-764",
       "query": "css/properties/transform.translateY",
       "name": "translateY",
       "category": "css/properties",
@@ -94757,7 +95156,7 @@
       }
     },
     {
-      "id": "feature-762",
+      "id": "feature-765",
       "query": "css/properties/transform.translateZ",
       "name": "translateZ",
       "category": "css/properties",
@@ -94793,7 +95192,7 @@
       }
     },
     {
-      "id": "feature-763",
+      "id": "feature-766",
       "query": "css/properties/transform.translate3d",
       "name": "translate3d",
       "category": "css/properties",
@@ -94829,7 +95228,7 @@
       }
     },
     {
-      "id": "feature-764",
+      "id": "feature-767",
       "query": "css/properties/transform.rotate",
       "name": "rotate",
       "category": "css/properties",
@@ -94865,7 +95264,7 @@
       }
     },
     {
-      "id": "feature-765",
+      "id": "feature-768",
       "query": "css/properties/transform.rotateZ",
       "name": "rotateZ",
       "category": "css/properties",
@@ -94901,7 +95300,7 @@
       }
     },
     {
-      "id": "feature-766",
+      "id": "feature-769",
       "query": "css/properties/transform.rotateX",
       "name": "rotateX",
       "category": "css/properties",
@@ -94937,7 +95336,7 @@
       }
     },
     {
-      "id": "feature-767",
+      "id": "feature-770",
       "query": "css/properties/transform.rotateY",
       "name": "rotateY",
       "category": "css/properties",
@@ -94973,7 +95372,7 @@
       }
     },
     {
-      "id": "feature-768",
+      "id": "feature-771",
       "query": "css/properties/transform.scale",
       "name": "scale",
       "category": "css/properties",
@@ -95009,7 +95408,7 @@
       }
     },
     {
-      "id": "feature-769",
+      "id": "feature-772",
       "query": "css/properties/transform.scaleX",
       "name": "scaleX",
       "category": "css/properties",
@@ -95045,7 +95444,7 @@
       }
     },
     {
-      "id": "feature-770",
+      "id": "feature-773",
       "query": "css/properties/transform.scaleY",
       "name": "scaleY",
       "category": "css/properties",
@@ -95081,7 +95480,7 @@
       }
     },
     {
-      "id": "feature-771",
+      "id": "feature-774",
       "query": "css/properties/transform.skew",
       "name": "skew",
       "category": "css/properties",
@@ -95117,7 +95516,7 @@
       }
     },
     {
-      "id": "feature-772",
+      "id": "feature-775",
       "query": "css/properties/transform.skewX",
       "name": "skewX",
       "category": "css/properties",
@@ -95153,7 +95552,7 @@
       }
     },
     {
-      "id": "feature-773",
+      "id": "feature-776",
       "query": "css/properties/transform.skewY",
       "name": "skewY",
       "category": "css/properties",
@@ -95189,7 +95588,7 @@
       }
     },
     {
-      "id": "feature-774",
+      "id": "feature-777",
       "query": "css/properties/transform.matrix",
       "name": "matrix",
       "category": "css/properties",
@@ -95225,7 +95624,7 @@
       }
     },
     {
-      "id": "feature-775",
+      "id": "feature-778",
       "query": "css/properties/transform.matrix3d",
       "name": "matrix3d",
       "category": "css/properties",
@@ -95261,7 +95660,7 @@
       }
     },
     {
-      "id": "feature-776",
+      "id": "feature-779",
       "query": "css/properties/transform.rotate3d",
       "name": "rotate3d",
       "category": "css/properties",
@@ -95297,7 +95696,7 @@
       }
     },
     {
-      "id": "feature-777",
+      "id": "feature-780",
       "query": "css/properties/transform.scale3d",
       "name": "scale3d",
       "category": "css/properties",
@@ -95333,7 +95732,7 @@
       }
     },
     {
-      "id": "feature-778",
+      "id": "feature-781",
       "query": "css/properties/transition-delay",
       "name": "transition-delay",
       "category": "css/properties",
@@ -95369,7 +95768,7 @@
       }
     },
     {
-      "id": "feature-779",
+      "id": "feature-782",
       "query": "css/properties/transition-duration",
       "name": "transition-duration",
       "category": "css/properties",
@@ -95405,7 +95804,7 @@
       }
     },
     {
-      "id": "feature-780",
+      "id": "feature-783",
       "query": "css/properties/transition-property",
       "name": "transition-property",
       "category": "css/properties",
@@ -95441,7 +95840,7 @@
       }
     },
     {
-      "id": "feature-781",
+      "id": "feature-784",
       "query": "css/properties/transition-timing-function",
       "name": "transition-timing-function",
       "category": "css/properties",
@@ -95477,7 +95876,7 @@
       }
     },
     {
-      "id": "feature-782",
+      "id": "feature-785",
       "query": "css/properties/transition-timing-function.linear",
       "name": "linear",
       "category": "css/properties",
@@ -95513,7 +95912,7 @@
       }
     },
     {
-      "id": "feature-783",
+      "id": "feature-786",
       "query": "css/properties/transition-timing-function.ease-in",
       "name": "ease-in",
       "category": "css/properties",
@@ -95549,7 +95948,7 @@
       }
     },
     {
-      "id": "feature-784",
+      "id": "feature-787",
       "query": "css/properties/transition-timing-function.ease-out",
       "name": "ease-out",
       "category": "css/properties",
@@ -95585,7 +95984,7 @@
       }
     },
     {
-      "id": "feature-785",
+      "id": "feature-788",
       "query": "css/properties/transition-timing-function.ease-in-ease-out",
       "name": "ease-in-ease-out",
       "category": "css/properties",
@@ -95621,7 +96020,7 @@
       }
     },
     {
-      "id": "feature-786",
+      "id": "feature-789",
       "query": "css/properties/transition-timing-function.ease",
       "name": "ease",
       "category": "css/properties",
@@ -95657,7 +96056,7 @@
       }
     },
     {
-      "id": "feature-787",
+      "id": "feature-790",
       "query": "css/properties/transition-timing-function.ease-in-out",
       "name": "ease-in-out",
       "category": "css/properties",
@@ -95693,7 +96092,7 @@
       }
     },
     {
-      "id": "feature-788",
+      "id": "feature-791",
       "query": "css/properties/transition-timing-function.square-bezier",
       "name": "square-bezier",
       "category": "css/properties",
@@ -95729,7 +96128,7 @@
       }
     },
     {
-      "id": "feature-789",
+      "id": "feature-792",
       "query": "css/properties/transition-timing-function.cubic-bezier",
       "name": "cubic-bezier",
       "category": "css/properties",
@@ -95765,7 +96164,7 @@
       }
     },
     {
-      "id": "feature-790",
+      "id": "feature-793",
       "query": "css/properties/transition-timing-function.step-start",
       "name": "step-start",
       "category": "css/properties",
@@ -95801,7 +96200,7 @@
       }
     },
     {
-      "id": "feature-791",
+      "id": "feature-794",
       "query": "css/properties/transition-timing-function.step-end",
       "name": "step-end",
       "category": "css/properties",
@@ -95837,7 +96236,7 @@
       }
     },
     {
-      "id": "feature-792",
+      "id": "feature-795",
       "query": "css/properties/transition-timing-function.steps",
       "name": "steps",
       "category": "css/properties",
@@ -95873,7 +96272,7 @@
       }
     },
     {
-      "id": "feature-793",
+      "id": "feature-796",
       "query": "css/properties/transition",
       "name": "transition",
       "category": "css/properties",
@@ -95909,7 +96308,7 @@
       }
     },
     {
-      "id": "feature-794",
+      "id": "feature-797",
       "query": "css/properties/vertical-align",
       "name": "vertical-align",
       "category": "css/properties",
@@ -95945,7 +96344,7 @@
       }
     },
     {
-      "id": "feature-795",
+      "id": "feature-798",
       "query": "css/properties/visibility",
       "name": "visibility",
       "category": "css/properties",
@@ -95981,7 +96380,7 @@
       }
     },
     {
-      "id": "feature-796",
+      "id": "feature-799",
       "query": "css/properties/white-space",
       "name": "white-space",
       "category": "css/properties",
@@ -96017,7 +96416,7 @@
       }
     },
     {
-      "id": "feature-797",
+      "id": "feature-800",
       "query": "css/properties/width",
       "name": "width",
       "category": "css/properties",
@@ -96053,7 +96452,7 @@
       }
     },
     {
-      "id": "feature-798",
+      "id": "feature-801",
       "query": "css/properties/width.max-content",
       "name": "max-content",
       "category": "css/properties",
@@ -96089,7 +96488,7 @@
       }
     },
     {
-      "id": "feature-799",
+      "id": "feature-802",
       "query": "css/properties/width.fit-content",
       "name": "fit-content",
       "category": "css/properties",
@@ -96125,7 +96524,7 @@
       }
     },
     {
-      "id": "feature-800",
+      "id": "feature-803",
       "query": "css/properties/width.min-content",
       "name": "min-content",
       "category": "css/properties",
@@ -96161,7 +96560,7 @@
       }
     },
     {
-      "id": "feature-801",
+      "id": "feature-804",
       "query": "css/properties/word-break",
       "name": "word-break",
       "category": "css/properties",
@@ -96197,7 +96596,7 @@
       }
     },
     {
-      "id": "feature-802",
+      "id": "feature-805",
       "query": "css/properties/z-index",
       "name": "z-index",
       "category": "css/properties",
@@ -96233,7 +96632,7 @@
       }
     },
     {
-      "id": "feature-803",
+      "id": "feature-806",
       "query": "css/at-rule/font-face",
       "name": "font-face",
       "category": "css/at-rule",
@@ -96269,7 +96668,7 @@
       }
     },
     {
-      "id": "feature-804",
+      "id": "feature-807",
       "query": "css/data-type/angle",
       "name": "<code>&lt;angle&gt;</code>",
       "category": "css/data-type",
@@ -96305,7 +96704,7 @@
       }
     },
     {
-      "id": "feature-805",
+      "id": "feature-808",
       "query": "css/data-type/angle.deg",
       "name": "deg",
       "category": "css/data-type",
@@ -96341,7 +96740,7 @@
       }
     },
     {
-      "id": "feature-806",
+      "id": "feature-809",
       "query": "css/data-type/angle.grad",
       "name": "grad",
       "category": "css/data-type",
@@ -96377,7 +96776,7 @@
       }
     },
     {
-      "id": "feature-807",
+      "id": "feature-810",
       "query": "css/data-type/angle.rad",
       "name": "rad",
       "category": "css/data-type",
@@ -96413,7 +96812,7 @@
       }
     },
     {
-      "id": "feature-808",
+      "id": "feature-811",
       "query": "css/data-type/angle.turn",
       "name": "turn",
       "category": "css/data-type",
@@ -96449,7 +96848,7 @@
       }
     },
     {
-      "id": "feature-809",
+      "id": "feature-812",
       "query": "css/data-type/color",
       "name": "<code>&lt;color&gt;</code>",
       "category": "css/data-type",
@@ -96485,7 +96884,7 @@
       }
     },
     {
-      "id": "feature-810",
+      "id": "feature-813",
       "query": "css/data-type/color.rgb()",
       "name": "<code>rgb()</code> (RGB color model)",
       "category": "css/data-type",
@@ -96521,7 +96920,7 @@
       }
     },
     {
-      "id": "feature-811",
+      "id": "feature-814",
       "query": "css/data-type/color.rgb().legacy-rgb-syntax",
       "name": "<a href='https://drafts.csswg.org/css-color/#typedef-legacy-rgb-syntax'><code>&lt;legacy-rgb-syntax&gt;</code></a>",
       "category": "css/data-type",
@@ -96557,7 +96956,7 @@
       }
     },
     {
-      "id": "feature-812",
+      "id": "feature-815",
       "query": "css/data-type/color.rgb().modern-rgb-syntax",
       "name": "<a href='https://drafts.csswg.org/css-color/#typedef-modern-rgb-syntax'><code>&lt;modern-rgb-syntax&gt;</code></a>",
       "category": "css/data-type",
@@ -96593,7 +96992,7 @@
       }
     },
     {
-      "id": "feature-813",
+      "id": "feature-816",
       "query": "css/data-type/color.rgb().legacy-rgba-syntax",
       "name": "<a href='https://drafts.csswg.org/css-color/#typedef-legacy-rgba-syntax'><code>&lt;legacy-rgba-syntax&gt;</code></a>",
       "category": "css/data-type",
@@ -96629,7 +97028,7 @@
       }
     },
     {
-      "id": "feature-814",
+      "id": "feature-817",
       "query": "css/data-type/color.rgb().modern-rgba-syntax",
       "name": "<a href='https://drafts.csswg.org/css-color/#typedef-modern-rgba-syntax'><code>&lt;modern-rgba-syntax&gt;</code></a>",
       "category": "css/data-type",
@@ -96665,7 +97064,7 @@
       }
     },
     {
-      "id": "feature-815",
+      "id": "feature-818",
       "query": "css/data-type/color.hsl",
       "name": "<code>hsl()</code> (HSL color model)",
       "category": "css/data-type",
@@ -96701,7 +97100,7 @@
       }
     },
     {
-      "id": "feature-816",
+      "id": "feature-819",
       "query": "css/data-type/fit-content",
       "name": "fit-content",
       "category": "css/data-type",
@@ -96737,7 +97136,7 @@
       }
     },
     {
-      "id": "feature-817",
+      "id": "feature-820",
       "query": "css/data-type/gradient",
       "name": "<code>&lt;gradient&gt;</code>",
       "category": "css/data-type",
@@ -96773,7 +97172,7 @@
       }
     },
     {
-      "id": "feature-818",
+      "id": "feature-821",
       "query": "css/data-type/gradient.linear-gradient()",
       "name": "linear-gradient()",
       "category": "css/data-type",
@@ -96809,7 +97208,7 @@
       }
     },
     {
-      "id": "feature-819",
+      "id": "feature-822",
       "query": "css/data-type/gradient.radial-gradient()",
       "name": "radial-gradient()",
       "category": "css/data-type",
@@ -96845,7 +97244,7 @@
       }
     },
     {
-      "id": "feature-820",
+      "id": "feature-823",
       "query": "css/data-type/gradient.conic-gradient()",
       "name": "conic-gradient()",
       "category": "css/data-type",
@@ -96881,7 +97280,7 @@
       }
     },
     {
-      "id": "feature-821",
+      "id": "feature-824",
       "query": "css/data-type/length-percentage",
       "name": "<code>&lt;length-percentage&gt;</code>",
       "category": "css/data-type",
@@ -96917,7 +97316,7 @@
       }
     },
     {
-      "id": "feature-822",
+      "id": "feature-825",
       "query": "css/data-type/length",
       "name": "<code>&lt;length&gt;</code>",
       "category": "css/data-type",
@@ -96953,7 +97352,7 @@
       }
     },
     {
-      "id": "feature-823",
+      "id": "feature-826",
       "query": "css/data-type/length.absolute",
       "name": "Absolute length units",
       "category": "css/data-type",
@@ -96989,7 +97388,7 @@
       }
     },
     {
-      "id": "feature-824",
+      "id": "feature-827",
       "query": "css/data-type/length.absolute.value_px",
       "name": "<code>px</code> unit",
       "category": "css/data-type",
@@ -97025,7 +97424,7 @@
       }
     },
     {
-      "id": "feature-825",
+      "id": "feature-828",
       "query": "css/data-type/length.absolute.value_ppx",
       "name": "<code>ppx</code> unit",
       "category": "css/data-type",
@@ -97061,7 +97460,7 @@
       }
     },
     {
-      "id": "feature-826",
+      "id": "feature-829",
       "query": "css/data-type/length.relative",
       "name": "Relative length units",
       "category": "css/data-type",
@@ -97097,7 +97496,7 @@
       }
     },
     {
-      "id": "feature-827",
+      "id": "feature-830",
       "query": "css/data-type/length.relative.value_rpx",
       "name": "<code>rpx</code> unit",
       "category": "css/data-type",
@@ -97133,7 +97532,7 @@
       }
     },
     {
-      "id": "feature-828",
+      "id": "feature-831",
       "query": "css/data-type/length.relative.value_rem",
       "name": "<code>rem</code> unit",
       "category": "css/data-type",
@@ -97169,7 +97568,7 @@
       }
     },
     {
-      "id": "feature-829",
+      "id": "feature-832",
       "query": "css/data-type/length.relative.value_em",
       "name": "<code>em</code> unit",
       "category": "css/data-type",
@@ -97205,7 +97604,7 @@
       }
     },
     {
-      "id": "feature-830",
+      "id": "feature-833",
       "query": "css/data-type/length.relative.value_vh",
       "name": "<code>vh</code> unit",
       "category": "css/data-type",
@@ -97241,7 +97640,7 @@
       }
     },
     {
-      "id": "feature-831",
+      "id": "feature-834",
       "query": "css/data-type/length.relative.value_vw",
       "name": "<code>vw</code> unit",
       "category": "css/data-type",
@@ -97277,7 +97676,7 @@
       }
     },
     {
-      "id": "feature-832",
+      "id": "feature-835",
       "query": "css/data-type/max-content",
       "name": "max-content",
       "category": "css/data-type",
@@ -97313,7 +97712,7 @@
       }
     },
     {
-      "id": "feature-833",
+      "id": "feature-836",
       "query": "css/data-type/number",
       "name": "<code>&lt;number&gt;</code>",
       "category": "css/data-type",
@@ -97349,7 +97748,7 @@
       }
     },
     {
-      "id": "feature-834",
+      "id": "feature-837",
       "query": "css/data-type/percentage",
       "name": "<code>&lt;percentage&gt;</code>",
       "category": "css/data-type",
@@ -97385,7 +97784,7 @@
       }
     },
     {
-      "id": "feature-835",
+      "id": "feature-838",
       "query": "css/data-type/string",
       "name": "<code>&lt;string&gt;</code>",
       "category": "css/data-type",
@@ -97421,7 +97820,7 @@
       }
     },
     {
-      "id": "feature-836",
+      "id": "feature-839",
       "query": "css/data-type/time",
       "name": "<code>&lt;time&gt;</code>",
       "category": "css/data-type",
@@ -97457,7 +97856,7 @@
       }
     },
     {
-      "id": "feature-837",
+      "id": "feature-840",
       "query": "lynx-api/global/SystemInfo",
       "name": "Information of the current system",
       "category": "lynx-api/global",
@@ -97493,7 +97892,7 @@
       }
     },
     {
-      "id": "feature-838",
+      "id": "feature-841",
       "query": "lynx-api/global/SystemInfo.SystemInfo.engineVersion",
       "name": "engineVersion",
       "category": "lynx-api/global",
@@ -97529,7 +97928,7 @@
       }
     },
     {
-      "id": "feature-839",
+      "id": "feature-842",
       "query": "lynx-api/global/SystemInfo.SystemInfo.lynxSdkVersion",
       "name": "lynxSdkVersion",
       "category": "lynx-api/global",
@@ -97565,7 +97964,7 @@
       }
     },
     {
-      "id": "feature-840",
+      "id": "feature-843",
       "query": "lynx-api/global/clearInterval",
       "name": "Cancels the timer set by `setInterval`.",
       "category": "lynx-api/global",
@@ -97601,7 +98000,7 @@
       }
     },
     {
-      "id": "feature-841",
+      "id": "feature-844",
       "query": "lynx-api/global/clearTimeout",
       "name": "Cancel the timer set by `setTimeout`.",
       "category": "lynx-api/global",
@@ -97637,7 +98036,7 @@
       }
     },
     {
-      "id": "feature-842",
+      "id": "feature-845",
       "query": "lynx-api/global/console/assert",
       "name": "assert failed and output error level message",
       "category": "lynx-api/global",
@@ -97673,7 +98072,7 @@
       }
     },
     {
-      "id": "feature-843",
+      "id": "feature-846",
       "query": "lynx-api/global/console/count",
       "name": "start count",
       "category": "lynx-api/global",
@@ -97709,7 +98108,7 @@
       }
     },
     {
-      "id": "feature-844",
+      "id": "feature-847",
       "query": "lynx-api/global/console/countReset",
       "name": "reset count",
       "category": "lynx-api/global",
@@ -97745,7 +98144,7 @@
       }
     },
     {
-      "id": "feature-845",
+      "id": "feature-848",
       "query": "lynx-api/global/console/debug",
       "name": "output a debug level message",
       "category": "lynx-api/global",
@@ -97781,7 +98180,7 @@
       }
     },
     {
-      "id": "feature-846",
+      "id": "feature-849",
       "query": "lynx-api/global/console/error",
       "name": "output a error level message",
       "category": "lynx-api/global",
@@ -97817,7 +98216,7 @@
       }
     },
     {
-      "id": "feature-847",
+      "id": "feature-850",
       "query": "lynx-api/global/console/group",
       "name": "start a console group",
       "category": "lynx-api/global",
@@ -97853,7 +98252,7 @@
       }
     },
     {
-      "id": "feature-848",
+      "id": "feature-851",
       "query": "lynx-api/global/console/groupCollapsed",
       "name": "start a collapsed console group",
       "category": "lynx-api/global",
@@ -97889,7 +98288,7 @@
       }
     },
     {
-      "id": "feature-849",
+      "id": "feature-852",
       "query": "lynx-api/global/console/groupEnd",
       "name": "end a console group",
       "category": "lynx-api/global",
@@ -97925,7 +98324,7 @@
       }
     },
     {
-      "id": "feature-850",
+      "id": "feature-853",
       "query": "lynx-api/global/console/info",
       "name": "output a info level message",
       "category": "lynx-api/global",
@@ -97961,7 +98360,7 @@
       }
     },
     {
-      "id": "feature-851",
+      "id": "feature-854",
       "query": "lynx-api/global/console/log",
       "name": "output a log level message",
       "category": "lynx-api/global",
@@ -97997,7 +98396,7 @@
       }
     },
     {
-      "id": "feature-852",
+      "id": "feature-855",
       "query": "lynx-api/global/console/profile",
       "name": "output a message",
       "category": "lynx-api/global",
@@ -98033,7 +98432,7 @@
       }
     },
     {
-      "id": "feature-853",
+      "id": "feature-856",
       "query": "lynx-api/global/console/profileEnd",
       "name": "end profile",
       "category": "lynx-api/global",
@@ -98069,7 +98468,7 @@
       }
     },
     {
-      "id": "feature-854",
+      "id": "feature-857",
       "query": "lynx-api/global/console/table",
       "name": "print message by table",
       "category": "lynx-api/global",
@@ -98105,7 +98504,7 @@
       }
     },
     {
-      "id": "feature-855",
+      "id": "feature-858",
       "query": "lynx-api/global/console/time",
       "name": "start a timer",
       "category": "lynx-api/global",
@@ -98141,7 +98540,7 @@
       }
     },
     {
-      "id": "feature-856",
+      "id": "feature-859",
       "query": "lynx-api/global/console/timeEnd",
       "name": "end a timer",
       "category": "lynx-api/global",
@@ -98177,7 +98576,7 @@
       }
     },
     {
-      "id": "feature-857",
+      "id": "feature-860",
       "query": "lynx-api/global/console/timeLog",
       "name": "print timer",
       "category": "lynx-api/global",
@@ -98213,7 +98612,7 @@
       }
     },
     {
-      "id": "feature-858",
+      "id": "feature-861",
       "query": "lynx-api/global/console/warn",
       "name": "output a warn level message",
       "category": "lynx-api/global",
@@ -98249,7 +98648,7 @@
       }
     },
     {
-      "id": "feature-859",
+      "id": "feature-862",
       "query": "lynx-api/global/setInterval",
       "name": "Repeatedly calls a function or executes a code fragment with a fixed time interval between each call.",
       "category": "lynx-api/global",
@@ -98285,7 +98684,7 @@
       }
     },
     {
-      "id": "feature-860",
+      "id": "feature-863",
       "query": "lynx-api/global/setTimeout",
       "name": "setTimeout",
       "category": "lynx-api/global",
@@ -98321,7 +98720,7 @@
       }
     },
     {
-      "id": "feature-861",
+      "id": "feature-864",
       "query": "lynx-api/event/AnimationEvent",
       "name": "AnimationEvent",
       "category": "lynx-api/event",
@@ -98357,7 +98756,7 @@
       }
     },
     {
-      "id": "feature-862",
+      "id": "feature-865",
       "query": "lynx-api/event/AnimationEvent.detail",
       "name": "detail",
       "category": "lynx-api/event",
@@ -98393,7 +98792,7 @@
       }
     },
     {
-      "id": "feature-863",
+      "id": "feature-866",
       "query": "lynx-api/event/AnimationEvent.animationstart",
       "name": "animationstart",
       "category": "lynx-api/event",
@@ -98429,7 +98828,7 @@
       }
     },
     {
-      "id": "feature-864",
+      "id": "feature-867",
       "query": "lynx-api/event/AnimationEvent.animationend",
       "name": "animationend",
       "category": "lynx-api/event",
@@ -98465,7 +98864,7 @@
       }
     },
     {
-      "id": "feature-865",
+      "id": "feature-868",
       "query": "lynx-api/event/AnimationEvent.animationiteration",
       "name": "animationiteration",
       "category": "lynx-api/event",
@@ -98501,7 +98900,7 @@
       }
     },
     {
-      "id": "feature-866",
+      "id": "feature-869",
       "query": "lynx-api/event/AnimationEvent.animationcancel",
       "name": "animationcancel",
       "category": "lynx-api/event",
@@ -98537,7 +98936,7 @@
       }
     },
     {
-      "id": "feature-867",
+      "id": "feature-870",
       "query": "lynx-api/event/AnimationEvent.transitionstart",
       "name": "transitionstart",
       "category": "lynx-api/event",
@@ -98573,7 +98972,7 @@
       }
     },
     {
-      "id": "feature-868",
+      "id": "feature-871",
       "query": "lynx-api/event/AnimationEvent.transitionend",
       "name": "transitionend",
       "category": "lynx-api/event",
@@ -98609,7 +99008,7 @@
       }
     },
     {
-      "id": "feature-869",
+      "id": "feature-872",
       "query": "lynx-api/event/AnimationEvent.transitioncancel",
       "name": "transitioncancel",
       "category": "lynx-api/event",
@@ -98645,7 +99044,7 @@
       }
     },
     {
-      "id": "feature-870",
+      "id": "feature-873",
       "query": "lynx-api/event/CustomEvent",
       "name": "CustomEvent",
       "category": "lynx-api/event",
@@ -98681,7 +99080,7 @@
       }
     },
     {
-      "id": "feature-871",
+      "id": "feature-874",
       "query": "lynx-api/event/CustomEvent.params",
       "name": "params",
       "category": "lynx-api/event",
@@ -98717,7 +99116,7 @@
       }
     },
     {
-      "id": "feature-872",
+      "id": "feature-875",
       "query": "lynx-api/event/CustomEvent.detail",
       "name": "detail",
       "category": "lynx-api/event",
@@ -98753,7 +99152,7 @@
       }
     },
     {
-      "id": "feature-873",
+      "id": "feature-876",
       "query": "lynx-api/event/Event",
       "name": "Event",
       "category": "lynx-api/event",
@@ -98789,7 +99188,7 @@
       }
     },
     {
-      "id": "feature-874",
+      "id": "feature-877",
       "query": "lynx-api/event/Event.TouchEvent",
       "name": "TouchEvent",
       "category": "lynx-api/event",
@@ -98825,7 +99224,7 @@
       }
     },
     {
-      "id": "feature-875",
+      "id": "feature-878",
       "query": "lynx-api/event/Event.CustomEvent",
       "name": "CustomEvent",
       "category": "lynx-api/event",
@@ -98861,7 +99260,7 @@
       }
     },
     {
-      "id": "feature-876",
+      "id": "feature-879",
       "query": "lynx-api/event/Event.AnimationEvent",
       "name": "AnimationEvent",
       "category": "lynx-api/event",
@@ -98897,7 +99296,7 @@
       }
     },
     {
-      "id": "feature-877",
+      "id": "feature-880",
       "query": "lynx-api/event/Event.type",
       "name": "type",
       "category": "lynx-api/event",
@@ -98933,7 +99332,7 @@
       }
     },
     {
-      "id": "feature-878",
+      "id": "feature-881",
       "query": "lynx-api/event/Event.timestamp",
       "name": "timestamp",
       "category": "lynx-api/event",
@@ -98969,7 +99368,7 @@
       }
     },
     {
-      "id": "feature-879",
+      "id": "feature-882",
       "query": "lynx-api/event/Event.target",
       "name": "target",
       "category": "lynx-api/event",
@@ -99005,7 +99404,7 @@
       }
     },
     {
-      "id": "feature-880",
+      "id": "feature-883",
       "query": "lynx-api/event/Event.currentTarget",
       "name": "currentTarget",
       "category": "lynx-api/event",
@@ -99041,7 +99440,7 @@
       }
     },
     {
-      "id": "feature-881",
+      "id": "feature-884",
       "query": "lynx-api/event/Event.stopPropagation",
       "name": "stopPropagation",
       "category": "lynx-api/event",
@@ -99077,7 +99476,7 @@
       }
     },
     {
-      "id": "feature-882",
+      "id": "feature-885",
       "query": "lynx-api/event/Event.stopImmediatePropagation",
       "name": "stopImmediatePropagation",
       "category": "lynx-api/event",
@@ -99113,7 +99512,7 @@
       }
     },
     {
-      "id": "feature-883",
+      "id": "feature-886",
       "query": "lynx-api/event/GlobalEvent",
       "name": "GlobalEvent",
       "category": "lynx-api/event",
@@ -99149,7 +99548,7 @@
       }
     },
     {
-      "id": "feature-884",
+      "id": "feature-887",
       "query": "lynx-api/event/GlobalEvent.keyboardstatuschanged",
       "name": "keyboardstatuschanged",
       "category": "lynx-api/event",
@@ -99185,7 +99584,7 @@
       }
     },
     {
-      "id": "feature-885",
+      "id": "feature-888",
       "query": "lynx-api/event/GlobalEvent.onWindowResize",
       "name": "onWindowResize",
       "category": "lynx-api/event",
@@ -99221,7 +99620,7 @@
       }
     },
     {
-      "id": "feature-886",
+      "id": "feature-889",
       "query": "lynx-api/event/GlobalEvent.exposure",
       "name": "exposure",
       "category": "lynx-api/event",
@@ -99257,7 +99656,7 @@
       }
     },
     {
-      "id": "feature-887",
+      "id": "feature-890",
       "query": "lynx-api/event/GlobalEvent.disexposure",
       "name": "disexposure",
       "category": "lynx-api/event",
@@ -99293,7 +99692,7 @@
       }
     },
     {
-      "id": "feature-888",
+      "id": "feature-891",
       "query": "lynx-api/event/KeyEvent",
       "name": "KeyEvent",
       "category": "lynx-api/event",
@@ -99329,7 +99728,7 @@
       }
     },
     {
-      "id": "feature-889",
+      "id": "feature-892",
       "query": "lynx-api/event/KeyEvent.key",
       "name": "key",
       "category": "lynx-api/event",
@@ -99365,7 +99764,7 @@
       }
     },
     {
-      "id": "feature-890",
+      "id": "feature-893",
       "query": "lynx-api/event/KeyEvent.repeat",
       "name": "repeat",
       "category": "lynx-api/event",
@@ -99401,7 +99800,7 @@
       }
     },
     {
-      "id": "feature-891",
+      "id": "feature-894",
       "query": "lynx-api/event/KeyEvent.altKey",
       "name": "altKey",
       "category": "lynx-api/event",
@@ -99437,7 +99836,7 @@
       }
     },
     {
-      "id": "feature-892",
+      "id": "feature-895",
       "query": "lynx-api/event/KeyEvent.ctrlKey",
       "name": "ctrlKey",
       "category": "lynx-api/event",
@@ -99473,7 +99872,7 @@
       }
     },
     {
-      "id": "feature-893",
+      "id": "feature-896",
       "query": "lynx-api/event/KeyEvent.metaKey",
       "name": "metaKey",
       "category": "lynx-api/event",
@@ -99509,7 +99908,7 @@
       }
     },
     {
-      "id": "feature-894",
+      "id": "feature-897",
       "query": "lynx-api/event/KeyEvent.shiftKey",
       "name": "shiftKey",
       "category": "lynx-api/event",
@@ -99545,7 +99944,7 @@
       }
     },
     {
-      "id": "feature-895",
+      "id": "feature-898",
       "query": "lynx-api/event/KeyEvent.keydown",
       "name": "keydown",
       "category": "lynx-api/event",
@@ -99581,7 +99980,7 @@
       }
     },
     {
-      "id": "feature-896",
+      "id": "feature-899",
       "query": "lynx-api/event/KeyEvent.keyup",
       "name": "keyup",
       "category": "lynx-api/event",
@@ -99617,7 +100016,7 @@
       }
     },
     {
-      "id": "feature-897",
+      "id": "feature-900",
       "query": "lynx-api/event/MemoryEvent",
       "name": "MemoryEvent",
       "category": "lynx-api/event",
@@ -99653,7 +100052,7 @@
       }
     },
     {
-      "id": "feature-898",
+      "id": "feature-901",
       "query": "lynx-api/event/MouseEvent",
       "name": "MouseEvent",
       "category": "lynx-api/event",
@@ -99689,7 +100088,7 @@
       }
     },
     {
-      "id": "feature-899",
+      "id": "feature-902",
       "query": "lynx-api/event/MouseEvent.button",
       "name": "button",
       "category": "lynx-api/event",
@@ -99725,7 +100124,7 @@
       }
     },
     {
-      "id": "feature-900",
+      "id": "feature-903",
       "query": "lynx-api/event/MouseEvent.buttons",
       "name": "buttons",
       "category": "lynx-api/event",
@@ -99761,7 +100160,7 @@
       }
     },
     {
-      "id": "feature-901",
+      "id": "feature-904",
       "query": "lynx-api/event/MouseEvent.x",
       "name": "x",
       "category": "lynx-api/event",
@@ -99797,7 +100196,7 @@
       }
     },
     {
-      "id": "feature-902",
+      "id": "feature-905",
       "query": "lynx-api/event/MouseEvent.y  ",
       "name": "y  ",
       "category": "lynx-api/event",
@@ -99833,7 +100232,7 @@
       }
     },
     {
-      "id": "feature-903",
+      "id": "feature-906",
       "query": "lynx-api/event/MouseEvent.pageX",
       "name": "pageX",
       "category": "lynx-api/event",
@@ -99869,7 +100268,7 @@
       }
     },
     {
-      "id": "feature-904",
+      "id": "feature-907",
       "query": "lynx-api/event/MouseEvent.pageY",
       "name": "pageY",
       "category": "lynx-api/event",
@@ -99905,7 +100304,7 @@
       }
     },
     {
-      "id": "feature-905",
+      "id": "feature-908",
       "query": "lynx-api/event/MouseEvent.clientX",
       "name": "clientX",
       "category": "lynx-api/event",
@@ -99941,7 +100340,7 @@
       }
     },
     {
-      "id": "feature-906",
+      "id": "feature-909",
       "query": "lynx-api/event/MouseEvent.clientY",
       "name": "clientY",
       "category": "lynx-api/event",
@@ -99977,7 +100376,7 @@
       }
     },
     {
-      "id": "feature-907",
+      "id": "feature-910",
       "query": "lynx-api/event/MouseEvent.mousedown",
       "name": "mousedown",
       "category": "lynx-api/event",
@@ -100013,7 +100412,7 @@
       }
     },
     {
-      "id": "feature-908",
+      "id": "feature-911",
       "query": "lynx-api/event/MouseEvent.mousemove",
       "name": "mousemove",
       "category": "lynx-api/event",
@@ -100049,7 +100448,7 @@
       }
     },
     {
-      "id": "feature-909",
+      "id": "feature-912",
       "query": "lynx-api/event/MouseEvent.mouseup",
       "name": "mouseup",
       "category": "lynx-api/event",
@@ -100085,7 +100484,7 @@
       }
     },
     {
-      "id": "feature-910",
+      "id": "feature-913",
       "query": "lynx-api/event/MouseEvent.mouseenter",
       "name": "mouseenter",
       "category": "lynx-api/event",
@@ -100121,7 +100520,7 @@
       }
     },
     {
-      "id": "feature-911",
+      "id": "feature-914",
       "query": "lynx-api/event/MouseEvent.mouseover",
       "name": "mouseover",
       "category": "lynx-api/event",
@@ -100157,7 +100556,7 @@
       }
     },
     {
-      "id": "feature-912",
+      "id": "feature-915",
       "query": "lynx-api/event/MouseEvent.mouseleave",
       "name": "mouseleave",
       "category": "lynx-api/event",
@@ -100193,7 +100592,7 @@
       }
     },
     {
-      "id": "feature-913",
+      "id": "feature-916",
       "query": "lynx-api/event/TouchEvent",
       "name": "TouchEvent",
       "category": "lynx-api/event",
@@ -100229,7 +100628,7 @@
       }
     },
     {
-      "id": "feature-914",
+      "id": "feature-917",
       "query": "lynx-api/event/TouchEvent.detail",
       "name": "detail",
       "category": "lynx-api/event",
@@ -100265,7 +100664,7 @@
       }
     },
     {
-      "id": "feature-915",
+      "id": "feature-918",
       "query": "lynx-api/event/TouchEvent.touches",
       "name": "touches",
       "category": "lynx-api/event",
@@ -100301,7 +100700,7 @@
       }
     },
     {
-      "id": "feature-916",
+      "id": "feature-919",
       "query": "lynx-api/event/TouchEvent.changedTouches",
       "name": "changedTouches",
       "category": "lynx-api/event",
@@ -100337,7 +100736,7 @@
       }
     },
     {
-      "id": "feature-917",
+      "id": "feature-920",
       "query": "lynx-api/event/TouchEvent.touchstart",
       "name": "touchstart",
       "category": "lynx-api/event",
@@ -100373,7 +100772,7 @@
       }
     },
     {
-      "id": "feature-918",
+      "id": "feature-921",
       "query": "lynx-api/event/TouchEvent.touchmove",
       "name": "touchmove",
       "category": "lynx-api/event",
@@ -100409,7 +100808,7 @@
       }
     },
     {
-      "id": "feature-919",
+      "id": "feature-922",
       "query": "lynx-api/event/TouchEvent.touchend",
       "name": "touchend",
       "category": "lynx-api/event",
@@ -100445,7 +100844,7 @@
       }
     },
     {
-      "id": "feature-920",
+      "id": "feature-923",
       "query": "lynx-api/event/TouchEvent.touchcancel",
       "name": "touchcancel",
       "category": "lynx-api/event",
@@ -100481,7 +100880,7 @@
       }
     },
     {
-      "id": "feature-921",
+      "id": "feature-924",
       "query": "lynx-api/event/TouchEvent.tap",
       "name": "tap",
       "category": "lynx-api/event",
@@ -100517,7 +100916,7 @@
       }
     },
     {
-      "id": "feature-922",
+      "id": "feature-925",
       "query": "lynx-api/event/TouchEvent.longpress",
       "name": "longpress",
       "category": "lynx-api/event",
@@ -100553,7 +100952,7 @@
       }
     },
     {
-      "id": "feature-923",
+      "id": "feature-926",
       "query": "lynx-api/event/TouchEvent.click",
       "name": "click",
       "category": "lynx-api/event",
@@ -100589,7 +100988,7 @@
       }
     },
     {
-      "id": "feature-924",
+      "id": "feature-927",
       "query": "lynx-api/event/WheelEvent",
       "name": "WheelEvent",
       "category": "lynx-api/event",
@@ -100625,7 +101024,7 @@
       }
     },
     {
-      "id": "feature-925",
+      "id": "feature-928",
       "query": "lynx-api/event/WheelEvent.deltaX",
       "name": "deltaX",
       "category": "lynx-api/event",
@@ -100661,7 +101060,7 @@
       }
     },
     {
-      "id": "feature-926",
+      "id": "feature-929",
       "query": "lynx-api/event/WheelEvent.deltaY",
       "name": "deltaY",
       "category": "lynx-api/event",
@@ -100697,7 +101096,7 @@
       }
     },
     {
-      "id": "feature-927",
+      "id": "feature-930",
       "query": "lynx-api/event/WheelEvent.wheel",
       "name": "wheel",
       "category": "lynx-api/event",
@@ -100733,7 +101132,7 @@
       }
     },
     {
-      "id": "feature-928",
+      "id": "feature-931",
       "query": "lynx-api/fetch/Headers",
       "name": "Headers",
       "category": "lynx-api/fetch",
@@ -100769,7 +101168,7 @@
       }
     },
     {
-      "id": "feature-929",
+      "id": "feature-932",
       "query": "lynx-api/fetch/Headers",
       "name": "<code>Headers()</code> constructor",
       "category": "lynx-api/fetch",
@@ -100805,7 +101204,7 @@
       }
     },
     {
-      "id": "feature-930",
+      "id": "feature-933",
       "query": "lynx-api/fetch/Headers.append",
       "name": "append",
       "category": "lynx-api/fetch",
@@ -100841,7 +101240,7 @@
       }
     },
     {
-      "id": "feature-931",
+      "id": "feature-934",
       "query": "lynx-api/fetch/Headers.delete",
       "name": "delete",
       "category": "lynx-api/fetch",
@@ -100877,7 +101276,7 @@
       }
     },
     {
-      "id": "feature-932",
+      "id": "feature-935",
       "query": "lynx-api/fetch/Headers.entries",
       "name": "entries",
       "category": "lynx-api/fetch",
@@ -100913,7 +101312,7 @@
       }
     },
     {
-      "id": "feature-933",
+      "id": "feature-936",
       "query": "lynx-api/fetch/Headers.forEach",
       "name": "forEach",
       "category": "lynx-api/fetch",
@@ -100949,7 +101348,7 @@
       }
     },
     {
-      "id": "feature-934",
+      "id": "feature-937",
       "query": "lynx-api/fetch/Headers.get",
       "name": "get",
       "category": "lynx-api/fetch",
@@ -100985,7 +101384,7 @@
       }
     },
     {
-      "id": "feature-935",
+      "id": "feature-938",
       "query": "lynx-api/fetch/Headers.getSetCookie",
       "name": "getSetCookie",
       "category": "lynx-api/fetch",
@@ -101021,7 +101420,7 @@
       }
     },
     {
-      "id": "feature-936",
+      "id": "feature-939",
       "query": "lynx-api/fetch/Headers.has",
       "name": "has",
       "category": "lynx-api/fetch",
@@ -101057,7 +101456,7 @@
       }
     },
     {
-      "id": "feature-937",
+      "id": "feature-940",
       "query": "lynx-api/fetch/Headers.keys",
       "name": "keys",
       "category": "lynx-api/fetch",
@@ -101093,7 +101492,7 @@
       }
     },
     {
-      "id": "feature-938",
+      "id": "feature-941",
       "query": "lynx-api/fetch/Headers.set",
       "name": "set",
       "category": "lynx-api/fetch",
@@ -101129,7 +101528,7 @@
       }
     },
     {
-      "id": "feature-939",
+      "id": "feature-942",
       "query": "lynx-api/fetch/Headers.values",
       "name": "values",
       "category": "lynx-api/fetch",
@@ -101165,7 +101564,7 @@
       }
     },
     {
-      "id": "feature-940",
+      "id": "feature-943",
       "query": "lynx-api/fetch/Headers.@@iterator",
       "name": "<code>[Symbol.iterator]</code>",
       "category": "lynx-api/fetch",
@@ -101201,7 +101600,7 @@
       }
     },
     {
-      "id": "feature-941",
+      "id": "feature-944",
       "query": "lynx-api/fetch/Request",
       "name": "Request",
       "category": "lynx-api/fetch",
@@ -101237,7 +101636,7 @@
       }
     },
     {
-      "id": "feature-942",
+      "id": "feature-945",
       "query": "lynx-api/fetch/Request",
       "name": "`Request()` constructor",
       "category": "lynx-api/fetch",
@@ -101273,7 +101672,7 @@
       }
     },
     {
-      "id": "feature-943",
+      "id": "feature-946",
       "query": "lynx-api/fetch/Request.cors",
       "name": "cors",
       "category": "lynx-api/fetch",
@@ -101309,7 +101708,7 @@
       }
     },
     {
-      "id": "feature-944",
+      "id": "feature-947",
       "query": "lynx-api/fetch/Request.init_attributionReporting_parameter",
       "name": "`init.attributionReporting` parameter",
       "category": "lynx-api/fetch",
@@ -101345,7 +101744,7 @@
       }
     },
     {
-      "id": "feature-945",
+      "id": "feature-948",
       "query": "lynx-api/fetch/Request.init_browsingTopics_parameter",
       "name": "`init.browsingTopics` parameter",
       "category": "lynx-api/fetch",
@@ -101381,7 +101780,7 @@
       }
     },
     {
-      "id": "feature-946",
+      "id": "feature-949",
       "query": "lynx-api/fetch/Request.init_keepalive_parameter",
       "name": "`init.keepalive` parameter",
       "category": "lynx-api/fetch",
@@ -101417,7 +101816,7 @@
       }
     },
     {
-      "id": "feature-947",
+      "id": "feature-950",
       "query": "lynx-api/fetch/Request.init_priority_parameter",
       "name": "`init.priority` parameter",
       "category": "lynx-api/fetch",
@@ -101453,7 +101852,7 @@
       }
     },
     {
-      "id": "feature-948",
+      "id": "feature-951",
       "query": "lynx-api/fetch/Request.init_referrer_parameter",
       "name": "`init.referrer` parameter",
       "category": "lynx-api/fetch",
@@ -101489,7 +101888,7 @@
       }
     },
     {
-      "id": "feature-949",
+      "id": "feature-952",
       "query": "lynx-api/fetch/Request.request_body_readablestream",
       "name": "Send `ReadableStream` in request body",
       "category": "lynx-api/fetch",
@@ -101525,7 +101924,7 @@
       }
     },
     {
-      "id": "feature-950",
+      "id": "feature-953",
       "query": "lynx-api/fetch/Request.response_body_readablestream",
       "name": "Consume `ReadableStream` as a response body",
       "category": "lynx-api/fetch",
@@ -101561,7 +101960,7 @@
       }
     },
     {
-      "id": "feature-951",
+      "id": "feature-954",
       "query": "lynx-api/fetch/Request.arrayBuffer",
       "name": "arrayBuffer",
       "category": "lynx-api/fetch",
@@ -101597,7 +101996,7 @@
       }
     },
     {
-      "id": "feature-952",
+      "id": "feature-955",
       "query": "lynx-api/fetch/Request.blob",
       "name": "blob",
       "category": "lynx-api/fetch",
@@ -101633,7 +102032,7 @@
       }
     },
     {
-      "id": "feature-953",
+      "id": "feature-956",
       "query": "lynx-api/fetch/Request.body",
       "name": "body",
       "category": "lynx-api/fetch",
@@ -101669,7 +102068,7 @@
       }
     },
     {
-      "id": "feature-954",
+      "id": "feature-957",
       "query": "lynx-api/fetch/Request.bodyUsed",
       "name": "bodyUsed",
       "category": "lynx-api/fetch",
@@ -101705,7 +102104,7 @@
       }
     },
     {
-      "id": "feature-955",
+      "id": "feature-958",
       "query": "lynx-api/fetch/Request.bytes",
       "name": "bytes",
       "category": "lynx-api/fetch",
@@ -101741,7 +102140,7 @@
       }
     },
     {
-      "id": "feature-956",
+      "id": "feature-959",
       "query": "lynx-api/fetch/Request.cache",
       "name": "cache",
       "category": "lynx-api/fetch",
@@ -101777,7 +102176,7 @@
       }
     },
     {
-      "id": "feature-957",
+      "id": "feature-960",
       "query": "lynx-api/fetch/Request.cache.only-if-cached",
       "name": "only-if-cached",
       "category": "lynx-api/fetch",
@@ -101813,7 +102212,7 @@
       }
     },
     {
-      "id": "feature-958",
+      "id": "feature-961",
       "query": "lynx-api/fetch/Request.clone",
       "name": "clone",
       "category": "lynx-api/fetch",
@@ -101849,7 +102248,7 @@
       }
     },
     {
-      "id": "feature-959",
+      "id": "feature-962",
       "query": "lynx-api/fetch/Request.credentials",
       "name": "credentials",
       "category": "lynx-api/fetch",
@@ -101885,7 +102284,7 @@
       }
     },
     {
-      "id": "feature-960",
+      "id": "feature-963",
       "query": "lynx-api/fetch/Request.destination",
       "name": "destination",
       "category": "lynx-api/fetch",
@@ -101921,7 +102320,7 @@
       }
     },
     {
-      "id": "feature-961",
+      "id": "feature-964",
       "query": "lynx-api/fetch/Request.duplex",
       "name": "duplex",
       "category": "lynx-api/fetch",
@@ -101957,7 +102356,7 @@
       }
     },
     {
-      "id": "feature-962",
+      "id": "feature-965",
       "query": "lynx-api/fetch/Request.formData",
       "name": "formData",
       "category": "lynx-api/fetch",
@@ -101993,7 +102392,7 @@
       }
     },
     {
-      "id": "feature-963",
+      "id": "feature-966",
       "query": "lynx-api/fetch/Request.headers",
       "name": "headers",
       "category": "lynx-api/fetch",
@@ -102029,7 +102428,7 @@
       }
     },
     {
-      "id": "feature-964",
+      "id": "feature-967",
       "query": "lynx-api/fetch/Request.integrity",
       "name": "integrity",
       "category": "lynx-api/fetch",
@@ -102065,7 +102464,7 @@
       }
     },
     {
-      "id": "feature-965",
+      "id": "feature-968",
       "query": "lynx-api/fetch/Request.isHistoryNavigation",
       "name": "isHistoryNavigation",
       "category": "lynx-api/fetch",
@@ -102101,7 +102500,7 @@
       }
     },
     {
-      "id": "feature-966",
+      "id": "feature-969",
       "query": "lynx-api/fetch/Request.json",
       "name": "json",
       "category": "lynx-api/fetch",
@@ -102137,7 +102536,7 @@
       }
     },
     {
-      "id": "feature-967",
+      "id": "feature-970",
       "query": "lynx-api/fetch/Request.keepalive",
       "name": "keepalive",
       "category": "lynx-api/fetch",
@@ -102173,7 +102572,7 @@
       }
     },
     {
-      "id": "feature-968",
+      "id": "feature-971",
       "query": "lynx-api/fetch/Request.method",
       "name": "method",
       "category": "lynx-api/fetch",
@@ -102209,7 +102608,7 @@
       }
     },
     {
-      "id": "feature-969",
+      "id": "feature-972",
       "query": "lynx-api/fetch/Request.mode",
       "name": "mode",
       "category": "lynx-api/fetch",
@@ -102245,7 +102644,7 @@
       }
     },
     {
-      "id": "feature-970",
+      "id": "feature-973",
       "query": "lynx-api/fetch/Request.mode.navigate_mode",
       "name": "`navigate` mode",
       "category": "lynx-api/fetch",
@@ -102281,7 +102680,7 @@
       }
     },
     {
-      "id": "feature-971",
+      "id": "feature-974",
       "query": "lynx-api/fetch/Request.redirect",
       "name": "redirect",
       "category": "lynx-api/fetch",
@@ -102317,7 +102716,7 @@
       }
     },
     {
-      "id": "feature-972",
+      "id": "feature-975",
       "query": "lynx-api/fetch/Request.referrer",
       "name": "referrer",
       "category": "lynx-api/fetch",
@@ -102353,7 +102752,7 @@
       }
     },
     {
-      "id": "feature-973",
+      "id": "feature-976",
       "query": "lynx-api/fetch/Request.referrerPolicy",
       "name": "referrerPolicy",
       "category": "lynx-api/fetch",
@@ -102389,7 +102788,7 @@
       }
     },
     {
-      "id": "feature-974",
+      "id": "feature-977",
       "query": "lynx-api/fetch/Request.signal",
       "name": "signal",
       "category": "lynx-api/fetch",
@@ -102425,7 +102824,7 @@
       }
     },
     {
-      "id": "feature-975",
+      "id": "feature-978",
       "query": "lynx-api/fetch/Request.targetAddressSpace",
       "name": "targetAddressSpace",
       "category": "lynx-api/fetch",
@@ -102461,7 +102860,7 @@
       }
     },
     {
-      "id": "feature-976",
+      "id": "feature-979",
       "query": "lynx-api/fetch/Request.text",
       "name": "text",
       "category": "lynx-api/fetch",
@@ -102497,7 +102896,7 @@
       }
     },
     {
-      "id": "feature-977",
+      "id": "feature-980",
       "query": "lynx-api/fetch/Request.url",
       "name": "url",
       "category": "lynx-api/fetch",
@@ -102533,7 +102932,7 @@
       }
     },
     {
-      "id": "feature-978",
+      "id": "feature-981",
       "query": "lynx-api/fetch/Response",
       "name": "Response",
       "category": "lynx-api/fetch",
@@ -102569,7 +102968,7 @@
       }
     },
     {
-      "id": "feature-979",
+      "id": "feature-982",
       "query": "lynx-api/fetch/Response",
       "name": "`Response()` constructor",
       "category": "lynx-api/fetch",
@@ -102605,7 +103004,7 @@
       }
     },
     {
-      "id": "feature-980",
+      "id": "feature-983",
       "query": "lynx-api/fetch/Response.accept_readablestream",
       "name": "body parameter accepts ReadableByteStream",
       "category": "lynx-api/fetch",
@@ -102641,7 +103040,7 @@
       }
     },
     {
-      "id": "feature-981",
+      "id": "feature-984",
       "query": "lynx-api/fetch/Response.body_parameter_optional",
       "name": "`body` parameter is optional",
       "category": "lynx-api/fetch",
@@ -102677,7 +103076,7 @@
       }
     },
     {
-      "id": "feature-982",
+      "id": "feature-985",
       "query": "lynx-api/fetch/Response.arrayBuffer",
       "name": "arrayBuffer",
       "category": "lynx-api/fetch",
@@ -102713,7 +103112,7 @@
       }
     },
     {
-      "id": "feature-983",
+      "id": "feature-986",
       "query": "lynx-api/fetch/Response.blob",
       "name": "blob",
       "category": "lynx-api/fetch",
@@ -102749,7 +103148,7 @@
       }
     },
     {
-      "id": "feature-984",
+      "id": "feature-987",
       "query": "lynx-api/fetch/Response.body",
       "name": "body",
       "category": "lynx-api/fetch",
@@ -102785,7 +103184,7 @@
       }
     },
     {
-      "id": "feature-985",
+      "id": "feature-988",
       "query": "lynx-api/fetch/Response.body.readable_byte_stream",
       "name": "`body` is a readable byte stream",
       "category": "lynx-api/fetch",
@@ -102821,7 +103220,7 @@
       }
     },
     {
-      "id": "feature-986",
+      "id": "feature-989",
       "query": "lynx-api/fetch/Response.bodyUsed",
       "name": "bodyUsed",
       "category": "lynx-api/fetch",
@@ -102857,7 +103256,7 @@
       }
     },
     {
-      "id": "feature-987",
+      "id": "feature-990",
       "query": "lynx-api/fetch/Response.bytes",
       "name": "bytes",
       "category": "lynx-api/fetch",
@@ -102893,7 +103292,7 @@
       }
     },
     {
-      "id": "feature-988",
+      "id": "feature-991",
       "query": "lynx-api/fetch/Response.clone",
       "name": "clone",
       "category": "lynx-api/fetch",
@@ -102929,7 +103328,7 @@
       }
     },
     {
-      "id": "feature-989",
+      "id": "feature-992",
       "query": "lynx-api/fetch/Response.error_static",
       "name": "`error()` static method",
       "category": "lynx-api/fetch",
@@ -102965,7 +103364,7 @@
       }
     },
     {
-      "id": "feature-990",
+      "id": "feature-993",
       "query": "lynx-api/fetch/Response.formData",
       "name": "formData",
       "category": "lynx-api/fetch",
@@ -103001,7 +103400,7 @@
       }
     },
     {
-      "id": "feature-991",
+      "id": "feature-994",
       "query": "lynx-api/fetch/Response.headers",
       "name": "headers",
       "category": "lynx-api/fetch",
@@ -103037,7 +103436,7 @@
       }
     },
     {
-      "id": "feature-992",
+      "id": "feature-995",
       "query": "lynx-api/fetch/Response.json",
       "name": "json",
       "category": "lynx-api/fetch",
@@ -103073,7 +103472,7 @@
       }
     },
     {
-      "id": "feature-993",
+      "id": "feature-996",
       "query": "lynx-api/fetch/Response.json_static",
       "name": "json_static",
       "category": "lynx-api/fetch",
@@ -103109,7 +103508,7 @@
       }
     },
     {
-      "id": "feature-994",
+      "id": "feature-997",
       "query": "lynx-api/fetch/Response.ok",
       "name": "ok",
       "category": "lynx-api/fetch",
@@ -103145,7 +103544,7 @@
       }
     },
     {
-      "id": "feature-995",
+      "id": "feature-998",
       "query": "lynx-api/fetch/Response.redirect_static",
       "name": "`redirect()` static method",
       "category": "lynx-api/fetch",
@@ -103181,7 +103580,7 @@
       }
     },
     {
-      "id": "feature-996",
+      "id": "feature-999",
       "query": "lynx-api/fetch/Response.redirected",
       "name": "redirected",
       "category": "lynx-api/fetch",
@@ -103217,7 +103616,7 @@
       }
     },
     {
-      "id": "feature-997",
+      "id": "feature-1000",
       "query": "lynx-api/fetch/Response.status",
       "name": "status",
       "category": "lynx-api/fetch",
@@ -103253,7 +103652,7 @@
       }
     },
     {
-      "id": "feature-998",
+      "id": "feature-1001",
       "query": "lynx-api/fetch/Response.statusText",
       "name": "statusText",
       "category": "lynx-api/fetch",
@@ -103289,7 +103688,7 @@
       }
     },
     {
-      "id": "feature-999",
+      "id": "feature-1002",
       "query": "lynx-api/fetch/Response.text",
       "name": "text",
       "category": "lynx-api/fetch",
@@ -103325,7 +103724,7 @@
       }
     },
     {
-      "id": "feature-1000",
+      "id": "feature-1003",
       "query": "lynx-api/fetch/Response.type",
       "name": "type",
       "category": "lynx-api/fetch",
@@ -103361,7 +103760,7 @@
       }
     },
     {
-      "id": "feature-1001",
+      "id": "feature-1004",
       "query": "lynx-api/fetch/Response.url",
       "name": "url",
       "category": "lynx-api/fetch",
@@ -103397,7 +103796,7 @@
       }
     },
     {
-      "id": "feature-1002",
+      "id": "feature-1005",
       "query": "lynx-api/fetch/fetch",
       "name": "<code>fetch</code>",
       "category": "lynx-api/fetch",
@@ -103433,7 +103832,7 @@
       }
     },
     {
-      "id": "feature-1003",
+      "id": "feature-1006",
       "query": "lynx-api/lynx/accessibilityAnnounce",
       "name": "Used to have the specified text content read by the screen reader.",
       "category": "lynx-api/lynx",
@@ -103469,7 +103868,7 @@
       }
     },
     {
-      "id": "feature-1004",
+      "id": "feature-1007",
       "query": "lynx-api/lynx/addFont",
       "name": "Used for dynamically adding fonts.",
       "category": "lynx-api/lynx",
@@ -103505,7 +103904,7 @@
       }
     },
     {
-      "id": "feature-1005",
+      "id": "feature-1008",
       "query": "lynx-api/lynx/animateAPI.compat",
       "name": "Used to import modules.",
       "category": "lynx-api/lynx",
@@ -103541,7 +103940,7 @@
       }
     },
     {
-      "id": "feature-1006",
+      "id": "feature-1009",
       "query": "lynx-api/lynx/animateAPI.multiple animation implementation",
       "name": "Multiple animate",
       "category": "lynx-api/lynx",
@@ -103577,7 +103976,7 @@
       }
     },
     {
-      "id": "feature-1007",
+      "id": "feature-1010",
       "query": "lynx-api/lynx/cancelAnimationFrame",
       "name": "Cancel a `requestAnimationFrame` callback.",
       "category": "lynx-api/lynx",
@@ -103613,7 +104012,7 @@
       }
     },
     {
-      "id": "feature-1008",
+      "id": "feature-1011",
       "query": "lynx-api/lynx/cancelResourcePrefetch",
       "name": "Used to cancel the prefetch of resource.",
       "category": "lynx-api/lynx",
@@ -103649,7 +104048,7 @@
       }
     },
     {
-      "id": "feature-1009",
+      "id": "feature-1012",
       "query": "lynx-api/lynx/createIntersectionObserver",
       "name": "Create an IntersectionObserver object.",
       "category": "lynx-api/lynx",
@@ -103685,7 +104084,7 @@
       }
     },
     {
-      "id": "feature-1010",
+      "id": "feature-1013",
       "query": "lynx-api/lynx/createSelectorQuery",
       "name": " Create a `SelectorQuery` with the root node of the page as the root.",
       "category": "lynx-api/lynx",
@@ -103721,7 +104120,7 @@
       }
     },
     {
-      "id": "feature-1011",
+      "id": "feature-1014",
       "query": "lynx-api/lynx/getElementById",
       "name": "Used to import modules.",
       "category": "lynx-api/lynx",
@@ -103757,7 +104156,7 @@
       }
     },
     {
-      "id": "feature-1012",
+      "id": "feature-1015",
       "query": "lynx-api/lynx/getJSModule",
       "name": "getJSModule",
       "category": "lynx-api/lynx",
@@ -103793,7 +104192,7 @@
       }
     },
     {
-      "id": "feature-1013",
+      "id": "feature-1016",
       "query": "lynx-api/lynx/getSessionStorageItem",
       "name": "The `lynx.getSessionStorageItem` method is used to retrieve data shared across multiple LynxViews. This enables data sharing between multiple pages via `SessionStorage`. You can call [lynx.setSessionStorageItem](./lynx-set-session-storage.mdx) to set the cached data.",
       "category": "lynx-api/lynx",
@@ -103829,7 +104228,7 @@
       }
     },
     {
-      "id": "feature-1014",
+      "id": "feature-1017",
       "query": "lynx-api/lynx/getSharedData",
       "name": "Get the shared data set by `lynx.setSharedData()` used on pages belonging to the same LynxGroup.",
       "category": "lynx-api/lynx",
@@ -103865,7 +104264,7 @@
       }
     },
     {
-      "id": "feature-1015",
+      "id": "feature-1018",
       "query": "lynx-api/lynx/getTextInfo",
       "name": "Used to measure the width of text content.",
       "category": "lynx-api/lynx",
@@ -103901,7 +104300,7 @@
       }
     },
     {
-      "id": "feature-1016",
+      "id": "feature-1019",
       "query": "lynx-api/lynx/globalProps",
       "name": "global data set by client.",
       "category": "lynx-api/lynx",
@@ -103937,7 +104336,7 @@
       }
     },
     {
-      "id": "feature-1017",
+      "id": "feature-1020",
       "query": "lynx-api/lynx/lynx-before-publish-event/BeforePublishEvent",
       "name": "Used to register/remove monitoring of an element event",
       "category": "lynx-api/lynx",
@@ -103973,7 +104372,7 @@
       }
     },
     {
-      "id": "feature-1018",
+      "id": "feature-1021",
       "query": "lynx-api/lynx/lynx-before-publish-event/BeforePublishEvent.add",
       "name": "Register to listen for an element event.",
       "category": "lynx-api/lynx",
@@ -104009,7 +104408,7 @@
       }
     },
     {
-      "id": "feature-1019",
+      "id": "feature-1022",
       "query": "lynx-api/lynx/lynx-before-publish-event/BeforePublishEvent.remove",
       "name": "Remove monitoring of an element event.",
       "category": "lynx-api/lynx",
@@ -104045,7 +104444,7 @@
       }
     },
     {
-      "id": "feature-1020",
+      "id": "feature-1023",
       "query": "lynx-api/lynx/lynx-before-publish-event/add",
       "name": "Register to listen for an element event.",
       "category": "lynx-api/lynx",
@@ -104081,7 +104480,7 @@
       }
     },
     {
-      "id": "feature-1021",
+      "id": "feature-1024",
       "query": "lynx-api/lynx/lynx-before-publish-event/remove",
       "name": "Remove monitoring of an element event.",
       "category": "lynx-api/lynx",
@@ -104117,7 +104516,7 @@
       }
     },
     {
-      "id": "feature-1022",
+      "id": "feature-1025",
       "query": "lynx-api/lynx/performance.lynx.performance",
       "name": "performance",
       "category": "lynx-api/lynx",
@@ -104153,7 +104552,7 @@
       }
     },
     {
-      "id": "feature-1023",
+      "id": "feature-1026",
       "query": "lynx-api/lynx/performance.createObserver()",
       "name": "createObserver()",
       "category": "lynx-api/lynx",
@@ -104189,7 +104588,7 @@
       }
     },
     {
-      "id": "feature-1024",
+      "id": "feature-1027",
       "query": "lynx-api/lynx/performance.profileStart()",
       "name": "profileStart()",
       "category": "lynx-api/lynx",
@@ -104225,7 +104624,7 @@
       }
     },
     {
-      "id": "feature-1025",
+      "id": "feature-1028",
       "query": "lynx-api/lynx/performance.profileEnd()",
       "name": "profileEnd()",
       "category": "lynx-api/lynx",
@@ -104261,7 +104660,7 @@
       }
     },
     {
-      "id": "feature-1026",
+      "id": "feature-1029",
       "query": "lynx-api/lynx/performance.profileMark()",
       "name": "profileMark()",
       "category": "lynx-api/lynx",
@@ -104297,7 +104696,7 @@
       }
     },
     {
-      "id": "feature-1027",
+      "id": "feature-1030",
       "query": "lynx-api/lynx/performance.profileFlowId()",
       "name": "profileFlowId()",
       "category": "lynx-api/lynx",
@@ -104333,7 +104732,7 @@
       }
     },
     {
-      "id": "feature-1028",
+      "id": "feature-1031",
       "query": "lynx-api/lynx/performance.isProfileRecording()",
       "name": "isProfileRecording()",
       "category": "lynx-api/lynx",
@@ -104369,7 +104768,7 @@
       }
     },
     {
-      "id": "feature-1029",
+      "id": "feature-1032",
       "query": "lynx-api/lynx/querySelector",
       "name": "querySelector",
       "category": "lynx-api/lynx",
@@ -104405,7 +104804,7 @@
       }
     },
     {
-      "id": "feature-1030",
+      "id": "feature-1033",
       "query": "lynx-api/lynx/querySelectorAll",
       "name": "querySelectorAll",
       "category": "lynx-api/lynx",
@@ -104441,7 +104840,7 @@
       }
     },
     {
-      "id": "feature-1031",
+      "id": "feature-1034",
       "query": "lynx-api/lynx/queueMicrotask",
       "name": "insert a task into microtask queue",
       "category": "lynx-api/lynx",
@@ -104477,7 +104876,7 @@
       }
     },
     {
-      "id": "feature-1032",
+      "id": "feature-1035",
       "query": "lynx-api/lynx/registerModule",
       "name": "registerModule",
       "category": "lynx-api/lynx",
@@ -104513,7 +104912,7 @@
       }
     },
     {
-      "id": "feature-1033",
+      "id": "feature-1036",
       "query": "lynx-api/lynx/registerSharedDataObserver",
       "name": "Listen for shared data updates initiated by `lynx.setSharedData()` within pages in the same LynxGroup.",
       "category": "lynx-api/lynx",
@@ -104549,7 +104948,7 @@
       }
     },
     {
-      "id": "feature-1034",
+      "id": "feature-1037",
       "query": "lynx-api/lynx/reload",
       "name": "Reloads the current page, like the Refresh button.",
       "category": "lynx-api/lynx",
@@ -104585,7 +104984,7 @@
       }
     },
     {
-      "id": "feature-1035",
+      "id": "feature-1038",
       "query": "lynx-api/lynx/removeSharedDataObserver",
       "name": "取消使用 `lynx.registerSharedDataObserver()` 进行的监听。",
       "category": "lynx-api/lynx",
@@ -104621,7 +105020,7 @@
       }
     },
     {
-      "id": "feature-1036",
+      "id": "feature-1039",
       "query": "lynx-api/lynx/reportError",
       "name": "Used to report a JavaScript Error.",
       "category": "lynx-api/lynx",
@@ -104657,7 +105056,7 @@
       }
     },
     {
-      "id": "feature-1037",
+      "id": "feature-1040",
       "query": "lynx-api/lynx/requestAnimationFrame",
       "name": "Invoke the specified callback function at the next VSYNC.",
       "category": "lynx-api/lynx",
@@ -104693,7 +105092,7 @@
       }
     },
     {
-      "id": "feature-1038",
+      "id": "feature-1041",
       "query": "lynx-api/lynx/requestResourcePrefetch",
       "name": "Used to request the prefetch of resource.",
       "category": "lynx-api/lynx",
@@ -104729,7 +105128,7 @@
       }
     },
     {
-      "id": "feature-1039",
+      "id": "feature-1042",
       "query": "lynx-api/lynx/requireModule",
       "name": "Used to import modules and JSON.",
       "category": "lynx-api/lynx",
@@ -104765,7 +105164,7 @@
       }
     },
     {
-      "id": "feature-1040",
+      "id": "feature-1043",
       "query": "lynx-api/lynx/requireModuleAsync",
       "name": "Used to import modules.",
       "category": "lynx-api/lynx",
@@ -104801,7 +105200,7 @@
       }
     },
     {
-      "id": "feature-1041",
+      "id": "feature-1044",
       "query": "lynx-api/lynx/resumeExposure",
       "name": "Turn on exposure detection, that is, to restart the detection of the visibility of the target node, and subsequently trigger the exposure/anti-exposure event normally.",
       "category": "lynx-api/lynx",
@@ -104837,7 +105236,7 @@
       }
     },
     {
-      "id": "feature-1042",
+      "id": "feature-1045",
       "query": "lynx-api/lynx/setObserverFrameRate",
       "name": "Set the frequency of exposure detection.",
       "category": "lynx-api/lynx",
@@ -104873,7 +105272,7 @@
       }
     },
     {
-      "id": "feature-1043",
+      "id": "feature-1046",
       "query": "lynx-api/lynx/setSessionStorageItem",
       "name": "The `lynx.setSessionStorageItem` method is used to set data shared across multiple LynxViews.",
       "category": "lynx-api/lynx",
@@ -104909,7 +105308,7 @@
       }
     },
     {
-      "id": "feature-1044",
+      "id": "feature-1047",
       "query": "lynx-api/lynx/setSharedData",
       "name": "设置同 LynxGroup 的页面间的共享数据。",
       "category": "lynx-api/lynx",
@@ -104945,7 +105344,7 @@
       }
     },
     {
-      "id": "feature-1045",
+      "id": "feature-1048",
       "query": "lynx-api/lynx/stopExposure",
       "name": "Stop exposure detection, that is, the visibility of the target node will no longer be detected, and exposure/anti-exposure events will no longer be triggered in the future.",
       "category": "lynx-api/lynx",
@@ -104981,7 +105380,7 @@
       }
     },
     {
-      "id": "feature-1046",
+      "id": "feature-1049",
       "query": "lynx-api/lynx/subscribeSessionStorage",
       "name": "The `lynx.subscribeSessionStorage` method is used to listen for changes in data shared across multiple LynxViews. This enables data sharing between multiple pages via `SessionStorage`. You can call [lynx.setSessionStorageItem](./lynx-set-session-storage.mdx) to set the cached data.",
       "category": "lynx-api/lynx",
@@ -105017,7 +105416,7 @@
       }
     },
     {
-      "id": "feature-1047",
+      "id": "feature-1050",
       "query": "lynx-api/lynx/unsubscribeSessionStorage",
       "name": "The `lynx.unsubscribeSessionStorage` method is used to cancel the listener for changes in data shared across multiple LynxViews. This enables data sharing between multiple pages via `SessionStorage`. You can call [lynx.setSessionStorageItem](./lynx-set-session-storage.mdx) to set the cached data. After cancellation, the cached data corresponding to this key will no longer be listened to.",
       "category": "lynx-api/lynx",
@@ -105053,7 +105452,7 @@
       }
     },
     {
-      "id": "feature-1048",
+      "id": "feature-1051",
       "query": "lynx-api/selector-query/SelectorQuery",
       "name": "Gets a reference to the specified node in order to call its methods or get its properties.",
       "category": "lynx-api/selector-query",
@@ -105089,7 +105488,7 @@
       }
     },
     {
-      "id": "feature-1049",
+      "id": "feature-1052",
       "query": "lynx-api/selector-query/SelectorQuery.`exec`",
       "name": "Execute all submitted operations.",
       "category": "lynx-api/selector-query",
@@ -105125,7 +105524,7 @@
       }
     },
     {
-      "id": "feature-1050",
+      "id": "feature-1053",
       "query": "lynx-api/selector-query/SelectorQuery.`select`",
       "name": "Select the first node that matches the specified selector in the descendants of the root node specified in `SelectorQuery`.",
       "category": "lynx-api/selector-query",
@@ -105161,7 +105560,7 @@
       }
     },
     {
-      "id": "feature-1051",
+      "id": "feature-1054",
       "query": "lynx-api/selector-query/SelectorQuery.`selectAll`",
       "name": "Select all nodes that match the specified CSS selector under the root node specified by `SelectorQuery`.",
       "category": "lynx-api/selector-query",
@@ -105197,7 +105596,7 @@
       }
     },
     {
-      "id": "feature-1052",
+      "id": "feature-1055",
       "query": "lynx-api/selector-query/SelectorQuery.`selectRoot`",
       "name": "Select the root node specified by `SelectorQuery`.",
       "category": "lynx-api/selector-query",
@@ -105233,7 +105632,7 @@
       }
     },
     {
-      "id": "feature-1053",
+      "id": "feature-1056",
       "query": "lynx-api/selector-query/SelectorQuery.`selectUniqueID`",
       "name": "Select nodes by specifying `uid`.",
       "category": "lynx-api/selector-query",
@@ -105269,7 +105668,7 @@
       }
     },
     {
-      "id": "feature-1054",
+      "id": "feature-1057",
       "query": "lynx-api/selector-query/exec",
       "name": "Execute all submitted operations.",
       "category": "lynx-api/selector-query",
@@ -105305,7 +105704,7 @@
       }
     },
     {
-      "id": "feature-1055",
+      "id": "feature-1058",
       "query": "lynx-api/selector-query/select",
       "name": "Select the first node that matches the specified selector in the descendants of the root node specified in `SelectorQuery`.",
       "category": "lynx-api/selector-query",
@@ -105341,7 +105740,7 @@
       }
     },
     {
-      "id": "feature-1056",
+      "id": "feature-1059",
       "query": "lynx-api/selector-query/select.`selector` parameter supporting `tag` selector",
       "name": "`selector` parameter supporting `tag` selector.",
       "category": "lynx-api/selector-query",
@@ -105377,7 +105776,7 @@
       }
     },
     {
-      "id": "feature-1057",
+      "id": "feature-1060",
       "query": "lynx-api/selector-query/select.`selector` parameter supporting `attribute` selector `[attr]`, `[attr=value]",
       "name": "`selector` parameter supporting `attribute` selector `[attr]`, `[attr=value].",
       "category": "lynx-api/selector-query",
@@ -105413,7 +105812,7 @@
       }
     },
     {
-      "id": "feature-1058",
+      "id": "feature-1061",
       "query": "lynx-api/selector-query/select.`selector` parameter supporting `attribute` selector `[attr*=value]`, `[attr^=value]`, `[attr$=value]`",
       "name": "`selector` parameter supporting `attribute` selector `[attr*=value]`, `[attr^=value]`, `[attr$=value]`.",
       "category": "lynx-api/selector-query",
@@ -105449,7 +105848,7 @@
       }
     },
     {
-      "id": "feature-1059",
+      "id": "feature-1062",
       "query": "lynx-api/selector-query/selectAll",
       "name": "Select all nodes that match the specified CSS selector under the root node specified by `SelectorQuery`.",
       "category": "lynx-api/selector-query",
@@ -105485,7 +105884,7 @@
       }
     },
     {
-      "id": "feature-1060",
+      "id": "feature-1063",
       "query": "lynx-api/selector-query/selectRoot",
       "name": "Select the root node specified by `SelectorQuery`.",
       "category": "lynx-api/selector-query",
@@ -105521,7 +105920,7 @@
       }
     },
     {
-      "id": "feature-1061",
+      "id": "feature-1064",
       "query": "lynx-api/selector-query/selectUniqueID",
       "name": "Select nodes by specifying `uid`.",
       "category": "lynx-api/selector-query",
@@ -105557,7 +105956,7 @@
       }
     },
     {
-      "id": "feature-1062",
+      "id": "feature-1065",
       "query": "lynx-api/nodes-ref/NodesRef",
       "name": "Represents a reference to one or more UI nodes. It can be used to call methods, get and set properties on UI nodes.",
       "category": "lynx-api/nodes-ref",
@@ -105593,7 +105992,7 @@
       }
     },
     {
-      "id": "feature-1063",
+      "id": "feature-1066",
       "query": "lynx-api/nodes-ref/NodesRef.`fields`",
       "name": "Query the attributes of the selected node.",
       "category": "lynx-api/nodes-ref",
@@ -105629,7 +106028,7 @@
       }
     },
     {
-      "id": "feature-1064",
+      "id": "feature-1067",
       "query": "lynx-api/nodes-ref/NodesRef.`invoke`",
       "name": "Execute the UI method of the selected node.",
       "category": "lynx-api/nodes-ref",
@@ -105665,7 +106064,7 @@
       }
     },
     {
-      "id": "feature-1065",
+      "id": "feature-1068",
       "query": "lynx-api/nodes-ref/NodesRef.`path`",
       "name": "Query the path information from the node to the root node of the page.",
       "category": "lynx-api/nodes-ref",
@@ -105701,7 +106100,7 @@
       }
     },
     {
-      "id": "feature-1066",
+      "id": "feature-1069",
       "query": "lynx-api/nodes-ref/NodesRef.`setNativeProps`",
       "name": "Directly set the attributes of the selected node.",
       "category": "lynx-api/nodes-ref",
@@ -105737,7 +106136,7 @@
       }
     },
     {
-      "id": "feature-1067",
+      "id": "feature-1070",
       "query": "lynx-api/nodes-ref/fields",
       "name": "Query the attributes of the selected node.",
       "category": "lynx-api/nodes-ref",
@@ -105773,7 +106172,7 @@
       }
     },
     {
-      "id": "feature-1068",
+      "id": "feature-1071",
       "query": "lynx-api/nodes-ref/fields.`fields` parameter supporting the `attribute` property",
       "name": "`fields` parameter supporting the `attribute` property.",
       "category": "lynx-api/nodes-ref",
@@ -105809,7 +106208,7 @@
       }
     },
     {
-      "id": "feature-1069",
+      "id": "feature-1072",
       "query": "lynx-api/nodes-ref/invoke",
       "name": "Execute the UI method of the selected node.",
       "category": "lynx-api/nodes-ref",
@@ -105845,7 +106244,7 @@
       }
     },
     {
-      "id": "feature-1070",
+      "id": "feature-1073",
       "query": "lynx-api/nodes-ref/path",
       "name": "Query the path information from the node to the root node of the page.",
       "category": "lynx-api/nodes-ref",
@@ -105881,7 +106280,7 @@
       }
     },
     {
-      "id": "feature-1071",
+      "id": "feature-1074",
       "query": "lynx-api/nodes-ref/setNativeProps",
       "name": "Directly set the attributes of the selected node.",
       "category": "lynx-api/nodes-ref",
@@ -105917,7 +106316,7 @@
       }
     },
     {
-      "id": "feature-1072",
+      "id": "feature-1075",
       "query": "lynx-api/intersection-observer/IntersectionObserver",
       "name": "Observe the intersection status between the target node and the reference node and the target node and the ancestor node. When the intersection status changes, the corresponding callback is triggered. Based on this, you can monitor whether the target node is exposed/de-exposed.",
       "category": "lynx-api/intersection-observer",
@@ -105953,7 +106352,7 @@
       }
     },
     {
-      "id": "feature-1073",
+      "id": "feature-1076",
       "query": "lynx-api/intersection-observer/IntersectionObserver.relativeTo",
       "name": "Specify a reference node. The reference node is specified by id.",
       "category": "lynx-api/intersection-observer",
@@ -105989,7 +106388,7 @@
       }
     },
     {
-      "id": "feature-1074",
+      "id": "feature-1077",
       "query": "lynx-api/intersection-observer/IntersectionObserver.relativeToViewport",
       "name": "Specify a LynxView as a reference node.",
       "category": "lynx-api/intersection-observer",
@@ -106025,7 +106424,7 @@
       }
     },
     {
-      "id": "feature-1075",
+      "id": "feature-1078",
       "query": "lynx-api/intersection-observer/IntersectionObserver.relativeToScreen",
       "name": "Specify the screen as the reference node.",
       "category": "lynx-api/intersection-observer",
@@ -106061,7 +106460,7 @@
       }
     },
     {
-      "id": "feature-1076",
+      "id": "feature-1079",
       "query": "lynx-api/intersection-observer/IntersectionObserver.observe",
       "name": "Specify the target node and callback, and the target node is specified according to id.",
       "category": "lynx-api/intersection-observer",
@@ -106097,7 +106496,7 @@
       }
     },
     {
-      "id": "feature-1077",
+      "id": "feature-1080",
       "query": "lynx-api/intersection-observer/IntersectionObserver.disconnect",
       "name": "Clear the target node and callback. The target node will no longer be observed and the corresponding callback will not be triggered.",
       "category": "lynx-api/intersection-observer",
@@ -106133,7 +106532,7 @@
       }
     },
     {
-      "id": "feature-1078",
+      "id": "feature-1081",
       "query": "lynx-api/intersection-observer/disconnect",
       "name": "Clear the target node and callback. The target node will no longer be observed and the corresponding callback will not be triggered.",
       "category": "lynx-api/intersection-observer",
@@ -106169,7 +106568,7 @@
       }
     },
     {
-      "id": "feature-1079",
+      "id": "feature-1082",
       "query": "lynx-api/intersection-observer/observe",
       "name": "Specify the target node and callback, and the target node is specified according to id.",
       "category": "lynx-api/intersection-observer",
@@ -106205,7 +106604,7 @@
       }
     },
     {
-      "id": "feature-1080",
+      "id": "feature-1083",
       "query": "lynx-api/intersection-observer/relativeTo",
       "name": "Specify a reference node. The reference node is specified by id.",
       "category": "lynx-api/intersection-observer",
@@ -106241,7 +106640,7 @@
       }
     },
     {
-      "id": "feature-1081",
+      "id": "feature-1084",
       "query": "lynx-api/intersection-observer/relativeToScreen",
       "name": "Specify the screen as the reference node.",
       "category": "lynx-api/intersection-observer",
@@ -106277,7 +106676,7 @@
       }
     },
     {
-      "id": "feature-1082",
+      "id": "feature-1085",
       "query": "lynx-api/intersection-observer/relativeToViewport",
       "name": "Specify a LynxView as a reference node.",
       "category": "lynx-api/intersection-observer",
@@ -106313,7 +106712,7 @@
       }
     },
     {
-      "id": "feature-1083",
+      "id": "feature-1086",
       "query": "lynx-api/main-thread/Element",
       "name": "Represents an element in the main thread.",
       "category": "lynx-api/main-thread",
@@ -106349,7 +106748,7 @@
       }
     },
     {
-      "id": "feature-1084",
+      "id": "feature-1087",
       "query": "lynx-api/main-thread/Element.Element.animate",
       "name": "animate",
       "category": "lynx-api/main-thread",
@@ -106385,7 +106784,7 @@
       }
     },
     {
-      "id": "feature-1085",
+      "id": "feature-1088",
       "query": "lynx-api/main-thread/Element.Element.getComputedStyleProperty",
       "name": "getComputedStyleProperty",
       "category": "lynx-api/main-thread",
@@ -106421,7 +106820,7 @@
       }
     },
     {
-      "id": "feature-1086",
+      "id": "feature-1089",
       "query": "lynx-api/main-thread/ElementAnimate",
       "name": "Create An Animation in MTS",
       "category": "lynx-api/main-thread",
@@ -106457,7 +106856,7 @@
       }
     },
     {
-      "id": "feature-1087",
+      "id": "feature-1090",
       "query": "lynx-api/main-thread/ElementAnimate.Animation.play()",
       "name": "play()",
       "category": "lynx-api/main-thread",
@@ -106493,7 +106892,7 @@
       }
     },
     {
-      "id": "feature-1088",
+      "id": "feature-1091",
       "query": "lynx-api/main-thread/ElementAnimate.Animation.pause()",
       "name": "pause()",
       "category": "lynx-api/main-thread",
@@ -106529,7 +106928,7 @@
       }
     },
     {
-      "id": "feature-1089",
+      "id": "feature-1092",
       "query": "lynx-api/main-thread/ElementAnimate.Animation.cancel()",
       "name": "cancel()",
       "category": "lynx-api/main-thread",
@@ -106565,7 +106964,7 @@
       }
     },
     {
-      "id": "feature-1090",
+      "id": "feature-1093",
       "query": "lynx-api/main-thread/ElementAnimate.Animation.finish()",
       "name": "finish()",
       "category": "lynx-api/main-thread",
@@ -106601,7 +107000,7 @@
       }
     },
     {
-      "id": "feature-1091",
+      "id": "feature-1094",
       "query": "lynx-api/main-thread/ElementGetComputedStyle",
       "name": "Create An Animation in MTS",
       "category": "lynx-api/main-thread",
@@ -106637,7 +107036,7 @@
       }
     },
     {
-      "id": "feature-1092",
+      "id": "feature-1095",
       "query": "lynx-api/main-thread/MainThread-APIs",
       "name": "APIs available on the main thread.",
       "category": "lynx-api/main-thread",
@@ -106673,7 +107072,7 @@
       }
     },
     {
-      "id": "feature-1093",
+      "id": "feature-1096",
       "query": "lynx-api/main-thread/MainThread-APIs.Element",
       "name": "Element",
       "category": "lynx-api/main-thread",
@@ -106709,7 +107108,7 @@
       }
     },
     {
-      "id": "feature-1094",
+      "id": "feature-1097",
       "query": "lynx-api/main-thread/MainThread-APIs.Element.animate",
       "name": "animate",
       "category": "lynx-api/main-thread",
@@ -106745,7 +107144,7 @@
       }
     },
     {
-      "id": "feature-1095",
+      "id": "feature-1098",
       "query": "lynx-api/main-thread/MainThread-APIs.Element.getComputedStyleProperty",
       "name": "getComputedStyleProperty",
       "category": "lynx-api/main-thread",
@@ -106781,7 +107180,7 @@
       }
     },
     {
-      "id": "feature-1096",
+      "id": "feature-1099",
       "query": "lynx-api/main-thread/MainThread-APIs.lynx.getTextInfo",
       "name": "getTextInfo",
       "category": "lynx-api/main-thread",
@@ -106817,7 +107216,7 @@
       }
     },
     {
-      "id": "feature-1097",
+      "id": "feature-1100",
       "query": "lynx-api/main-thread/MainThread-APIs.lynx.querySelector",
       "name": "querySelector",
       "category": "lynx-api/main-thread",
@@ -106853,7 +107252,7 @@
       }
     },
     {
-      "id": "feature-1098",
+      "id": "feature-1101",
       "query": "lynx-api/main-thread/MainThread-APIs.lynx.querySelectorAll",
       "name": "querySelectorAll",
       "category": "lynx-api/main-thread",
@@ -106889,7 +107288,7 @@
       }
     },
     {
-      "id": "feature-1099",
+      "id": "feature-1102",
       "query": "lynx-api/main-thread/MainThread-APIs.lynx.requestAnimationFrame",
       "name": "requestAnimationFrame",
       "category": "lynx-api/main-thread",
@@ -106925,7 +107324,7 @@
       }
     },
     {
-      "id": "feature-1100",
+      "id": "feature-1103",
       "query": "lynx-api/main-thread/MainThread-APIs.lynx.__globalProps",
       "name": "__globalProps",
       "category": "lynx-api/main-thread",
@@ -106961,7 +107360,7 @@
       }
     },
     {
-      "id": "feature-1101",
+      "id": "feature-1104",
       "query": "lynx-api/performance-api/framework-pipeline-timing",
       "name": "framework-pipeline-timing",
       "category": "lynx-api/performance-api",
@@ -106997,7 +107396,7 @@
       }
     },
     {
-      "id": "feature-1102",
+      "id": "feature-1105",
       "query": "lynx-api/performance-api/host-platform-timing/android-host-platform-timing",
       "name": "android-host-platform-timing",
       "category": "lynx-api/performance-api",
@@ -107033,7 +107432,7 @@
       }
     },
     {
-      "id": "feature-1103",
+      "id": "feature-1106",
       "query": "lynx-api/performance-api/host-platform-timing/harmony-host-platform-timing",
       "name": "harmony-host-platform-timing",
       "category": "lynx-api/performance-api",
@@ -107069,7 +107468,7 @@
       }
     },
     {
-      "id": "feature-1104",
+      "id": "feature-1107",
       "query": "lynx-api/performance-api/host-platform-timing/ios-host-platform-timing",
       "name": "ios-host-platform-timing",
       "category": "lynx-api/performance-api",
@@ -107105,7 +107504,7 @@
       }
     },
     {
-      "id": "feature-1105",
+      "id": "feature-1108",
       "query": "lynx-api/performance-api/performance-entry/entry-type",
       "name": "entry-type",
       "category": "lynx-api/performance-api",
@@ -107141,7 +107540,7 @@
       }
     },
     {
-      "id": "feature-1106",
+      "id": "feature-1109",
       "query": "lynx-api/performance-api/performance-entry/init-background-runtime-entry",
       "name": "Entry for background runtime initialization performance data.",
       "category": "lynx-api/performance-api",
@@ -107177,7 +107576,7 @@
       }
     },
     {
-      "id": "feature-1107",
+      "id": "feature-1110",
       "query": "lynx-api/performance-api/performance-entry/init-container-entry",
       "name": "init-container-entry",
       "category": "lynx-api/performance-api",
@@ -107213,7 +107612,7 @@
       }
     },
     {
-      "id": "feature-1108",
+      "id": "feature-1111",
       "query": "lynx-api/performance-api/performance-entry/init-lynxview-entry",
       "name": "init-lynxview-entry",
       "category": "lynx-api/performance-api",
@@ -107249,7 +107648,7 @@
       }
     },
     {
-      "id": "feature-1109",
+      "id": "feature-1112",
       "query": "lynx-api/performance-api/performance-entry/lazy-bundle-entry",
       "name": "lazy-bundle-entry",
       "category": "lynx-api/performance-api",
@@ -107285,7 +107684,7 @@
       }
     },
     {
-      "id": "feature-1110",
+      "id": "feature-1113",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry",
       "name": "load-bundle-entry",
       "category": "lynx-api/performance-api",
@@ -107321,7 +107720,7 @@
       }
     },
     {
-      "id": "feature-1111",
+      "id": "feature-1114",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.entryType",
       "name": "entryType",
       "category": "lynx-api/performance-api",
@@ -107357,7 +107756,7 @@
       }
     },
     {
-      "id": "feature-1112",
+      "id": "feature-1115",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.name",
       "name": "name",
       "category": "lynx-api/performance-api",
@@ -107393,7 +107792,7 @@
       }
     },
     {
-      "id": "feature-1113",
+      "id": "feature-1116",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.identifier",
       "name": "identifier",
       "category": "lynx-api/performance-api",
@@ -107429,7 +107828,7 @@
       }
     },
     {
-      "id": "feature-1114",
+      "id": "feature-1117",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.loadBundleStart",
       "name": "loadBundleStart",
       "category": "lynx-api/performance-api",
@@ -107465,7 +107864,7 @@
       }
     },
     {
-      "id": "feature-1115",
+      "id": "feature-1118",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.loadBundleEnd",
       "name": "loadBundleEnd",
       "category": "lynx-api/performance-api",
@@ -107501,7 +107900,7 @@
       }
     },
     {
-      "id": "feature-1116",
+      "id": "feature-1119",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.parseStart",
       "name": "parseStart",
       "category": "lynx-api/performance-api",
@@ -107537,7 +107936,7 @@
       }
     },
     {
-      "id": "feature-1117",
+      "id": "feature-1120",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.parseEnd",
       "name": "parseEnd",
       "category": "lynx-api/performance-api",
@@ -107573,7 +107972,7 @@
       }
     },
     {
-      "id": "feature-1118",
+      "id": "feature-1121",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.loadBackgroundStart",
       "name": "loadBackgroundStart",
       "category": "lynx-api/performance-api",
@@ -107609,7 +108008,7 @@
       }
     },
     {
-      "id": "feature-1119",
+      "id": "feature-1122",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.loadBackgroundEnd",
       "name": "loadBackgroundEnd",
       "category": "lynx-api/performance-api",
@@ -107645,7 +108044,7 @@
       }
     },
     {
-      "id": "feature-1120",
+      "id": "feature-1123",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.pipelineStart",
       "name": "pipelineStart",
       "category": "lynx-api/performance-api",
@@ -107681,7 +108080,7 @@
       }
     },
     {
-      "id": "feature-1121",
+      "id": "feature-1124",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.pipelineEnd",
       "name": "pipelineEnd",
       "category": "lynx-api/performance-api",
@@ -107717,7 +108116,7 @@
       }
     },
     {
-      "id": "feature-1122",
+      "id": "feature-1125",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.mtsRenderStart",
       "name": "mtsRenderStart",
       "category": "lynx-api/performance-api",
@@ -107753,7 +108152,7 @@
       }
     },
     {
-      "id": "feature-1123",
+      "id": "feature-1126",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.mtsRenderEnd",
       "name": "mtsRenderEnd",
       "category": "lynx-api/performance-api",
@@ -107789,7 +108188,7 @@
       }
     },
     {
-      "id": "feature-1124",
+      "id": "feature-1127",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.resolveStart",
       "name": "resolveStart",
       "category": "lynx-api/performance-api",
@@ -107825,7 +108224,7 @@
       }
     },
     {
-      "id": "feature-1125",
+      "id": "feature-1128",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.resolveEnd",
       "name": "resolveEnd",
       "category": "lynx-api/performance-api",
@@ -107861,7 +108260,7 @@
       }
     },
     {
-      "id": "feature-1126",
+      "id": "feature-1129",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.layoutStart",
       "name": "layoutStart",
       "category": "lynx-api/performance-api",
@@ -107897,7 +108296,7 @@
       }
     },
     {
-      "id": "feature-1127",
+      "id": "feature-1130",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.paintingUiOperationExecuteEnd",
       "name": "paintingUiOperationExecuteEnd",
       "category": "lynx-api/performance-api",
@@ -107933,7 +108332,7 @@
       }
     },
     {
-      "id": "feature-1128",
+      "id": "feature-1131",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.layoutUiOperationExecuteStart",
       "name": "layoutUiOperationExecuteStart",
       "category": "lynx-api/performance-api",
@@ -107969,7 +108368,7 @@
       }
     },
     {
-      "id": "feature-1129",
+      "id": "feature-1132",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.layoutUiOperationExecuteEnd",
       "name": "layoutUiOperationExecuteEnd",
       "category": "lynx-api/performance-api",
@@ -108005,7 +108404,7 @@
       }
     },
     {
-      "id": "feature-1130",
+      "id": "feature-1133",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.paintEnd",
       "name": "paintEnd",
       "category": "lynx-api/performance-api",
@@ -108041,7 +108440,7 @@
       }
     },
     {
-      "id": "feature-1131",
+      "id": "feature-1134",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.frameworkPipelineTiming",
       "name": "frameworkPipelineTiming",
       "category": "lynx-api/performance-api",
@@ -108077,7 +108476,7 @@
       }
     },
     {
-      "id": "feature-1132",
+      "id": "feature-1135",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.loadCoreStart",
       "name": "loadCoreStart",
       "category": "lynx-api/performance-api",
@@ -108113,7 +108512,7 @@
       }
     },
     {
-      "id": "feature-1133",
+      "id": "feature-1136",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.loadCoreEnd",
       "name": "loadCoreEnd",
       "category": "lynx-api/performance-api",
@@ -108149,7 +108548,7 @@
       }
     },
     {
-      "id": "feature-1134",
+      "id": "feature-1137",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.openTime",
       "name": "openTime",
       "category": "lynx-api/performance-api",
@@ -108185,7 +108584,7 @@
       }
     },
     {
-      "id": "feature-1135",
+      "id": "feature-1138",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.containerInitStart",
       "name": "containerInitStart",
       "category": "lynx-api/performance-api",
@@ -108221,7 +108620,7 @@
       }
     },
     {
-      "id": "feature-1136",
+      "id": "feature-1139",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.containerInitEnd",
       "name": "containerInitEnd",
       "category": "lynx-api/performance-api",
@@ -108257,7 +108656,7 @@
       }
     },
     {
-      "id": "feature-1137",
+      "id": "feature-1140",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.prepareTemplateStart",
       "name": "prepareTemplateStart",
       "category": "lynx-api/performance-api",
@@ -108293,7 +108692,7 @@
       }
     },
     {
-      "id": "feature-1138",
+      "id": "feature-1141",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.prepareTemplateEnd",
       "name": "prepareTemplateEnd",
       "category": "lynx-api/performance-api",
@@ -108329,7 +108728,7 @@
       }
     },
     {
-      "id": "feature-1139",
+      "id": "feature-1142",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.createLynxStart",
       "name": "createLynxStart",
       "category": "lynx-api/performance-api",
@@ -108365,7 +108764,7 @@
       }
     },
     {
-      "id": "feature-1140",
+      "id": "feature-1143",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.createLynxEnd",
       "name": "createLynxEnd",
       "category": "lynx-api/performance-api",
@@ -108401,7 +108800,7 @@
       }
     },
     {
-      "id": "feature-1141",
+      "id": "feature-1144",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.fcp",
       "name": "fcp",
       "category": "lynx-api/performance-api",
@@ -108437,7 +108836,7 @@
       }
     },
     {
-      "id": "feature-1142",
+      "id": "feature-1145",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.lynxFcp",
       "name": "lynxFcp",
       "category": "lynx-api/performance-api",
@@ -108473,7 +108872,7 @@
       }
     },
     {
-      "id": "feature-1143",
+      "id": "feature-1146",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.totalFcp",
       "name": "totalFcp",
       "category": "lynx-api/performance-api",
@@ -108509,7 +108908,7 @@
       }
     },
     {
-      "id": "feature-1144",
+      "id": "feature-1147",
       "query": "lynx-api/performance-api/performance-entry/metric-actual-fmp-entry",
       "name": "metric-actual-fmp-entry",
       "category": "lynx-api/performance-api",
@@ -108545,7 +108944,7 @@
       }
     },
     {
-      "id": "feature-1145",
+      "id": "feature-1148",
       "query": "lynx-api/performance-api/performance-entry/metric-fcp-entry",
       "name": "metric-fcp-entry",
       "category": "lynx-api/performance-api",
@@ -108581,7 +108980,7 @@
       }
     },
     {
-      "id": "feature-1146",
+      "id": "feature-1149",
       "query": "lynx-api/performance-api/performance-entry/name",
       "name": "name",
       "category": "lynx-api/performance-api",
@@ -108617,7 +109016,7 @@
       }
     },
     {
-      "id": "feature-1147",
+      "id": "feature-1150",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry",
       "name": "pipeline-entry",
       "category": "lynx-api/performance-api",
@@ -108653,7 +109052,7 @@
       }
     },
     {
-      "id": "feature-1148",
+      "id": "feature-1151",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.entryType",
       "name": "entryType",
       "category": "lynx-api/performance-api",
@@ -108689,7 +109088,7 @@
       }
     },
     {
-      "id": "feature-1149",
+      "id": "feature-1152",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.name",
       "name": "name",
       "category": "lynx-api/performance-api",
@@ -108725,7 +109124,7 @@
       }
     },
     {
-      "id": "feature-1150",
+      "id": "feature-1153",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.identifier",
       "name": "identifier",
       "category": "lynx-api/performance-api",
@@ -108761,7 +109160,7 @@
       }
     },
     {
-      "id": "feature-1151",
+      "id": "feature-1154",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.pipelineStart",
       "name": "pipelineStart",
       "category": "lynx-api/performance-api",
@@ -108797,7 +109196,7 @@
       }
     },
     {
-      "id": "feature-1152",
+      "id": "feature-1155",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.pipelineEnd",
       "name": "pipelineEnd",
       "category": "lynx-api/performance-api",
@@ -108833,7 +109232,7 @@
       }
     },
     {
-      "id": "feature-1153",
+      "id": "feature-1156",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.mtsRenderStart",
       "name": "mtsRenderStart",
       "category": "lynx-api/performance-api",
@@ -108869,7 +109268,7 @@
       }
     },
     {
-      "id": "feature-1154",
+      "id": "feature-1157",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.mtsRenderEnd",
       "name": "mtsRenderEnd",
       "category": "lynx-api/performance-api",
@@ -108905,7 +109304,7 @@
       }
     },
     {
-      "id": "feature-1155",
+      "id": "feature-1158",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.resolveStart",
       "name": "resolveStart",
       "category": "lynx-api/performance-api",
@@ -108941,7 +109340,7 @@
       }
     },
     {
-      "id": "feature-1156",
+      "id": "feature-1159",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.resolveEnd",
       "name": "resolveEnd",
       "category": "lynx-api/performance-api",
@@ -108977,7 +109376,7 @@
       }
     },
     {
-      "id": "feature-1157",
+      "id": "feature-1160",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.layoutStart",
       "name": "layoutStart",
       "category": "lynx-api/performance-api",
@@ -109013,7 +109412,7 @@
       }
     },
     {
-      "id": "feature-1158",
+      "id": "feature-1161",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.paintingUiOperationExecuteEnd",
       "name": "paintingUiOperationExecuteEnd",
       "category": "lynx-api/performance-api",
@@ -109049,7 +109448,7 @@
       }
     },
     {
-      "id": "feature-1159",
+      "id": "feature-1162",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.layoutUiOperationExecuteStart",
       "name": "layoutUiOperationExecuteStart",
       "category": "lynx-api/performance-api",
@@ -109085,7 +109484,7 @@
       }
     },
     {
-      "id": "feature-1160",
+      "id": "feature-1163",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.layoutUiOperationExecuteEnd",
       "name": "layoutUiOperationExecuteEnd",
       "category": "lynx-api/performance-api",
@@ -109121,7 +109520,7 @@
       }
     },
     {
-      "id": "feature-1161",
+      "id": "feature-1164",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.paintEnd",
       "name": "paintEnd",
       "category": "lynx-api/performance-api",
@@ -109157,7 +109556,7 @@
       }
     },
     {
-      "id": "feature-1162",
+      "id": "feature-1165",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.frameworkPipelineTiming",
       "name": "frameworkPipelineTiming",
       "category": "lynx-api/performance-api",
@@ -109193,7 +109592,7 @@
       }
     },
     {
-      "id": "feature-1163",
+      "id": "feature-1166",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.hostPlatformTiming",
       "name": "hostPlatformTiming",
       "category": "lynx-api/performance-api",
@@ -109229,7 +109628,7 @@
       }
     },
     {
-      "id": "feature-1164",
+      "id": "feature-1167",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.actualFmp",
       "name": "actualFmp",
       "category": "lynx-api/performance-api",
@@ -109265,7 +109664,7 @@
       }
     },
     {
-      "id": "feature-1165",
+      "id": "feature-1168",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.lynxActualFmp",
       "name": "lynxActualFmp",
       "category": "lynx-api/performance-api",
@@ -109301,7 +109700,7 @@
       }
     },
     {
-      "id": "feature-1166",
+      "id": "feature-1169",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.totalActualFmp",
       "name": "totalActualFmp",
       "category": "lynx-api/performance-api",
@@ -109337,7 +109736,7 @@
       }
     },
     {
-      "id": "feature-1167",
+      "id": "feature-1170",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry",
       "name": "reload-bundle-entry",
       "category": "lynx-api/performance-api",
@@ -109373,7 +109772,7 @@
       }
     },
     {
-      "id": "feature-1168",
+      "id": "feature-1171",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.entryType",
       "name": "entryType",
       "category": "lynx-api/performance-api",
@@ -109409,7 +109808,7 @@
       }
     },
     {
-      "id": "feature-1169",
+      "id": "feature-1172",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.name",
       "name": "name",
       "category": "lynx-api/performance-api",
@@ -109445,7 +109844,7 @@
       }
     },
     {
-      "id": "feature-1170",
+      "id": "feature-1173",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.identifier",
       "name": "identifier",
       "category": "lynx-api/performance-api",
@@ -109481,7 +109880,7 @@
       }
     },
     {
-      "id": "feature-1171",
+      "id": "feature-1174",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.reloadBundleStart",
       "name": "reloadBundleStart",
       "category": "lynx-api/performance-api",
@@ -109517,7 +109916,7 @@
       }
     },
     {
-      "id": "feature-1172",
+      "id": "feature-1175",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.reloadBundleEnd",
       "name": "reloadBundleEnd",
       "category": "lynx-api/performance-api",
@@ -109553,7 +109952,7 @@
       }
     },
     {
-      "id": "feature-1173",
+      "id": "feature-1176",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.reloadBackgroundStart",
       "name": "reloadBackgroundStart",
       "category": "lynx-api/performance-api",
@@ -109589,7 +109988,7 @@
       }
     },
     {
-      "id": "feature-1174",
+      "id": "feature-1177",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.reloadBackgroundEnd",
       "name": "reloadBackgroundEnd",
       "category": "lynx-api/performance-api",
@@ -109625,7 +110024,7 @@
       }
     },
     {
-      "id": "feature-1175",
+      "id": "feature-1178",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.pipelineStart",
       "name": "pipelineStart",
       "category": "lynx-api/performance-api",
@@ -109661,7 +110060,7 @@
       }
     },
     {
-      "id": "feature-1176",
+      "id": "feature-1179",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.pipelineEnd",
       "name": "pipelineEnd",
       "category": "lynx-api/performance-api",
@@ -109697,7 +110096,7 @@
       }
     },
     {
-      "id": "feature-1177",
+      "id": "feature-1180",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.mtsRenderStart",
       "name": "mtsRenderStart",
       "category": "lynx-api/performance-api",
@@ -109733,7 +110132,7 @@
       }
     },
     {
-      "id": "feature-1178",
+      "id": "feature-1181",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.mtsRenderEnd",
       "name": "mtsRenderEnd",
       "category": "lynx-api/performance-api",
@@ -109769,7 +110168,7 @@
       }
     },
     {
-      "id": "feature-1179",
+      "id": "feature-1182",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.resolveStart",
       "name": "resolveStart",
       "category": "lynx-api/performance-api",
@@ -109805,7 +110204,7 @@
       }
     },
     {
-      "id": "feature-1180",
+      "id": "feature-1183",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.resolveEnd",
       "name": "resolveEnd",
       "category": "lynx-api/performance-api",
@@ -109841,7 +110240,7 @@
       }
     },
     {
-      "id": "feature-1181",
+      "id": "feature-1184",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.layoutStart",
       "name": "layoutStart",
       "category": "lynx-api/performance-api",
@@ -109877,7 +110276,7 @@
       }
     },
     {
-      "id": "feature-1182",
+      "id": "feature-1185",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.paintingUiOperationExecuteEnd",
       "name": "paintingUiOperationExecuteEnd",
       "category": "lynx-api/performance-api",
@@ -109913,7 +110312,7 @@
       }
     },
     {
-      "id": "feature-1183",
+      "id": "feature-1186",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.layoutUiOperationExecuteStart",
       "name": "layoutUiOperationExecuteStart",
       "category": "lynx-api/performance-api",
@@ -109949,7 +110348,7 @@
       }
     },
     {
-      "id": "feature-1184",
+      "id": "feature-1187",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.layoutUiOperationExecuteEnd",
       "name": "layoutUiOperationExecuteEnd",
       "category": "lynx-api/performance-api",
@@ -109985,7 +110384,7 @@
       }
     },
     {
-      "id": "feature-1185",
+      "id": "feature-1188",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.paintEnd",
       "name": "paintEnd",
       "category": "lynx-api/performance-api",
@@ -110021,7 +110420,7 @@
       }
     },
     {
-      "id": "feature-1186",
+      "id": "feature-1189",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.frameworkPipelineTiming",
       "name": "frameworkPipelineTiming",
       "category": "lynx-api/performance-api",
@@ -110057,7 +110456,7 @@
       }
     },
     {
-      "id": "feature-1187",
+      "id": "feature-1190",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.loadCoreStart",
       "name": "loadCoreStart",
       "category": "lynx-api/performance-api",
@@ -110093,7 +110492,7 @@
       }
     },
     {
-      "id": "feature-1188",
+      "id": "feature-1191",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.loadCoreEnd",
       "name": "loadCoreEnd",
       "category": "lynx-api/performance-api",
@@ -110129,7 +110528,7 @@
       }
     },
     {
-      "id": "feature-1189",
+      "id": "feature-1192",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.openTime",
       "name": "openTime",
       "category": "lynx-api/performance-api",
@@ -110165,7 +110564,7 @@
       }
     },
     {
-      "id": "feature-1190",
+      "id": "feature-1193",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.containerInitStart",
       "name": "containerInitStart",
       "category": "lynx-api/performance-api",
@@ -110201,7 +110600,7 @@
       }
     },
     {
-      "id": "feature-1191",
+      "id": "feature-1194",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.containerInitEnd",
       "name": "containerInitEnd",
       "category": "lynx-api/performance-api",
@@ -110237,7 +110636,7 @@
       }
     },
     {
-      "id": "feature-1192",
+      "id": "feature-1195",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.prepareTemplateStart",
       "name": "prepareTemplateStart",
       "category": "lynx-api/performance-api",
@@ -110273,7 +110672,7 @@
       }
     },
     {
-      "id": "feature-1193",
+      "id": "feature-1196",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.prepareTemplateEnd",
       "name": "prepareTemplateEnd",
       "category": "lynx-api/performance-api",
@@ -110309,7 +110708,7 @@
       }
     },
     {
-      "id": "feature-1194",
+      "id": "feature-1197",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.createLynxStart",
       "name": "createLynxStart",
       "category": "lynx-api/performance-api",
@@ -110345,7 +110744,7 @@
       }
     },
     {
-      "id": "feature-1195",
+      "id": "feature-1198",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.createLynxEnd",
       "name": "createLynxEnd",
       "category": "lynx-api/performance-api",
@@ -110381,7 +110780,7 @@
       }
     },
     {
-      "id": "feature-1196",
+      "id": "feature-1199",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.fcp",
       "name": "fcp",
       "category": "lynx-api/performance-api",
@@ -110417,7 +110816,7 @@
       }
     },
     {
-      "id": "feature-1197",
+      "id": "feature-1200",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.lynxFcp",
       "name": "lynxFcp",
       "category": "lynx-api/performance-api",
@@ -110453,7 +110852,7 @@
       }
     },
     {
-      "id": "feature-1198",
+      "id": "feature-1201",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.totalFcp",
       "name": "totalFcp",
       "category": "lynx-api/performance-api",
@@ -110489,7 +110888,7 @@
       }
     },
     {
-      "id": "feature-1199",
+      "id": "feature-1202",
       "query": "lynx-api/performance-api/performance-entry",
       "name": "performance-entry",
       "category": "lynx-api/performance-api",
@@ -110525,7 +110924,7 @@
       }
     },
     {
-      "id": "feature-1200",
+      "id": "feature-1203",
       "query": "lynx-api/performance-api/performance-metric",
       "name": "performance-metric",
       "category": "lynx-api/performance-api",
@@ -110561,7 +110960,7 @@
       }
     },
     {
-      "id": "feature-1201",
+      "id": "feature-1204",
       "query": "lynx-api/performance-api/performance-observer/disconnect",
       "name": "disconnect",
       "category": "lynx-api/performance-api",
@@ -110597,7 +110996,7 @@
       }
     },
     {
-      "id": "feature-1202",
+      "id": "feature-1205",
       "query": "lynx-api/performance-api/performance-observer/observe",
       "name": "observe",
       "category": "lynx-api/performance-api",
@@ -110633,7 +111032,7 @@
       }
     },
     {
-      "id": "feature-1203",
+      "id": "feature-1206",
       "query": "lynx-api/performance-api/performance-observer",
       "name": "performance-observer",
       "category": "lynx-api/performance-api",
@@ -110669,7 +111068,7 @@
       }
     },
     {
-      "id": "feature-1204",
+      "id": "feature-1207",
       "query": "lynx-api/performance-api/timing-flag",
       "name": "timing-flag",
       "category": "lynx-api/performance-api",
@@ -110705,7 +111104,7 @@
       }
     },
     {
-      "id": "feature-1205",
+      "id": "feature-1208",
       "query": "lynx-native-api/lynx-background-runtime/add-lynx-background-runtime-client",
       "name": "register lifecycle observer for background runtime",
       "category": "lynx-native-api",
@@ -110741,7 +111140,7 @@
       }
     },
     {
-      "id": "feature-1206",
+      "id": "feature-1209",
       "query": "lynx-native-api/lynx-background-runtime/call-js-function",
       "name": "invoke js function from background runtime",
       "category": "lynx-native-api",
@@ -110777,7 +111176,7 @@
       }
     },
     {
-      "id": "feature-1207",
+      "id": "feature-1210",
       "query": "lynx-native-api/lynx-background-runtime/destroy",
       "name": "manually destroy background runtime instance",
       "category": "lynx-native-api",
@@ -110813,7 +111212,7 @@
       }
     },
     {
-      "id": "feature-1208",
+      "id": "feature-1211",
       "query": "lynx-native-api/lynx-background-runtime/evaluate-java-script",
       "name": "evaluate background runtime script",
       "category": "lynx-native-api",
@@ -110849,7 +111248,7 @@
       }
     },
     {
-      "id": "feature-1209",
+      "id": "feature-1212",
       "query": "lynx-native-api/lynx-background-runtime/remove-lynx-background-runtime-client",
       "name": "remove lifecycle observer for background runtime",
       "category": "lynx-native-api",
@@ -110885,7 +111284,7 @@
       }
     },
     {
-      "id": "feature-1210",
+      "id": "feature-1213",
       "query": "lynx-native-api/lynx-background-runtime/send-global-event",
       "name": "send global event to js enviroment from background runtime",
       "category": "lynx-native-api",
@@ -110921,7 +111320,7 @@
       }
     },
     {
-      "id": "feature-1211",
+      "id": "feature-1214",
       "query": "lynx-native-api/lynx-background-runtime-client/on-evaluate-java-script-end",
       "name": "Called when background script evaluation finished.",
       "category": "lynx-native-api",
@@ -110957,7 +111356,7 @@
       }
     },
     {
-      "id": "feature-1212",
+      "id": "feature-1215",
       "query": "lynx-native-api/lynx-background-runtime-client/on-module-method-invoked",
       "name": "Called when a module method invocation completed in background runtime.",
       "category": "lynx-native-api",
@@ -110993,7 +111392,7 @@
       }
     },
     {
-      "id": "feature-1213",
+      "id": "feature-1216",
       "query": "lynx-native-api/lynx-background-runtime-client/on-received-error",
       "name": "Called when an error is received in background runtime.",
       "category": "lynx-native-api",
@@ -111029,7 +111428,7 @@
       }
     },
     {
-      "id": "feature-1214",
+      "id": "feature-1217",
       "query": "lynx-native-api/lynx-context/send-global-event",
       "name": "send global event to js enviroment",
       "category": "lynx-native-api",
@@ -111065,7 +111464,7 @@
       }
     },
     {
-      "id": "feature-1215",
+      "id": "feature-1218",
       "query": "lynx-native-api/lynx-context/set-extra-timing",
       "name": "set extra timing from outside.",
       "category": "lynx-native-api",
@@ -111101,7 +111500,7 @@
       }
     },
     {
-      "id": "feature-1216",
+      "id": "feature-1219",
       "query": "lynx-native-api/lynx-context/update-font-scale",
       "name": "update font scale of lynxView",
       "category": "lynx-native-api",
@@ -111137,7 +111536,7 @@
       }
     },
     {
-      "id": "feature-1217",
+      "id": "feature-1220",
       "query": "lynx-native-api/lynx-context/update-meta-data",
       "name": "update lynx page by new data.",
       "category": "lynx-native-api",
@@ -111173,7 +111572,7 @@
       }
     },
     {
-      "id": "feature-1218",
+      "id": "feature-1221",
       "query": "lynx-native-api/lynx-context/update-viewport",
       "name": "update viewport of lynxView",
       "category": "lynx-native-api",
@@ -111209,7 +111608,7 @@
       }
     },
     {
-      "id": "feature-1219",
+      "id": "feature-1222",
       "query": "lynx-native-api/lynx-env/trim-memory",
       "name": "dispatch memory pressure signal to registered callbacks",
       "category": "lynx-native-api",
@@ -111245,7 +111644,7 @@
       }
     },
     {
-      "id": "feature-1220",
+      "id": "feature-1223",
       "query": "lynx-native-api/lynx-extension-module",
       "name": "Desktop-only extension module entry for lifecycle hooks, NAPI binding, VSync, and native view registration.",
       "category": "lynx-native-api",
@@ -111281,7 +111680,7 @@
       }
     },
     {
-      "id": "feature-1221",
+      "id": "feature-1224",
       "query": "lynx-native-api/lynx-generic-resource-fetcher/cancel",
       "name": "Cancel the request of the requiring resource.",
       "category": "lynx-native-api",
@@ -111317,7 +111716,7 @@
       }
     },
     {
-      "id": "feature-1222",
+      "id": "feature-1225",
       "query": "lynx-native-api/lynx-generic-resource-fetcher/fetch-resource-path",
       "name": "LynxEngine internally calls this method to obtain the path of the common resource on the local disk, and the return result is required to be of String type.",
       "category": "lynx-native-api",
@@ -111353,7 +111752,7 @@
       }
     },
     {
-      "id": "feature-1223",
+      "id": "feature-1226",
       "query": "lynx-native-api/lynx-generic-resource-fetcher/fetch-resource",
       "name": "LynxEngine internally calls this method to obtain the general resource content, and the return result is required to be the resource content byte[] type.",
       "category": "lynx-native-api",
@@ -111389,7 +111788,7 @@
       }
     },
     {
-      "id": "feature-1224",
+      "id": "feature-1227",
       "query": "lynx-native-api/lynx-generic-resource-fetcher/fetch-stream",
       "name": "LynxEngine internally calls this method to obtain resource content in a streaming manner.",
       "category": "lynx-native-api",
@@ -111425,7 +111824,7 @@
       }
     },
     {
-      "id": "feature-1225",
+      "id": "feature-1228",
       "query": "lynx-native-api/lynx-load-meta",
       "name": "MetaData of LynxEngine loadProcess",
       "category": "lynx-native-api",
@@ -111461,7 +111860,7 @@
       }
     },
     {
-      "id": "feature-1226",
+      "id": "feature-1229",
       "query": "lynx-native-api/lynx-media-resource-fetcher/fetch-image",
       "name": "LynxEngine will use this method to obtain the bitmap information of the image, and the return content must be of Closeable type.",
       "category": "lynx-native-api",
@@ -111497,7 +111896,7 @@
       }
     },
     {
-      "id": "feature-1227",
+      "id": "feature-1230",
       "query": "lynx-native-api/lynx-media-resource-fetcher/is-local-resource",
       "name": "LynxEngine internally calls this method to determine whether the resource path exists on disk.",
       "category": "lynx-native-api",
@@ -111533,7 +111932,7 @@
       }
     },
     {
-      "id": "feature-1228",
+      "id": "feature-1231",
       "query": "lynx-native-api/lynx-media-resource-fetcher/should-redirect-url",
       "name": "LynxEngine redirects the image path by calling this method internally, and the return result is required to be of String type.",
       "category": "lynx-native-api",
@@ -111569,7 +111968,7 @@
       }
     },
     {
-      "id": "feature-1229",
+      "id": "feature-1232",
       "query": "lynx-native-api/lynx-service/lynx-service",
       "name": "LynxService API",
       "category": "lynx-native-api",
@@ -111605,7 +112004,7 @@
       }
     },
     {
-      "id": "feature-1230",
+      "id": "feature-1233",
       "query": "lynx-native-api/lynx-template-resource-fetcher/fetch-template",
       "name": "LynxEngine internally calls this method to obtain the contents of Bundle and Lazy Bundle. The returned result type can contain byte[] or TemplateBundle.",
       "category": "lynx-native-api",
@@ -111641,7 +112040,7 @@
       }
     },
     {
-      "id": "feature-1231",
+      "id": "feature-1234",
       "query": "lynx-native-api/lynx-update-meta",
       "name": "MetaData of LynxEngine updateProcess",
       "category": "lynx-native-api",
@@ -111677,7 +112076,7 @@
       }
     },
     {
-      "id": "feature-1232",
+      "id": "feature-1235",
       "query": "lynx-native-api/lynx-view/add-lynx-view-client",
       "name": "register lifecycle observer for lynxView",
       "category": "lynx-native-api",
@@ -111713,7 +112112,7 @@
       }
     },
     {
-      "id": "feature-1233",
+      "id": "feature-1236",
       "query": "lynx-native-api/lynx-view/destroy",
       "name": "manually destroy lynxView instance",
       "category": "lynx-native-api",
@@ -111749,7 +112148,7 @@
       }
     },
     {
-      "id": "feature-1234",
+      "id": "feature-1237",
       "query": "lynx-native-api/lynx-view/find-ui-by-id-selector",
       "name": "find ui by idselector",
       "category": "lynx-native-api",
@@ -111785,7 +112184,7 @@
       }
     },
     {
-      "id": "feature-1235",
+      "id": "feature-1238",
       "query": "lynx-native-api/lynx-view/find-ui-by-name",
       "name": "find ui by name",
       "category": "lynx-native-api",
@@ -111821,7 +112220,7 @@
       }
     },
     {
-      "id": "feature-1236",
+      "id": "feature-1239",
       "query": "lynx-native-api/lynx-view/find-view-by-id-selector",
       "name": "find view by idselector",
       "category": "lynx-native-api",
@@ -111857,7 +112256,7 @@
       }
     },
     {
-      "id": "feature-1237",
+      "id": "feature-1240",
       "query": "lynx-native-api/lynx-view/find-view-by-name",
       "name": "find view by name",
       "category": "lynx-native-api",
@@ -111893,7 +112292,7 @@
       }
     },
     {
-      "id": "feature-1238",
+      "id": "feature-1241",
       "query": "lynx-native-api/lynx-view/load-template",
       "name": "load a lynx template file by LynxView.",
       "category": "lynx-native-api",
@@ -111929,7 +112328,7 @@
       }
     },
     {
-      "id": "feature-1239",
+      "id": "feature-1242",
       "query": "lynx-native-api/lynx-view/lynx-view-custom-element",
       "name": "<code>lynx-view</code> The custom element of LynxView.",
       "category": "lynx-native-api",
@@ -111965,7 +112364,7 @@
       }
     },
     {
-      "id": "feature-1240",
+      "id": "feature-1243",
       "query": "lynx-native-api/lynx-view/reload",
       "name": "reload lynx page.",
       "category": "lynx-native-api",
@@ -112001,7 +112400,7 @@
       }
     },
     {
-      "id": "feature-1241",
+      "id": "feature-1244",
       "query": "lynx-native-api/lynx-view/remove-lynx-view-client",
       "name": "remove lifecycle observer of lynxView",
       "category": "lynx-native-api",
@@ -112037,7 +112436,7 @@
       }
     },
     {
-      "id": "feature-1242",
+      "id": "feature-1245",
       "query": "lynx-native-api/lynx-view/send-global-event",
       "name": "send global event to js enviroment",
       "category": "lynx-native-api",
@@ -112073,7 +112472,7 @@
       }
     },
     {
-      "id": "feature-1243",
+      "id": "feature-1246",
       "query": "lynx-native-api/lynx-view/set-extra-timing",
       "name": "set extra timing from outside.",
       "category": "lynx-native-api",
@@ -112109,7 +112508,7 @@
       }
     },
     {
-      "id": "feature-1244",
+      "id": "feature-1247",
       "query": "lynx-native-api/lynx-view/update-font-scale",
       "name": "update font scale of lynxView",
       "category": "lynx-native-api",
@@ -112145,7 +112544,7 @@
       }
     },
     {
-      "id": "feature-1245",
+      "id": "feature-1248",
       "query": "lynx-native-api/lynx-view/update-meta-data",
       "name": "update lynx page by new data.",
       "category": "lynx-native-api",
@@ -112181,7 +112580,7 @@
       }
     },
     {
-      "id": "feature-1246",
+      "id": "feature-1249",
       "query": "lynx-native-api/lynx-view/update-screen-metrics",
       "name": "update screen metrics",
       "category": "lynx-native-api",
@@ -112217,7 +112616,7 @@
       }
     },
     {
-      "id": "feature-1247",
+      "id": "feature-1250",
       "query": "lynx-native-api/lynx-view/update-viewport",
       "name": "update viewport of lynxView",
       "category": "lynx-native-api",
@@ -112253,7 +112652,7 @@
       }
     },
     {
-      "id": "feature-1248",
+      "id": "feature-1251",
       "query": "lynx-native-api/lynx-view-client/on-data-updated",
       "name": "Called when data update, but the view may not be updated.",
       "category": "lynx-native-api",
@@ -112289,7 +112688,7 @@
       }
     },
     {
-      "id": "feature-1249",
+      "id": "feature-1252",
       "query": "lynx-native-api/lynx-view-client/on-destroy",
       "name": "Called after the page is destroyed.",
       "category": "lynx-native-api",
@@ -112325,7 +112724,7 @@
       }
     },
     {
-      "id": "feature-1250",
+      "id": "feature-1253",
       "query": "lynx-native-api/lynx-view-client/on-first-load-perf-ready",
       "name": "Performance data statistics callback after the first load is completed.",
       "category": "lynx-native-api",
@@ -112361,7 +112760,7 @@
       }
     },
     {
-      "id": "feature-1251",
+      "id": "feature-1254",
       "query": "lynx-native-api/lynx-view-client/on-first-screen",
       "name": "Called when first screen layout completed.",
       "category": "lynx-native-api",
@@ -112397,7 +112796,7 @@
       }
     },
     {
-      "id": "feature-1252",
+      "id": "feature-1255",
       "query": "lynx-native-api/lynx-view-client/on-fling",
       "name": "Called when inertial scrolling starts after releasing the finger.",
       "category": "lynx-native-api",
@@ -112433,7 +112832,7 @@
       }
     },
     {
-      "id": "feature-1253",
+      "id": "feature-1256",
       "query": "lynx-native-api/lynx-view-client/on-flush-finish",
       "name": "Called when UI flush end in async render mode.",
       "category": "lynx-native-api",
@@ -112469,7 +112868,7 @@
       }
     },
     {
-      "id": "feature-1254",
+      "id": "feature-1257",
       "query": "lynx-native-api/lynx-view-client/on-key-event",
       "name": "Report all android key events with flag indicating whether has been handled.",
       "category": "lynx-native-api",
@@ -112505,7 +112904,7 @@
       }
     },
     {
-      "id": "feature-1255",
+      "id": "feature-1258",
       "query": "lynx-native-api/lynx-view-client/on-load-success",
       "name": "Called when page load finish.",
       "category": "lynx-native-api",
@@ -112541,7 +112940,7 @@
       }
     },
     {
-      "id": "feature-1256",
+      "id": "feature-1259",
       "query": "lynx-native-api/lynx-view-client/on-lynx-event",
       "name": "Report Lynx events that sended to frontend.",
       "category": "lynx-native-api",
@@ -112577,7 +112976,7 @@
       }
     },
     {
-      "id": "feature-1257",
+      "id": "feature-1260",
       "query": "lynx-native-api/lynx-view-client/on-lynx-view-and-js-runtime-destroy",
       "name": "Called when lynx view and js runtime destroy.",
       "category": "lynx-native-api",
@@ -112613,7 +113012,7 @@
       }
     },
     {
-      "id": "feature-1258",
+      "id": "feature-1261",
       "query": "lynx-native-api/lynx-view-client/on-module-method-invoked",
       "name": "Called when module method invocation completed.",
       "category": "lynx-native-api",
@@ -112649,7 +113048,7 @@
       }
     },
     {
-      "id": "feature-1259",
+      "id": "feature-1262",
       "query": "lynx-native-api/lynx-view-client/on-page-start",
       "name": "Called when page start loading.",
       "category": "lynx-native-api",
@@ -112685,7 +113084,7 @@
       }
     },
     {
-      "id": "feature-1260",
+      "id": "feature-1263",
       "query": "lynx-native-api/lynx-view-client/on-page-update",
       "name": "Called when page update.",
       "category": "lynx-native-api",
@@ -112721,7 +113120,7 @@
       }
     },
     {
-      "id": "feature-1261",
+      "id": "feature-1264",
       "query": "lynx-native-api/lynx-view-client/on-performance-event",
       "name": "Notify the client that a performance event has been sent. It will be called every time a performance event is generated, including but not limited to container initialization, engine rendering, rendering metrics update, etc.",
       "category": "lynx-native-api",
@@ -112757,7 +113156,7 @@
       }
     },
     {
-      "id": "feature-1262",
+      "id": "feature-1265",
       "query": "lynx-native-api/lynx-view-client/on-piper-invoked",
       "name": "Called when JSBridge invoked.",
       "category": "lynx-native-api",
@@ -112793,7 +113192,7 @@
       }
     },
     {
-      "id": "feature-1263",
+      "id": "feature-1266",
       "query": "lynx-native-api/lynx-view-client/on-received-error",
       "name": "Called when error received.",
       "category": "lynx-native-api",
@@ -112829,7 +113228,7 @@
       }
     },
     {
-      "id": "feature-1264",
+      "id": "feature-1267",
       "query": "lynx-native-api/lynx-view-client/on-received-java-error",
       "name": "Called when java error received.",
       "category": "lynx-native-api",
@@ -112865,7 +113264,7 @@
       }
     },
     {
-      "id": "feature-1265",
+      "id": "feature-1268",
       "query": "lynx-native-api/lynx-view-client/on-received-js-error",
       "name": "Called when JS error received.",
       "category": "lynx-native-api",
@@ -112901,7 +113300,7 @@
       }
     },
     {
-      "id": "feature-1266",
+      "id": "feature-1269",
       "query": "lynx-native-api/lynx-view-client/on-received-native-error",
       "name": "Called when C++ layer error received.",
       "category": "lynx-native-api",
@@ -112937,7 +113336,7 @@
       }
     },
     {
-      "id": "feature-1267",
+      "id": "feature-1270",
       "query": "lynx-native-api/lynx-view-client/on-report-component-info",
       "name": "Return the used component tagName.",
       "category": "lynx-native-api",
@@ -112973,7 +113372,7 @@
       }
     },
     {
-      "id": "feature-1268",
+      "id": "feature-1271",
       "query": "lynx-native-api/lynx-view-client/on-runtime-ready",
       "name": "Called when JS environment preparation completed.",
       "category": "lynx-native-api",
@@ -113009,7 +113408,7 @@
       }
     },
     {
-      "id": "feature-1269",
+      "id": "feature-1272",
       "query": "lynx-native-api/lynx-view-client/on-scroll-start",
       "name": "Called when the UI start scrolling.",
       "category": "lynx-native-api",
@@ -113045,7 +113444,7 @@
       }
     },
     {
-      "id": "feature-1270",
+      "id": "feature-1273",
       "query": "lynx-native-api/lynx-view-client/on-scroll-stop",
       "name": "Called when the UI finished scrolling.",
       "category": "lynx-native-api",
@@ -113081,7 +113480,7 @@
       }
     },
     {
-      "id": "feature-1271",
+      "id": "feature-1274",
       "query": "lynx-native-api/lynx-view-client/on-tasm-finished-by-native",
       "name": "Called when native layout finish in ui or most_on_tasm mode, or diff finish in multi_thread mode.",
       "category": "lynx-native-api",
@@ -113117,7 +113516,7 @@
       }
     },
     {
-      "id": "feature-1272",
+      "id": "feature-1275",
       "query": "lynx-native-api/lynx-view-client/on-template-bundle-ready",
       "name": "Provide a reusable TemplateBundle after template is decode.",
       "category": "lynx-native-api",
@@ -113153,7 +113552,7 @@
       }
     },
     {
-      "id": "feature-1273",
+      "id": "feature-1276",
       "query": "lynx-native-api/lynx-view-client/on-update-data-without-change",
       "name": "If there is no need to update the UI after calling updateData, this method is called back.",
       "category": "lynx-native-api",
@@ -113189,7 +113588,7 @@
       }
     },
     {
-      "id": "feature-1274",
+      "id": "feature-1277",
       "query": "lynx-native-api/lynx-view-client/on-update-perf-ready",
       "name": "Performance data statistics callback after the interface update is completed.",
       "category": "lynx-native-api",
@@ -113225,7 +113624,7 @@
       }
     },
     {
-      "id": "feature-1275",
+      "id": "feature-1278",
       "query": "lynx-native-api/template-bundle/from-template-async-with-option",
       "name": "Asynchronously creates a TemplateBundle from a template binary data with options. This method avoids blocking the main thread.",
       "category": "lynx-native-api",
@@ -113261,7 +113660,7 @@
       }
     },
     {
-      "id": "feature-1276",
+      "id": "feature-1279",
       "query": "lynx-native-api/template-bundle/from-template-async",
       "name": "Asynchronously creates a TemplateBundle from a template binary data. This method avoids blocking the main thread.",
       "category": "lynx-native-api",
@@ -113297,7 +113696,7 @@
       }
     },
     {
-      "id": "feature-1277",
+      "id": "feature-1280",
       "query": "lynx-native-api/template-bundle/from-template",
       "name": "Input Lynx template binary content and return the parsed TemplateBundle object.",
       "category": "lynx-native-api",
@@ -113333,7 +113732,7 @@
       }
     },
     {
-      "id": "feature-1278",
+      "id": "feature-1281",
       "query": "lynx-native-api/template-bundle/get-error-message",
       "name": "When TemplateBundle is an invalid object, use this method to obtain the exception information that occurred during template parsing.",
       "category": "lynx-native-api",
@@ -113369,7 +113768,7 @@
       }
     },
     {
-      "id": "feature-1279",
+      "id": "feature-1282",
       "query": "lynx-native-api/template-bundle/get-extra-info",
       "name": "Read the content of the extraInfo field configured in the pageConfig of the front-end template.",
       "category": "lynx-native-api",
@@ -113405,7 +113804,7 @@
       }
     },
     {
-      "id": "feature-1280",
+      "id": "feature-1283",
       "query": "lynx-native-api/template-bundle/get-template-size",
       "name": "Get the size of current template.",
       "category": "lynx-native-api",
@@ -113441,7 +113840,7 @@
       }
     },
     {
-      "id": "feature-1281",
+      "id": "feature-1284",
       "query": "lynx-native-api/template-bundle/is-element-bundle-valid",
       "name": "Whether the TemplateBundle contains a Valid ElementBundle.",
       "category": "lynx-native-api",
@@ -113477,7 +113876,7 @@
       }
     },
     {
-      "id": "feature-1282",
+      "id": "feature-1285",
       "query": "lynx-native-api/template-bundle/is-valid",
       "name": "Determines whether the current TemplateBundle object is valid.",
       "category": "lynx-native-api",
@@ -113513,7 +113912,7 @@
       }
     },
     {
-      "id": "feature-1283",
+      "id": "feature-1286",
       "query": "lynx-native-api/template-bundle/post-js-cache-generation-task",
       "name": "Start a sub-thread task to generate the js code cache of the current template.",
       "category": "lynx-native-api",
@@ -113549,7 +113948,7 @@
       }
     },
     {
-      "id": "feature-1284",
+      "id": "feature-1287",
       "query": "lynx-native-api/template-bundle/release",
       "name": "Release the Native memory held by the current TemplateBundle object. After executing the release method, the TemplateBundle will become the inValid state.",
       "category": "lynx-native-api",
@@ -113585,7 +113984,7 @@
       }
     },
     {
-      "id": "feature-1285",
+      "id": "feature-1288",
       "query": "lynx-native-api/template-data/constructor",
       "name": "Input data in string, key-value or json format and return the parsed TemplateData object.",
       "category": "lynx-native-api",
@@ -113621,7 +114020,7 @@
       }
     },
     {
-      "id": "feature-1286",
+      "id": "feature-1289",
       "query": "lynx-native-api/template-data/data",
       "name": "Get the data in TemplateData object.",
       "category": "lynx-native-api",
@@ -113657,7 +114056,7 @@
       }
     },
     {
-      "id": "feature-1287",
+      "id": "feature-1290",
       "query": "lynx-native-api/template-data/from-map",
       "name": "Input data in key-value format and return the parsed TemplateData object.",
       "category": "lynx-native-api",
@@ -113693,7 +114092,7 @@
       }
     },
     {
-      "id": "feature-1288",
+      "id": "feature-1291",
       "query": "lynx-native-api/template-data/from-string",
       "name": "Input data in json and return the parsed TemplateData object.",
       "category": "lynx-native-api",
@@ -113729,7 +114128,7 @@
       }
     },
     {
-      "id": "feature-1289",
+      "id": "feature-1292",
       "query": "lynx-native-api/template-data/mark-state",
       "name": "Mark the current TemplateData with the associated dataProcessor name. When this TemplateData is used in UpdateData, the corresponding dataProcessor will be found based on this name for data preprocessing.",
       "category": "lynx-native-api",
@@ -113765,7 +114164,7 @@
       }
     },
     {
-      "id": "feature-1290",
+      "id": "feature-1293",
       "query": "lynx-native-api/template-data/merge",
       "name": "Merge the incoming data with the current data.",
       "category": "lynx-native-api",
@@ -113801,7 +114200,7 @@
       }
     },
     {
-      "id": "feature-1291",
+      "id": "feature-1294",
       "query": "lynx-native-api/trace-event",
       "name": "TraceEvent",
       "category": "lynx-native-api",
@@ -113837,7 +114236,7 @@
       }
     },
     {
-      "id": "feature-1292",
+      "id": "feature-1295",
       "query": "react/main-thread/MainThread-APIs",
       "name": "APIs available on the main thread.",
       "category": "react",
@@ -113873,7 +114272,7 @@
       }
     },
     {
-      "id": "feature-1293",
+      "id": "feature-1296",
       "query": "react/main-thread/MainThread-APIs.runOnBackground",
       "name": "runOnBackground: Create a value that can be shared between main thread scripts.",
       "category": "react",
@@ -113909,7 +114308,7 @@
       }
     },
     {
-      "id": "feature-1294",
+      "id": "feature-1297",
       "query": "devtool/integration.lazy_load",
       "name": "Lazy load",
       "category": "devtool",
@@ -113945,7 +114344,7 @@
       }
     },
     {
-      "id": "feature-1295",
+      "id": "feature-1298",
       "query": "devtool/integration.switch.switchPage",
       "name": "Switch page",
       "category": "devtool",
@@ -113981,7 +114380,7 @@
       }
     },
     {
-      "id": "feature-1296",
+      "id": "feature-1299",
       "query": "devtool/integration.connection.usb",
       "name": "USB connection",
       "category": "devtool",
@@ -114017,7 +114416,7 @@
       }
     },
     {
-      "id": "feature-1297",
+      "id": "feature-1300",
       "query": "devtool/logbox",
       "name": "Shows logbox details",
       "category": "devtool",
@@ -114053,7 +114452,7 @@
       }
     },
     {
-      "id": "feature-1298",
+      "id": "feature-1301",
       "query": "devtool/logbox.notification",
       "name": "Notification with a brief message",
       "category": "devtool",
@@ -114089,7 +114488,7 @@
       }
     },
     {
-      "id": "feature-1299",
+      "id": "feature-1302",
       "query": "devtool/logbox.MTS Analysis",
       "name": "MTS Analysis",
       "category": "devtool",
@@ -114125,7 +114524,7 @@
       }
     },
     {
-      "id": "feature-1300",
+      "id": "feature-1303",
       "query": "devtool/logbox.BTS Analysis",
       "name": "BTS Analysis",
       "category": "devtool",
@@ -114161,7 +114560,7 @@
       }
     },
     {
-      "id": "feature-1301",
+      "id": "feature-1304",
       "query": "devtool/panels.elements.preview.reload",
       "name": "Reload",
       "category": "devtool",
@@ -114197,7 +114596,7 @@
       }
     },
     {
-      "id": "feature-1302",
+      "id": "feature-1305",
       "query": "devtool/panels.elements.preview.lynxview",
       "name": "LynxView mirroring",
       "category": "devtool",
@@ -114233,7 +114632,7 @@
       }
     },
     {
-      "id": "feature-1303",
+      "id": "feature-1306",
       "query": "devtool/panels.elements.preview.fullscreen",
       "name": "Fullscreen mirroring",
       "category": "devtool",
@@ -114269,7 +114668,7 @@
       }
     },
     {
-      "id": "feature-1304",
+      "id": "feature-1307",
       "query": "devtool/panels.elements.preview.box_model",
       "name": "Interact via the box model",
       "category": "devtool",
@@ -114305,7 +114704,7 @@
       }
     },
     {
-      "id": "feature-1305",
+      "id": "feature-1308",
       "query": "devtool/panels.elements.view-and-edit.element_tree",
       "name": "View and edit the element tree",
       "category": "devtool",
@@ -114341,7 +114740,7 @@
       }
     },
     {
-      "id": "feature-1306",
+      "id": "feature-1309",
       "query": "devtool/panels.elements.view-and-edit.hot_reload",
       "name": "View and edit CSS styles",
       "category": "devtool",
@@ -114377,7 +114776,7 @@
       }
     },
     {
-      "id": "feature-1307",
+      "id": "feature-1310",
       "query": "devtool/panels.console.print",
       "name": "View Logged messages",
       "category": "devtool",
@@ -114413,7 +114812,7 @@
       }
     },
     {
-      "id": "feature-1308",
+      "id": "feature-1311",
       "query": "devtool/panels.console.execution",
       "name": "Run JavaScript",
       "category": "devtool",
@@ -114449,7 +114848,7 @@
       }
     },
     {
-      "id": "feature-1309",
+      "id": "feature-1312",
       "query": "devtool/panels.sources.breakpoints.BTS",
       "name": "Background thread breakpoints",
       "category": "devtool",
@@ -114485,7 +114884,7 @@
       }
     },
     {
-      "id": "feature-1310",
+      "id": "feature-1313",
       "query": "devtool/panels.sources.breakpoints.MTS",
       "name": "Main thread breakpoints",
       "category": "devtool",
@@ -114521,7 +114920,7 @@
       }
     },
     {
-      "id": "feature-1311",
+      "id": "feature-1314",
       "query": "devtool/panels.sources.JSEngine.PrimJS",
       "name": "PrimJS",
       "category": "devtool",
@@ -114557,7 +114956,7 @@
       }
     },
     {
-      "id": "feature-1312",
+      "id": "feature-1315",
       "query": "devtool/panels.sources.JSEngine.V8",
       "name": "V8",
       "category": "devtool",
@@ -114593,7 +114992,7 @@
       }
     },
     {
-      "id": "feature-1313",
+      "id": "feature-1316",
       "query": "devtool/panels.layers",
       "name": "View page layers",
       "category": "devtool",
@@ -114629,7 +115028,7 @@
       }
     },
     {
-      "id": "feature-1314",
+      "id": "feature-1317",
       "query": "devtool/recorder",
       "name": "Lynx Recorder Support",
       "category": "devtool",
@@ -114665,7 +115064,7 @@
       }
     },
     {
-      "id": "feature-1315",
+      "id": "feature-1318",
       "query": "devtool/trace",
       "name": "Trace Tool",
       "category": "devtool",
@@ -114701,7 +115100,7 @@
       }
     },
     {
-      "id": "feature-1316",
+      "id": "feature-1319",
       "query": "errors/lynx-error",
       "name": "Structure used to represent an error",
       "category": "errors",
@@ -114755,7 +115154,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 683,
+          "supported": 686,
           "coverage": 63
         },
         "clay_android": {
@@ -114797,7 +115196,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 683,
+          "supported": 686,
           "coverage": 63
         },
         "clay_android": {
@@ -114828,18 +115227,18 @@
       "platforms": {
         "android": {
           "supported": 640,
-          "coverage": 59
+          "coverage": 58
         },
         "ios": {
           "supported": 639,
-          "coverage": 59
+          "coverage": 58
         },
         "harmony": {
           "supported": 0,
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 683,
+          "supported": 686,
           "coverage": 63
         },
         "clay_android": {
@@ -114848,7 +115247,7 @@
         },
         "clay_ios": {
           "supported": 432,
-          "coverage": 40
+          "coverage": 39
         },
         "clay_macos": {
           "supported": 496,
@@ -114870,18 +115269,18 @@
       "platforms": {
         "android": {
           "supported": 640,
-          "coverage": 59
+          "coverage": 58
         },
         "ios": {
           "supported": 639,
-          "coverage": 59
+          "coverage": 58
         },
         "harmony": {
           "supported": 0,
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 683,
+          "supported": 686,
           "coverage": 63
         },
         "clay_android": {
@@ -114890,7 +115289,7 @@
         },
         "clay_ios": {
           "supported": 432,
-          "coverage": 40
+          "coverage": 39
         },
         "clay_macos": {
           "supported": 496,
@@ -114912,18 +115311,18 @@
       "platforms": {
         "android": {
           "supported": 684,
-          "coverage": 63
+          "coverage": 62
         },
         "ios": {
           "supported": 683,
-          "coverage": 63
+          "coverage": 62
         },
         "harmony": {
           "supported": 0,
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 683,
+          "supported": 686,
           "coverage": 63
         },
         "clay_android": {
@@ -114965,7 +115364,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 683,
+          "supported": 686,
           "coverage": 63
         },
         "clay_android": {
@@ -115007,7 +115406,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 683,
+          "supported": 686,
           "coverage": 63
         },
         "clay_android": {
@@ -115049,7 +115448,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 683,
+          "supported": 686,
           "coverage": 63
         },
         "clay_android": {
@@ -115079,11 +115478,11 @@
       "release_date": "2025/5/26",
       "platforms": {
         "android": {
-          "supported": 769,
-          "coverage": 70
+          "supported": 772,
+          "coverage": 71
         },
         "ios": {
-          "supported": 768,
+          "supported": 771,
           "coverage": 70
         },
         "harmony": {
@@ -115091,7 +115490,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 683,
+          "supported": 686,
           "coverage": 63
         },
         "clay_android": {
@@ -115121,11 +115520,11 @@
       "release_date": "2025/7/21",
       "platforms": {
         "android": {
-          "supported": 828,
+          "supported": 831,
           "coverage": 76
         },
         "ios": {
-          "supported": 827,
+          "supported": 830,
           "coverage": 76
         },
         "harmony": {
@@ -115133,7 +115532,7 @@
           "coverage": 61
         },
         "web_lynx": {
-          "supported": 683,
+          "supported": 686,
           "coverage": 63
         },
         "clay_android": {

--- a/packages/lynx-compat-data/css/properties-manual/offset-distance.json
+++ b/packages/lynx-compat-data/css/properties-manual/offset-distance.json
@@ -1,0 +1,43 @@
+{
+  "css": {
+    "properties": {
+      "offset-distance": {
+        "__compat": {
+          "lynx_path": "api/css/properties/offset-distance",
+          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/CSS/offset-distance",
+          "spec_url": [],
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "3.3"
+            },
+            "ios": {
+              "version_added": "3.3"
+            },
+            "harmony": {
+              "version_added": "3.8"
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": true
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/lynx-compat-data/css/properties-manual/offset-path.json
+++ b/packages/lynx-compat-data/css/properties-manual/offset-path.json
@@ -1,0 +1,43 @@
+{
+  "css": {
+    "properties": {
+      "offset-path": {
+        "__compat": {
+          "lynx_path": "api/css/properties/offset-path",
+          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/CSS/offset-path",
+          "spec_url": [],
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "3.3"
+            },
+            "ios": {
+              "version_added": "3.3"
+            },
+            "harmony": {
+              "version_added": "3.8"
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": true
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/lynx-compat-data/css/properties-manual/offset-rotate.json
+++ b/packages/lynx-compat-data/css/properties-manual/offset-rotate.json
@@ -1,0 +1,43 @@
+{
+  "css": {
+    "properties": {
+      "offset-rotate": {
+        "__compat": {
+          "lynx_path": "api/css/properties/offset-rotate",
+          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/CSS/offset-rotate",
+          "spec_url": [],
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "3.3"
+            },
+            "ios": {
+              "version_added": "3.3"
+            },
+            "harmony": {
+              "version_added": "3.8"
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": true
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/lynx-example-packages/package.json
+++ b/packages/lynx-example-packages/package.json
@@ -17,7 +17,7 @@
     "@lynx-example/blur-view": "0.1.0",
     "@lynx-example/composing-elements": "0.6.5",
     "@lynx-example/css": "0.6.5",
-    "@lynx-example/css-api": "0.9.2",
+    "@lynx-example/css-api": "0.10.0",
     "@lynx-example/design-guide": "0.4.2",
     "@lynx-example/desktop": "0.2.0",
     "@lynx-example/element-manipulation": "0.6.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,8 +299,8 @@ importers:
         specifier: 0.6.5
         version: 0.6.5(@lynx-js/types@3.9.0)(@types/react@18.3.18)
       '@lynx-example/css-api':
-        specifier: 0.9.2
-        version: 0.9.2(@lynx-js/types@3.9.0)(@types/react@18.3.18)
+        specifier: 0.10.0
+        version: 0.10.0(@lynx-js/types@3.9.0)(@types/react@18.3.18)
       '@lynx-example/design-guide':
         specifier: 0.4.2
         version: 0.4.2(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1397,8 +1397,8 @@ packages:
     resolution: {integrity: sha512-McxesZ9cBeCDE9wkfW/55UGB7Bh5Gwceq/WZ1aKONk8LmQqdtrfLF/5jwfMOu5NYUl+2g20yPmvudFW1bluT2A==}
     engines: {node: '>=18'}
 
-  '@lynx-example/css-api@0.9.2':
-    resolution: {integrity: sha512-xXOln1/Yv01K5rNb3DmWbdccSBh31l2m3jjcZS3QuCbgqtNA1ix92ICXh3c3qCx+e+bIK6zG866U/CXkVscjoQ==}
+  '@lynx-example/css-api@0.10.0':
+    resolution: {integrity: sha512-T6ZTEtmhus3SqKrk1HafXif6yiPSykXInH6FBzZDTjyvoveoEHrWz1lrGSlSi09LgLMgjTbUiuis6//yAVyKzw==}
     engines: {node: '>=18'}
 
   '@lynx-example/css@0.6.5':
@@ -7321,9 +7321,9 @@ snapshots:
       - '@lynx-js/types'
       - '@types/react'
 
-  '@lynx-example/css-api@0.9.2(@lynx-js/types@3.9.0)(@types/react@18.3.18)':
+  '@lynx-example/css-api@0.10.0(@lynx-js/types@3.9.0)(@types/react@18.3.18)':
     dependencies:
-      '@lynx-js/react': 0.120.0(@lynx-js/types@3.9.0)(@types/react@18.3.18)
+      '@lynx-js/react': 0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18)
     transitivePeerDependencies:
       - '@lynx-js/types'
       - '@types/react'


### PR DESCRIPTION
add offset-path, offset-distance, and offset-rotate docs

Change-Id: Iae2d1c5190bb92bbba1d8ec9199fdb2bd369d1d8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Document CSS offset motion properties

- Document English API pages for `offset-distance`, `offset-path`, and `offset-rotate` with syntax/value, `PropertyDefinition`, and compatibility tables
- Document Chinese API pages for `offset-distance`, `offset-path`, and `offset-rotate` with syntax/value, `PropertyDefinition`, and compatibility tables
- Add `lynx-compat-data` compatibility metadata JSON files for `offset-distance`, `offset-path`, and `offset-rotate`
- Bump `@lynx-example/css-api` dependency to `0.10.0` in `packages/lynx-example-packages/package.json`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->