### PR TITLE
fix(prettier): ignore generated genui API docs

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,10 +5,12 @@ packages/lynx-compat-data/api-stats.json
 
 /docs/en/api/react/**
 /docs/en/api/rspeedy/**
+/docs/en/api/genui/**
 /docs/en/api/lynx-testing-environment/**
 /docs/en/api/reactlynx-testing-library/**
 /docs/zh/api/react/**
 /docs/zh/api/rspeedy/**
+/docs/zh/api/genui/**
 /docs/zh/api/lynx-testing-environment/**
 /docs/zh/api/reactlynx-testing-library/**
 # generated files


### PR DESCRIPTION
## Why

Every auto-generated API doc directory is already excluded from Prettier — `react`, `rspeedy`, `lynx-testing-environment`, `reactlynx-testing-library`. **`genui` was missed** when its generation was added to `scripts/update-api-docs.sh`.

It went unnoticed because the husky `pre-commit` hook ran `prettier --write` and silently formatted the generated genui files on commit. The `update-api-docs` workflow now commits with `HUSKY=0` (to avoid the cspell hook blocking the bot PR — see #1117), so the generated genui docs are committed **as-generated** and the `Format Check` (`prettier --check .`) CI gate fails on them.

Generated docs shouldn't be hand-formatted; they should be ignored — same as the sibling generated dirs. This adds `genui` to `.prettierignore` for both locales.

## Effect

- The weekly **Update API docs** auto-PR stops failing `Format Check`.
- No behavior change for hand-written docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Add `genui` to `.prettierignore` for auto-generated API documentation

Add `genui` to `.prettierignore` for both English and Chinese locale directories (`/docs/en/api/genui/**` and `/docs/zh/api/genui/**`) to exclude auto-generated API documentation from formatting checks. This prevents the Format Check CI gate from failing on unformatted generated files while maintaining consistency with other auto-generated documentation directories like `react`, `rspeedy`, `lynx-testing-environment`, and `reactlynx-testing-library`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->