### PR TITLE
fix(og): include all blog authors in byline

### DIFF
--- a/scripts/og/generate.ts
+++ b/scripts/og/generate.ts
@@ -28,7 +28,7 @@ import { renderPng } from './lib';
 import { coverTemplate, blogTemplate } from './templates';
 
 /** Bump to invalidate every cached image after a template/layout change. */
-const TEMPLATE_VERSION = 'og-v8';
+const TEMPLATE_VERSION = 'og-v9';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(__dirname, '..', '..');
@@ -140,7 +140,7 @@ function buildByline(
 ): string {
   const raw = frontmatter.authors ?? frontmatter.author;
   const ids = (Array.isArray(raw) ? raw : raw ? [raw] : []).map(String);
-  const names = ids.slice(0, 3).map((id) => authorName(id, lang));
+  const names = ids.map((id) => authorName(id, lang));
   const by = names.length
     ? `${lang === 'zh' ? '作者：' : 'By '}${names.join(lang === 'zh' ? '、' : ', ')}`
     : '';


### PR DESCRIPTION
## Summary
- The blog OG byline was capped at the first 3 authors (`ids.slice(0, 3)` in `scripts/og/generate.ts`), so posts with more contributors showed an incomplete credit — most visibly the A2UI launch (8 authors), which read "By Jing Hu, HaoYang Wang, Hao Ai · Jun 8, 2026".
- Drop the cap so every author renders. Satori wraps the byline within the 1056 px content area; the layout still clears the footer even with a 2-line title.
- Bump `TEMPLATE_VERSION` (`og-v8` → `og-v9`) so the next build regenerates every cached blog/cover image.

### Before / after (A2UI blog, 8 authors)

**Before** — "By Jing Hu, HaoYang Wang, Hao Ai · Jun 8, 2026"
**After** — "By Jing Hu, HaoYang Wang, Hao Ai, ChenChao Gao, Zhou Fang, MoonfaceX, Jingkai Zhao, Xuan Huang · Jun 8, 2026" (wraps to 2 lines)

Verified with EN, ZH (`、` separator), and a stressed 2-line-title variant — all fit above the footer.

## Test plan
- [ ] `pnpm gen:og --force` regenerates without errors
- [ ] Inspect `docs/public/og/blog/en/lynx-a2ui.png` — byline lists all 8 authors and clears the `lynxjs.org/blog` footer
- [ ] Inspect `docs/public/og/blog/zh/lynx-a2ui.png` — same with `作者：` prefix and `、` separators
- [ ] Spot-check a single-author post (e.g. `lynx-3-8`) — byline still single-line, unchanged otherwise

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Remove author limit in blog OG byline generation

Remove the three-author cap in the `buildByline` function to display all post authors instead of the first three. The byline text automatically wraps within the existing 1056px content area, and the design maintains proper spacing with wrapped content.

Bump `TEMPLATE_VERSION` from `og-v8` to `og-v9` to force cache invalidation and regenerate all cached OG images on the next build.

**Changes:**
- `scripts/og/generate.ts`: Remove `slice(0, 3)` limitation and bump template version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->