### PR TITLE
docs(3.7): backport universal link fixes from #1126

### DIFF
--- a/docs/en/api/lynx-api/lynx/lynx-stop-exposure.mdx
+++ b/docs/en/api/lynx-api/lynx/lynx-stop-exposure.mdx
@@ -9,7 +9,7 @@ import { APISummary, APITable } from '@lynx';
 
 <APISummary />
 
-The `lynx.stopExposure` method can be used to stop exposure detection, that is, the visibility of the target node will no longer be detected, and exposure/anti-exposure events will no longer be triggered in the future. You can call [lynx.resumeExposure](./lynx-resume-exposure .mdx) to restart exposure detection.
+The `lynx.stopExposure` method can be used to stop exposure detection, that is, the visibility of the target node will no longer be detected, and exposure/anti-exposure events will no longer be triggered in the future. You can call [lynx.resumeExposure](./lynx-resume-exposure.mdx) to restart exposure detection.
 
 ## Syntax
 

--- a/docs/en/api/lynx-api/main-thread/lynx-stop-exposure.mdx
+++ b/docs/en/api/lynx-api/main-thread/lynx-stop-exposure.mdx
@@ -9,7 +9,7 @@ import { APISummary, APITable } from '@lynx';
 
 <APISummary />
 
-The `lynx.stopExposure` method can be used to stop exposure detection, that is, the visibility of the target node will no longer be detected, and exposure/anti-exposure events will no longer be triggered in the future. You can call [lynx.resumeExposure](./lynx-resume-exposure .mdx) to restart exposure detection.
+The `lynx.stopExposure` method can be used to stop exposure detection, that is, the visibility of the target node will no longer be detected, and exposure/anti-exposure events will no longer be triggered in the future. You can call [lynx.resumeExposure](./lynx-resume-exposure.mdx) to restart exposure detection.
 
 ## Syntax
 

--- a/docs/en/guide/custom-native-modules/native-module-android.mdx
+++ b/docs/en/guide/custom-native-modules/native-module-android.mdx
@@ -139,7 +139,7 @@ Add the following registration code to the `Init` method in the `explorer/androi
 
 After preparing everything, you can now build and run your code.
 
-First, follow the [Compile and Run Android Lynx Explorer](https://github.com/lynx-family/lynx/tree/develop/explorer/android#compile-and-run) guide to build Lynx Explorer from source code and install it on your phone.
+First, follow the [Compile and Run Android Lynx Explorer](https://github.com/lynx-family/lynx/tree/develop/explorer/android#build-and-run) guide to build Lynx Explorer from source code and install it on your phone.
 
 Then, refer to the [Install Dependencies & Start the Development Server](../start/quick-start#Installation) guide to install dependencies and start the development server in the root directory of your Lynx project.
 

--- a/docs/en/guide/start/fragments/web/integrating-lynx-with-web.mdx
+++ b/docs/en/guide/start/fragments/web/integrating-lynx-with-web.mdx
@@ -56,7 +56,7 @@ First, run:
 
 You will see an additional `dist/main.web.bundle` file in this project, which is the final web build artifact.
 
-Open [Lynx Explorer Web Edition](https://www.unpkg.com/@lynx-js/web-explorer@0.0.15/index.html), fill in the accessible URL of your artifact, and you can see the effect in production mode.
+Open [Lynx Explorer Web Edition](https://www.unpkg.com/@lynx-js/web-explorer@latest/index.html), fill in the accessible URL of your artifact, and you can see the effect in production mode.
 
 </Steps>
 

--- a/docs/en/rspeedy/build-profiling.mdx
+++ b/docs/en/rspeedy/build-profiling.mdx
@@ -48,7 +48,7 @@ RSPACK_PROFILE=ALL rspeedy build
 This command will generate a `rspack-profile-${timestamp}` folder in the dist folder, and it will contain `logging.json`, `trace.json` and `jscpuprofile.json` files:
 
 - `trace.json`: The time spent on each phase of the Rust side is recorded at a granular level using tracing and can be viewed using [ui.perfetto.dev](https://ui.perfetto.dev/).
-- `jscpuprofile.json`: The time spent at each stage on the JavaScript side is recorded at a granular level using [Node.js inspector](https://nodejs.org/dist/latest-v18.x/docs/api/inspector.html) and can be viewed using [speedscope.app](https://www.speedscope.app/).
+- `jscpuprofile.json`: The time spent at each stage on the JavaScript side is recorded at a granular level using [Node.js inspector](https://nodejs.org/api/inspector.html) and can be viewed using [speedscope.app](https://www.speedscope.app/).
 - `logging.json`: Includes some logging information that keeps a coarse-grained record of how long each phase of the build took. (Not supported in development environment yet)
 
 > For more information about Rspack build performance analysis usage, please refer to [Rspack - Profiling](https://web-infra-dev.github.io/rspack-dev-guide/profiling/intro.html#profiling).

--- a/docs/en/rspeedy/styling.mdx
+++ b/docs/en/rspeedy/styling.mdx
@@ -375,7 +375,7 @@ export default {
 
 4. Configuring `tailwind.config.js` and adding `@lynx-js/tailwind-preset`:
 
-   You must use [`@lynx-js/tailwind-preset`](https://github.com/lynx-family/lynx-stack/tree/main/packages/third-party/tailwind-preset) to remove all the tailwindcss utilities not supported in Lynx or adapt to Lynx-specific alternatives.
+   You must use [`@lynx-js/tailwind-preset`](https://github.com/lynx-family/lynx-stack/tree/main/packages/tailwind-preset) to remove all the tailwindcss utilities not supported in Lynx or adapt to Lynx-specific alternatives.
 
    ```js title=tailwind.config.js
    import lynxPreset from '@lynx-js/tailwind-preset';

--- a/docs/zh/guide/custom-native-modules/native-module-android.mdx
+++ b/docs/zh/guide/custom-native-modules/native-module-android.mdx
@@ -135,7 +135,7 @@ class NativeLocalStorageModule(context: Context) : LynxModule(context) {
 
 准备好所有内容后，现在可以构建运行你的代码。
 
-首先参照[编译和运行 Android Lynx Explorer](https://github.com/lynx-family/lynx/tree/develop/explorer/android#compile-and-run) 指南从源码构建 Lynx Explorer，并安装到你的手机上。
+首先参照[编译和运行 Android Lynx Explorer](https://github.com/lynx-family/lynx/tree/develop/explorer/android#build-and-run) 指南从源码构建 Lynx Explorer，并安装到你的手机上。
 
 接着参考[安装依赖&启动开发服务器](../start/quick-start#安装)指南，在 Lynx 项目根目录下安装依赖并且启动开发服务器。
 

--- a/docs/zh/rspeedy/build-profiling.mdx
+++ b/docs/zh/rspeedy/build-profiling.mdx
@@ -48,7 +48,7 @@ RSPACK_PROFILE=ALL rspeedy build
 此命令将在 dist 文件夹中生成 `rspack-profile-${timestamp}` 文件夹，其中包含 `logging.json`、`trace.json` 和 `jscpuprofile.json` 文件：
 
 - `trace.json`: 使用 tracing 记录 Rust 端每个阶段的时间消耗，可以通过 [ui.perfetto.dev](https://ui.perfetto.dev/) 查看
-- `jscpuprofile.json`: 使用 [Node.js inspector](https://nodejs.org/dist/latest-v18.x/docs/api/inspector.html) 记录 JavaScript 端每个阶段的时间消耗，可以通过 [speedscope.app](https://www.speedscope.app/) 查看。
+- `jscpuprofile.json`: 使用 [Node.js inspector](https://nodejs.org/api/inspector.html) 记录 JavaScript 端每个阶段的时间消耗，可以通过 [speedscope.app](https://www.speedscope.app/) 查看。
 - `logging.json`: 包含一些日志信息，粗略记录了构建每个阶段所花费的时间。（开发环境中尚不支持）
 
 > 有关 Rspack 构建性能分析使用的更多信息，请参阅 [Rspack - Profiling](https://web-infra-dev.github.io/rspack-dev-guide/profiling/intro.html#profiling)。

--- a/docs/zh/rspeedy/styling.mdx
+++ b/docs/zh/rspeedy/styling.mdx
@@ -346,7 +346,7 @@ export default {
 
 4. 配置 `tailwind.config.js` 并添加 `@lynx-js/tailwind-preset`：
 
-   您必须使用 [`@lynx-js/tailwind-preset`](https://github.com/lynx-family/lynx-stack/tree/main/packages/third-party/tailwind-preset) 删除 Lynx 中不支持的所有 tailwindcss 工具类或替换至特定于 Lynx 的替代方案。
+   您必须使用 [`@lynx-js/tailwind-preset`](https://github.com/lynx-family/lynx-stack/tree/main/packages/tailwind-preset) 删除 Lynx 中不支持的所有 tailwindcss 工具类或替换至特定于 Lynx 的替代方案。
 
    ```js title=tailwind.config.js
    import lynxPreset from '@lynx-js/tailwind-preset';


### PR DESCRIPTION
## Summary

Selective backport of link fixes from #1126 that apply equally to the 3.7 docs. Excludes version bumps (Lynx 3.8.1, Node 20.19+, rspeedy 0.15.0), roadmap-year text, web-explorer pinning, .md→.mdx churn, and the pnpm-lock dedup since those are either time-bound or specific to main.

Each fix verified against the live upstream resource and against the current state of \`release/3.7\`.

### Fixes included

- **lynx-stop-exposure.mdx (en/main + en/lynx)**: drop stray space in \`./lynx-resume-exposure .mdx\` URL.
- **native-module-android (en + zh)**: \`explorer/android#compile-and-run\` → \`#build-and-run\`; upstream README section was renamed.
- **rspeedy/styling (en + zh)**: \`packages/third-party/tailwind-preset\` → \`packages/tailwind-preset\`; upstream lynx-stack directory was moved (old path 404s).
- **rspeedy/build-profiling (en + zh)**: Node inspector URL → \`https://nodejs.org/api/inspector.html\` (canonical page; previous \`/dist/latest-v18.x/\` was a historical mirror).

### Verification

- \`curl -I https://github.com/lynx-family/lynx-stack/tree/main/packages/tailwind-preset\` → 200; \`/third-party/tailwind-preset\` → 404.
- \`README.md\` at lynx-family/lynx/develop/explorer/android: section is \`## Build and Run\`; no \`compile-and-run\` anchor.
- \`lynx-resume-exposure.mdx\` exists in both \`docs/en/api/lynx-api/lynx/\` and \`docs/en/api/lynx-api/main-thread/\`; the trailing space in the old URL definitely broke the link.

## Test plan

- [ ] Site builds (\`pnpm build\`)
- [ ] Updated links resolve in preview deploy