### PR TITLE
ci: add version-consistency guardrail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Asset URL Check
         run: node scripts/ci/check-asset-urls.mjs
 
+      - name: Version Consistency Check
+        run: node scripts/ci/check-version-consistency.mjs
+
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/version-freshness.yml
+++ b/.github/workflows/version-freshness.yml
@@ -1,0 +1,43 @@
+name: Version Freshness
+
+# Runs the version-consistency guardrail with --remote on a weekly schedule.
+# Unlike the PR-blocking Version Consistency Check in ci.yml, this hits the
+# GitHub API to flag when our LYNX_VERSION has fallen behind upstream patches.
+# Failures here open a tracking issue rather than block merges, so a new
+# upstream release doesn't suddenly red all open PRs.
+
+on:
+  schedule:
+    - cron: '0 12 * * 1' # Mondays 12:00 UTC
+  workflow_dispatch:
+
+jobs:
+  freshness:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6
+        with:
+          node-version-file: '.node-version'
+
+      - name: Run guardrail (remote)
+        id: check
+        run: |
+          set +e
+          node scripts/ci/check-version-consistency.mjs --remote 2>&1 | tee out.log
+          echo "exit_code=$?" >> $GITHUB_OUTPUT
+
+      - name: Open issue if stale
+        if: steps.check.outputs.exit_code != '0' || contains(steps.check.outputs.exit_code, 'warning')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          body=$(cat out.log)
+          gh issue create \
+            --title "Version drift detected by guardrail" \
+            --body "Weekly version-freshness check flagged drift between docs/public/version.json and upstream releases. Output:\n\n\`\`\`\n$body\n\`\`\`" \
+            --label "docs,version-drift" || true

--- a/scripts/ci/check-version-consistency.mjs
+++ b/scripts/ci/check-version-consistency.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+// Validates that hand-pinned Lynx version strings across docs match
+// docs/public/version.json. Run from repo root or pass --root <path>.
+//
+// Checks:
+//   A. Internal consistency: every `lynx-family/lynx/releases/(download|tag)/X.Y.Z/`
+//      occurrence in docs/** must equal LYNX_VERSION (with an exception list
+//      for historical blog posts).
+//   B. en/zh parity (Lynx release URLs and whitelisted npm/unpkg packages):
+//      docs/en/<path> and docs/zh/<path> must reference the same versions.
+//   C. `releases/latest/download/` warning: this redirect resolves to whatever
+//      GitHub marks latest, which drifts away from the current branch's line.
+//   D. (--remote) LYNX_VERSION freshness against upstream lynx-family/lynx.
+//
+// Exits non-zero on hard failures; warnings print but don't fail.
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+const args = new Map();
+for (let i = 2; i < process.argv.length; i++) {
+  const a = process.argv[i];
+  if (a.startsWith('--')) args.set(a.slice(2), process.argv[++i] ?? true);
+}
+const ROOT = path.resolve(args.get('root') ?? '.');
+const DOCS = path.join(ROOT, 'docs');
+const VERSION_JSON = path.join(DOCS, 'public', 'version.json');
+const CHECK_REMOTE = args.get('remote') === true || args.get('remote') === 'true';
+
+const versionJson = JSON.parse(readFileSync(VERSION_JSON, 'utf8'));
+const LYNX = versionJson.LYNX_VERSION;
+const PRIMJS = versionJson.PRIMJS_VERSION;
+
+if (!LYNX) {
+  console.warn(
+    `[warn] LYNX_VERSION missing in ${VERSION_JSON}; only running parity + latest checks.`,
+  );
+}
+
+// Files where a historical version pin is legitimate (release blog posts).
+const HISTORICAL_PIN_ALLOWLIST = [
+  /\/docs\/(en|zh)\/blog\/lynx-\d+-\d+\.mdx$/,
+];
+
+const PINNED_RE =
+  /lynx-family\/lynx\/releases\/(download|tag)\/(\d+\.\d+\.\d+(?:-[\w.]+)?)/g;
+const LATEST_RE = /lynx-family\/lynx\/releases\/latest\/download\//g;
+// Matches unpkg / npm package pins like @lynx-js/web-explorer@0.0.15 or @latest
+const PKG_PIN_RE =
+  /(@?[a-z0-9][\w./-]*?)@(\d+\.\d+\.\d+(?:-[\w.]+)?|latest)\b/gi;
+// Only audit these packages for en/zh parity; others may legitimately differ.
+const PARITY_PACKAGES = new Set([
+  '@lynx-js/web-explorer',
+  'upgrade-rspeedy',
+  'upgrade-rspeedy-canary',
+  '@lynx-js/rspeedy',
+  'create-rspeedy',
+]);
+
+const errors = [];
+const warnings = [];
+
+function* walk(dir) {
+  for (const name of readdirSync(dir)) {
+    const p = path.join(dir, name);
+    const s = statSync(p);
+    if (s.isDirectory()) yield* walk(p);
+    else if (/\.(mdx?|tsx?|jsx?)$/.test(name)) yield p;
+  }
+}
+
+const pinsByFile = new Map();
+const pkgPinsByFile = new Map();
+
+for (const file of walk(DOCS)) {
+  const rel = path.relative(ROOT, file);
+  const text = readFileSync(file, 'utf8');
+  const allowHistorical = HISTORICAL_PIN_ALLOWLIST.some((r) =>
+    r.test('/' + rel),
+  );
+
+  // A. Pinned Lynx versions
+  const pins = new Set();
+  for (const m of text.matchAll(PINNED_RE)) {
+    const ver = m[2];
+    pins.add(ver);
+    if (LYNX && ver !== LYNX && !allowHistorical) {
+      errors.push(
+        `${rel}: pinned Lynx version ${ver} does not match LYNX_VERSION (${LYNX})`,
+      );
+    }
+  }
+  pinsByFile.set(rel, pins);
+
+  // B'. Package version pins (for parity checks)
+  const pkgPins = new Map();
+  for (const m of text.matchAll(PKG_PIN_RE)) {
+    const pkg = m[1];
+    const ver = m[2];
+    if (!PARITY_PACKAGES.has(pkg)) continue;
+    if (!pkgPins.has(pkg)) pkgPins.set(pkg, new Set());
+    pkgPins.get(pkg).add(ver);
+  }
+  pkgPinsByFile.set(rel, pkgPins);
+
+  // C. /releases/latest/download/ drift
+  if (LATEST_RE.test(text) && !allowHistorical) {
+    warnings.push(
+      `${rel}: uses releases/latest/download/ which resolves to whatever GitHub marks latest. Pin to {versionJson.LYNX_VERSION} or an explicit version.`,
+    );
+  }
+}
+
+// B. en/zh parity (Lynx releases URLs)
+for (const [rel, pins] of pinsByFile) {
+  if (!rel.startsWith('docs/en/')) continue;
+  const zh = 'docs/zh/' + rel.slice('docs/en/'.length);
+  const zhPins = pinsByFile.get(zh);
+  if (!zhPins) continue;
+  const enOnly = [...pins].filter((v) => !zhPins.has(v));
+  const zhOnly = [...zhPins].filter((v) => !pins.has(v));
+  if (enOnly.length || zhOnly.length) {
+    errors.push(
+      `en/zh Lynx-release mismatch between ${rel} and ${zh}: en-only=[${enOnly.join(',')}] zh-only=[${zhOnly.join(',')}]`,
+    );
+  }
+}
+
+// B'. en/zh parity (npm/unpkg pkg pins for whitelisted PARITY_PACKAGES)
+for (const [rel, pkgPins] of pkgPinsByFile) {
+  if (!rel.startsWith('docs/en/')) continue;
+  const zh = 'docs/zh/' + rel.slice('docs/en/'.length);
+  const zhPkgPins = pkgPinsByFile.get(zh);
+  if (!zhPkgPins) continue;
+  for (const [pkg, enVers] of pkgPins) {
+    const zhVers = zhPkgPins.get(pkg) ?? new Set();
+    const enOnly = [...enVers].filter((v) => !zhVers.has(v));
+    const zhOnly = [...zhVers].filter((v) => !enVers.has(v));
+    if (enOnly.length || zhOnly.length) {
+      errors.push(
+        `en/zh ${pkg} version mismatch between ${rel} and ${zh}: en=[${[...enVers].join(',')}] zh=[${[...zhVers].join(',')}]`,
+      );
+    }
+  }
+  for (const pkg of zhPkgPins.keys()) {
+    if (!pkgPins.has(pkg)) {
+      errors.push(
+        `en/zh ${pkg} version mismatch between ${rel} and ${zh}: en=[] zh=[${[...zhPkgPins.get(pkg)].join(',')}]`,
+      );
+    }
+  }
+}
+
+// D. Optional remote freshness: LYNX_VERSION must be the latest stable patch
+//    in its major.minor line per GitHub releases.
+if (CHECK_REMOTE && LYNX) {
+  const want = LYNX.split('.').slice(0, 2).join('.');
+  try {
+    const res = await fetch(
+      'https://api.github.com/repos/lynx-family/lynx/releases?per_page=50',
+      { headers: { 'User-Agent': 'lynx-website-guardrail' } },
+    );
+    const data = await res.json();
+    const stableInLine = data
+      .filter((r) => !r.draft && !r.prerelease)
+      .map((r) => r.tag_name)
+      .filter((t) => t.startsWith(want + '.'))
+      .sort((a, b) => {
+        const pa = a.split('.').map(Number);
+        const pb = b.split('.').map(Number);
+        for (let i = 0; i < 3; i++) if (pa[i] !== pb[i]) return pb[i] - pa[i];
+        return 0;
+      });
+    const latestInLine = stableInLine[0];
+    if (latestInLine && latestInLine !== LYNX) {
+      warnings.push(
+        `LYNX_VERSION=${LYNX} is stale in the ${want}.x line; latest stable is ${latestInLine}.`,
+      );
+    } else if (!latestInLine) {
+      warnings.push(
+        `Could not find a stable release in the ${want}.x line on upstream.`,
+      );
+    }
+  } catch (e) {
+    warnings.push(`Remote freshness check failed: ${e.message}`);
+  }
+}
+
+if (errors.length) {
+  console.error('=== version consistency: ERRORS ===');
+  for (const e of errors) console.error('  ' + e);
+}
+if (warnings.length) {
+  console.warn('=== version consistency: warnings ===');
+  for (const w of warnings) console.warn('  ' + w);
+}
+
+if (errors.length) {
+  console.error(`\n${errors.length} error(s), ${warnings.length} warning(s)`);
+  process.exit(1);
+}
+console.log(
+  `OK: 0 errors, ${warnings.length} warning(s). LYNX_VERSION=${LYNX} PRIMJS_VERSION=${PRIMJS}`,
+);


### PR DESCRIPTION
## Motivation

#1126 spent a manual audit cleaning up version drift that should have been mechanically caught: \`quick-start.mdx\` was hard-pinned to \`3.7.0\` while \`version.json\` claimed \`3.8.0\`, and \`@lynx-js/web-explorer\` had \`@0.0.15\` (en) vs \`@latest\` (zh) introduced by the same commit. Neither is the kind of thing that should rely on a human noticing.

This PR adds a static guardrail that runs on every PR.

## Checks

| | Check | Severity |
|---|---|---|
| A | Every \`lynx-family/lynx/releases/(download\|tag)/X.Y.Z\` in \`docs/**\` matches \`LYNX_VERSION\`. Historical release blog posts (\`docs/{en,zh}/blog/lynx-N-M.mdx\`) are allow-listed. | error |
| B | \`docs/en/<path>\` and \`docs/zh/<path>\` reference the same set of Lynx-release URLs and the same versions for parity-tracked npm packages (\`@lynx-js/web-explorer\`, \`upgrade-rspeedy\`, \`@lynx-js/rspeedy\`, \`create-rspeedy\`, \`upgrade-rspeedy-canary\`). | error |
| C | \`releases/latest/download/\` is flagged because it silently resolves to whatever GitHub marks latest. A user reading 3.5 docs would end up downloading 3.8.x Explorer. | warning |
| D | (\`--remote\`, weekly cron only) Hits the lynx-family/lynx releases API and warns if \`LYNX_VERSION\` has fallen behind upstream patches in the same major.minor line. | warning |

## Wiring

- \`.github/workflows/ci.yml\` — runs A/B/C on every PR. Blocks merge on errors.
- \`.github/workflows/version-freshness.yml\` — runs D on a weekly cron. Opens a tracking issue rather than blocking, so a brand-new upstream release doesn't suddenly red all open PRs.

## Verification matrix

Ran the guardrail against every release branch in the repo before this PR:

| Branch | Result |
|---|---|
| \`main\` post-#1126 | ✅ 0 errors |
| \`release/3.8\` | ❌ 11 errors — 10× quick-start drift (\`3.7.0\` vs LYNX_VERSION \`3.8.0\`) + 1× \`web-explorer\` en/zh mismatch |
| \`release/3.7\` | ❌ 1 error — \`web-explorer\` en/zh mismatch (missed in #1127; follow-up incoming) |
| \`release/3.6\` | ⚠️ 2 warnings — \`releases/latest/download/\` in quick-start (en+zh) |
| \`release/3.5\` | ⚠️ 2 warnings — same |
| \`release/3.4\` | ⚠️ 2 warnings — same |

Each release branch result matches what we'd expect; no false positives observed against \`main\`'s post-fix state. The \`release/3.7\` finding is new: the guardrail surfaced a bug we missed in #1127, which I'll fix in a follow-up commit there.

## Recommended follow-ups (out of scope here)

- Migrate hand-pinned Explorer URLs in \`quick-start.mdx\` to \`{versionJson.LYNX_VERSION}\` placeholders so they auto-track \`version.json\` (the build-time replacement already exists in \`rspress.config.ts\`).
- For \`release/3.4\` / \`3.5\` / \`3.6\`: decide whether to backfill \`LYNX_VERSION\` into their \`version.json\` and replace \`releases/latest/download/\` with a pinned URL.

## Test plan

- [x] \`node scripts/ci/check-version-consistency.mjs\` exits 0 against current \`main\`
- [x] Same script against each \`release/*\` branch matches expected errors/warnings
- [ ] CI workflow runs green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Add automated guardrails to catch version inconsistencies in documentation

Implement four distinct version consistency checks (A–D) to prevent manual auditing overhead and catch documentation parity bugs:

- **Check A (error):** Validate that all `lynx-family/lynx/releases/(download|tag)/X.Y.Z` references in `docs/**` match `LYNX_VERSION` from `version.json`, with historical release blog posts exempt.

- **Check B (error):** Ensure English and Chinese documentation at `docs/en/<path>` and `docs/zh/<path>` reference identical Lynx release URLs and pinned versions for parity-tracked npm packages (`@lynx-js/web-explorer`, `upgrade-rspeedy`, `@lynx-js/rspeedy`, `create-rspeedy`, `upgrade-rspeedy-canary`).

- **Check C (warning):** Flag `releases/latest/download/` URLs since they dynamically resolve to GitHub's current "latest" release, causing older documentation to pull newer versions.

- **Check D (warning, optional):** Query the upstream releases API to warn if `LYNX_VERSION` falls behind available patches, running weekly via cron.

Wire Checks A–C into `.github/workflows/ci.yml` to run on every PR and block merges on errors. Add `.github/workflows/version-freshness.yml` for weekly Check D execution, creating tracking issues instead of blocking.

Implement `scripts/ci/check-version-consistency.mjs` to walk the docs tree, extract version pins from multiple file formats, and validate against `LYNX_VERSION` and en/zh parity constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->