### PR TITLE
docs(rspeedy): add guides for mapping production errors and the UI tree back to source

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -5,6 +5,9 @@
   "name": "cspell check for lynx website",
   "language": "en",
   "words": [
+    "jridgewell",
+    "worklet",
+    "backtrace",
     "huxpro",
     "rdream",
     "minalwws",

--- a/docs/en/rspeedy/_meta.json
+++ b/docs/en/rspeedy/_meta.json
@@ -22,6 +22,8 @@
   "build-profiling",
   "runtime-profiling",
   "use-rsdoctor",
+  "map-errors-to-source",
+  "ui-source-map",
   {
     "type": "divider"
   },

--- a/docs/en/rspeedy/index.md
+++ b/docs/en/rspeedy/index.md
@@ -8,7 +8,7 @@ hero:
   actions:
     - theme: brand
       text: Get Started
-      link: /guide/start/quick-start.html
+      link: /rspeedy/cli.html
     - theme: alt
       text: API
       link: /api/rspeedy.html

--- a/docs/en/rspeedy/map-errors-to-source.mdx
+++ b/docs/en/rspeedy/map-errors-to-source.mdx
@@ -1,0 +1,654 @@
+# Map Production Errors to Source
+
+import { Mermaid } from '@lynx';
+
+A production Lynx error reaches your monitoring as a minified, bundled stack. For example (large fields shown as `...`):
+
+```jsonc
+{
+  "error_code": 1101,
+  "error": {
+    // the `error` field is itself a JSON string; shown parsed here
+    "message": "main-thread.js exception: Error: boom from main thread",
+    "stack": "backtrace:\n    at <anonymous> (file:///main-thread.js:23:13)\n    ...",
+    "sentry": {
+      "exception": {
+        "values": [
+          {
+            "stacktrace": {
+              "frames": [
+                // your code, tagged with the release; 23:13 is function_id:pc
+                {
+                  "filename": "file:///main-thread.js",
+                  "lineno": 23,
+                  "colno": 13,
+                  "release": "debugmetadata:0a62b9f5435af49d34a238d276a986d1bb64b6d1",
+                },
+                // ... worklet-runtime frames
+              ],
+            },
+          },
+        ],
+      },
+    },
+  },
+}
+```
+
+Every position points into a bundle, never at the `.tsx` you wrote, and
+`main-thread.js:23:13` is trickier than it looks. It is printed like a
+`line:column`, but the main thread runs as bytecode, so the two numbers are
+actually `function_id:pc`: function `23`, program-counter offset `13`. That is a
+location inside the bytecode, not a source line. (`background.js:247:77` _is_ a
+real `line:column`.) This guide maps both back to your source (file, line,
+column).
+
+Lynx bundles everything needed for that into one `debug-metadata.json` per
+build: the source maps, bytecode debug info, UI source map, and build metadata.
+It is produced by
+[`@lynx-js/debug-metadata-rsbuild-plugin`](https://www.npmjs.com/package/@lynx-js/debug-metadata-rsbuild-plugin)
+and auto-registered by
+[`@lynx-js/rspeedy`](https://www.npmjs.com/package/@lynx-js/rspeedy) (enabled by
+default; no config needed).
+
+<Mermaid title="From build to mapped source">{`
+flowchart LR
+  A["Build"] -->|"emits"| B["debug-metadata.json"]
+  B -->|"upload by release"| C[("Your store")]
+  D["Production error  (minified stack)"] -->|"look up by release"| C
+  C -->|"map back"| E["Your source  file:line:col"]
+`}</Mermaid>
+
+## What lands on disk
+
+One unified file per entry, under the entry's intermediate directory
+(`.rspeedy/<entry>` by default):
+
+```text
+dist/.rspeedy/<entry>/debug-metadata.json
+```
+
+:::warning Production builds remove it by default
+In a production build the file is emitted and then deleted from the output. It is
+not meant to ship with your app; it is just a debugging artifact. It stays on
+disk only
+in `dev`, or when `DEBUG` contains `rspeedy` (e.g.
+`DEBUG=rspeedy pnpm build`, handy for inspecting the file locally). To use it
+for production error mapping, upload and host it yourself (see
+[Using it in production](#using-it-in-production)).
+:::
+
+## The DebugMetadata file
+
+It matches the `DebugMetadataAsset` type from
+[`@lynx-js/debug-metadata`](https://www.npmjs.com/package/@lynx-js/debug-metadata):
+
+```ts
+interface DebugMetadataAsset {
+  artifacts: Artifact[]; // one entry per JS / CSS / bytecode bundle
+  uiSourceMap: UiSourceMapData; // compact UI source-map payload
+  buildInfo: { git?: GitMetadata; rspeedy?: RspeedyMeta };
+}
+```
+
+Each `Artifact` carries a `debugSources[]` array ordered for the
+**decode chain**:
+
+1. `bytecode-debug-info` (if present) maps a bytecode position back to encoded
+   JS `(line, column)`.
+2. `source-map` then maps that back to your authored source.
+
+Abbreviated (large values shown as `...`), a real file looks like this. Note the
+per-chunk `source-map` `key`, which is the release the runtime reports:
+
+```jsonc
+{
+  "artifacts": [
+    {
+      "kind": "main-thread",
+      "filename": "main-thread.js",
+      "debugSources": [
+        // function_id:pc → encoded main-thread.js (line, col)
+        {
+          "kind": "bytecode-debug-info",
+          "debugInfo": { "lepusNG_debug_info": { "function_info": ["..."] } },
+        },
+        // encoded (line, col) → your source; `key` is this chunk's release
+        {
+          "kind": "source-map",
+          "filename": "main-thread.js.map",
+          "key": "0a62b9f5435af49d34a238d276a986d1bb64b6d1",
+          "map": {
+            "version": 3,
+            "sources": [".../src/App.tsx", "..."],
+            "mappings": "...",
+          },
+        },
+      ],
+    },
+    {
+      "kind": "background",
+      "filename": "background.js",
+      "debugSources": [
+        {
+          "kind": "source-map",
+          "filename": "background.js.map",
+          "key": "566b7d2bd791a6d9b5280f368223d729d8f57f9c",
+          "map": {
+            "version": 3,
+            "sources": [".../src/App.tsx", "..."],
+            "mappings": "...",
+          },
+        },
+      ],
+    },
+    // ... css + hot-update artifacts
+  ],
+  "uiSourceMap": {
+    "version": 1,
+    "sources": ["..."],
+    "mappings": ["..."],
+    "uiMaps": ["..."],
+  },
+  "buildInfo": {
+    "git": {
+      "commit": "62a8e780...",
+      "remoteUrl": "https://github.com/lynx-family/lynx-stack",
+    },
+    "rspeedy": {
+      "entryFiles": ["src/index.tsx"],
+      "bundlePath": "main/template.js",
+    },
+  },
+}
+```
+
+### What `bytecode-debug-info` is
+
+Lynx runs your main thread script as PrimJS bytecode, not the JS text on
+disk. So when the main thread throws, the engine can only report where in the
+bytecode it happened: a `function_id:pc` pair (a function index plus a
+program-counter offset), not a line and column you'd recognize.
+
+`bytecode-debug-info` is the lookup table that closes that gap. It maps a
+`function_id:pc` back to a `(line, column)` in the encoded `main-thread.js`.
+That position is still generated code, so the `source-map` then takes the second
+step to your original `.ts` / `.tsx`. The two steps
+(`bytecode-debug-info` and `source-map`) live in the same `Artifact`.
+
+Background-thread JS runs normally, so its frames already carry real `(line,
+column)` positions and need only the `source-map` step, with no bytecode step.
+
+<Mermaid title="The decode chain">{`
+flowchart LR
+  P["main-thread frame  function_id:pc"] -->|"bytecode-debug-info"| Q["encoded main-thread.js  line:col"]
+  Q -->|"source-map"| R["your source  file:line:col"]
+  S["background frame  file:line:col"] -->|"source-map"| R
+`}</Mermaid>
+
+:::tip Mapping a main-thread stack by hand
+The community
+[`lynx-debug-info-remapping`](https://github.com/lynx-community/skills/tree/release/skills/lynx-debug-info-remapping)
+skill takes a `function_id:pc` backtrace plus this file and prints the original
+source positions with code context, so you don't have to write your own decoder.
+:::
+
+## Dev-server endpoints
+
+During `dev`, the plugin serves the file and lets you query a single field
+without parsing the whole thing:
+
+```http
+GET <publicPath>/.rspeedy/<entry>/debug-metadata.json
+GET <publicPath>/.rspeedy/<entry>/debug-metadata.json?field=source-map&filename=main-thread.js.map
+GET <publicPath>/.rspeedy/<entry>/debug-metadata.json?field=bytecode-debug-info&filename=main-thread.js
+```
+
+In dev the plugin also rewrites the bundle's `sourceMappingURL` trailers and the
+tasm `templateDebugUrl` / `debugMetadataUrl` to point at these dev-server
+endpoints, so devtools resolve sources automatically.
+
+### Queryable fields
+
+| `field=`              | query keys                  | returns                  |
+| --------------------- | --------------------------- | ------------------------ |
+| `source-map`          | `path` / `filename` / `key` | inner `SourceMap` (v3)   |
+| `bytecode-debug-info` | `filename` (JS asset)       | inner `LepusNGDebugInfo` |
+| `artifact`            | `filename`                  | full `Artifact`          |
+| `artifacts`           | none                        | `Artifact[]`             |
+| `ui-source-map`       | none                        | `UiSourceMapData`        |
+| `buildInfo`           | none (or `git` / `rspeedy`) | the `buildInfo` block    |
+
+A match returns the field's content directly (e.g. `?field=source-map` returns
+the raw v3 map, not a wrapper object). Unknown fields return `400`; a registered
+field with no matching value returns `404`.
+
+## Using it in production
+
+Lynx defines the format and produces the file; it does not host it. There is no
+built-in upload, and the URL rewrites above only happen against the dev server.
+You wire up production yourself, and there are two models depending on how your
+stacks find their metadata:
+
+- Model A, backend keyed by release: upload the file to your own service at
+  build time. The build already injects a `release` into the bundle (the runtime
+  reports it on error) and embeds the same key in the file, so your backend
+  indexes by it and maps `release → file` at error time. Nothing extra is
+  injected into the bundle.
+- Model B, point the bundle at your host: also inject
+  `debugMetadataUrl` / `templateDebugUrl` into the shipped template (and rewrite
+  the JS `sourceMappingURL` trailers) so devtools or your error-monitoring
+  service can fetch the file directly.
+
+### Model A: upload and store
+
+The default plugin deletes `debug-metadata.json` at the very end of the build
+(`PROCESS_ASSETS_STAGE_REPORT + 1`). Tap one stage earlier to read it and hand
+it to your uploader:
+
+:::details plugins/upload-debug-metadata.ts
+
+```ts
+import type { RsbuildPlugin, Rspack } from '@rsbuild/core';
+
+const ASSET = 'debug-metadata.json';
+
+export function pluginUploadDebugMetadata(
+  upload: (json: string, assetName: string) => Promise<void>,
+): RsbuildPlugin {
+  return {
+    name: 'upload-debug-metadata',
+    setup(api) {
+      api.modifyBundlerChain((chain, { environment, isProd }) => {
+        const isLynx =
+          environment.name === 'lynx' || environment.name.startsWith('lynx-');
+        if (!isProd || !isLynx) return;
+
+        chain.plugin('upload-debug-metadata').use(
+          class {
+            apply(compiler: Rspack.Compiler) {
+              const { Compilation } = compiler.webpack;
+              compiler.hooks.thisCompilation.tap('upload', (compilation) => {
+                compilation.hooks.processAssets.tapPromise(
+                  // one stage before the default plugin's cleanup
+                  {
+                    name: 'upload',
+                    stage: Compilation.PROCESS_ASSETS_STAGE_REPORT,
+                  },
+                  async (assets) => {
+                    for (const name of Object.keys(assets)) {
+                      if (name !== ASSET && !name.endsWith(`/${ASSET}`))
+                        continue;
+                      const json = compilation
+                        .getAsset(name)
+                        ?.source.source()
+                        .toString();
+                      if (json) await upload(json, name);
+                    }
+                  },
+                );
+              });
+            }
+          },
+        );
+      });
+    },
+  };
+}
+```
+
+:::
+
+Wire it into `lynx.config.ts`. You upload the file as-is; the `release` your
+backend indexes by is the one the build injected and embedded, not something you
+pick here:
+
+```ts title="lynx.config.ts"
+import { defineConfig } from '@lynx-js/rspeedy';
+import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
+import { pluginUploadDebugMetadata } from './plugins/upload-debug-metadata.js';
+
+export default defineConfig({
+  plugins: [
+    pluginReactLynx(),
+    pluginUploadDebugMetadata(async (json) => {
+      await fetch('https://your-monitoring.example.com/debug-metadata', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: json,
+      });
+    }),
+  ],
+});
+```
+
+> If you only need the file on disk for a one-off, build with `DEBUG=rspeedy`
+> instead; that keeps it under `dist/.rspeedy/<entry>/` without any plugin.
+
+:::note How the runtime release maps to the file
+
+The runtime reports each chunk's release as `debugmetadata:<key>`, e.g.
+`debugmetadata:0a62b9f5435af49d34a238d276a986d1bb64b6d1`. Strip the
+`debugmetadata:` prefix and `<key>` is exactly an artifact's `source-map` `key`
+inside `debug-metadata.json` (one key per chunk: `main-thread.js`,
+`background.js`, ...). So your backend reads those keys out of the uploaded file
+and indexes by them; at error time it strips the prefix and looks the file up.
+You never assign a release yourself.
+
+:::
+
+### Model B: also point the bundle at your host
+
+To make devtools / error-monitoring services fetch the file automatically
+you must write the URLs into the template before it is encoded. That means
+tapping `LynxTemplatePlugin.beforeEncode`, obtained via the exposure that DSL
+plugins publish:
+
+- Read the class with `api.useExposed(Symbol.for('LynxTemplatePlugin'))`.
+- Order your plugin `.after('lynx:debug-metadata')`, otherwise your
+  `beforeEncode` runs before the default plugin emits the file and reads empty.
+
+:::details plugins/host-debug-metadata.ts
+
+```ts
+import crypto from 'node:crypto';
+import path from 'node:path';
+import type { RsbuildPlugin, Rspack } from '@rsbuild/core';
+
+const ASSET = 'debug-metadata.json';
+
+export function pluginHostDebugMetadata(opts: {
+  baseUrl: string;
+  upload: (json: string, key: string) => Promise<void>;
+}): RsbuildPlugin {
+  const { baseUrl, upload } = opts;
+  return {
+    name: 'host-debug-metadata',
+    setup(api) {
+      api.modifyBundlerChain((chain, { environment, isProd }) => {
+        const isLynx =
+          environment.name === 'lynx' || environment.name.startsWith('lynx-');
+        if (!isProd || !isLynx) return;
+
+        const exposed = api.useExposed<{
+          LynxTemplatePlugin: {
+            getLynxTemplatePluginHooks: (c: Rspack.Compilation) => {
+              beforeEncode: { tap: (n: string, fn: (a: any) => any) => void };
+            };
+          };
+        }>(Symbol.for('LynxTemplatePlugin'));
+        if (!exposed) return;
+        const { LynxTemplatePlugin } = exposed;
+
+        chain
+          .plugin('host-debug-metadata')
+          .after('lynx:debug-metadata')
+          .use(
+            class {
+              apply(compiler: Rspack.Compiler) {
+                const { Compilation, sources } = compiler.webpack;
+                const keyByAsset = new Map<string, string>();
+
+                compiler.hooks.thisCompilation.tap('host-dm', (compilation) => {
+                  const hooks =
+                    LynxTemplatePlugin.getLynxTemplatePluginHooks(compilation);
+
+                  hooks.beforeEncode.tap('host-dm', (args) => {
+                    const assetName = path.posix.format({
+                      dir: args.intermediate,
+                      base: ASSET,
+                    });
+                    const content = compilation
+                      .getAsset(assetName)
+                      ?.source.source()
+                      .toString();
+                    if (!content) return args; // not the lynx template
+
+                    const key = crypto
+                      .createHash('sha1')
+                      .update(content)
+                      .digest('hex');
+                    keyByAsset.set(assetName, key);
+                    const fileUrl = `${baseUrl}/${key}/${ASSET}`;
+
+                    const root = args.encodeData.lepusCode.root?.name;
+                    const mainThread = root
+                      ? path.posix.basename(root.replace(/\\/g, '/'))
+                      : 'main-thread.js';
+
+                    // baked into the encoded template
+                    args.encodeData.sourceContent.config.debugMetadataUrl =
+                      fileUrl;
+                    args.encodeData.compilerOptions.templateDebugUrl =
+                      `${fileUrl}?field=bytecode-debug-info` +
+                      `&filename=${encodeURIComponent(mainThread)}`;
+
+                    // repoint each JS sourceMappingURL trailer at the host
+                    for (const a of JSON.parse(content).artifacts ?? []) {
+                      if (!a.path?.endsWith('.js')) continue;
+                      const name = a.path.replaceAll('/./', '/');
+                      const asset = compilation.getAsset(name);
+                      if (!asset) continue;
+                      const before = asset.source.source().toString();
+                      if (!before.includes('//# sourceMappingURL=')) continue;
+                      const after = before.replace(
+                        /\/\/# sourceMappingURL=\S*/g,
+                        `//# sourceMappingURL=${fileUrl}?field=source-map` +
+                          `&path=${encodeURIComponent(`${name}.map`)}`,
+                      );
+                      compilation.updateAsset(
+                        name,
+                        new sources.RawSource(after),
+                        asset.info,
+                      );
+                    }
+                    return args;
+                  });
+
+                  compilation.hooks.processAssets.tapPromise(
+                    {
+                      name: 'host-dm',
+                      stage: Compilation.PROCESS_ASSETS_STAGE_REPORT,
+                    },
+                    async (assets) => {
+                      for (const name of Object.keys(assets)) {
+                        if (name !== ASSET && !name.endsWith(`/${ASSET}`))
+                          continue;
+                        const json = compilation
+                          .getAsset(name)
+                          ?.source.source()
+                          .toString();
+                        const key = keyByAsset.get(name);
+                        if (json && key) await upload(json, key);
+                      }
+                    },
+                  );
+                });
+              }
+            },
+          );
+      });
+    },
+  };
+}
+```
+
+:::
+
+Wire it in with the base URL of wherever you serve the files:
+
+```ts title="lynx.config.ts"
+pluginHostDebugMetadata({
+  baseUrl: 'https://your-cdn.example.com/dm',
+  upload: async (json, key) => {
+    await fetch(`https://your-cdn.example.com/dm/${key}/debug-metadata.json`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: json,
+    });
+  },
+});
+```
+
+The emitted Lynx bundle now carries `compilerOptions.templateDebugUrl` and
+`sourceContent.config.debugMetadataUrl` pointing at
+`<baseUrl>/<key>/debug-metadata.json`, and each JS `sourceMappingURL` trailer is
+rewritten to the same host. The `key` in the URL and the `key` you upload under
+are the same, so the links always resolve.
+
+> The content read at `beforeEncode` is the pre-enrichment version; the default
+> plugin enriches the file afterward (in `beforeEmit`). The `key` is therefore
+> derived from that in-flight content; treat it as an opaque unique id, not a
+> hash of the final stored bytes.
+
+### Remap at error time
+
+When a production stack arrives, run the decode chain against the
+stored file: use [`resolveField`](#consuming-the-file) to pull the right
+`source-map` / `bytecode-debug-info` (locate the file by `release` in Model A,
+or follow the in-bundle `debugMetadataUrl` in Model B), or the
+[`lynx-debug-info-remapping`](https://github.com/lynx-community/skills/tree/release/skills/lynx-debug-info-remapping)
+skill for a main-thread `function_id:pc` backtrace.
+
+## Consuming the file
+
+You can `JSON.parse` it and use it directly:
+
+```ts
+import type { DebugMetadataAsset } from '@lynx-js/debug-metadata';
+
+const metadata = JSON.parse(
+  await readFile('debug-metadata.json', 'utf8'),
+) as DebugMetadataAsset;
+```
+
+To resolve one field in code (the same dispatch the dev server uses):
+
+```ts
+import { resolveField } from '@lynx-js/debug-metadata';
+
+const res = resolveField(metadata, 'source-map', {
+  filename: 'main-thread.js.map',
+});
+// res === undefined  → unknown field
+// res.found === false → no match
+// res.payload        → the SourceMap itself
+```
+
+:::tip Treat unknown fields as opaque
+The schema grows alongside the emitter. Consumers should ignore fields they
+don't recognize rather than rejecting the payload.
+:::
+
+## Walkthrough: map a real error
+
+To see both paths end to end, `examples/react`'s `App.tsx` throws in two
+places: once during `render` (background thread) and once in a main-thread tap
+handler:
+
+```tsx title="src/App.tsx"
+function App() {
+  const [crashRender, setCrashRender] = useState(false);
+
+  if (crashRender) {
+    throw new Error('boom from render (background thread)'); // line 15
+  }
+  // ...
+  return (
+    <text
+      main-thread:bindtap={() => {
+        'main thread';
+        throw new Error('boom from main thread'); // line 65
+      }}
+    >
+      Throw on main thread
+    </text>
+  );
+}
+```
+
+Build and run it, then trigger each error. Below, `metadata` is this build's
+`debug-metadata.json` parsed with `JSON.parse` (fetched from your store by
+release, [Model A](#model-a-upload-and-store)).
+
+### Background error: one step
+
+Tapping **Throw in render** throws on the background thread. The console frame
+points into `background.js`:
+
+```text
+unhandled rejection: boom from render (background thread)
+    at App (background.js:247:77)
+    at doRender (background.js:2994:44)
+    ...
+```
+
+<img
+  src="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/plugin/static/map-errors-background.png"
+  alt="The background-thread error in the devtool console, pointing into background.js"
+/>
+
+`background.js:247:77` is a real `(line, column)`, so a single `source-map` step
+maps it back:
+
+```ts
+import { resolveField } from '@lynx-js/debug-metadata';
+// any v3 source-map library works; this uses @jridgewell/trace-mapping
+import { TraceMap, originalPositionFor } from '@jridgewell/trace-mapping';
+
+const map = resolveField(metadata, 'source-map', {
+  filename: 'background.js.map',
+}).payload;
+
+originalPositionFor(new TraceMap(map), { line: 247, column: 77 });
+// → { source: 'src/App.tsx', line: 14, column: 2 }
+```
+
+`background.js:247:77` maps to `src/App.tsx:14`, the `if (crashRender)` line. The
+bundle's source map resolves the `throw` to its enclosing statement, so the
+frame lands on line 14 (the `if`), not the `throw` on line 15.
+
+### Main-thread error: two steps
+
+Tapping **Throw on main thread** throws on the main thread. In the console:
+
+<img
+  src="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/plugin/static/map-errors-main-thread.png"
+  alt="The main-thread error in the devtool console, a function_id:pc frame in main-thread.js"
+/>
+
+The report sent to your monitoring is the JSON from the top of this page; the
+frame that matters carries a `release`:
+
+```jsonc
+{
+  "function": "<anonymous>",
+  "filename": "file:///main-thread.js",
+  "lineno": 23,
+  "colno": 13,
+  "release": "debugmetadata:0a62b9f5435af49d34a238d276a986d1bb64b6d1",
+}
+```
+
+First, find the DebugMetadata by `release`. Strip the `debugmetadata:` prefix;
+the rest, `0a62b9f...`, is a chunk's `source-map` `key`, so fetch that build's
+file from your store by it:
+
+```ts
+const release = frame.release.replace('debugmetadata:', '');
+// '0a62b9f5435af49d34a238d276a986d1bb64b6d1'
+const metadata = await fetchByKey(release); // your backend, indexed by source-map key
+```
+
+Then map the frame. `23:13` is function_id 23, pc 13 (not a `line:column`), in
+two steps:
+
+```text
+main-thread.js:23:13 (function_id:pc)
+  bytecode-debug-info → main-thread.js:238:45 (encoded JS line:col)
+  source-map          → src/App.tsx:65:14
+```
+
+`main-thread.js:23:13` maps to `src/App.tsx:65`, the main-thread `throw`. The
+[`lynx-debug-info-remapping`](https://github.com/lynx-community/skills/tree/release/skills/lynx-debug-info-remapping)
+skill runs this whole chain for you.

--- a/docs/en/rspeedy/map-errors-to-source.mdx
+++ b/docs/en/rspeedy/map-errors-to-source.mdx
@@ -506,10 +506,12 @@ Each JS `sourceMappingURL` trailer is also rewritten to the same host. The `key`
 in the URL and the `key` you upload under are the same, so the links always
 resolve.
 
-> The content read at `beforeEncode` is the pre-enrichment version; the default
-> plugin enriches the file afterward (in `beforeEmit`). The `key` is therefore
-> derived from that in-flight content; treat it as an opaque unique id, not a
-> hash of the final stored bytes.
+> The `debug-metadata.json` you read at `beforeEncode` is not complete yet: the
+> default plugin only fills in `bytecode-debug-info` and the like later, at
+> `beforeEmit`. So the `key` you compute here is based on that partial
+> intermediate content and won't match the bytes of the final file on disk.
+> Don't treat it as a hash of the final file; treat it as a unique id (upload
+> under the same value and the links still resolve).
 
 ### Remap at error time
 

--- a/docs/en/rspeedy/map-errors-to-source.mdx
+++ b/docs/en/rspeedy/map-errors-to-source.mdx
@@ -490,11 +490,21 @@ pluginHostDebugMetadata({
 });
 ```
 
-The emitted Lynx bundle now carries `compilerOptions.templateDebugUrl` and
-`sourceContent.config.debugMetadataUrl` pointing at
-`<baseUrl>/<key>/debug-metadata.json`, and each JS `sourceMappingURL` trailer is
-rewritten to the same host. The `key` in the URL and the `key` you upload under
-are the same, so the links always resolve.
+The emitted Lynx bundle now carries two fields pointing at the host, and they
+are shaped differently. `sourceContent.config.debugMetadataUrl` is the bare link
+`<baseUrl>/<key>/debug-metadata.json`, which devtools or your own remap service
+fetch whole. `compilerOptions.templateDebugUrl` points at the same file but with
+a fetch query appended (`?field=bytecode-debug-info&filename=<main-thread.js>`).
+
+The query on `templateDebugUrl` is deliberate: Lynx's built-in red-screen decode
+reads this field, so when the main thread throws it pulls `bytecode-debug-info`
+straight from that link and decodes the frame. Writing it into the template is
+all it takes to reuse Lynx's built-in debugging; the red screen shows source
+locations with nothing extra to wire up.
+
+Each JS `sourceMappingURL` trailer is also rewritten to the same host. The `key`
+in the URL and the `key` you upload under are the same, so the links always
+resolve.
 
 > The content read at `beforeEncode` is the pre-enrichment version; the default
 > plugin enriches the file afterward (in `beforeEmit`). The `key` is therefore

--- a/docs/en/rspeedy/map-errors-to-source.mdx
+++ b/docs/en/rspeedy/map-errors-to-source.mdx
@@ -604,9 +604,12 @@ originalPositionFor(new TraceMap(map), { line: 247, column: 77 });
 // → { source: 'src/App.tsx', line: 14, column: 2 }
 ```
 
-`background.js:247:77` maps to `src/App.tsx:14`, the `if (crashRender)` line. The
-bundle's source map resolves the `throw` to its enclosing statement, so the
-frame lands on line 14 (the `if`), not the `throw` on line 15.
+`background.js:247:77` maps to `src/App.tsx:14`, the `if (crashRender)` line; the
+real `throw` is on line 15. Being one line off is source-map imprecision: the
+bundle collapses `if (crashRender) { throw ... }` onto a single line and only
+records a mapping for the start of that statement, so the decode lands on the
+outer `if`. The production red screen decodes to the same line, which is close
+enough to find the bug.
 
 ### Main-thread error: two steps
 

--- a/docs/en/rspeedy/map-errors-to-source.mdx
+++ b/docs/en/rspeedy/map-errors-to-source.mdx
@@ -506,13 +506,6 @@ Each JS `sourceMappingURL` trailer is also rewritten to the same host. The `key`
 in the URL and the `key` you upload under are the same, so the links always
 resolve.
 
-> The `debug-metadata.json` you read at `beforeEncode` is not complete yet: the
-> default plugin only fills in `bytecode-debug-info` and the like later, at
-> `beforeEmit`. So the `key` you compute here is based on that partial
-> intermediate content and won't match the bytes of the final file on disk.
-> Don't treat it as a hash of the final file; treat it as a unique id (upload
-> under the same value and the links still resolve).
-
 ### Remap at error time
 
 When a production stack arrives, run the decode chain against the

--- a/docs/en/rspeedy/map-errors-to-source.mdx
+++ b/docs/en/rspeedy/map-errors-to-source.mdx
@@ -509,13 +509,13 @@ resolve.
 ### Remap at error time
 
 When a production stack arrives, run the decode chain against the
-stored file: use [`resolveField`](#consuming-the-file) to pull the right
+stored file: use [`resolveField`](#reading-the-debugmetadata-file) to pull the right
 `source-map` / `bytecode-debug-info` (locate the file by `release` in Model A,
 or follow the in-bundle `debugMetadataUrl` in Model B), or the
 [`lynx-debug-info-remapping`](https://github.com/lynx-community/skills/tree/release/skills/lynx-debug-info-remapping)
 skill for a main-thread `function_id:pc` backtrace.
 
-## Consuming the file
+## Reading the DebugMetadata file
 
 You can `JSON.parse` it and use it directly:
 

--- a/docs/en/rspeedy/ui-source-map.mdx
+++ b/docs/en/rspeedy/ui-source-map.mdx
@@ -147,9 +147,8 @@ text) simply won't be resolved.
 [`@lynx-js/debug-metadata`](https://www.npmjs.com/package/@lynx-js/debug-metadata)
 reads `nodeIndex` and
 `debugMetadataUrl` at the top level of each node, while the engine nests them
-under `debugInfo`, so hoist them up first, then remap. You supply the loader
-that turns a `debugMetadataUrl` into its `DebugMetadataAsset`, so fetching,
-caching, and auth stay in your hands:
+under `debugInfo`, so hoist them up first, then remap. Its second argument is a
+loader you supply that turns a `debugMetadataUrl` into its `DebugMetadataAsset`:
 
 ```ts
 import { remapUiTree } from '@lynx-js/debug-metadata';

--- a/docs/en/rspeedy/ui-source-map.mdx
+++ b/docs/en/rspeedy/ui-source-map.mdx
@@ -1,0 +1,183 @@
+# Map the UI Tree to Source
+
+import { Tab, Tabs } from '@rspress/core/theme';
+import { Mermaid } from '@lynx';
+
+At runtime a Lynx page is a tree of UI nodes: the elements the engine actually
+rendered. The UI source map lets you take that runtime tree and map each
+node back to the JSX that created it (`repo`, `source`, `line`, `column`).
+
+It has three parts:
+
+1. Build: turn on [`enableUiSourceMap`](#1-enable-it) so the build emits the
+   UI source map into [`debug-metadata.json`](./map-errors-to-source) and tags elements
+   with a `nodeIndex`.
+2. Dump: ask the Lynx client to
+   [serialize the runtime UI tree](#2-dump-the-ui-tree-from-the-client) as JSON.
+3. Remap: feed that JSON plus the `debug-metadata.json` to
+   [`remapUiTree`](#3-remap-the-tree), which annotates every node with its source
+   location.
+
+<Mermaid title="From UI tree to source">{`
+flowchart LR
+  A["LynxView"] -->|"getLynxElementRoot + toJSONString"| B["UI tree JSON  (nodeIndex, debugMetadataUrl)"]
+  B -->|"flatten + remapUiTree"| C["annotated tree  repo/source/line/column"]
+  D["debug-metadata.json  uiSourceMap"] --> C
+`}</Mermaid>
+
+## 1. Enable it
+
+UI source-map generation is off by default. Turn it on in `pluginReactLynx`:
+
+```ts title="lynx.config.ts"
+import { defineConfig } from '@lynx-js/rspeedy';
+import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
+
+export default defineConfig({
+  plugins: [
+    pluginReactLynx({
+      enableUiSourceMap: true,
+    }),
+  ],
+});
+```
+
+With it on, the main-thread transform tags each created element with a
+`nodeIndex` and records a `nodeIndex → (source, line, column)` table. That table
+is emitted as the `uiSourceMap` field of `debug-metadata.json`:
+
+```ts
+interface UiSourceMapData {
+  version: 1;
+  sources: string[]; // authored files
+  mappings: [number, number, number][]; // [sourceIndex, line, column]
+  uiMaps: number[]; // uiMaps[i] is a nodeIndex; mappings[i] is its location
+}
+```
+
+For the runtime to point at this file you also need its `debugMetadataUrl` baked
+into the template: that happens automatically against the dev server, and in
+production you inject it yourself (see
+[Map Production Errors to Source → Model B](./map-errors-to-source#model-b-also-point-the-bundle-at-your-host)).
+Without it, the dumped nodes carry an empty `debugMetadataUrl` and can't be
+resolved.
+
+## 2. Dump the UI tree from the client
+
+The API is the same on every platform: from a `LynxView`, asynchronously get the
+root `LynxElement`, then call `toJSONString` on it to serialize the whole tree.
+Both callbacks fire on the UI / main thread.
+
+<Tabs>
+<Tab label="iOS (Objective-C)">
+
+```objc
+#import <Lynx/LynxView.h>
+#import <Lynx/LynxElement.h>
+
+[lynxView getLynxElementRoot:^(LynxElement *_Nullable root) {
+  if (root == nil) return;
+  [root toJSONString:^(NSString *_Nullable json) {
+    if (json == nil) return;
+    NSLog(@"LynxElement tree json: %@", json);
+  }];
+}];
+```
+
+</Tab>
+<Tab label="Android (Java)">
+
+```java
+import com.lynx.tasm.LynxElement;
+import com.lynx.tasm.LynxView;
+
+lynxView.getLynxElementRoot(root -> {
+  if (root == null) return;
+  root.toJSONString(json -> {
+    if (json == null) return;
+    Log.i("LynxElement", json);
+  });
+});
+```
+
+</Tab>
+<Tab label="Harmony (ArkTS)">
+
+```ts
+import { LynxView, LynxElement } from '@lynx/lynx';
+
+lynxView.getLynxElementRoot((root: LynxElement | null) => {
+  if (!root) return;
+  root.toJSONString((json: string | null) => {
+    if (!json) return;
+    console.info(`LynxElement tree json: ${json}`);
+  });
+});
+```
+
+</Tab>
+</Tabs>
+
+Each serialized node looks like this. The two fields remapping needs,
+`nodeIndex` and `debugMetadataUrl`, are nested under `debugInfo`:
+
+```jsonc
+{
+  "tag": "view",
+  "nodeId": 11,
+  "position": { "x": 0, "y": 0, "width": 300, "height": 80 },
+  "events": [],
+  "debugInfo": {
+    "nodeIndex": 100,
+    "debugMetadataUrl": "https://your-cdn.example.com/dm/<key>/debug-metadata.json",
+  },
+  "children": [
+    { "tag": "text", "debugInfo": { "nodeIndex": 200 }, "children": [] },
+  ],
+}
+```
+
+`nodeIndex` is the compile-time identity from step 1; `debugMetadataUrl` is the
+URL baked into the template. Nodes without a `debugInfo.nodeIndex` (e.g. raw
+text) simply won't be resolved.
+
+## 3. Remap the tree
+
+`remapUiTree` from
+[`@lynx-js/debug-metadata`](https://www.npmjs.com/package/@lynx-js/debug-metadata)
+reads `nodeIndex` and
+`debugMetadataUrl` at the top level of each node, while the engine nests them
+under `debugInfo`, so hoist them up first, then remap. You supply the loader
+that turns a `debugMetadataUrl` into its `DebugMetadataAsset`, so fetching,
+caching, and auth stay in your hands:
+
+```ts
+import { remapUiTree } from '@lynx-js/debug-metadata';
+
+// lift the engine's nested `debugInfo` fields to the top level
+function flatten(node) {
+  const { debugInfo, children, ...rest } = node;
+  return {
+    ...rest,
+    nodeIndex: debugInfo?.nodeIndex,
+    debugMetadataUrl: debugInfo?.debugMetadataUrl,
+    children: children?.map(flatten),
+  };
+}
+
+const tree = JSON.parse(jsonFromClient);
+const remapped = await remapUiTree(flatten(tree), async (debugMetadataUrl) => {
+  const res = await fetch(debugMetadataUrl);
+  return res.json(); // a DebugMetadataAsset
+});
+```
+
+Every node whose `nodeIndex` is known to its `debugMetadataUrl`'s `uiSourceMap`
+gains `repo` / `source` / `line` / `column`; unresolvable nodes and all other
+fields pass through unchanged. `remapUiTree` calls the loader once per distinct
+`debugMetadataUrl`.
+
+The `npx @lynx-js/debug-metadata remap --ui <tree.json>` CLI does the same, for a
+tree whose nodes already carry top-level `nodeIndex` / `debugMetadataUrl`. The
+lower-level `buildUiSourceMapLookup` (`nodeIndex → location`) and `normalizeRepo`
+(git remote → `owner/repo`) helpers are exported too.

--- a/docs/zh/rspeedy/_meta.json
+++ b/docs/zh/rspeedy/_meta.json
@@ -22,6 +22,8 @@
   "build-profiling",
   "runtime-profiling",
   "use-rsdoctor",
+  "map-errors-to-source",
+  "ui-source-map",
   {
     "type": "divider"
   },

--- a/docs/zh/rspeedy/index.md
+++ b/docs/zh/rspeedy/index.md
@@ -8,7 +8,7 @@ hero:
   actions:
     - theme: brand
       text: 开始
-      link: /zh/guide/start/quick-start.html
+      link: /zh/rspeedy/cli.html
     - theme: alt
       text: API
       link: /api/rspeedy.html

--- a/docs/zh/rspeedy/map-errors-to-source.mdx
+++ b/docs/zh/rspeedy/map-errors-to-source.mdx
@@ -432,8 +432,6 @@ pluginHostDebugMetadata({
 
 每个 JS 的 `sourceMappingURL` 注释也改写到了同一托管地址。URL 里的 `key` 与你上传所用的 `key` 一致，所以链接始终能解析。
 
-> `beforeEncode` 这个时机读到的 `debug-metadata.json` 还不完整：默认插件要到更晚的 `beforeEmit` 才往里补上 `bytecode-debug-info` 等内容。所以你在这里算出来的 `key` 是基于这份没补全的中间内容，和最终落盘文件的字节对不上。别把它当成最终文件的哈希，当成一个唯一 id 就行（上传时用同一个值，链接照样对得上）。
-
 ### 在出错时反解
 
 线上堆栈到来时，对存好的文件做反解：用 [`resolveField`](#消费该文件) 取出对应的 `source-map` / `bytecode-debug-info`（方案 1 按 release 定位文件，方案 2 跟随产物里的 `debugMetadataUrl`），或者用 [`lynx-debug-info-remapping`](https://github.com/lynx-community/skills/tree/release/skills/lynx-debug-info-remapping) skill 处理主线程的 `function_id:pc` backtrace。

--- a/docs/zh/rspeedy/map-errors-to-source.mdx
+++ b/docs/zh/rspeedy/map-errors-to-source.mdx
@@ -521,7 +521,7 @@ originalPositionFor(new TraceMap(map), { line: 247, column: 77 });
 // → { source: 'src/App.tsx', line: 14, column: 2 }
 ```
 
-`background.js:247:77` 映射回 `src/App.tsx:14`，也就是 `if (crashRender)` 那行。source map 会把 `throw` 归到它所在的外层语句，所以落在第 14 行（`if`），不是第 15 行的 `throw`。
+`background.js:247:77` 映射回 `src/App.tsx:14`，也就是 `if (crashRender)` 那行；真正的 `throw` 在第 15 行。差这一行是 source map 的精度问题：产物把 `if (crashRender) { throw ... }` 压成了一行，map 只对这条语句的开头记了映射，反解就落在外层的 `if` 上。线上红屏的反解也是停在上一行，定位问题已经够用了。
 
 ### 主线程错误（两步）
 

--- a/docs/zh/rspeedy/map-errors-to-source.mdx
+++ b/docs/zh/rspeedy/map-errors-to-source.mdx
@@ -432,7 +432,7 @@ pluginHostDebugMetadata({
 
 每个 JS 的 `sourceMappingURL` 注释也改写到了同一托管地址。URL 里的 `key` 与你上传所用的 `key` 一致，所以链接始终能解析。
 
-> `beforeEncode` 时读到的是富化前的内容；默认插件会在之后（`beforeEmit`）富化该文件。所以这个 `key` 派生自那份在途内容，把它当作一个不透明的唯一 id，不是最终落盘字节的哈希。
+> `beforeEncode` 这个时机读到的 `debug-metadata.json` 还不完整：默认插件要到更晚的 `beforeEmit` 才往里补上 `bytecode-debug-info` 等内容。所以你在这里算出来的 `key` 是基于这份没补全的中间内容，和最终落盘文件的字节对不上。别把它当成最终文件的哈希，当成一个唯一 id 就行（上传时用同一个值，链接照样对得上）。
 
 ### 在出错时反解
 

--- a/docs/zh/rspeedy/map-errors-to-source.mdx
+++ b/docs/zh/rspeedy/map-errors-to-source.mdx
@@ -1,0 +1,563 @@
+# 线上错误反解
+
+import { Mermaid } from '@lynx';
+
+Lynx 线上报错上报到你的监控时，是一段被打包过的堆栈，例如（大字段用 `...` 省略）：
+
+```jsonc
+{
+  "error_code": 1101,
+  "error": {
+    // `error` 字段本身是一个 JSON 字符串，这里展示解析后的样子
+    "message": "main-thread.js exception: Error: boom from main thread",
+    "stack": "backtrace:\n    at <anonymous> (file:///main-thread.js:23:13)\n    ...",
+    "sentry": {
+      "exception": {
+        "values": [
+          {
+            "stacktrace": {
+              "frames": [
+                // 你的代码帧，带着 release；23:13 就是 function_id:pc
+                {
+                  "filename": "file:///main-thread.js",
+                  "lineno": 23,
+                  "colno": 13,
+                  "release": "debugmetadata:0a62b9f5435af49d34a238d276a986d1bb64b6d1",
+                },
+                // ... worklet-runtime 的帧
+              ],
+            },
+          },
+        ],
+      },
+    },
+  },
+}
+```
+
+注意：堆栈里这些行列号对应的是打包产物（`background.js`、`main-thread.js`）里的位置，不是你的源码。其中 `main-thread.js:23:13` 还要当心：它看着像`行:列`，但主线程跑的是字节码，这两个数其实是 `function_id:pc`（第 23 号函数、第 13 条指令），跟源码行列没关系；`background.js:247:77` 才是真的行列号。本文要做的，就是把它们还原回源码位置（文件、行、列）。
+
+反解需要的东西都在每次构建产出的同一个 `debug-metadata.json` 里：source map、字节码调试信息、UI source map、构建信息。它由 [`@lynx-js/debug-metadata-rsbuild-plugin`](https://www.npmjs.com/package/@lynx-js/debug-metadata-rsbuild-plugin) 产出，并由 [`@lynx-js/rspeedy`](https://www.npmjs.com/package/@lynx-js/rspeedy) 自动注册（默认启用，无需在配置中声明）。
+
+<Mermaid title="从构建到映射回源码">{`
+flowchart LR
+  A["构建"] -->|"产出"| B["debug-metadata.json"]
+  B -->|"按 release 上传"| C[("你的存储")]
+  D["线上错误  （压缩堆栈）"] -->|"按 release 查回"| C
+  C -->|"映射回"| E["你的源码  file:line:col"]
+`}</Mermaid>
+
+## 落盘内容
+
+每个 entry 一个文件，位于该 entry 的中间目录下（默认 `.rspeedy/<entry>`）：
+
+```text
+dist/.rspeedy/<entry>/debug-metadata.json
+```
+
+:::warning 生产构建默认会删除它
+生产构建里，这个文件会生成，但随后就从产物里删掉，它不该跟着 app 发出去，只是调试用的辅助信息。只有在 `dev`、或 `DEBUG` 里带 `rspeedy` 时（例如 `DEBUG=rspeedy pnpm build`，方便本地查看）才会留在磁盘上。要用它做线上反解，需要你自己上传并托管，见 [在生产环境中使用](#在生产环境中使用)。
+:::
+
+## DebugMetadata 文件结构
+
+这个文件对应 [`@lynx-js/debug-metadata`](https://www.npmjs.com/package/@lynx-js/debug-metadata) 导出的 `DebugMetadataAsset` 类型：
+
+```ts
+interface DebugMetadataAsset {
+  artifacts: Artifact[]; // 每个 JS / CSS / 字节码 bundle 一项
+  uiSourceMap: UiSourceMapData; // 精简的 UI source-map 负载
+  buildInfo: { git?: GitMetadata; rspeedy?: RspeedyMeta };
+}
+```
+
+每个 `Artifact` 里有一个 `debugSources[]`，顺序对应反解的两步：
+
+1. `bytecode-debug-info`（若存在）把字节码位置映射回编码后 JS 的 `(line, column)`。
+2. `source-map` 再把它映射回你编写的源码。
+
+精简后（大字段用 `...` 表示）一个真实文件长这样。注意每个 chunk 的 `source-map` `key`，它就是运行时上报的 release：
+
+```jsonc
+{
+  "artifacts": [
+    {
+      "kind": "main-thread",
+      "filename": "main-thread.js",
+      "debugSources": [
+        // function_id:pc → 编码后 main-thread.js 的 (line, col)
+        {
+          "kind": "bytecode-debug-info",
+          "debugInfo": { "lepusNG_debug_info": { "function_info": ["..."] } },
+        },
+        // 编码后 (line, col) → 你的源码；`key` 就是这个 chunk 的 release
+        {
+          "kind": "source-map",
+          "filename": "main-thread.js.map",
+          "key": "0a62b9f5435af49d34a238d276a986d1bb64b6d1",
+          "map": {
+            "version": 3,
+            "sources": [".../src/App.tsx", "..."],
+            "mappings": "...",
+          },
+        },
+      ],
+    },
+    {
+      "kind": "background",
+      "filename": "background.js",
+      "debugSources": [
+        {
+          "kind": "source-map",
+          "filename": "background.js.map",
+          "key": "566b7d2bd791a6d9b5280f368223d729d8f57f9c",
+          "map": {
+            "version": 3,
+            "sources": [".../src/App.tsx", "..."],
+            "mappings": "...",
+          },
+        },
+      ],
+    },
+    // ... css 与 hot-update artifacts
+  ],
+  "uiSourceMap": {
+    "version": 1,
+    "sources": ["..."],
+    "mappings": ["..."],
+    "uiMaps": ["..."],
+  },
+  "buildInfo": {
+    "git": {
+      "commit": "62a8e780...",
+      "remoteUrl": "https://github.com/lynx-family/lynx-stack",
+    },
+    "rspeedy": {
+      "entryFiles": ["src/index.tsx"],
+      "bundlePath": "main/template.js",
+    },
+  },
+}
+```
+
+### `bytecode-debug-info` 是什么
+
+Lynx 的主线程脚本是以 PrimJS 字节码运行的，不是磁盘上的 JS 文本。所以主线程抛错时，引擎只能告诉你它发生在字节码的哪个位置：一个 `function_id:pc`（函数下标加程序计数器偏移），而不是你能看懂的行列号。
+
+`bytecode-debug-info` 就是补上这一步的查找表。它把 `function_id:pc` 映射回**编码后 `main-thread.js`** 中的 `(line, column)`。这个位置仍然是生成代码，所以再由 `source-map` 走第二步，回到你原始的 `.ts` / `.tsx`。这两步（`bytecode-debug-info` 和 `source-map`）放在同一个 `Artifact` 里。
+
+后台线程的 JS 是正常运行的，它的堆栈帧本身就带有真实的 `(line, column)`，只需走 `source-map` 这一步，不需要字节码这一步。
+
+<Mermaid title="反解过程">{`
+flowchart LR
+  P["主线程帧  function_id:pc"] -->|"bytecode-debug-info"| Q["编码后 main-thread.js  line:col"]
+  Q -->|"source-map"| R["你的源码  file:line:col"]
+  S["后台帧  file:line:col"] -->|"source-map"| R
+`}</Mermaid>
+
+:::tip 手动反解主线程堆栈
+社区的 [`lynx-debug-info-remapping`](https://github.com/lynx-community/skills/tree/release/skills/lynx-debug-info-remapping) skill 接收一段 `function_id:pc` 的 backtrace 加上这个文件，直接打印出原始源码位置（带代码上下文），省得你自己写解码器。
+:::
+
+## Dev server 接口
+
+`dev` 期间，插件会托管该文件，并允许你只查询单个字段而不必解析整个文件：
+
+```http
+GET <publicPath>/.rspeedy/<entry>/debug-metadata.json
+GET <publicPath>/.rspeedy/<entry>/debug-metadata.json?field=source-map&filename=main-thread.js.map
+GET <publicPath>/.rspeedy/<entry>/debug-metadata.json?field=bytecode-debug-info&filename=main-thread.js
+```
+
+在 dev 下，插件还会把 bundle 内的 `sourceMappingURL` 注释，以及 tasm 的 `templateDebugUrl` / `debugMetadataUrl` 改写为指向这些 dev server 接口，从而让 devtools 自动解析源码。
+
+### 可查询字段
+
+| `field=`              | 查询键                      | 返回                    |
+| --------------------- | --------------------------- | ----------------------- |
+| `source-map`          | `path` / `filename` / `key` | 内层 `SourceMap`（v3）  |
+| `bytecode-debug-info` | `filename`（JS 资源）       | 内层 `LepusNGDebugInfo` |
+| `artifact`            | `filename`                  | 完整 `Artifact`         |
+| `artifacts`           | 无                          | `Artifact[]`            |
+| `ui-source-map`       | 无                          | `UiSourceMapData`       |
+| `buildInfo`           | 无（或 `git` / `rspeedy`）  | `buildInfo` 块          |
+
+命中时直接返回该字段对应的内容（例如 `?field=source-map` 返回原始 v3 map，而不是包装对象）。未知字段返回 `400`；字段合法但无匹配值返回 `404`。
+
+## 在生产环境中使用
+
+Lynx 只定义格式、产出文件，不负责托管，也没有内置上传，上面那些 URL 改写也只发生在 dev server。线上的反解需要你自己接入，具体怎么接取决于你的堆栈如何找到对应的元数据，有两种做法：
+
+- 模型 A，后端按 release 索引：构建时把文件传到你自己的服务。`release` 是构建自动注入产物的（出错时运行时会带上它），同一个值也存在文件里，所以后端读出它来建索引，出错时按 `release` 找回文件。产物里不用再加别的东西。
+- 模型 B，让产物指向你的托管地址：再把 `debugMetadataUrl` / `templateDebugUrl` 写进随包发布的模板（并改写 JS 的 `sourceMappingURL` 注释），这样 devtools 或反解服务能直接 fetch 到文件。
+
+### 模型 A：上传并托管
+
+默认插件会在构建的最末尾（`PROCESS_ASSETS_STAGE_REPORT + 1`）删除 `debug-metadata.json`。在前一个 stage tap 即可读到它并交给你的上传逻辑：
+
+:::details plugins/upload-debug-metadata.ts
+
+```ts
+import type { RsbuildPlugin, Rspack } from '@rsbuild/core';
+
+const ASSET = 'debug-metadata.json';
+
+export function pluginUploadDebugMetadata(
+  upload: (json: string, assetName: string) => Promise<void>,
+): RsbuildPlugin {
+  return {
+    name: 'upload-debug-metadata',
+    setup(api) {
+      api.modifyBundlerChain((chain, { environment, isProd }) => {
+        const isLynx =
+          environment.name === 'lynx' || environment.name.startsWith('lynx-');
+        if (!isProd || !isLynx) return;
+
+        chain.plugin('upload-debug-metadata').use(
+          class {
+            apply(compiler: Rspack.Compiler) {
+              const { Compilation } = compiler.webpack;
+              compiler.hooks.thisCompilation.tap('upload', (compilation) => {
+                compilation.hooks.processAssets.tapPromise(
+                  // 比默认插件的清理早一个 stage
+                  {
+                    name: 'upload',
+                    stage: Compilation.PROCESS_ASSETS_STAGE_REPORT,
+                  },
+                  async (assets) => {
+                    for (const name of Object.keys(assets)) {
+                      if (name !== ASSET && !name.endsWith(`/${ASSET}`))
+                        continue;
+                      const json = compilation
+                        .getAsset(name)
+                        ?.source.source()
+                        .toString();
+                      if (json) await upload(json, name);
+                    }
+                  },
+                );
+              });
+            }
+          },
+        );
+      });
+    },
+  };
+}
+```
+
+:::
+
+把它接进 `lynx.config.ts`。你只需原样上传文件，后端用来索引的 `release` 是构建注入、并嵌在文件里的，不用你在这里指定：
+
+```ts title="lynx.config.ts"
+import { defineConfig } from '@lynx-js/rspeedy';
+import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
+import { pluginUploadDebugMetadata } from './plugins/upload-debug-metadata.js';
+
+export default defineConfig({
+  plugins: [
+    pluginReactLynx(),
+    pluginUploadDebugMetadata(async (json) => {
+      await fetch('https://your-monitoring.example.com/debug-metadata', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: json,
+      });
+    }),
+  ],
+});
+```
+
+> 如果只是临时想拿到磁盘上的文件，改用 `DEBUG=rspeedy` 构建即可，它会把文件留在 `dist/.rspeedy/<entry>/` 下，不需要任何插件。
+
+:::note 运行时 release 如何对应到文件
+
+运行时上报的每个 chunk 的 release 形如 `debugmetadata:<key>`，例如 `debugmetadata:0a62b9f5435af49d34a238d276a986d1bb64b6d1`。去掉 `debugmetadata:` 前缀，`<key>` 恰好就是 `debug-metadata.json` 里某个 artifact 的 `source-map` 的 `key`（每个 chunk 一个：`main-thread.js`、`background.js` ......）。所以你的后端从上传的文件里读出这些 key 建索引；出错时去掉前缀按 key 查回文件。你自始至终不需要自己指定 release。
+
+:::
+
+### 模型 B：让产物指向你的托管地址
+
+要让 devtools 或反解服务自动 fetch 到文件，你得在模板被编码之前把 URL 写进去。这意味着要 tap `LynxTemplatePlugin.beforeEncode`，而它通过 DSL 插件发布的 exposure 拿到：
+
+- 用 `api.useExposed(Symbol.for('LynxTemplatePlugin'))` 读到这个类。
+- 把你的插件排到 `.after('lynx:debug-metadata')`，否则你的 `beforeEncode` 会跑在默认插件产出文件之前，读到空内容。
+
+:::details plugins/host-debug-metadata.ts
+
+```ts
+import crypto from 'node:crypto';
+import path from 'node:path';
+import type { RsbuildPlugin, Rspack } from '@rsbuild/core';
+
+const ASSET = 'debug-metadata.json';
+
+export function pluginHostDebugMetadata(opts: {
+  baseUrl: string;
+  upload: (json: string, key: string) => Promise<void>;
+}): RsbuildPlugin {
+  const { baseUrl, upload } = opts;
+  return {
+    name: 'host-debug-metadata',
+    setup(api) {
+      api.modifyBundlerChain((chain, { environment, isProd }) => {
+        const isLynx =
+          environment.name === 'lynx' || environment.name.startsWith('lynx-');
+        if (!isProd || !isLynx) return;
+
+        const exposed = api.useExposed<{
+          LynxTemplatePlugin: {
+            getLynxTemplatePluginHooks: (c: Rspack.Compilation) => {
+              beforeEncode: { tap: (n: string, fn: (a: any) => any) => void };
+            };
+          };
+        }>(Symbol.for('LynxTemplatePlugin'));
+        if (!exposed) return;
+        const { LynxTemplatePlugin } = exposed;
+
+        chain
+          .plugin('host-debug-metadata')
+          .after('lynx:debug-metadata')
+          .use(
+            class {
+              apply(compiler: Rspack.Compiler) {
+                const { Compilation, sources } = compiler.webpack;
+                const keyByAsset = new Map<string, string>();
+
+                compiler.hooks.thisCompilation.tap('host-dm', (compilation) => {
+                  const hooks =
+                    LynxTemplatePlugin.getLynxTemplatePluginHooks(compilation);
+
+                  hooks.beforeEncode.tap('host-dm', (args) => {
+                    const assetName = path.posix.format({
+                      dir: args.intermediate,
+                      base: ASSET,
+                    });
+                    const content = compilation
+                      .getAsset(assetName)
+                      ?.source.source()
+                      .toString();
+                    if (!content) return args; // 不是 lynx 模板
+
+                    const key = crypto
+                      .createHash('sha1')
+                      .update(content)
+                      .digest('hex');
+                    keyByAsset.set(assetName, key);
+                    const fileUrl = `${baseUrl}/${key}/${ASSET}`;
+
+                    const root = args.encodeData.lepusCode.root?.name;
+                    const mainThread = root
+                      ? path.posix.basename(root.replace(/\\/g, '/'))
+                      : 'main-thread.js';
+
+                    // 写进编码后的模板
+                    args.encodeData.sourceContent.config.debugMetadataUrl =
+                      fileUrl;
+                    args.encodeData.compilerOptions.templateDebugUrl =
+                      `${fileUrl}?field=bytecode-debug-info` +
+                      `&filename=${encodeURIComponent(mainThread)}`;
+
+                    // 把每个 JS 的 sourceMappingURL 注释重新指向托管地址
+                    for (const a of JSON.parse(content).artifacts ?? []) {
+                      if (!a.path?.endsWith('.js')) continue;
+                      const name = a.path.replaceAll('/./', '/');
+                      const asset = compilation.getAsset(name);
+                      if (!asset) continue;
+                      const before = asset.source.source().toString();
+                      if (!before.includes('//# sourceMappingURL=')) continue;
+                      const after = before.replace(
+                        /\/\/# sourceMappingURL=\S*/g,
+                        `//# sourceMappingURL=${fileUrl}?field=source-map` +
+                          `&path=${encodeURIComponent(`${name}.map`)}`,
+                      );
+                      compilation.updateAsset(
+                        name,
+                        new sources.RawSource(after),
+                        asset.info,
+                      );
+                    }
+                    return args;
+                  });
+
+                  compilation.hooks.processAssets.tapPromise(
+                    {
+                      name: 'host-dm',
+                      stage: Compilation.PROCESS_ASSETS_STAGE_REPORT,
+                    },
+                    async (assets) => {
+                      for (const name of Object.keys(assets)) {
+                        if (name !== ASSET && !name.endsWith(`/${ASSET}`))
+                          continue;
+                        const json = compilation
+                          .getAsset(name)
+                          ?.source.source()
+                          .toString();
+                        const key = keyByAsset.get(name);
+                        if (json && key) await upload(json, key);
+                      }
+                    },
+                  );
+                });
+              }
+            },
+          );
+      });
+    },
+  };
+}
+```
+
+:::
+
+用你实际托管文件的 base URL 接入：
+
+```ts title="lynx.config.ts"
+pluginHostDebugMetadata({
+  baseUrl: 'https://your-cdn.example.com/dm',
+  upload: async (json, key) => {
+    await fetch(`https://your-cdn.example.com/dm/${key}/debug-metadata.json`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: json,
+    });
+  },
+});
+```
+
+产出的 Lynx Bundle 现在带有 `compilerOptions.templateDebugUrl` 和 `sourceContent.config.debugMetadataUrl`，均指向 `<baseUrl>/<key>/debug-metadata.json`，每个 JS 的 `sourceMappingURL` 注释也改写到了同一托管地址。URL 里的 `key` 与你上传所用的 `key` 一致，所以链接始终能解析。
+
+> `beforeEncode` 时读到的是富化前的内容；默认插件会在之后（`beforeEmit`）富化该文件。所以这个 `key` 派生自那份在途内容，把它当作一个不透明的唯一 id，不是最终落盘字节的哈希。
+
+### 在出错时反解
+
+线上堆栈到来时，对存好的文件做反解：用 [`resolveField`](#消费该文件) 取出对应的 `source-map` / `bytecode-debug-info`（模型 A 按 release 定位文件，模型 B 跟随产物里的 `debugMetadataUrl`），或者用 [`lynx-debug-info-remapping`](https://github.com/lynx-community/skills/tree/release/skills/lynx-debug-info-remapping) skill 处理主线程的 `function_id:pc` backtrace。
+
+## 消费该文件
+
+可以直接 `JSON.parse` 后使用：
+
+```ts
+import type { DebugMetadataAsset } from '@lynx-js/debug-metadata';
+
+const metadata = JSON.parse(
+  await readFile('debug-metadata.json', 'utf8'),
+) as DebugMetadataAsset;
+```
+
+在代码中解析单个字段（与 dev server 使用的是同一套分发逻辑）：
+
+```ts
+import { resolveField } from '@lynx-js/debug-metadata';
+
+const res = resolveField(metadata, 'source-map', {
+  filename: 'main-thread.js.map',
+});
+// res === undefined  → 未知字段
+// res.found === false → 无匹配
+// res.payload        → 该字段对应的 SourceMap（即 SourceMap 本身）
+```
+
+:::tip 对未知字段保持开放
+schema 会随产出端演进，所以遇到不认识的字段，忽略就好，别因此把整份数据判为无效。
+:::
+
+## 实战：把一个真实错误映射回源码
+
+为了把两条路径都走通，`examples/react` 的 `App.tsx` 在两处抛错：一处在 `render`（后台线程），一处在主线程 tap 处理器里：
+
+```tsx title="src/App.tsx"
+function App() {
+  const [crashRender, setCrashRender] = useState(false);
+
+  if (crashRender) {
+    throw new Error('boom from render (background thread)'); // line 15
+  }
+  // ...
+  return (
+    <text
+      main-thread:bindtap={() => {
+        'main thread';
+        throw new Error('boom from main thread'); // line 65
+      }}
+    >
+      Throw on main thread
+    </text>
+  );
+}
+```
+
+构建并运行，分别触发两个错误。下文里的 `metadata` 就是这次构建的 `debug-metadata.json`（用 `JSON.parse` 解析，按 release 从你的存储取回，[模型 A](#模型-a上传并托管)）。
+
+### 后台错误（一步）
+
+点击 **Throw in render**，在后台线程抛错。控制台里的帧指向 `background.js`：
+
+```text
+unhandled rejection: boom from render (background thread)
+    at App (background.js:247:77)
+    at doRender (background.js:2994:44)
+    ...
+```
+
+<img
+  src="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/plugin/static/map-errors-background.png"
+  alt="devtool 控制台里的后台线程错误，指向 background.js"
+/>
+
+`background.js:247:77` 是真实的 `(line, column)`，所以一步 `source-map` 就能映射回去：
+
+```ts
+import { resolveField } from '@lynx-js/debug-metadata';
+// 任何 v3 source-map 库都行，这里用 @jridgewell/trace-mapping
+import { TraceMap, originalPositionFor } from '@jridgewell/trace-mapping';
+
+const map = resolveField(metadata, 'source-map', {
+  filename: 'background.js.map',
+}).payload;
+
+originalPositionFor(new TraceMap(map), { line: 247, column: 77 });
+// → { source: 'src/App.tsx', line: 14, column: 2 }
+```
+
+`background.js:247:77` 映射回 `src/App.tsx:14`，也就是 `if (crashRender)` 那行。source map 会把 `throw` 归到它所在的外层语句，所以落在第 14 行（`if`），不是第 15 行的 `throw`。
+
+### 主线程错误（两步）
+
+点击 **Throw on main thread**，主线程抛错，控制台里是这样：
+
+<img
+  src="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/plugin/static/map-errors-main-thread.png"
+  alt="devtool 控制台里的主线程错误，main-thread.js 里的 function_id:pc 帧"
+/>
+
+上报到监控的就是开头那段 JSON，关键是带 `release` 的那一帧：
+
+```jsonc
+{
+  "function": "<anonymous>",
+  "filename": "file:///main-thread.js",
+  "lineno": 23,
+  "colno": 13,
+  "release": "debugmetadata:0a62b9f5435af49d34a238d276a986d1bb64b6d1",
+}
+```
+
+先按 `release` 找到对应的 DebugMetadata。去掉 `debugmetadata:` 前缀，剩下的 `0a62b9f...` 就是某个 chunk 的 `source-map` `key`，据此从你的存储取回这次构建的文件：
+
+```ts
+const release = frame.release.replace('debugmetadata:', '');
+// '0a62b9f5435af49d34a238d276a986d1bb64b6d1'
+const metadata = await fetchByKey(release); // 你的后端：按 source-map key 索引
+```
+
+再反解这一帧。`23:13` 是 function_id 23、pc 13（不是行列号），分两步：
+
+```text
+main-thread.js:23:13 (function_id:pc)
+  bytecode-debug-info → main-thread.js:238:45 (编码后 JS line:col)
+  source-map          → src/App.tsx:65:14
+```
+
+`main-thread.js:23:13` 最终映射回 `src/App.tsx:65`，也就是主线程那个 `throw`。这条链可以用 [`lynx-debug-info-remapping`](https://github.com/lynx-community/skills/tree/release/skills/lynx-debug-info-remapping) skill 一把跑完。

--- a/docs/zh/rspeedy/map-errors-to-source.mdx
+++ b/docs/zh/rspeedy/map-errors-to-source.mdx
@@ -188,10 +188,10 @@ GET <publicPath>/.rspeedy/<entry>/debug-metadata.json?field=bytecode-debug-info&
 
 Lynx 只定义格式、产出文件，不负责托管，也没有内置上传，上面那些 URL 改写也只发生在 dev server。线上的反解需要你自己接入，具体怎么接取决于你的堆栈如何找到对应的元数据，有两种做法：
 
-- 模型 A，后端按 release 索引：构建时把文件传到你自己的服务。`release` 是构建自动注入产物的（出错时运行时会带上它），同一个值也存在文件里，所以后端读出它来建索引，出错时按 `release` 找回文件。产物里不用再加别的东西。
-- 模型 B，让产物指向你的托管地址：再把 `debugMetadataUrl` / `templateDebugUrl` 写进随包发布的模板（并改写 JS 的 `sourceMappingURL` 注释），这样 devtools 或反解服务能直接 fetch 到文件。
+- 方案 1，后端按 release 索引：构建时把文件传到你自己的服务。`release` 是构建自动注入产物的（出错时运行时会带上它），同一个值也存在文件里，所以后端读出它来建索引，出错时按 `release` 找回文件。产物里不用再加别的东西。
+- 方案 2，让产物指向你的托管地址：再把 `debugMetadataUrl` / `templateDebugUrl` 写进随包发布的模板（并改写 JS 的 `sourceMappingURL` 注释），这样 devtools 或反解服务能直接 fetch 到文件。
 
-### 模型 A：上传并托管
+### 方案 1：上传并托管
 
 默认插件会在构建的最末尾（`PROCESS_ASSETS_STAGE_REPORT + 1`）删除 `debug-metadata.json`。在前一个 stage tap 即可读到它并交给你的上传逻辑：
 
@@ -277,7 +277,7 @@ export default defineConfig({
 
 :::
 
-### 模型 B：让产物指向你的托管地址
+### 方案 2：让产物指向你的托管地址
 
 要让 devtools 或反解服务自动 fetch 到文件，你得在模板被编码之前把 URL 写进去。这意味着要 tap `LynxTemplatePlugin.beforeEncode`，而它通过 DSL 插件发布的 exposure 拿到：
 
@@ -426,13 +426,17 @@ pluginHostDebugMetadata({
 });
 ```
 
-产出的 Lynx Bundle 现在带有 `compilerOptions.templateDebugUrl` 和 `sourceContent.config.debugMetadataUrl`，均指向 `<baseUrl>/<key>/debug-metadata.json`，每个 JS 的 `sourceMappingURL` 注释也改写到了同一托管地址。URL 里的 `key` 与你上传所用的 `key` 一致，所以链接始终能解析。
+产出的 Lynx Bundle 现在带两个指向托管地址的字段，注意它们形态不一样：`sourceContent.config.debugMetadataUrl` 是裸链接 `<baseUrl>/<key>/debug-metadata.json`，给 devtools 或你自己的反解服务整份拉取；`compilerOptions.templateDebugUrl` 指向同一个文件，但带上了取数 query（`?field=bytecode-debug-info&filename=<main-thread.js>`）。
+
+`templateDebugUrl` 带 query 是有意的：Lynx 自带的红屏反解会读这个字段，主线程抛错时直接按链接拉到 `bytecode-debug-info` 做反解。所以只要把它写进模板，就能复用 Lynx 内置的调试能力，红屏里直接显示源码位置，不用你再接一套。
+
+每个 JS 的 `sourceMappingURL` 注释也改写到了同一托管地址。URL 里的 `key` 与你上传所用的 `key` 一致，所以链接始终能解析。
 
 > `beforeEncode` 时读到的是富化前的内容；默认插件会在之后（`beforeEmit`）富化该文件。所以这个 `key` 派生自那份在途内容，把它当作一个不透明的唯一 id，不是最终落盘字节的哈希。
 
 ### 在出错时反解
 
-线上堆栈到来时，对存好的文件做反解：用 [`resolveField`](#消费该文件) 取出对应的 `source-map` / `bytecode-debug-info`（模型 A 按 release 定位文件，模型 B 跟随产物里的 `debugMetadataUrl`），或者用 [`lynx-debug-info-remapping`](https://github.com/lynx-community/skills/tree/release/skills/lynx-debug-info-remapping) skill 处理主线程的 `function_id:pc` backtrace。
+线上堆栈到来时，对存好的文件做反解：用 [`resolveField`](#消费该文件) 取出对应的 `source-map` / `bytecode-debug-info`（方案 1 按 release 定位文件，方案 2 跟随产物里的 `debugMetadataUrl`），或者用 [`lynx-debug-info-remapping`](https://github.com/lynx-community/skills/tree/release/skills/lynx-debug-info-remapping) skill 处理主线程的 `function_id:pc` backtrace。
 
 ## 消费该文件
 
@@ -488,7 +492,7 @@ function App() {
 }
 ```
 
-构建并运行，分别触发两个错误。下文里的 `metadata` 就是这次构建的 `debug-metadata.json`（用 `JSON.parse` 解析，按 release 从你的存储取回，[模型 A](#模型-a上传并托管)）。
+构建并运行，分别触发两个错误。下文里的 `metadata` 就是这次构建的 `debug-metadata.json`（用 `JSON.parse` 解析，按 release 从你的存储取回，[方案 1](#方案-1上传并托管)）。
 
 ### 后台错误（一步）
 

--- a/docs/zh/rspeedy/map-errors-to-source.mdx
+++ b/docs/zh/rspeedy/map-errors-to-source.mdx
@@ -434,9 +434,9 @@ pluginHostDebugMetadata({
 
 ### 在出错时反解
 
-线上堆栈到来时，对存好的文件做反解：用 [`resolveField`](#消费该文件) 取出对应的 `source-map` / `bytecode-debug-info`（方案 1 按 release 定位文件，方案 2 跟随产物里的 `debugMetadataUrl`），或者用 [`lynx-debug-info-remapping`](https://github.com/lynx-community/skills/tree/release/skills/lynx-debug-info-remapping) skill 处理主线程的 `function_id:pc` backtrace。
+线上堆栈到来时，对存好的文件做反解：用 [`resolveField`](#读取-debugmetadata-文件) 取出对应的 `source-map` / `bytecode-debug-info`（方案 1 按 release 定位文件，方案 2 跟随产物里的 `debugMetadataUrl`），或者用 [`lynx-debug-info-remapping`](https://github.com/lynx-community/skills/tree/release/skills/lynx-debug-info-remapping) skill 处理主线程的 `function_id:pc` backtrace。
 
-## 消费该文件
+## 读取 DebugMetadata 文件
 
 可以直接 `JSON.parse` 后使用：
 

--- a/docs/zh/rspeedy/ui-source-map.mdx
+++ b/docs/zh/rspeedy/ui-source-map.mdx
@@ -1,0 +1,152 @@
+# 反解 UI 节点树
+
+import { Tab, Tabs } from '@rspress/core/theme';
+import { Mermaid } from '@lynx';
+
+运行时一个 Lynx 页面就是一棵 UI 节点树，也就是引擎真正渲染出来的那些元素。UI source map 让你把树里的每个节点映射回创建它的 JSX（`repo`、`source`、`line`、`column`）。
+
+它分三步：
+
+1. 构建：打开 [`enableUiSourceMap`](#1-开启开关)，让构建把 UI source map 写进 [`debug-metadata.json`](./map-errors-to-source)，并给元素打上 `nodeIndex`。
+2. 导出：让 Lynx 客户端把[运行时 UI 树序列化](#2-从客户端导出-ui-树)成 JSON。
+3. 反解：把这份 JSON 加上 `debug-metadata.json` 喂给 [`remapUiTree`](#3-反解这棵树)，它会给每个节点标注源码位置。
+
+<Mermaid title="从 UI 树到源码">{`
+flowchart LR
+  A["LynxView"] -->|"getLynxElementRoot + toJSONString"| B["UI 树 JSON  (nodeIndex, debugMetadataUrl)"]
+  B -->|"flatten + remapUiTree"| C["带源码位置的树  repo/source/line/column"]
+  D["debug-metadata.json  uiSourceMap"] --> C
+`}</Mermaid>
+
+## 1. 开启开关
+
+UI source map 生成默认是关的。在 `pluginReactLynx` 里打开：
+
+```ts title="lynx.config.ts"
+import { defineConfig } from '@lynx-js/rspeedy';
+import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
+
+export default defineConfig({
+  plugins: [
+    pluginReactLynx({
+      enableUiSourceMap: true,
+    }),
+  ],
+});
+```
+
+打开后，主线程的 transform 会给每个创建出来的元素打上 `nodeIndex`，并记录一张 `nodeIndex → (source, line, column)` 表。这张表会作为 `debug-metadata.json` 的 `uiSourceMap` 字段产出：
+
+```ts
+interface UiSourceMapData {
+  version: 1;
+  sources: string[]; // 源文件
+  mappings: [number, number, number][]; // [sourceIndex, line, column]
+  uiMaps: number[]; // uiMaps[i] 是一个 nodeIndex；mappings[i] 是它的位置
+}
+```
+
+要让运行时指向这个文件，模板里还得带上它的 `debugMetadataUrl`：对着 dev server 时这是自动的，生产环境则需要你自己注入（见 [线上错误反解 → 模型 B](./map-errors-to-source#模型-b让产物指向你的托管地址)）。否则导出的节点 `debugMetadataUrl` 为空，没法反解。
+
+## 2. 从客户端导出 UI 树
+
+三端用法一致：从 `LynxView` 异步拿到根 `LynxElement`，再对它调 `toJSONString` 把整棵树序列化出来。两个 callback 都在 UI / 主线程回调。
+
+<Tabs>
+<Tab label="iOS (Objective-C)">
+
+```objc
+#import <Lynx/LynxView.h>
+#import <Lynx/LynxElement.h>
+
+[lynxView getLynxElementRoot:^(LynxElement *_Nullable root) {
+  if (root == nil) return;
+  [root toJSONString:^(NSString *_Nullable json) {
+    if (json == nil) return;
+    NSLog(@"LynxElement tree json: %@", json);
+  }];
+}];
+```
+
+</Tab>
+<Tab label="Android (Java)">
+
+```java
+import com.lynx.tasm.LynxElement;
+import com.lynx.tasm.LynxView;
+
+lynxView.getLynxElementRoot(root -> {
+  if (root == null) return;
+  root.toJSONString(json -> {
+    if (json == null) return;
+    Log.i("LynxElement", json);
+  });
+});
+```
+
+</Tab>
+<Tab label="Harmony (ArkTS)">
+
+```ts
+import { LynxView, LynxElement } from '@lynx/lynx';
+
+lynxView.getLynxElementRoot((root: LynxElement | null) => {
+  if (!root) return;
+  root.toJSONString((json: string | null) => {
+    if (!json) return;
+    console.info(`LynxElement tree json: ${json}`);
+  });
+});
+```
+
+</Tab>
+</Tabs>
+
+序列化出来的每个节点长这样，反解需要的 `nodeIndex` 和 `debugMetadataUrl` 这两个字段嵌在 `debugInfo` 里：
+
+```jsonc
+{
+  "tag": "view",
+  "nodeId": 11,
+  "position": { "x": 0, "y": 0, "width": 300, "height": 80 },
+  "events": [],
+  "debugInfo": {
+    "nodeIndex": 100,
+    "debugMetadataUrl": "https://your-cdn.example.com/dm/<key>/debug-metadata.json",
+  },
+  "children": [
+    { "tag": "text", "debugInfo": { "nodeIndex": 200 }, "children": [] },
+  ],
+}
+```
+
+`nodeIndex` 是第 1 步里给的编译期标识；`debugMetadataUrl` 是写进模板的那个 URL。没有 `debugInfo.nodeIndex` 的节点（比如纯文本）不会被反解。
+
+## 3. 反解这棵树
+
+[`@lynx-js/debug-metadata`](https://www.npmjs.com/package/@lynx-js/debug-metadata) 的 `remapUiTree` 读取的是每个节点顶层的 `nodeIndex` 和 `debugMetadataUrl`，而引擎把它们嵌在 `debugInfo` 里，所以先把它们提上来再反解。loader 由你提供，负责把一个 `debugMetadataUrl` 变成它的 `DebugMetadataAsset`，拉取、缓存、鉴权都在你手里：
+
+```ts
+import { remapUiTree } from '@lynx-js/debug-metadata';
+
+// 把引擎嵌套的 `debugInfo` 字段提到顶层
+function flatten(node) {
+  const { debugInfo, children, ...rest } = node;
+  return {
+    ...rest,
+    nodeIndex: debugInfo?.nodeIndex,
+    debugMetadataUrl: debugInfo?.debugMetadataUrl,
+    children: children?.map(flatten),
+  };
+}
+
+const tree = JSON.parse(jsonFromClient);
+const remapped = await remapUiTree(flatten(tree), async (debugMetadataUrl) => {
+  const res = await fetch(debugMetadataUrl);
+  return res.json(); // 一个 DebugMetadataAsset
+});
+```
+
+凡是 `nodeIndex` 能被其 `debugMetadataUrl` 的 `uiSourceMap` 命中的节点，都会获得 `repo` / `source` / `line` / `column`；解析不出的节点和其它字段原样保留。`remapUiTree` 对每个不同的 `debugMetadataUrl` 只调用一次 loader。
+
+`npx @lynx-js/debug-metadata remap --ui <tree.json>` CLI 做的是同样的事，适用于节点已经在顶层带有 `nodeIndex` / `debugMetadataUrl` 的树。更底层的 `buildUiSourceMapLookup`（`nodeIndex → 位置`）和 `normalizeRepo`（git remote → `owner/repo`）辅助函数也都有导出。

--- a/docs/zh/rspeedy/ui-source-map.mdx
+++ b/docs/zh/rspeedy/ui-source-map.mdx
@@ -7,7 +7,7 @@ import { Mermaid } from '@lynx';
 
 它分三步：
 
-1. 构建：打开 [`enableUiSourceMap`](#1-开启开关)，让构建把 UI source map 写进 [`debug-metadata.json`](./map-errors-to-source)，并给元素打上 `nodeIndex`。
+1. 构建：打开 [`enableUiSourceMap`](#1-开启开关)，把 UI source map 写进 [`debug-metadata.json`](./map-errors-to-source)，并给元素打上 `nodeIndex`。
 2. 导出：让 Lynx 客户端把[运行时 UI 树序列化](#2-从客户端导出-ui-树)成 JSON。
 3. 反解：把这份 JSON 加上 `debug-metadata.json` 喂给 [`remapUiTree`](#3-反解这棵树)，它会给每个节点标注源码位置。
 
@@ -46,11 +46,11 @@ interface UiSourceMapData {
 }
 ```
 
-要让运行时指向这个文件，模板里还得带上它的 `debugMetadataUrl`：对着 dev server 时这是自动的，生产环境则需要你自己注入（见 [线上错误反解 → 模型 B](./map-errors-to-source#模型-b让产物指向你的托管地址)）。否则导出的节点 `debugMetadataUrl` 为空，没法反解。
+要让运行时指向这个文件，模板里还得带上它的 `debugMetadataUrl`：连到 dev server 时会自动写入，生产环境则要你自己注入（见 [线上错误反解 → 方案 2](./map-errors-to-source#方案-2让产物指向你的托管地址)）。否则导出的节点 `debugMetadataUrl` 为空，没法反解。
 
 ## 2. 从客户端导出 UI 树
 
-三端用法一致：从 `LynxView` 异步拿到根 `LynxElement`，再对它调 `toJSONString` 把整棵树序列化出来。两个 callback 都在 UI / 主线程回调。
+三端用法一致：从 `LynxView` 异步拿到根 `LynxElement`，再对它调 `toJSONString` 把整棵树序列化出来。两个 callback 都会回调到 UI 线程（主线程）。
 
 <Tabs>
 <Tab label="iOS (Objective-C)">
@@ -147,6 +147,6 @@ const remapped = await remapUiTree(flatten(tree), async (debugMetadataUrl) => {
 });
 ```
 
-凡是 `nodeIndex` 能被其 `debugMetadataUrl` 的 `uiSourceMap` 命中的节点，都会获得 `repo` / `source` / `line` / `column`；解析不出的节点和其它字段原样保留。`remapUiTree` 对每个不同的 `debugMetadataUrl` 只调用一次 loader。
+凡是 `nodeIndex` 能在对应 `debugMetadataUrl` 的 `uiSourceMap` 里命中的节点，都会拿到 `repo` / `source` / `line` / `column`；命中不了的节点，连同节点上原有的其它字段，都原样保留。`remapUiTree` 对每个不同的 `debugMetadataUrl` 只调用一次 loader。
 
 `npx @lynx-js/debug-metadata remap --ui <tree.json>` CLI 做的是同样的事，适用于节点已经在顶层带有 `nodeIndex` / `debugMetadataUrl` 的树。更底层的 `buildUiSourceMapLookup`（`nodeIndex → 位置`）和 `normalizeRepo`（git remote → `owner/repo`）辅助函数也都有导出。

--- a/docs/zh/rspeedy/ui-source-map.mdx
+++ b/docs/zh/rspeedy/ui-source-map.mdx
@@ -124,7 +124,7 @@ lynxView.getLynxElementRoot((root: LynxElement | null) => {
 
 ## 3. 反解这棵树
 
-[`@lynx-js/debug-metadata`](https://www.npmjs.com/package/@lynx-js/debug-metadata) 的 `remapUiTree` 读取的是每个节点顶层的 `nodeIndex` 和 `debugMetadataUrl`，而引擎把它们嵌在 `debugInfo` 里，所以先把它们提上来再反解。loader 由你提供，负责把一个 `debugMetadataUrl` 变成它的 `DebugMetadataAsset`，拉取、缓存、鉴权都在你手里：
+[`@lynx-js/debug-metadata`](https://www.npmjs.com/package/@lynx-js/debug-metadata) 的 `remapUiTree` 读取的是每个节点顶层的 `nodeIndex` 和 `debugMetadataUrl`，而引擎把它们嵌在 `debugInfo` 里，所以先把它们提上来再反解。它的第二个参数是一个由你提供的 loader，负责把一个 `debugMetadataUrl` 取成对应的 `DebugMetadataAsset`：
 
 ```ts
 import { remapUiTree } from '@lynx-js/debug-metadata';


### PR DESCRIPTION
## What

Adds two guides under the rspeedy "Debug" section (EN + ZH), both built around `debug-metadata.json`, the build output from [`@lynx-js/debug-metadata-rsbuild-plugin`](https://www.npmjs.com/package/@lynx-js/debug-metadata-rsbuild-plugin) (auto-registered by rspeedy).

### 1. Map production errors to source (`map-errors-to-source.mdx`)

Takes a real production stack (a `release`-tagged frame from a monitoring payload) and walks it back to the original `.tsx`:

- What `debug-metadata.json` contains and that production builds delete it from `dist` by default (kept on disk only in dev or with `DEBUG=rspeedy`).
- The file shape, plus a plain explanation of `bytecode-debug-info`: the main thread runs PrimJS bytecode, so a main-thread frame is `function_id:pc`, not `line:col`.
- The decode chain: background frames are one `source-map` step; main-thread frames are two steps (`bytecode-debug-info` → encoded `main-thread.js` line:col → `source-map`).
- How `release` (`debugmetadata:<key>`) maps to a chunk's `source-map` key, so a backend can index uploads and look them up on error.
- Two production setups: Model A (upload + index by release) and Model B (inject `debugMetadataUrl` / `templateDebugUrl` and rewrite `sourceMappingURL` via `LynxTemplatePlugin.beforeEncode`).
- A worked example using `examples/react`: throws once on each thread, with devtool screenshots and the real decode for both.

### 2. Map the UI tree to source (`ui-source-map.mdx`)

How the `enableUISourceMap` switch works, the client API for exporting the element tree (`getLynxElementRoot` + `toJSONString` across iOS / Android / Harmony), the serialized JSON shape, and how to flatten it and run `remapUiTree`.

Also: adds the new pages to `_meta.json`, points the rspeedy hero "Get Started" link at `/rspeedy/cli`, and whitelists a few words in cspell.

## Verification

- Both production setups were checked against a production build of the OSS `examples/react` (Model A captures the file before the default plugin cleans it; Model B's injected URLs and rewritten `sourceMappingURL` show up in `tasm.json` and the JS trailers).
- The worked-example frames were decoded with `@lynx-js/debug-metadata` + `@jridgewell/trace-mapping` against the real `debug-metadata.json`. The background frame lands one line above the `throw` (source-map imprecision); this matches the production red-screen decode.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Add rspeedy guides for mapping production errors and UI trees back to source in English and Chinese
- Update rspeedy navigation metadata to include the new guides
- Point the rspeedy home hero “Get Started” link to the CLI docs in English and Chinese
- Extend the cspell whitelist with new project terms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->