### PR TITLE
refactor(platform): move mapPlatformNameToIconName to shared lib

### DIFF
--- a/src/components/api-badge/PlatformBadge.tsx
+++ b/src/components/api-badge/PlatformBadge.tsx
@@ -2,8 +2,7 @@ import type LCD from '@lynx-js/lynx-compat-data';
 import { getFullPlatformName } from '@lynx-js/lynx-compat-data';
 import { Badge } from '@rspress/core/theme';
 
-// TODO(xuan.huang): move this to a common place.
-import { mapPlatformNameToIconName as mapPlatformNameToIconNameInHeaders } from '../api-table/compat-table/headers';
+import { mapPlatformNameToIconName as mapCompatPlatformNameToIconName } from '../../lib/platform';
 import { PlatformSvg } from '../platform-navigation/PlatformIcon';
 
 import './PlatformBadge.css';
@@ -23,7 +22,7 @@ function mapPlatformNameToIconName(platform: ExtendedPlatformName) {
   if (platform === 'windows') {
     return 'windows';
   }
-  return mapPlatformNameToIconNameInHeaders(platform);
+  return mapCompatPlatformNameToIconName(platform);
 }
 
 // Extend LCD-defined platform names with labels that are useful in prose but

--- a/src/components/api-table/compat-table/headers.tsx
+++ b/src/components/api-table/compat-table/headers.tsx
@@ -12,6 +12,7 @@
  *   Licensed under the Mozilla Public License, v. 2.0
  */
 import type BCD from '@lynx-js/lynx-compat-data';
+import { mapPlatformNameToIconName } from '../../../lib/platform';
 import { BrowserName } from './browser-info';
 
 function mapPlatformKindToIconName(platformType: BCD.PlatformType) {
@@ -24,27 +25,6 @@ function mapPlatformKindToIconName(platformType: BCD.PlatformType) {
       return 'web';
     default:
       return platformType;
-  }
-}
-
-export function mapPlatformNameToIconName(platformName: BCD.PlatformName) {
-  switch (platformName) {
-    case 'ios':
-    case 'clay_ios':
-      return 'apple';
-    case 'clay_macos':
-      return 'macos-text';
-    case 'android':
-    case 'clay_android':
-      return 'android';
-    case 'clay_windows':
-      return 'windows';
-    case 'web_lynx':
-      return 'web';
-    case 'harmony':
-      return 'harmony';
-    default:
-      return platformName;
   }
 }
 

--- a/src/components/platform-navigation/PlatformIcon.tsx
+++ b/src/components/platform-navigation/PlatformIcon.tsx
@@ -1,7 +1,7 @@
 import type { PlatformName } from '@lynx-js/lynx-compat-data';
 import { withBase } from '@rspress/core/runtime';
 import { cn } from '../../lib/utils';
-import { mapPlatformNameToIconName } from '../api-table/compat-table/headers';
+import { mapPlatformNameToIconName } from '../../lib/platform';
 import { PlatformIconProps } from './types';
 import './icon.scss';
 

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -1,0 +1,41 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This file incorporates work covered by the following copyright and
+ * permission notice:
+ *
+ *   Original source from MDN Yari:
+ *   https://github.com/mdn/yari/tree/main/client/src/document/ingredients/browser-compatibility-table
+ *   Copyright Mozilla Contributors
+ *   Licensed under the Mozilla Public License, v. 2.0
+ */
+import type BCD from '@lynx-js/lynx-compat-data';
+
+/**
+ * Maps a BCD platform name to the icon name used by the shared icon set
+ * (see `PlatformSvg`'s `ICON_NAME_TO_URL`). Shared across the compat-table
+ * headers, platform badges, and platform-navigation icons so every surface
+ * derives the same icon for a given platform.
+ */
+export function mapPlatformNameToIconName(platformName: BCD.PlatformName) {
+  switch (platformName) {
+    case 'ios':
+    case 'clay_ios':
+      return 'apple';
+    case 'clay_macos':
+      return 'macos-text';
+    case 'android':
+    case 'clay_android':
+      return 'android';
+    case 'clay_windows':
+      return 'windows';
+    case 'web_lynx':
+      return 'web';
+    case 'harmony':
+      return 'harmony';
+    default:
+      return platformName;
+  }
+}


### PR DESCRIPTION
Resolve the TODO in PlatformBadge by extracting the platform-name to
icon-name mapping out of compat-table/headers.tsx into src/lib/platform.ts.
The mapping was consumed across three unrelated components
(headers, PlatformBadge, PlatformIcon) via cross-component imports; a
shared module is a more natural home and removes the awkward
"InHeaders" alias.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019662ZCtTzhEtwnd59NJCYv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Consolidate platform icon mapping

- Move `mapPlatformNameToIconName` to `src/lib/platform.ts`
- Import the shared helper in headers, `PlatformBadge`, and `PlatformIcon`
- Remove the duplicate helper and obsolete TODO comment
<!-- end of auto-generated comment: release notes by coderabbit.ai -->