### PR TITLE
docs: point all release_blog URLs to the canonical /blog root

### DIFF
--- a/docs/public/version.json
+++ b/docs/public/version.json
@@ -15,7 +15,7 @@
       "repo_branch": "release/3.8",
       "docs_link": "/",
       "release_number": "3.8.1",
-      "release_blog": "/3.8/blog/lynx-3-8.html"
+      "release_blog": "/blog/lynx-3-8.html"
     },
     {
       "type": "previous",
@@ -23,7 +23,7 @@
       "repo_branch": "release/3.7",
       "docs_link": "/3.7",
       "release_number": "3.7.0",
-      "release_blog": "/3.7/blog/lynx-3-7.html"
+      "release_blog": "/blog/lynx-3-7.html"
     },
     {
       "type": "previous",
@@ -31,7 +31,7 @@
       "repo_branch": "release/3.6",
       "docs_link": "/3.6",
       "release_number": "3.6.0",
-      "release_blog": "/3.6/blog/lynx-3-6.html"
+      "release_blog": "/blog/lynx-3-6.html"
     },
     {
       "type": "previous",
@@ -39,7 +39,7 @@
       "repo_branch": "release/3.5",
       "docs_link": "/3.5",
       "release_number": "3.5.2",
-      "release_blog": "/3.5/blog/lynx-3-5.html"
+      "release_blog": "/blog/lynx-3-5.html"
     },
     {
       "type": "previous",
@@ -47,7 +47,7 @@
       "repo_branch": "release/3.4",
       "docs_link": "/3.4",
       "release_number": "3.4.2",
-      "release_blog": "/3.4/blog/lynx-3-4.html"
+      "release_blog": "/blog/lynx-3-4.html"
     },
     {
       "type": "previous",
@@ -58,7 +58,7 @@
       "type": "previous",
       "version_number": "3.2",
       "release_number": "3.2.0",
-      "release_blog": "/3.2/blog/lynx-3-2.html"
+      "release_blog": "/blog/lynx-3-2.html"
     }
   ]
 }

--- a/src/components/VersionTable.tsx
+++ b/src/components/VersionTable.tsx
@@ -99,7 +99,12 @@ export function VersionTable({ type }: VersionTableProps) {
               </td>
               <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">
                 {item.release_blog ? (
-                  <Link href={'https://lynxjs.org/' + item.release_blog}>
+                  <Link
+                    href={new URL(
+                      item.release_blog,
+                      'https://lynxjs.org',
+                    ).toString()}
+                  >
                     blog
                   </Link>
                 ) : (


### PR DESCRIPTION
## Summary

The version table currently links each release's blog post via `/3.X/blog/lynx-3-X.html`, which resolves against that version's deploy. Whether the page exists there depends entirely on when the corresponding `release/3.X` branch was last built:

| URL | Status |
|---|---|
| `https://lynxjs.org/3.8/blog/lynx-3-8.html` | 302 → `/blog/...` |
| `https://lynxjs.org/3.7/blog/lynx-3-7.html` | 200 (served by 3.7 deploy) |
| `https://lynxjs.org/3.6/blog/lynx-3-6.html` | 200 (served by 3.6 deploy) |
| `https://lynxjs.org/3.5/blog/lynx-3-5.html` | **404** |
| `https://lynxjs.org/3.4/blog/lynx-3-4.html` | 200 (served by 3.4 deploy) |
| `https://lynxjs.org/3.2/blog/lynx-3-2.html` | **404** |

The four 200s are coincidental — any future redeploy of those release branches could drop the blog page and break the link the same way 3.5 and 3.2 are broken today.

Blog posts live on `main` and are built into the root `/blog/...` namespace for every release. Pointing `release_blog` at the root form makes the link stable regardless of versioned-deploy state.

| URL | Status |
|---|---|
| `https://lynxjs.org/blog/lynx-3-8.html` | 200 |
| `https://lynxjs.org/blog/lynx-3-7.html` | 200 |
| `https://lynxjs.org/blog/lynx-3-6.html` | 200 |
| `https://lynxjs.org/blog/lynx-3-5.html` | 200 |
| `https://lynxjs.org/blog/lynx-3-4.html` | 200 |
| `https://lynxjs.org/blog/lynx-3-2.html` | 200 |

## Changes

- `docs/public/version.json`: rewrite the six `release_blog` values from `/3.X/blog/...` to `/blog/...`.
- `src/components/VersionTable.tsx`: build the href with `new URL(item.release_blog, 'https://lynxjs.org')` instead of string concatenation. The previous form (`'https://lynxjs.org/' + value`) coupled the slash placement between two files; with `URL()`, both `"blog/..."` and `"/blog/..."` resolve correctly.

## Notes

- Carved out of #1139 so the broader link-fix PR there stays focused; that PR has been reverted to drop these two files.
- A separate redirect-rule backport to `release/3.X` branches was considered and skipped — the URLs canonical-ized here remove the dependency on those rules.

## Test plan

- [ ] Visit `/versions` (or wherever `<VersionTable>` is mounted) on the Netlify preview and click the "blog" link for each version listed; confirm all 6 resolve.
- [ ] Confirm no other callsite references `release_blog` with the old prefix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Point release blog links at canonical `/blog` paths in `docs/public/version.json`
- Resolve `VersionTable` release blog URLs with `new URL()` against `https://lynxjs.org`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->