### PR TITLE
docs: Change header level for Examples section

### DIFF
--- a/docs/en/api/css/properties/background-position.mdx
+++ b/docs/en/api/css/properties/background-position.mdx
@@ -9,7 +9,7 @@ import { APISummary, APITable, Go } from '@lynx';
 
 The `background-position` CSS property sets the initial position for each background image. The position is relative to the position layer set by [`background-origin`](./background-origin.mdx).
 
-# Examples
+## Examples
 
 <APISummary />
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Refine the `Examples` section heading level in `docs/en/api/css/properties/background-position.mdx`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->