### PR TITLE
chore(deps): bump @lynx-example/video example to 0.2.0

### DIFF
--- a/packages/lynx-example-packages/package.json
+++ b/packages/lynx-example-packages/package.json
@@ -54,7 +54,7 @@
     "@lynx-example/text": "0.6.6",
     "@lynx-example/textarea": "0.6.7",
     "@lynx-example/title-bar-view": "^0.6.11",
-    "@lynx-example/video": "0.1.0",
+    "@lynx-example/video": "0.2.0",
     "@lynx-example/view": "0.6.5",
     "@lynx-example/viewpager": "0.6.12",
     "@lynx-example/webassembly": "0.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -413,8 +413,8 @@ importers:
         specifier: ^0.6.11
         version: 0.6.11(@lynx-js/types@3.9.0)(@types/react@18.3.18)
       '@lynx-example/video':
-        specifier: 0.1.0
-        version: 0.1.0(@lynx-js/types@3.9.0)(@types/react@18.3.18)
+        specifier: 0.2.0
+        version: 0.2.0(@lynx-js/types@3.9.0)(@types/react@18.3.18)
       '@lynx-example/view':
         specifier: 0.6.5
         version: 0.6.5(@lynx-js/types@3.9.0)(@types/react@18.3.18)
@@ -1587,8 +1587,8 @@ packages:
   '@lynx-example/title-bar-view@0.6.11':
     resolution: {integrity: sha512-r6BqhLij0b1lOvcZP3bdo1K4FyyCB+i7KVneatQyRcrrHJ0Rf73cNQfdtoYXEJnOmz4maMp8VILtU+w4f8aINQ==}
 
-  '@lynx-example/video@0.1.0':
-    resolution: {integrity: sha512-v32CfpMn4gCY44Mlz7Xolsi1cCXXwODByUnaixCX1J/SX4h0EpnYm/hKcdgLPXS05QbvFtoZ5tdIPrDWR02DlA==}
+  '@lynx-example/video@0.2.0':
+    resolution: {integrity: sha512-T5R7pe8pywf4UNVp+oKjNFdnfFQ+ZvBmNG6TQel2nVItfGC/THtAQfE1z4W0yaB8Gu7vpGRKjzc2uPlcLeLMhw==}
     engines: {node: '>=18'}
 
   '@lynx-example/view@0.6.5':
@@ -7824,7 +7824,7 @@ snapshots:
       - '@lynx-js/types'
       - '@types/react'
 
-  '@lynx-example/video@0.1.0(@lynx-js/types@3.9.0)(@types/react@18.3.18)':
+  '@lynx-example/video@0.2.0(@lynx-js/types@3.9.0)(@types/react@18.3.18)':
     dependencies:
       '@lynx-js/react': 0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18)
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

Bump the `@lynx-example/video` example package pin in `packages/lynx-example-packages` from `0.1.0` to `0.2.0`.

`0.2.0` is the current `latest` published version on npm; the lockfile is regenerated to match (same transitive deps).

## Why

The video example was added in #1135 pinned at `0.1.0`. `0.2.0` is now the latest published release, so align the pin to it.

## Test plan

- `pnpm install` resolves `@lynx-example/video@0.2.0` cleanly (lockfile updated, integrity hash refreshed).