### PR TITLE
fix(docs): repair dead links

### DIFF
--- a/docs/en/api/css/properties/mask.mdx
+++ b/docs/en/api/css/properties/mask.mdx
@@ -48,23 +48,23 @@ Sets the mask image source. See [mask-image](./mask-image).
 
 #### `<position>`
 
-Sets the position of the mask image. See [mask-position]().
+Sets the position of the mask image. See [mask-position](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-position).
 
 #### `<bg-size>`
 
-Sets the size of the mask image. See [mask-size]().
+Sets the size of the mask image. See [mask-size](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-size).
 
 #### `<repeat-style>`
 
-Sets the repetition of the mask image. See [mask-repeat]().
+Sets the repetition of the mask image. See [mask-repeat](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-repeat).
 
 #### `<geometry-box>`
 
-If only one `<geometry-box` value is given, it sets both [mask-origin]() and [mask-clip](). If two `<geometry-box>` values are present, then the first sets mask-origin and the second sets [mask-clip]().
+If only one `<geometry-box` value is given, it sets both [mask-origin](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-origin) and [mask-clip](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-clip). If two `<geometry-box>` values are present, then the first sets mask-origin and the second sets [mask-clip](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-clip).
 
 #### `<geometry-box> | no-clip`
 
-Sets the area that is affected by the mask image. See [mask-clip]().
+Sets the area that is affected by the mask image. See [mask-clip](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-clip).
 
 ## Formal definition
 
@@ -166,7 +166,7 @@ mask =
 ## Difference with the Web
 
 1. `mask-type` not supported in Lynx.
-2. `mask-image` not support [SVG]() reference.
+2. `mask-image` does not support SVG references.
 3. only support border-box, padding-box and content-box.
 
 ## Compatibility

--- a/docs/en/guide/styling/appearance.mdx
+++ b/docs/en/guide/styling/appearance.mdx
@@ -4,8 +4,8 @@ import { Go } from '@lynx';
 
 ## Background and Borders
 
-You can do a lot creative things with background and borders. Using [`background-image`](api/css/properties/background-image) to
-apply network image or gradient effects to the background area of an element, using [`border-radius`](api/css/properties/border-radius) to add a rounded corner, using [`box-shadow`](api/css/properties/box-shadow) to create a shadow effect.
+You can do a lot creative things with background and borders. Using [`background-image`](/api/css/properties/background-image) to
+apply network image or gradient effects to the background area of an element, using [`border-radius`](/api/css/properties/border-radius) to add a rounded corner, using [`box-shadow`](/api/css/properties/box-shadow) to create a shadow effect.
 
 In the following example, we add a background with gradient effect, two styles of borders at top and left sides, a black shadow to an element with the top right corner rounded.
 
@@ -32,19 +32,19 @@ With Lynx CSS, you can apply color values to various properties to create the lo
 
 #### Text
 
-- [`color`](api/css/properties/color): The color to use when drawing the text.
-- [`-x-handle-color`](): The color of selection handlers (the cursur on the two ends of the selected text) when text is selected.
-- [`text-shadow`](api/css/properties/text-shadow): The color of the shadow in the shape of text.
-- [`text-decoration-color`](api/css/properties/text-decoration#text-decoration-color): The color to use when drawing the decoration line on the text.
+- [`color`](/api/css/properties/color): The color to use when drawing the text.
+- [`-x-handle-color`](/api/css/properties/-x-handle-color): The color of selection handlers (the cursor on the two ends of the selected text) when text is selected.
+- [`text-shadow`](/api/css/properties/text-shadow): The color of the shadow in the shape of text.
+- [`text-decoration-color`](/api/css/properties/text-decoration#text-decoration-color): The color to use when drawing the decoration line on the text.
 
 #### Background and Border
 
-- [`background-color`](api/css/properties/background-color): The background color of the element.
-- [`box-shadow`](api/css/properties/box-shadow): The color of shadow.
-- [`border-color`](api/css/properties/border-color): The color to use when drawing the border. Can be set separately for the foursides via [`border-top-color`](api/css/properties/border-color), [`border-top-color`](api/css/properties/border-color), [`border-top-color`](api/css/properties/border-color) or [`border-top-color`](api/css/properties/border-color) as well.
+- [`background-color`](/api/css/properties/background-color): The background color of the element.
+- [`box-shadow`](/api/css/properties/box-shadow): The color of shadow.
+- [`border-color`](/api/css/properties/border-color): The color to use when drawing the border. Can be set separately for the foursides via [`border-top-color`](/api/css/properties/border-color), [`border-top-color`](/api/css/properties/border-color), [`border-top-color`](/api/css/properties/border-color) or [`border-top-color`](/api/css/properties/border-color) as well.
 
-Colors can be set to the property via [`selectors`](api/css/selectors) or the `style` property of the element directly.
-The color value should be a hex number start with a '#', or a value calculated by function `rgb()`, `rgba()` or `hsl()`. View the specification for [`<color>`](api/css/data-type/color) value for more details.
+Colors can be set to the property via [`selectors`](/api/css/selectors) or the `style` property of the element directly.
+The color value should be a hex number start with a '#', or a value calculated by function `rgb()`, `rgba()` or `hsl()`. View the specification for [`<color>`](/api/css/data-type/color) value for more details.
 
 ## Gradient
 

--- a/docs/zh/api/css/properties/mask.mdx
+++ b/docs/zh/api/css/properties/mask.mdx
@@ -55,23 +55,23 @@ mask:
 
 #### `<position>`
 
-设置遮罩图片的位置。详见 [mask-position]().
+设置遮罩图片的位置。详见 [mask-position](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-position).
 
 #### `<bg-size>`
 
-设置遮罩的大小。详见 [mask-size]().
+设置遮罩的大小。详见 [mask-size](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-size).
 
 #### `<repeat-style>`
 
-设置遮罩图片的重复性。详见 [mask-repeat]().
+设置遮罩图片的重复性。详见 [mask-repeat](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-repeat).
 
 #### `<geometry-box>`
 
-如果只有一个 `<geometry-box>` 值被赋予，他将会设置 [mask-origin]() and [mask-clip](). 如果两个 `<geometry-box>` 值显示，第一个值代表 [mask-origin](), 第二个值代表 [mask-clip]().
+如果只有一个 `<geometry-box>` 值被赋予，它将会设置 [mask-origin](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-origin) 和 [mask-clip](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-clip)。如果两个 `<geometry-box>` 值显示，第一个值代表 [mask-origin](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-origin)，第二个值代表 [mask-clip](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-clip)。
 
 #### `<geometry-box> | no-clip`
 
-设置区域，会被遮罩图片影响。详见 [mask-clip]().
+设置区域，会被遮罩图片影响。详见 [mask-clip](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-clip).
 
 ## 形式定义
 

--- a/docs/zh/guide/styling/appearance.mdx
+++ b/docs/zh/guide/styling/appearance.mdx
@@ -4,8 +4,8 @@ import { Go } from '@lynx';
 
 ## 边框与背景
 
-我们为你提供了多种样式属性用于给元件添加背景图片，圆角，边框和阴影。例如你可以通过 [`background-image`](api/css/properties/background-image) 属性为元件添加
-来自网络的图片或是渐变；通过 [`border-radius`](api/css/properties/border-radius) 属性为元件添加圆角; 通过 [`box-shadow`](api/css/properties/box-shadow) 来为元件添加阴影。
+我们为你提供了多种样式属性用于给元件添加背景图片，圆角，边框和阴影。例如你可以通过 [`background-image`](/api/css/properties/background-image) 属性为元件添加
+来自网络的图片或是渐变；通过 [`border-radius`](/api/css/properties/border-radius) 属性为元件添加圆角; 通过 [`box-shadow`](/api/css/properties/box-shadow) 来为元件添加阴影。
 
 下面的例子中，我们为元件添加了圆角、阴影、渐变色的背景和多种样式的边框：
 
@@ -32,19 +32,19 @@ import { Go } from '@lynx';
 
 #### 文本
 
-- [`color`](api/css/properties/color)：修改用于绘制文本的颜色。
-- [`-x-handle-color`]()：用于调整选中文本时，选中区域两段浮标的颜色。
-- [`text-shadow`](api/css/properties/text-shadow)：设置文本的阴影特效的颜色。
-- [`text-decoration-color`](api/css/properties/text-decoration#text-decoration-color)：文本装饰线的颜色。
+- [`color`](/api/css/properties/color)：修改用于绘制文本的颜色。
+- [`-x-handle-color`](/api/css/properties/-x-handle-color)：用于调整选中文本时，选中区域两段浮标的颜色。
+- [`text-shadow`](/api/css/properties/text-shadow)：设置文本的阴影特效的颜色。
+- [`text-decoration-color`](/api/css/properties/text-decoration#text-decoration-color)：文本装饰线的颜色。
 
 #### 边框与背景
 
-- [`background-color`](api/css/properties/background-color)：元件的背景填充色。
-- [`box-shadow`](api/css/properties/box-shadow)：配置阴影区域的颜色。
-- [`border-color`](api/css/properties/border-color)：设置用于绘制边框的颜色。也可以通过 [`border-top-color`](api/css/properties/border-color)，[`border-top-color`](api/css/properties/border-color)，[`border-top-color`](api/css/properties/border-color) 和 [`border-top-color`](api/css/properties/border-color) 分别设置各个方向的边框的颜色。
+- [`background-color`](/api/css/properties/background-color)：元件的背景填充色。
+- [`box-shadow`](/api/css/properties/box-shadow)：配置阴影区域的颜色。
+- [`border-color`](/api/css/properties/border-color)：设置用于绘制边框的颜色。也可以通过 [`border-top-color`](/api/css/properties/border-color)，[`border-top-color`](/api/css/properties/border-color)，[`border-top-color`](/api/css/properties/border-color) 和 [`border-top-color`](/api/css/properties/border-color) 分别设置各个方向的边框的颜色。
 
 你可以将颜色定义在 CSS 文件中设置给对应属性或是通过 `style` 属性直接设置给元件。
-颜色的值可以通过一个以“#”开头的十六进制数来分别表示对应的红、绿、蓝和透明度通道的值。这个值也可以通过 `rgb()`、`hsl()` 等相关函数定义。更多关于颜色的取值可以参考 [`<color>`](api/css/data-type/color)。
+颜色的值可以通过一个以“#”开头的十六进制数来分别表示对应的红、绿、蓝和透明度通道的值。这个值也可以通过 `rgb()`、`hsl()` 等相关函数定义。更多关于颜色的取值可以参考 [`<color>`](/api/css/data-type/color)。
 
 ## 渐变
 


### PR DESCRIPTION
Change-Id: I66e4a0182663ad9932a96ecb02b36e0215a7de62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected several broken or placeholder reference links in CSS documentation.
  * Improved the `mask` property pages in English and Chinese with proper links and clearer wording.
  * Fixed styling guide links for background, border, and color-related properties so they point to the correct API pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->