### PR TITLE
docs: add bundle size performance guide

### DIFF
--- a/docs/en/guide/performance/analysis-performance.mdx
+++ b/docs/en/guide/performance/analysis-performance.mdx
@@ -23,3 +23,7 @@ The [Memory analysis](/guide/performance/analysis-performance/analysis-memory) p
 ## Fluency
 
 The [Fluency analysis](/guide/performance/analysis-performance/analysis-fluency) page explains how to analyze dropped frames and jank, enabling developers to quickly locate and optimize page interaction performance.
+
+## Bundle Size
+
+The [Bundle size](/guide/performance/analysis-performance/analysis-bundle-size) page explains why output size matters for startup, how to analyze it with Rsdoctor and the `rspeedy-bundle-size` skill, and the common levers for reducing it.

--- a/docs/en/guide/performance/analysis-performance/_meta.json
+++ b/docs/en/guide/performance/analysis-performance/_meta.json
@@ -18,5 +18,10 @@
     "type": "file",
     "name": "analysis-native-module",
     "label": "NativeModule"
+  },
+  {
+    "type": "file",
+    "name": "analysis-bundle-size",
+    "label": "Bundle Size"
   }
 ]

--- a/docs/en/guide/performance/analysis-performance/analysis-bundle-size.mdx
+++ b/docs/en/guide/performance/analysis-performance/analysis-bundle-size.mdx
@@ -1,0 +1,104 @@
+---
+description: 'Understand the Lynx bundle structure under the dual-thread architecture, analyze size with Rsdoctor and a layered view, and apply levers like main-thread slimming, dependency deduplication, and asset compression.'
+---
+
+# Bundle Size
+
+Bundle size directly shapes download, parse, and first-screen time, yet it is the easiest metric to overlook: a dependency upgrade, an uncompressed image, or a piece of code that should run only in the background but got bundled into the first-screen render path can all quietly inflate your output.
+
+Unlike a regular web app, a Lynx app has a distinctive output structure because of its **dual-thread architecture** — and understanding that structure is the prerequisite for analyzing and optimizing size. Rspeedy is built on top of [Rsbuild](https://rsbuild.rs/) and [Rspack](https://rspack.rs/), so most of their size-optimization techniques apply. This page first explains the Lynx-specific output structure, then gives you the analysis workflow and optimization directions, with links out to the deeper docs.
+
+## Understand the Lynx output structure
+
+### Dual-thread architecture: two JS layers
+
+ReactLynx splits React across **two threads** (see [Thinking in ReactLynx](/react/thinking-in-reactlynx)):
+
+- **Main thread**: a lightweight UI driver responsible for [Instant First-Frame Rendering (IFR)](/guide/interaction/ifr), UI updates, and touch-following animation and gestures. It sits on the rendering critical path and must stay lean.
+- **Background thread**: the logic and state center — full render, lifecycle, `setState`, data requests, telemetry, and so on.
+
+Accordingly, the build emits **two JS compilation intermediates** per entry, then encodes them into the final binary artifact:
+
+| Layer                    | Compilation intermediate               | Notes                                                                                                            |
+| ------------------------ | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Main-thread output       | `main-thread.js` (`react:main-thread`) | First-screen render-path code; its size has the biggest impact on the first screen                               |
+| Background-thread output | `background.js` (`react:background`)   | App logic code; also produces the CSS. Does not block the first frame, but counts toward download and parse cost |
+| Static assets            | images / fonts / media                 | Often the largest single contributor to a bundle                                                                 |
+
+The two JS layers are encoded together into a single binary `.lynx.bundle` (located under `dist/` after a production build — see [Output Files](/rspeedy/output)). That binary is what the Lynx engine actually loads, and it is the final metric to watch when measuring size.
+
+:::tip Main-thread output ≠ Main Thread Script
+"Main-thread output / `main-thread.js`" here means the **compiled output of the main-thread layer**. It is _not_ the same thing as the [Main Thread Script](/react/main-thread-script) — the programming model written with the `'main thread'` directive for touch-following animation and gestures. Keep the two distinct.
+:::
+
+### Inspect the readable intermediates
+
+`.lynx.bundle` is binary and can't be read directly. To inspect the readable `main-thread.js` / `background.js`, build with `DEBUG`, which keeps the intermediates under `dist/.rspeedy/<entry>/`:
+
+```bash
+DEBUG=rspeedy rspeedy build
+```
+
+(A development build also emits these intermediates under `dist/.rspeedy/` — see [Output Files](/rspeedy/output).)
+
+### Code elimination: why the main-thread output should be small
+
+Because the main thread sits on the rendering critical path, any code only the background needs (network requests, [NativeModule](/guide/performance/analysis-performance/analysis-native-module) calls, loggers, telemetry, lifecycle, etc.) bloats both the bundle and the first-frame cost the moment it gets **bundled into the main-thread output**.
+
+ReactLynx **automatically eliminates** code that shouldn't run on the main thread: by default, the callbacks of `useEffect` / `useLayoutEffect` and some event handlers are removed from `main-thread.js` (see [Thinking in ReactLynx](/react/thinking-in-reactlynx)). When the compiler can't statically decide which thread a piece of code belongs to, you mark it explicitly:
+
+- Use the [`'background only'` directive](/api/react/Document.directives) to keep a function body only on the background thread.
+- Use the [`__BACKGROUND__` / `__MAIN_THREAD__` built-in macros](/api/react/Document.built-in-macros) to eliminate code blocks per thread.
+
+This elimination mechanism is exactly what the "slim down the main-thread output" lever below relies on.
+
+## How to analyze bundle size
+
+The guiding principle is **measure first, optimize second**: use data to confirm which layer the bytes are in before deciding what to touch — never guess and edit. We recommend breaking the size down across three layers: static assets, background-thread output, and main-thread output.
+
+### Use Rsdoctor
+
+[Rsdoctor](/rspeedy/use-rsdoctor) is a build-analysis tool that visualizes the asset list, module dependency graph, duplicate modules, and more. Enable it in a Rspeedy-based project:
+
+```bash
+RSDOCTOR=true rspeedy build
+```
+
+It opens an analysis page once the build finishes. Its module data carries a `layer` field, so you can attribute bytes to the `react:main-thread` and `react:background` layers, locate the largest modules, and trace "why was this module bundled in" through the real module graph rather than intuition. See [Use Rsdoctor](/rspeedy/use-rsdoctor) for the full workflow.
+
+### Use the rspeedy-bundle-size Skill
+
+If you work with an AI coding tool that supports Agent Skills, load the [`rspeedy-bundle-size`](/ai/skills/rspeedy-bundle-size) skill. It follows a measure-first workflow: it reads how your project builds, generates a size breakdown, attributes bytes layer by layer, and proposes optimizations in priority order — a good way to get an evidence-based report when you are not deeply familiar with the build internals.
+
+## How to reduce bundle size
+
+Once you have located where the size comes from, pick the lever that matches the layer. You can also refer to Rsbuild's [Bundle size optimization](https://rsbuild.rs/guide/optimization/optimize-bundle) guide.
+
+### Slim down the main-thread output (strip background-only code)
+
+This is the Lynx-specific layer, and the first one to check. Move code only the background needs (requests / NativeModule calls / loggers / monitoring SDKs) off the render path with [`'background only'`](/api/react/Document.directives) or [`__BACKGROUND__`](/api/react/Document.built-in-macros), keeping it out of `main-thread.js`. If such code comes from a third-party library you can't edit, it becomes a library-side ask to add the directive at the definition site.
+
+### Trim the background-thread output
+
+- **Reduce duplicate dependencies**: use Rsdoctor's duplicate-package detection to find dependencies bundled more than once, then converge them with [`resolve.dedupe`](/api/rspeedy/rspeedy.resolve.dedupe) or `pnpm dedupe`.
+- **Use lighter libraries**: use Rsdoctor to find the largest dependencies and evaluate lighter alternatives (for example `dayjs` instead of `moment`), or switch to importing only what you use.
+
+### Compress static assets
+
+Images, fonts, and media are usually the largest part of a bundle. Compress them at the source, use appropriately sized assets, and split large, non-first-screen assets out of the main bundle.
+
+### Split and lazy-load
+
+Distinguish **first-screen size** from **total size**: the first screen only needs the main-thread output and first-screen assets, so splitting out the rest noticeably improves startup.
+
+- Use [code splitting](/react/code-splitting) to defer non-first-screen components until they actually render.
+- Tune chunking with [`splitChunks`](/api/rspeedy/rspeedy.config.splitchunks) (which maps onto Rspack's [code splitting](https://rspack.rs/guide/optimization/code-splitting)).
+- Use [External Bundle](/rspeedy/external-bundle) to factor out reusable parts.
+
+### Compile-layer options
+
+- [`extractStr`](/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.extractstr): merges duplicate string literals to reduce size — especially effective for strings that are duplicated across the main-thread and background-thread layers, such as i18n text and class names.
+
+---
+
+For a more systematic checklist and lower-level control, continue from Rsbuild's [Bundle size optimization](https://rsbuild.rs/guide/optimization/optimize-bundle) and Rspack's [optimization guide](https://rspack.rs/guide/optimization/code-splitting).

--- a/docs/en/guide/performance/analysis-performance/analysis-bundle-size.mdx
+++ b/docs/en/guide/performance/analysis-performance/analysis-bundle-size.mdx
@@ -4,9 +4,9 @@ description: 'Understand the Lynx bundle structure under the dual-thread archite
 
 # Bundle Size
 
-Bundle size directly shapes download, parse, and first-screen time, yet it is the easiest metric to overlook: a dependency upgrade, an uncompressed image, or a piece of code that should run only in the background but got bundled into the first-screen render path can all quietly inflate your output.
+Bundle size directly shapes download, parse, and first-screen time, yet it is the easiest metric to overlook. A dependency upgrade, an uncompressed image, or background-only code that leaks into the first-screen render path can each inflate your output.
 
-Unlike a regular web app, a Lynx app has a distinctive output structure because of its **dual-thread architecture** — and understanding that structure is the prerequisite for analyzing and optimizing size. Rspeedy is built on top of [Rsbuild](https://rsbuild.rs/) and [Rspack](https://rspack.rs/), so most of their size-optimization techniques apply. This page first explains the Lynx-specific output structure, then gives you the analysis workflow and optimization directions, with links out to the deeper docs.
+Unlike a regular web app, a Lynx app has a distinctive output structure because of its **dual-thread architecture**, and understanding that structure is the prerequisite for analyzing and optimizing size. Rspeedy is built on top of [Rsbuild](https://rsbuild.rs/) and [Rspack](https://rspack.rs/), so most of their size-optimization techniques apply. This page explains the Lynx-specific output structure, then the analysis workflow and optimization levers, linking out to the deeper docs.
 
 ## Understand the Lynx output structure
 
@@ -15,7 +15,7 @@ Unlike a regular web app, a Lynx app has a distinctive output structure because 
 ReactLynx splits React across **two threads** (see [Thinking in ReactLynx](/react/thinking-in-reactlynx)):
 
 - **Main thread**: a lightweight UI driver responsible for [Instant First-Frame Rendering (IFR)](/guide/interaction/ifr), UI updates, and touch-following animation and gestures. It sits on the rendering critical path and must stay lean.
-- **Background thread**: the logic and state center — full render, lifecycle, `setState`, data requests, telemetry, and so on.
+- **Background thread**: the logic and state center that handles full render, lifecycle, `setState`, data requests, telemetry, and so on.
 
 Accordingly, the build emits **two JS compilation intermediates** per entry, then encodes them into the final binary artifact:
 
@@ -25,10 +25,10 @@ Accordingly, the build emits **two JS compilation intermediates** per entry, the
 | Background-thread output | `background.js` (`react:background`)   | App logic code; also produces the CSS. Does not block the first frame, but counts toward download and parse cost |
 | Static assets            | images / fonts / media                 | Often the largest single contributor to a bundle                                                                 |
 
-The two JS layers are encoded together into a single binary `.lynx.bundle` (located under `dist/` after a production build — see [Output Files](/rspeedy/output)). That binary is what the Lynx engine actually loads, and it is the final metric to watch when measuring size.
+The two JS layers are encoded together into a single binary `.lynx.bundle`, located under `dist/` after a production build (see [Output Files](/rspeedy/output)). That binary is what the Lynx engine loads, and it is the final metric to watch when measuring size.
 
 :::tip Main-thread output ≠ Main Thread Script
-"Main-thread output / `main-thread.js`" here means the **compiled output of the main-thread layer**. It is _not_ the same thing as the [Main Thread Script](/react/main-thread-script) — the programming model written with the `'main thread'` directive for touch-following animation and gestures. Keep the two distinct.
+"Main-thread output / `main-thread.js`" here means the **compiled output of the main-thread layer**. It is _not_ the [Main Thread Script](/react/main-thread-script), the programming model written with the `'main thread'` directive for touch-following animation and gestures. Keep the two distinct.
 :::
 
 ### Inspect the readable intermediates
@@ -39,11 +39,11 @@ The two JS layers are encoded together into a single binary `.lynx.bundle` (loca
 DEBUG=rspeedy rspeedy build
 ```
 
-(A development build also emits these intermediates under `dist/.rspeedy/` — see [Output Files](/rspeedy/output).)
+A development build also emits these intermediates under `dist/.rspeedy/`; see [Output Files](/rspeedy/output).
 
 ### Code elimination: why the main-thread output should be small
 
-Because the main thread sits on the rendering critical path, any code only the background needs (network requests, [NativeModule](/guide/performance/analysis-performance/analysis-native-module) calls, loggers, telemetry, lifecycle, etc.) bloats both the bundle and the first-frame cost the moment it gets **bundled into the main-thread output**.
+Because the main thread sits on the rendering critical path, any code only the background needs (network requests, [NativeModule](/guide/performance/analysis-performance/analysis-native-module) calls, loggers, telemetry, lifecycle, etc.) bloats both the bundle and the first-frame cost once it is **bundled into the main-thread output**.
 
 ReactLynx **automatically eliminates** code that shouldn't run on the main thread: by default, the callbacks of `useEffect` / `useLayoutEffect` and some event handlers are removed from `main-thread.js` (see [Thinking in ReactLynx](/react/thinking-in-reactlynx)). When the compiler can't statically decide which thread a piece of code belongs to, you mark it explicitly:
 
@@ -52,9 +52,9 @@ ReactLynx **automatically eliminates** code that shouldn't run on the main threa
 
 This elimination mechanism is exactly what the "slim down the main-thread output" lever below relies on.
 
-## How to analyze bundle size
+## Analyze bundle size
 
-The guiding principle is **measure first, optimize second**: use data to confirm which layer the bytes are in before deciding what to touch — never guess and edit. We recommend breaking the size down across three layers: static assets, background-thread output, and main-thread output.
+The guiding principle is measure first, optimize second: use data to confirm which layer the bytes are in before deciding what to touch, never guess and edit. Break the size down across three layers: static assets, background-thread output, and main-thread output.
 
 ### Use Rsdoctor
 
@@ -68,11 +68,11 @@ It opens an analysis page once the build finishes. Its module data carries a `la
 
 ### Use the rspeedy-bundle-size Skill
 
-If you work with an AI coding tool that supports Agent Skills, load the [`rspeedy-bundle-size`](/ai/skills/rspeedy-bundle-size) skill. It follows a measure-first workflow: it reads how your project builds, generates a size breakdown, attributes bytes layer by layer, and proposes optimizations in priority order — a good way to get an evidence-based report when you are not deeply familiar with the build internals.
+If you work with an AI coding tool that supports Agent Skills, load the [`rspeedy-bundle-size`](/ai/skills/rspeedy-bundle-size) skill. It follows a measure-first workflow: it reads how your project builds, generates a size breakdown, attributes bytes layer by layer, and proposes optimizations in priority order. It is a good way to get an evidence-based report when you are not deeply familiar with the build internals.
 
-## How to reduce bundle size
+## Optimize bundle size
 
-Once you have located where the size comes from, pick the lever that matches the layer. You can also refer to Rsbuild's [Bundle size optimization](https://rsbuild.rs/guide/optimization/optimize-bundle) guide.
+Once you have located where the size comes from, pick the lever that matches the layer.
 
 ### Slim down the main-thread output (strip background-only code)
 
@@ -97,8 +97,8 @@ Distinguish **first-screen size** from **total size**: the first screen only nee
 
 ### Compile-layer options
 
-- [`extractStr`](/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.extractstr): merges duplicate string literals to reduce size — especially effective for strings that are duplicated across the main-thread and background-thread layers, such as i18n text and class names.
+- [`extractStr`](/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.extractstr): merges duplicate string literals to reduce size, especially effective for strings that are duplicated across the main-thread and background-thread layers, such as i18n text and class names.
 
----
+## Next Steps
 
 For a more systematic checklist and lower-level control, continue from Rsbuild's [Bundle size optimization](https://rsbuild.rs/guide/optimization/optimize-bundle) and Rspack's [optimization guide](https://rspack.rs/guide/optimization/code-splitting).

--- a/docs/en/rspeedy/output.md
+++ b/docs/en/rspeedy/output.md
@@ -63,8 +63,8 @@ dist/
     └── js
         ├── [id].[hash].js
         │   └── async
-        │       ├── [id].[hash].js
-        ├── lib-preact.[hash].js
+        │       └── [id].[hash].js
+        └── lib-preact.[hash].js
 ```
 
 In addition, Rspeedy generates some extra files in development:

--- a/docs/en/rspeedy/output.md
+++ b/docs/en/rspeedy/output.md
@@ -71,7 +71,7 @@ In addition, Rspeedy generates some extra files in development:
 
 - Background Thread Script(BTS): The background script file that is inlined into the bundle, default output to `.rspeedy/[name]/background.js`.
 - MainThread Thread Script(MTS): The main-thread script file that is inlined into the bundle, default output to `.rspeedy/[name]/main-thread.js`.
-- Source Map files: contains the source code mappings, which is output to the same level directory of JS files and adds a `.map` suffix.
+- Debug Metadata: the metadata needed to map production errors back to source (source map, bytecode debug info, UI source map, and build info), default output to `.rspeedy/[name]/debug-metadata.json`. See [Map Production Errors to Source](./map-errors-to-source).
 
 ## Modify the Directory
 

--- a/docs/en/rspeedy/output.md
+++ b/docs/en/rspeedy/output.md
@@ -45,16 +45,14 @@ dist/
 ├── .rspeedy
 │   ├── async
 │   │   └── [name]
-│   │       ├── debug-info.json
+│   │       ├── debug-metadata.json
 │   │       ├── tasm.json
 │   │       └── [name].css
 │   ├── [name]
 │   │   ├── background.js
-│   │   ├── background.js.map
-│   │   ├── debug-info.json
+│   │   ├── debug-metadata.json
 │   │   ├── [name].css
 │   │   ├── main-thread.js
-│   │   ├── main-thread.js.map
 │   │   └── tasm.json
 │   └── rspeedy.config.js
 ├── [name].lynx.bundle
@@ -66,9 +64,7 @@ dist/
         ├── [id].[hash].js
         │   └── async
         │       ├── [id].[hash].js
-        │       └── [id].[hash].js.map
         ├── lib-preact.[hash].js
-        └── lib-preact.[hash].js.map
 ```
 
 In addition, Rspeedy generates some extra files in development:

--- a/docs/zh/guide/performance/analysis-performance.mdx
+++ b/docs/zh/guide/performance/analysis-performance.mdx
@@ -23,3 +23,7 @@ Trace 支持开发者添加[自定义 Trace 埋点](/guide/performance/analysis-
 ## 流畅度
 
 [流畅度分析](/guide/performance/analysis-performance/analysis-fluency)页面详细介绍了如何分析掉帧，卡顿等问题，助力开发者及时定位并优化页面交互体验。
+
+## 产物体积
+
+[产物体积](/guide/performance/analysis-performance/analysis-bundle-size)页面介绍了产物体积为何影响启动性能，如何使用 Rsdoctor 与 `rspeedy-bundle-size` skill 分析体积分布，以及常见的体积优化手段。

--- a/docs/zh/guide/performance/analysis-performance/_meta.json
+++ b/docs/zh/guide/performance/analysis-performance/_meta.json
@@ -18,5 +18,10 @@
     "type": "file",
     "name": "analysis-native-module",
     "label": "原生模块"
+  },
+  {
+    "type": "file",
+    "name": "analysis-bundle-size",
+    "label": "产物体积"
   }
 ]

--- a/docs/zh/guide/performance/analysis-performance/analysis-bundle-size.mdx
+++ b/docs/zh/guide/performance/analysis-performance/analysis-bundle-size.mdx
@@ -1,0 +1,104 @@
+---
+description: '理解 Lynx 双线程架构下的产物结构，学会用 Rsdoctor 与分层视角分析产物体积，并掌握主线程瘦身、依赖去重、资源压缩等优化手段。'
+---
+
+# 产物体积
+
+产物体积直接影响下载、解析与首屏到达时间，却最容易被忽视：一次依赖升级、一张未压缩的图片、一段本该只跑在后台却漏进首屏渲染路径的代码，都会让产物悄悄变大。
+
+和普通 Web 应用不同，Lynx 应用因为**双线程架构**，产物结构有其特殊性——理解这套结构，是分析和优化体积的前提。Rspeedy 基于 [Rsbuild](https://rsbuild.rs/) 与 [Rspack](https://rspack.rs/) 构建，它们的体积优化经验大多可以复用；本页先讲清 Lynx 特有的产物结构，再给出分析方法与优化方向，并指向更深入的文档。
+
+## 理解 Lynx 的产物结构
+
+### 双线程架构：两层 JS 产物
+
+ReactLynx 把 React 拆到**双线程**上运行（详见 [ReactLynx 编程思想](/react/thinking-in-reactlynx)）：
+
+- **主线程**：轻量的 UI 驱动，负责[首帧直出（IFR）](/guide/interaction/ifr)、界面更新、以及跟手动画与手势处理。它在渲染关键路径上，必须保持精简。
+- **后台线程**：逻辑与状态中心，承载完整渲染、生命周期、`setState`、数据请求、埋点等。
+
+对应地，构建会按入口产出**两份 JS 编译中间产物**，再编码合成为最终交付的二进制产物：
+
+| 层           | 编译中间产物                            | 说明                                                         |
+| ------------ | --------------------------------------- | ------------------------------------------------------------ |
+| 主线程产物   | `main-thread.js`（`react:main-thread`） | 首屏渲染路径代码，体积对首屏影响最大                         |
+| 后台线程产物 | `background.js`（`react:background`）   | 业务逻辑代码，同时产出 CSS；不阻塞首屏，但计入下载与解析成本 |
+| 静态资源     | 图片 / 字体 / 媒体                      | 往往是单个产物中体积最大的部分                               |
+
+两份 JS 经过编码合成为一个二进制的 `.lynx.bundle`（生产构建后位于 `dist/`，详见 [构建输出文件](/rspeedy/output)），这才是 Lynx 引擎真正加载的交付产物，也是衡量体积时应当盯住的最终指标。
+
+:::tip 主线程产物 ≠ 主线程脚本
+这里的「主线程产物 / `main-thread.js`」指的是**主线程层的编译产物**。它和 [主线程脚本（Main Thread Script）](/react/main-thread-script)——那套用 `'main thread'` 指示符编写、用于跟手动画与手势的编程模型——不是一回事，注意区分。
+:::
+
+### 查看可读的中间产物
+
+`.lynx.bundle` 是二进制，无法直接阅读。想查看可读的 `main-thread.js` / `background.js`，可以用 `DEBUG` 构建，它会把中间产物保留在 `dist/.rspeedy/<entry>/` 下：
+
+```bash
+DEBUG=rspeedy rspeedy build
+```
+
+（开发构建同样会在 `dist/.rspeedy/` 下生成这些中间产物，详见 [构建输出文件](/rspeedy/output)。）
+
+### 代码裁剪：为什么主线程产物应该很小
+
+既然主线程在渲染关键路径上，只有后台才需要的代码（网络请求、[原生模块（NativeModule）](/guide/performance/analysis-performance/analysis-native-module)调用、日志、埋点、生命周期等）一旦被**打包进主线程产物**，就会同时拖大包体积和首帧成本。
+
+ReactLynx 会**自动裁剪**不该在主线程运行的代码：默认情况下 `useEffect`、`useLayoutEffect` 的回调以及部分事件处理函数会从 `main-thread.js` 中移除（详见 [ReactLynx 编程思想](/react/thinking-in-reactlynx)）。当编译器无法静态判断某段代码归属哪个线程时，需要你手动标注：
+
+- 用 [`'background only'` 指示符](/api/react/Document.directives) 把一个函数体标记为只在后台线程保留。
+- 用 [`__BACKGROUND__` / `__MAIN_THREAD__` 内置宏](/api/react/Document.built-in-macros) 按线程裁剪代码块。
+
+这套裁剪机制，正是后面「给主线程产物瘦身」这条优化手段的基础。
+
+## 分析产物体积
+
+核心原则是**先测量、再优化**：先用数据确认字节到底在哪一层，再决定动哪里，而不是凭猜测改代码。推荐按「静态资源 / 后台线程产物 / 主线程产物」三层拆解。
+
+### 使用 Rsdoctor
+
+[Rsdoctor](/rspeedy/use-rsdoctor) 是一个构建分析工具，可以可视化资源列表、模块依赖关系、重复模块等信息。在基于 Rspeedy 的项目中开启：
+
+```bash
+RSDOCTOR=true rspeedy build
+```
+
+构建完成后会自动打开分析页面。它的模块信息带有 `layer` 字段，可据此把字节归到 `react:main-thread` 与 `react:background` 两层，从而定位体积最大的模块，并通过真实的模块引用关系（module graph）追踪「某个模块为什么被打进了产物里」，而不是凭直觉判断。完整用法见 [使用 Rsdoctor](/rspeedy/use-rsdoctor)。
+
+### 使用 rspeedy-bundle-size Skill
+
+如果你使用支持 Agent Skills 的 AI 编码工具，可以加载 [`rspeedy-bundle-size`](/ai/skills/rspeedy-bundle-size) skill。它会按「先测量再优化」的流程，自动读取你的构建方式、生成体积分布、分层定位字节去向，并按收益优先级给出优化建议——适合在不熟悉构建细节时快速得到一份有依据的分析报告。
+
+## 优化产物体积
+
+定位到体积来源后，按层选择手段。也可参考 Rsbuild 的 [缩小产物体积](https://rsbuild.rs/zh/guide/optimization/optimize-bundle) 指南。
+
+### 给主线程产物瘦身（裁掉后台专属代码）
+
+这是 Lynx 特有、也最该优先检查的一层。把只在后台需要的代码（请求 / NativeModule 调用 / 日志 / 监控 SDK）用 [`'background only'`](/api/react/Document.directives) 或 [`__BACKGROUND__`](/api/react/Document.built-in-macros) 移出渲染路径，避免它被打包进 `main-thread.js`。若这类代码来自你无法修改的第三方库，则需要推动库侧在定义处加上标注。
+
+### 精简后台线程产物
+
+- **减少重复依赖**：用 Rsdoctor 的重复包检测找出被多份打包的依赖，再用 [`resolve.dedupe`](/api/rspeedy/rspeedy.resolve.dedupe) 或 `pnpm dedupe` 收敛。
+- **使用更轻量的库**：用 Rsdoctor 找出体积最大的依赖，评估替代品（例如用 `dayjs` 替换 `moment`），或改为按需引入。
+
+### 压缩静态资源
+
+图片、字体、媒体通常是单个产物中最大的部分。优先在源头压缩、使用合适尺寸的资源，并把体积大、非首屏必需的资源拆出主产物。
+
+### 拆分与懒加载
+
+区分**首屏体积**与**总体积**：首屏只需要主线程产物与首屏资源，把非首屏内容拆出去能显著改善启动体验。
+
+- 用 [代码拆分](/react/code-splitting) 把非首屏组件延迟到真正渲染时再加载。
+- 通过 [`splitChunks`](/api/rspeedy/rspeedy.config.splitchunks) 调整分包策略（底层即 Rspack 的 [代码分割](https://rspack.rs/zh/guide/optimization/code-splitting)）。
+- 用 [External Bundle](/rspeedy/external-bundle) 把可复用的部分独立出去。
+
+### 编译层选项
+
+- [`extractStr`](/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.extractstr)：合并重复的字符串字面量来减小体积，对 i18n 文案、类名等「在主线程与后台线程两层中重复」的字符串尤其有效。
+
+---
+
+更系统的清单与更底层的能力，可以从 Rsbuild 的 [缩小产物体积](https://rsbuild.rs/zh/guide/optimization/optimize-bundle) 与 Rspack 的 [优化指南](https://rspack.rs/zh/guide/optimization/code-splitting) 继续深入。

--- a/docs/zh/guide/performance/analysis-performance/analysis-bundle-size.mdx
+++ b/docs/zh/guide/performance/analysis-performance/analysis-bundle-size.mdx
@@ -6,7 +6,7 @@ description: '理解 Lynx 双线程架构下的产物结构，学会用 Rsdoctor
 
 产物体积直接影响下载、解析与首屏到达时间，却最容易被忽视：一次依赖升级、一张未压缩的图片、一段本该只跑在后台却漏进首屏渲染路径的代码，都会让产物悄悄变大。
 
-和普通 Web 应用不同，Lynx 应用因为**双线程架构**，产物结构有其特殊性——理解这套结构，是分析和优化体积的前提。Rspeedy 基于 [Rsbuild](https://rsbuild.rs/) 与 [Rspack](https://rspack.rs/) 构建，它们的体积优化经验大多可以复用；本页先讲清 Lynx 特有的产物结构，再给出分析方法与优化方向，并指向更深入的文档。
+和普通 Web 应用不同，Lynx 应用因为**双线程架构**，产物结构有其特殊性，而理解这套结构正是分析和优化体积的前提。Rspeedy 基于 [Rsbuild](https://rsbuild.rs/) 与 [Rspack](https://rspack.rs/) 构建，它们的体积优化经验大多可以复用；本页先讲清 Lynx 特有的产物结构，再给出分析方法与优化方向，并指向更深入的文档。
 
 ## 理解 Lynx 的产物结构
 
@@ -28,7 +28,7 @@ ReactLynx 把 React 拆到**双线程**上运行（详见 [ReactLynx 编程思�
 两份 JS 经过编码合成为一个二进制的 `.lynx.bundle`（生产构建后位于 `dist/`，详见 [构建输出文件](/rspeedy/output)），这才是 Lynx 引擎真正加载的交付产物，也是衡量体积时应当盯住的最终指标。
 
 :::tip 主线程产物 ≠ 主线程脚本
-这里的「主线程产物 / `main-thread.js`」指的是**主线程层的编译产物**。它和 [主线程脚本（Main Thread Script）](/react/main-thread-script)——那套用 `'main thread'` 指示符编写、用于跟手动画与手势的编程模型——不是一回事，注意区分。
+这里的「主线程产物 / `main-thread.js`」指的是**主线程层的编译产物**。它和 [主线程脚本（Main Thread Script）](/react/main-thread-script) 不是一回事，后者是那套用 `'main thread'` 指示符编写、用于跟手动画与手势的编程模型，注意区分。
 :::
 
 ### 查看可读的中间产物
@@ -39,7 +39,7 @@ ReactLynx 把 React 拆到**双线程**上运行（详见 [ReactLynx 编程思�
 DEBUG=rspeedy rspeedy build
 ```
 
-（开发构建同样会在 `dist/.rspeedy/` 下生成这些中间产物，详见 [构建输出文件](/rspeedy/output)。）
+开发构建同样会在 `dist/.rspeedy/` 下生成这些中间产物，详见 [构建输出文件](/rspeedy/output)。
 
 ### 代码裁剪：为什么主线程产物应该很小
 
@@ -54,7 +54,7 @@ ReactLynx 会**自动裁剪**不该在主线程运行的代码：默认情况下
 
 ## 分析产物体积
 
-核心原则是**先测量、再优化**：先用数据确认字节到底在哪一层，再决定动哪里，而不是凭猜测改代码。推荐按「静态资源 / 后台线程产物 / 主线程产物」三层拆解。
+核心原则是先测量、再优化：先用数据确认字节到底在哪一层，再决定动哪里，而不是凭猜测改代码。推荐按「静态资源 / 后台线程产物 / 主线程产物」三层拆解。
 
 ### 使用 Rsdoctor
 
@@ -68,11 +68,11 @@ RSDOCTOR=true rspeedy build
 
 ### 使用 rspeedy-bundle-size Skill
 
-如果你使用支持 Agent Skills 的 AI 编码工具，可以加载 [`rspeedy-bundle-size`](/ai/skills/rspeedy-bundle-size) skill。它会按「先测量再优化」的流程，自动读取你的构建方式、生成体积分布、分层定位字节去向，并按收益优先级给出优化建议——适合在不熟悉构建细节时快速得到一份有依据的分析报告。
+如果你使用支持 Agent Skills 的 AI 编码工具，可以加载 [`rspeedy-bundle-size`](/ai/skills/rspeedy-bundle-size) skill。它会按「先测量再优化」的流程，自动读取你的构建方式、生成体积分布、分层定位字节去向，并按收益优先级给出优化建议，适合在不熟悉构建细节时快速得到一份有依据的分析报告。
 
 ## 优化产物体积
 
-定位到体积来源后，按层选择手段。也可参考 Rsbuild 的 [缩小产物体积](https://rsbuild.rs/zh/guide/optimization/optimize-bundle) 指南。
+定位到体积来源后，按层选择手段。
 
 ### 给主线程产物瘦身（裁掉后台专属代码）
 
@@ -99,6 +99,6 @@ RSDOCTOR=true rspeedy build
 
 - [`extractStr`](/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.extractstr)：合并重复的字符串字面量来减小体积，对 i18n 文案、类名等「在主线程与后台线程两层中重复」的字符串尤其有效。
 
----
+## Next Steps
 
 更系统的清单与更底层的能力，可以从 Rsbuild 的 [缩小产物体积](https://rsbuild.rs/zh/guide/optimization/optimize-bundle) 与 Rspack 的 [优化指南](https://rspack.rs/zh/guide/optimization/code-splitting) 继续深入。

--- a/docs/zh/rspeedy/output.md
+++ b/docs/zh/rspeedy/output.md
@@ -75,7 +75,7 @@ dist/
 
 - 后台线程脚本（Background Thread Script）：内联到 Bundle 中的脚本，默认输出到 `.rspeedy/[name]/background.js`
 - 主线程脚本（MainThread Thread Script）：默认输出到 `.rspeedy/[name]/main-thread.js`
-- Source Map 文件：与 JS 文件同目录，以 `.map` 为后缀
+- Debug Metadata：反解线上错误所需的元数据（包含 source map、字节码调试信息、UI source map 与构建信息），默认输出到 `.rspeedy/[name]/debug-metadata.json`，详见 [线上错误反解](./map-errors-to-source)
 
 ## 修改目录结构
 

--- a/docs/zh/rspeedy/output.md
+++ b/docs/zh/rspeedy/output.md
@@ -49,16 +49,14 @@ dist/
 ├── .rspeedy
 │   ├── async
 │   │   └── [name]
-│   │       ├── debug-info.json
+│   │       ├── debug-metadata.json
 │   │       ├── tasm.json
 │   │       └── [name].css
 │   ├── [name]
 │   │   ├── background.js
-│   │   ├── background.js.map
-│   │   ├── debug-info.json
+│   │   ├── debug-metadata.json
 │   │   ├── [name].css
 │   │   ├── main-thread.js
-│   │   ├── main-thread.js.map
 │   │   └── tasm.json
 │   └── rspeedy.config.js
 ├── [name].lynx.bundle
@@ -69,10 +67,8 @@ dist/
     └── js
         ├── [id].[hash].js
         │   └── async
-        │       ├── [id].[hash].js
-        │       └── [id].[hash].js.map
-        ├── lib-preact.[hash].js
-        └── lib-preact.[hash].js.map
+        │       └── [id].[hash].js
+        └── lib-preact.[hash].js
 ```
 
 开发环境额外生成的文件包括：


### PR DESCRIPTION
## What

Adds a **Bundle Size** guide under **Performance → Performance Analysis** (`guide/performance/analysis-performance/analysis-bundle-size`), in both zh and en.

The Performance section acts as a discoverable entry point into the deeper (and easy-to-miss) Rspeedy/Rspack docs. The guide follows the format: **introduce the metric → how to analyze → how to optimize**.

### Contents
- **Understand the Lynx output structure** — the dual-thread architecture and the two JS layers (`main-thread.js` / `react:main-thread` vs `background.js` / `react:background`), how they encode into the binary `.lynx.bundle`, how to inspect the readable intermediates with `DEBUG=rspeedy`, and the code-elimination mechanism (`'background only'` / `__BACKGROUND__`).
  - Includes an explicit callout that **main-thread output is not the [Main Thread Script](https://lynxjs.org/react/main-thread-script.html)** (the MTS programming model).
- **Analyze** — Rsdoctor (`RSDOCTOR=true rspeedy build`, with the per-module `layer` field) and the `rspeedy-bundle-size` skill.
- **Optimize** — main-thread slimming, dependency deduplication (`resolve.dedupe`), lighter libraries, code splitting (`splitChunks`, lazy, External Bundle), asset compression, and `extractStr`. Mirrors Rsbuild's *Bundle size optimization* outline, keeping only the Lynx-relevant levers and linking to the canonical Rsbuild/Rspack docs.

### Also
- Updates `docs/{zh,en}/rspeedy/output.md`: renames `debug-info.json` to `debug-metadata.json` and drops the source-map files that are no longer emitted by default.

## Notes
- Terminology checked against existing docs (IFR, NativeModule, dual-thread, etc.).
- Draft — pending review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Add bilingual Bundle Size guides under Performance Analysis.
- Document bundle analysis and optimization with Rsdoctor, `rspeedy-bundle-size`, code splitting, compression, and `extractStr`.
- Align Rspeedy output docs with `debug-metadata.json` and current emitted artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->