### PR TITLE
docs(debug-metadata-visualization): credit evanw + load-an-example button

### DIFF
--- a/docs/public/debug-metadata-visualization/index.html
+++ b/docs/public/debug-metadata-visualization/index.html
@@ -202,6 +202,7 @@ svg#wire path { fill: none; stroke-width: 2; opacity: 0; }
     <h2><a id="docsLink" href="../rspeedy/map-errors-to-source" target="_blank" rel="noreferrer">Drop a <code>debug-metadata.json</code></a></h2>
     <div>Drop its <code>.js</code> / <code>.css</code> bundles alongside it to see the generated side (bundle names depend on your build entry)</div>
     <div style="margin-top:12px">or <label for="file">choose files</label> (select the json + bundles together)</div>
+    <div style="margin-top:28px;font-size:12px">Inspired by <a href="https://evanw.github.io/source-map-visualization/" target="_blank" rel="noreferrer">Evan Wallace's source-map-visualization</a></div>
   </div>
 
   <div id="app">


### PR DESCRIPTION
Two follow-ups to #1149:

- Adds a visible credit line on the tool's drop screen linking to [Evan Wallace's source-map-visualization](https://evanw.github.io/source-map-visualization/), which inspired the interaction model (the tool itself is a from-scratch reimplementation with Lynx-specific decoding).
- Adds a **load an example** link (same spirit as evanw's *Load an example*): bundles the Lynx react demo's production build artifacts under `example/` as gzip (~350KB total, local build paths scrubbed) and inflates them in the browser with the native `DecompressionStream` — still zero dependencies. One click shows the full main-thread + background + css visualization without needing your own build.