### PR TITLE
fix(home): keep hero badge on one line with ellipsis

### DIFF
--- a/theme/blog-btn.scss
+++ b/theme/blog-btn.scss
@@ -2,8 +2,17 @@
   font-size: 14px;
   align-self: center;
   position: relative;
-  display: flex;
-  align-items: center;
+  // Keep the announcement to a single line: a long blog title (the badge
+  // shows the latest post) used to wrap and spill out of the fixed-height
+  // pill. Block + line-height centering (the icon is absolutely positioned,
+  // so no flexbox is needed) lets text-overflow clip it with an ellipsis;
+  // `max-width` caps the pill at its container so the clip actually engages.
+  display: block;
+  max-width: 100%;
+  box-sizing: border-box;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   height: 36px;
   flex-shrink: 0;
   border-radius: 37px;
@@ -24,6 +33,9 @@
   @media (max-width: 768px) {
     font-size: 12px;
     height: 28px;
+    // Match the shorter pill so the single line stays vertically centered
+    // and isn't clipped by `overflow: hidden` (content box = 28px − 2px border).
+    line-height: 26px;
     padding-left: 38px;
     padding-right: 16px;
   }


### PR DESCRIPTION
## Problem

The hero announcement badge shows the latest blog title. A long one — currently "New: Lynx × Rspack 2.0, Faster, Smaller, Closer to the Web" — wrapped to two lines and spilled out of the fixed-height pill:

<img width="760" alt="badge wrapping out of the pill" src="https://github.com/user-attachments/assets/placeholder" />

## Fix

The badge (`.rp-home-hero__badge`) was a flex container with its text set directly as `textContent` (via `use-blog-btn-dom.ts`), so `text-overflow` had no block box to apply to. This switches it to a block box — the leading icon is absolutely positioned, so flex bought nothing — and clips overflow:

- `white-space: nowrap` + `overflow: hidden` + `text-overflow: ellipsis`
- `max-width: 100%` + `box-sizing: border-box` so the clip actually engages within the hero column
- vertical centering now comes from `line-height`, matched to the shorter pill at the mobile breakpoint (content box = 28px − 2px border) so the single line isn't clipped

CSS-only, scoped to the badge, so it covers every badge uniformly — the dynamic main-home blog badge and the static subsite badges (which render their text via rspress frontmatter, not the hook).

## Verification

Checked in the dev server:

- **Desktop (900px)**: the full title now sits on one line, vertically centered.
- **Mobile (375px)**: the title truncates to `…` on a single line, centered — no more spill.
- **Subsite (react, 1280px)**: short static text ("ReactLynx") stays centered with its icon — the block change is a no-op for non-overflowing text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Keep the home hero announcement badge to a single line with ellipsis overflow
- Switch the badge from flex centering to block layout with clipped sizing
- Adjust mobile line height to preserve vertical centering in the shorter pill

<!-- end of auto-generated comment: release notes by coderabbit.ai -->