### PR TITLE
chore: add CODEOWNERS for docs/**/ui/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -113,6 +113,7 @@ tsconfig.json                           @Huxpro
 # ═════════════════════════════════════════════
 # DOCS: Other Sections
 # ═════════════════════════════════════════════
+/docs/**/ui/                            @MoonfaceX @f0rdream @toretto-wt @fzx2666-fz
 /docs/**/blog/                          @Huxpro
 /docs/**/react/                         @colinaaa @Yradex @gaoachao @upupming
 /docs/**/rspeedy/                       @colinaaa


### PR DESCRIPTION
## Summary
- Add `@MoonfaceX @f0rdream @toretto-wt @fzx2666-fz` as code owners for `/docs/**/ui/` (covers both `en` and `zh` Lynx UI docs).

## Test plan
- [ ] Verify CODEOWNERS syntax is valid
- [ ] Confirm the pattern matches `docs/en/ui/` and `docs/zh/ui/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Assign `@MoonfaceX`, `@f0rdream`, `@toretto-wt`, and `@fzx2666-fz` to `/docs/**/ui/` in CODEOWNERS
- Cover both `docs/en/ui/` and `docs/zh/ui/` for lynx-ui documentation ownership

<!-- end of auto-generated comment: release notes by coderabbit.ai -->