### PR TITLE
fix: preserve lynx-ui route compatibility

### DIFF
--- a/theme/index.tsx
+++ b/theme/index.tsx
@@ -43,9 +43,16 @@ import { useBlogBtnDom } from './hooks/use-blog-btn-dom';
 // Match subsite by checking if any path segment exactly equals the subsite value
 const findSubsite = (pathname: string) => {
   const segments = pathname.split('/');
-  return SUBSITES_CONFIG.find((s) =>
-    segments.some((seg) => seg.replace(/\.html$/, '') === s.value),
-  );
+  return SUBSITES_CONFIG.find((s) => {
+    if (s.value === 'ui') {
+      return segments.some((seg) => {
+        const normalized = seg.replace(/\.html$/, '');
+        return normalized === s.value || normalized === 'lynx-ui';
+      });
+    }
+
+    return segments.some((seg) => seg.replace(/\.html$/, '') === s.value);
+  });
 };
 
 const NULL_BYTE_RE = /\u0000/g;


### PR DESCRIPTION
Change-Id: I2c7791f53dba1cbe327df3cb8bda811db21758c9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Preserve `lynx-ui` subsite matching in `findSubsite`
- Treat `ui` routes as compatible with either `ui` or `lynx-ui` path segments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->