### PR TITLE
fix(ui): raise Sheet content above its overlay

### DIFF
--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -58,7 +58,7 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-[100] flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
           side === "right" &&
             "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
           side === "left" &&


### PR DESCRIPTION
The Sheet overlay was bumped to z-[100] (to sit above the rspress
navbar) while the content stayed at z-50, so on mobile the dark
overlay stacked on top of the drawer and swallowed all pointer
events — the API status side navigation was visible but not
interactive. Raise the content to z-[100] so it wins over the
overlay by DOM order, matching the drawer.tsx pattern.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AuDYQmRnJVob7zpKpN4e1p

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Raise Sheet content z-index to keep mobile drawer navigation above the overlay

<!-- end of auto-generated comment: release notes by coderabbit.ai -->