### PR TITLE
Cherry-pick PR #1169 to release/3.9

### DIFF
--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -58,7 +58,7 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-[100] flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
           side === "right" &&
             "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
           side === "left" &&


### PR DESCRIPTION
Cherry-pick of #1169 onto `release/3.9`.

**Fix:** raise mobile `SheetContent` z-index from `z-50` to `z-[100]` so the API-status side-navigation drawer stacks above its overlay and stays interactive on mobile (previously the `z-[100]` overlay covered the drawer and swallowed all taps).

Source PR: #1169
Source commit: 4b47b6d81cc1d3f6fd3f9d1581173c2d9aa72800
Applies cleanly — single-line change to `src/components/ui/sheet.tsx`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AuDYQmRnJVob7zpKpN4e1p)_