### PR TITLE
chore(deps): bump @lynx-example/react-apis example to 0.1.1

### DIFF
--- a/packages/lynx-example-packages/package.json
+++ b/packages/lynx-example-packages/package.json
@@ -44,7 +44,7 @@
     "@lynx-example/overlay": "^0.6.7",
     "@lynx-example/page": "0.6.5",
     "@lynx-example/performance-api": "0.7.0",
-    "@lynx-example/react-apis": "0.1.0",
+    "@lynx-example/react-apis": "0.1.1",
     "@lynx-example/react-lifecycle": "0.5.6",
     "@lynx-example/refresh": "^0.6.9",
     "@lynx-example/scroll-coordinator": "0.6.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -383,8 +383,8 @@ importers:
         specifier: 0.7.0
         version: 0.7.0(@lynx-js/types@3.9.0)(@types/react@18.3.18)
       '@lynx-example/react-apis':
-        specifier: 0.1.0
-        version: 0.1.0(@lynx-js/types@3.9.0)(@types/react@18.3.18)
+        specifier: 0.1.1
+        version: 0.1.1(@lynx-js/types@3.9.0)(@types/react@18.3.31)
       '@lynx-example/react-lifecycle':
         specifier: 0.5.6
         version: 0.5.6(@lynx-js/types@3.9.0)(@types/react@18.3.18)
@@ -1578,8 +1578,8 @@ packages:
   '@lynx-example/performance-api@0.7.0':
     resolution: {integrity: sha512-xpdzvFc3pukN1+N6p6pVsFzgDA+73+eFYyWV3TrKmXqeeQ6wRoxczrL7/rkjjCvtBZbTEX5h0fklu/GrdvOrQQ==}
 
-  '@lynx-example/react-apis@0.1.0':
-    resolution: {integrity: sha512-cDupcz4h6ZuOe5cebtiW5oUmnwPAVB+V6tbOvFGYpm9X1fby/GYOhTxLwpRff62iYfd8fRkc3KsYM0lracE9wA==}
+  '@lynx-example/react-apis@0.1.1':
+    resolution: {integrity: sha512-MQg0rdZIMh8UbirSQNtadL5AuxVpu/FzsnKK1E3RTDVKMcOoDE4rE4D2SPXM4G5lJ3b+20Qh6+iQ7POQ7VBVxg==}
     engines: {node: '>=22'}
 
   '@lynx-example/react-lifecycle@0.5.6':
@@ -7856,9 +7856,9 @@ snapshots:
       - '@lynx-js/types'
       - '@types/react'
 
-  '@lynx-example/react-apis@0.1.0(@lynx-js/types@3.9.0)(@types/react@18.3.18)':
+  '@lynx-example/react-apis@0.1.1(@lynx-js/types@3.9.0)(@types/react@18.3.31)':
     dependencies:
-      '@lynx-js/react': 0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18)
+      '@lynx-js/react': 0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.31)
     transitivePeerDependencies:
       - '@lynx-js/types'
       - '@types/react'
@@ -8757,6 +8757,13 @@ snapshots:
   '@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18)':
     dependencies:
       '@types/react': 18.3.18
+      preact: '@lynx-js/internal-preact@10.29.1-20260519060144-e6da44c'
+    optionalDependencies:
+      '@lynx-js/types': 3.9.0
+
+  '@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.31)':
+    dependencies:
+      '@types/react': 18.3.31
       preact: '@lynx-js/internal-preact@10.29.1-20260519060144-e6da44c'
     optionalDependencies:
       '@lynx-js/types': 3.9.0


### PR DESCRIPTION
## Summary

Bump the `@lynx-example/react-apis` example package pin from `0.1.0` to `0.1.1` (the latest published release), following the same pattern as #1144.

Downstream consumers that mirror the example packages under their own scope only publish the latest release, so pinning an older version breaks their install of `packages/lynx-example-packages`. Tracking the latest release fixes that and keeps the docs examples current.

## Changes

- `packages/lynx-example-packages/package.json`: `@lynx-example/react-apis` `0.1.0` → `0.1.1`
- `pnpm-lock.yaml`: regenerated via `pnpm install --lockfile-only`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Update `@lynx-example/react-apis` to version `0.1.1`.
- Regenerate `pnpm-lock.yaml` for the latest example package release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->