### PR TITLE
docs: bump LynxExplorer download links to 4.0.0 in quick-start (release/4.0)

### DIFF
--- a/docs/en/guide/start/quick-start.mdx
+++ b/docs/en/guide/start/quick-start.mdx
@@ -76,7 +76,7 @@ Open up the Mac App Store, search for [Xcode](https://apps.apple.com/us/app/xcod
 
 <PlatformTabs.Tab platform="macos-arm64">
 
-Download [`LynxExplorer-arm64.app.tar.gz`](https://github.com/lynx-family/lynx/releases/download/3.8.1/LynxExplorer-arm64.app.tar.gz).
+Download [`LynxExplorer-arm64.app.tar.gz`](https://github.com/lynx-family/lynx/releases/download/4.0.0/LynxExplorer-arm64.app.tar.gz).
 
 Then extract the downloaded archive:
 
@@ -93,7 +93,7 @@ Open Xcode, choose **Open Developer Tool** from the Xcode menu. Click the **Simu
 
 <PlatformTabs.Tab platform="macos-intel">
 
-Download [`LynxExplorer-x86_64.app.tar.gz`](https://github.com/lynx-family/lynx/releases/download/3.8.1/LynxExplorer-x86_64.app.tar.gz).
+Download [`LynxExplorer-x86_64.app.tar.gz`](https://github.com/lynx-family/lynx/releases/download/4.0.0/LynxExplorer-x86_64.app.tar.gz).
 
 Then, extract the downloaded archive:
 
@@ -114,12 +114,12 @@ Open Xcode, choose **Open Developer Tool** from the Xcode menu. Click the **Simu
 
 <PlatformTabs.Tab platform="android">
 
-Scan the QR code to download the pre-built app from [GitHub Release 3.8.1](https://github.com/lynx-family/lynx/releases/tag/3.8.1).
+Scan the QR code to download the pre-built app from [GitHub Release 4.0.0](https://github.com/lynx-family/lynx/releases/tag/4.0.0).
 
 <QRCodeSVG
   style={{ border: '2px solid #fff' }}
   size={220}
-  value="https://github.com/lynx-family/lynx/releases/download/3.8.1/LynxExplorer-noasan-release.apk"
+  value="https://github.com/lynx-family/lynx/releases/download/4.0.0/LynxExplorer-noasan-release.apk"
 />
 
 Or, you may build from source by following the [Build Lynx Explorer for Android](https://github.com/lynx-family/lynx/tree/develop/explorer/android) guide.
@@ -140,7 +140,7 @@ Download the latest DevEco Studio from the [official website](https://developer.
 
 2. **<div id="download-lynx-explorer">Download Lynx Explorer</div>**
 
-Download the pre-built app [`lynx_explorer-default-unsigned.hap`](https://github.com/lynx-family/lynx/releases/download/3.8.1/lynx_explorer-default-unsigned.hap).
+Download the pre-built app [`lynx_explorer-default-unsigned.hap`](https://github.com/lynx-family/lynx/releases/download/4.0.0/lynx_explorer-default-unsigned.hap).
 
 Or, you may build from source by following the [Build Lynx Explorer for Harmony](https://github.com/lynx-family/lynx/tree/develop/explorer/harmony) guide.
 

--- a/docs/zh/guide/start/quick-start.mdx
+++ b/docs/zh/guide/start/quick-start.mdx
@@ -76,7 +76,7 @@ Lynx Explorer 是一个可以快速试用 Lynx 的沙盒环境。
 
 <PlatformTabs.Tab platform="macos-arm64">
 
-下载 [`LynxExplorer-arm64.app.tar.gz`](https://github.com/lynx-family/lynx/releases/download/3.8.1/LynxExplorer-arm64.app.tar.gz)。
+下载 [`LynxExplorer-arm64.app.tar.gz`](https://github.com/lynx-family/lynx/releases/download/4.0.0/LynxExplorer-arm64.app.tar.gz)。
 
 然后，解压下载的压缩包：
 
@@ -93,7 +93,7 @@ tar -zxf LynxExplorer-arm64.app.tar.gz -C LynxExplorer-arm64.app/
 
 <PlatformTabs.Tab platform="macos-intel">
 
-下载 [`LynxExplorer-x86_64.app.tar.gz`](https://github.com/lynx-family/lynx/releases/download/3.8.1/LynxExplorer-x86_64.app.tar.gz)。
+下载 [`LynxExplorer-x86_64.app.tar.gz`](https://github.com/lynx-family/lynx/releases/download/4.0.0/LynxExplorer-x86_64.app.tar.gz)。
 
 然后，解压下载的压缩包：
 
@@ -114,12 +114,12 @@ tar -zxf LynxExplorer-x86_64.app.tar.gz -C LynxExplorer-x86_64.app/
 
 <PlatformTabs.Tab platform="android">
 
-扫描二维码从 [GitHub Release 3.8.1](https://github.com/lynx-family/lynx/releases/tag/3.8.1) 下载预编译应用。
+扫描二维码从 [GitHub Release 4.0.0](https://github.com/lynx-family/lynx/releases/tag/4.0.0) 下载预编译应用。
 
 <QRCodeSVG
   style={{ border: '2px solid #fff' }}
   size={220}
-  value="https://github.com/lynx-family/lynx/releases/download/3.8.1/LynxExplorer-noasan-release.apk"
+  value="https://github.com/lynx-family/lynx/releases/download/4.0.0/LynxExplorer-noasan-release.apk"
 />
 
 或者，你可以按照[为 Android 构建 Lynx Explorer](https://github.com/lynx-family/lynx/tree/develop/explorer/android) 指南从源代码构建。
@@ -140,7 +140,7 @@ tar -zxf LynxExplorer-x86_64.app.tar.gz -C LynxExplorer-x86_64.app/
 
 2. **<div id="download-lynx-explorer">下载 Lynx Explorer</div>**
 
-下载预编译应用 [`lynx_explorer-default-unsigned.hap`](https://github.com/lynx-family/lynx/releases/download/3.8.1/lynx_explorer-default-unsigned.hap)。
+下载预编译应用 [`lynx_explorer-default-unsigned.hap`](https://github.com/lynx-family/lynx/releases/download/4.0.0/lynx_explorer-default-unsigned.hap)。
 
 或者，你可以按照[为 Harmony 构建 Lynx Explorer](https://github.com/lynx-family/lynx/tree/develop/explorer/harmony) 指南从源代码构建。
 


### PR DESCRIPTION
Closes part of #1232. This is the `release/4.0` companion to #1185. The published quick-start at the site root is built from this branch, and it still points every LynxExplorer download at release `3.8.1` even though `4.0.0` is the current release.

- Bump macOS arm64 `LynxExplorer-arm64.app.tar.gz` link to 4.0.0 (en + zh)
- Bump macOS x86_64 `LynxExplorer-x86_64.app.tar.gz` link to 4.0.0 (en + zh)
- Bump Android `LynxExplorer-noasan-release.apk` QR link and the GitHub Release tag link to 4.0.0 (en + zh)
- Bump HarmonyOS `lynx_explorer-default-unsigned.hap` link to 4.0.0 (en + zh)

All four referenced assets exist on the 4.0.0 release. The change stays limited to the Explorer download links.

Originally opened against `release/3.9`; retargeted and rebased onto `release/4.0` now that it serves the site root. Happy to open the same change against `release/3.9` and `release/3.8` if the older docs should carry it too.
