### PR TITLE
docs(ai): add missing agent skill guides

### DIFF
--- a/docs/en/ai/_meta.json
+++ b/docs/en/ai/_meta.json
@@ -28,11 +28,19 @@
   },
   {
     "type": "file",
+    "name": "skills/lynx-check-css-support.mdx"
+  },
+  {
+    "type": "file",
     "name": "skills/lynx-devtool.mdx"
   },
   {
     "type": "file",
     "name": "skills/lynx-ui.mdx"
+  },
+  {
+    "type": "file",
+    "name": "skills/lynx-a2ui.mdx"
   },
   {
     "type": "file",

--- a/docs/en/ai/skills/lynx-a2ui.mdx
+++ b/docs/en/ai/skills/lynx-a2ui.mdx
@@ -1,0 +1,71 @@
+---
+description: 'Generate catalog-valid A2UI v0.9 JSON messages for Lynx GenUI from natural-language UI requests.'
+---
+
+# lynx-a2ui
+
+Turns natural-language UI requests into [A2UI v0.9](https://a2ui.org/specification/v0.9-a2ui/) protocol messages that [`@lynx-js/genui/a2ui`](/react/genui/a2ui) can render. The skill produces declarative JSON data rather than application code, so the generated UI stays within the components and functions authorized by an A2UI Catalog.
+
+Use it when an agent needs to:
+
+- generate a new A2UI surface from a UI description
+- bind shared, editable, or repeated values through the A2UI data model
+- respond to an A2UI user action with a minimal surface patch
+- target the default Lynx GenUI Catalog or a custom Catalog supplied by your application
+- avoid inventing components, props, functions, or action shapes that the active Catalog does not expose
+
+## Installation
+
+```bash
+npx skills add lynx-community/skills -s lynx-a2ui
+```
+
+This installs the `lynx-a2ui` rules so compatible coding agents can generate catalog-constrained A2UI messages and check them against the active Catalog.
+
+## How It Works
+
+The skill follows a catalog-first workflow:
+
+1. It fetches the latest default [Lynx GenUI A2UI Catalog](https://unpkg.com/@lynx-js/genui/a2ui/dist/catalog.json), unless you provide another Catalog URL or its JSON content.
+2. It reads the Catalog ID, component and function schemas, required fields, enum values, and examples.
+3. It translates the request into a data model and a flat component graph that validates against that Catalog.
+4. It returns only a pretty-printed JSON array of A2UI v0.9 messages.
+
+For a new surface, the output is ordered so the renderer can consume it progressively:
+
+1. `createSurface`, using `main` as the default surface ID and the fetched Catalog's `catalogId`
+2. `updateDataModel` for initial values used by bindings
+3. `updateComponents` with exactly one component whose ID is `root`
+
+When the latest request begins with `A2UI_USER_ACTION:`, the skill updates the existing surface instead. It prefers the smallest valid patch, using `updateDataModel` for data-only changes and adding `updateComponents` only when the visible structure changes.
+
+:::info
+The agent must be able to fetch the active Catalog before generating a non-trivial UI. If the Catalog is unreachable, provide its JSON content or a reachable Catalog URL.
+:::
+
+## Output Contract
+
+The skill instructs the agent to:
+
+- emit JSON only, without Markdown, prose, comments, or trailing commas
+- include `"version": "v0.9"` in every message
+- create bound data before a component reads it
+- keep component IDs unique and kebab-case, and reference child components by ID instead of nesting them inline
+- use only components, props, functions, enum values, and action schemas from the latest fetched Catalog
+- never emit arbitrary JavaScript, HTML, CSS, scripts, or executable snippets
+
+For example, you can ask:
+
+```text
+Use lynx-a2ui to generate a compact trip-planning card with three data-bound destinations and a button that sends the selected destination back to the agent.
+```
+
+The response should be the A2UI message array itself, ready for an A2UI renderer to consume.
+
+## Learn More
+
+- [A2UI in ReactLynx](/react/genui/a2ui)
+- [`@lynx-js/genui/a2ui` API reference](/api/genui/a2ui/index.html)
+- [lynx-a2ui skill source](https://github.com/lynx-community/skills/tree/release/skills/lynx-a2ui)
+- [lynx-community/skills on GitHub](https://github.com/lynx-community/skills)
+- [Agent Skills specification](https://agentskills.io/specification)

--- a/docs/en/ai/skills/lynx-check-css-support.mdx
+++ b/docs/en/ai/skills/lynx-check-css-support.mdx
@@ -1,0 +1,85 @@
+---
+description: 'Check Lynx CSS support by property, nested feature, rendering backend, and Lynx version.'
+---
+
+# lynx-check-css-support
+
+Queries bundled [`@lynx-js/css-defines`](https://www.npmjs.com/package/@lynx-js/css-defines) compatibility data to determine whether a CSS property or nested feature is available on a specific Lynx rendering backend and version. It gives coding agents structured evidence instead of relying on browser behavior, examples, or TypeScript types to infer Lynx support.
+
+Use it when an agent needs to:
+
+- check whether a CSS property or value is supported in Lynx or ReactLynx
+- compare support across the backends declared by the dataset, including Android, iOS, HarmonyOS, Web Lynx, and Clay variants
+- find the Lynx version in which support was added
+- verify whether a proposed style change is compatible with the application's target versions
+- inspect the raw compatibility definition or check whether a newer dataset is available
+
+## Installation
+
+```bash
+npx skills add lynx-community/skills -s lynx-check-css-support
+```
+
+This installs the skill and its pinned compatibility dataset so compatible coding agents can run queries without downloading or executing packages at query time.
+
+## Ask a Compatibility Question
+
+Include the property, nested feature or value when relevant, rendering backend, and target Lynx version in your request. For example:
+
+```text
+Use lynx-check-css-support to check whether display: grid is available on Android in Lynx 2.0, and tell me when it was added.
+```
+
+```text
+Compare gap support across every Lynx rendering backend and include the dataset version.
+```
+
+The skill runs its bundled CLI. A detailed query looks like this:
+
+```bash
+node <skill-directory>/scripts/query-css-compat.mjs display \
+  --feature grid \
+  --backend android \
+  --lynx-version 2.0
+```
+
+Nested feature keys are case-sensitive and may contain punctuation. If the exact key is unknown, the agent can inspect the property's raw `compat_data` with `--json` before running a targeted query.
+
+## Understand the Result
+
+Every answer should include the queried property and feature, backend and target version, published `version_added` value or condition, relevant notes, `partial_implementation`, deprecated or experimental status, and the bundled `@lynx-js/css-defines` version.
+
+The CLI classifies the result as:
+
+- `available`: supported at the requested version, or supported at some version when no target was supplied
+- `requires-newer-version`: supported only after the requested version
+- `conditional`: gated by a non-numeric condition such as a `targetSdkVersion` requirement
+- `unavailable`: explicitly unsupported
+- `unknown`: not established by the dataset
+
+If a definition has no `compat_data`, compatibility is unspecified rather than unsupported. Declared availability also does not guarantee browser parity or describe runtime behavior.
+
+Backend support comes from `compat_data.__compat.support`. The skill does not infer support from a definition's top-level `version` or a value's `version` field.
+
+:::tip
+Use this skill to establish **whether and when** a feature is available. For syntax, behavior, layout semantics, and examples, continue with the [CSS reference](/api/css/properties) and [API status dashboard](/api/status).
+:::
+
+## Keep the Dataset Current
+
+Normal queries use the dataset bundled with the skill and do not require network access. When freshness matters, the agent can run:
+
+```bash
+node <skill-directory>/scripts/query-css-compat.mjs --check-updates
+```
+
+This checks the latest numeric package version in the public npm registry. It does not download a new dataset or modify the installed skill; if an update exists, update the skill to use the reviewed compatibility data from a newer release.
+
+## Learn More
+
+- [Lynx CSS property reference](/api/css/properties)
+- [Lynx API status dashboard](/api/status)
+- [Bundle and Lynx Engine compatibility guide](/guide/compatibility)
+- [lynx-check-css-support skill source](https://github.com/lynx-community/skills/tree/release/skills/lynx-check-css-support)
+- [lynx-community/skills on GitHub](https://github.com/lynx-community/skills)
+- [Agent Skills specification](https://agentskills.io/specification)

--- a/docs/zh/ai/_meta.json
+++ b/docs/zh/ai/_meta.json
@@ -28,11 +28,19 @@
   },
   {
     "type": "file",
+    "name": "skills/lynx-check-css-support.mdx"
+  },
+  {
+    "type": "file",
     "name": "skills/lynx-devtool.mdx"
   },
   {
     "type": "file",
     "name": "skills/lynx-ui.mdx"
+  },
+  {
+    "type": "file",
+    "name": "skills/lynx-a2ui.mdx"
   },
   {
     "type": "file",

--- a/docs/zh/ai/skills/lynx-a2ui.mdx
+++ b/docs/zh/ai/skills/lynx-a2ui.mdx
@@ -1,0 +1,71 @@
+---
+description: '根据自然语言界面需求，为 Lynx GenUI 生成符合 Catalog 约束的 A2UI v0.9 JSON 消息。'
+---
+
+# lynx-a2ui
+
+将自然语言界面需求转换为 [`@lynx-js/genui/a2ui`](/react/genui/a2ui) 可渲染的 [A2UI v0.9](https://a2ui.org/specification/v0.9-a2ui/) 协议消息。该 skill 生成声明式 JSON 数据，而不是应用代码，因此生成的界面始终受 A2UI Catalog 已授权的组件和 Function 约束。
+
+当 coding agent 需要完成以下任务时，可以使用这个 skill：
+
+- 根据界面描述生成新的 A2UI Surface
+- 通过 A2UI 数据模型绑定共享、可编辑或重复展示的数据
+- 响应 A2UI 用户操作，并返回尽可能小的 Surface 补丁
+- 使用 Lynx GenUI 默认 Catalog，或应用提供的自定义 Catalog
+- 避免编造当前 Catalog 未提供的组件、属性、Function 或 Action 结构
+
+## 安装
+
+```bash
+npx skills add lynx-community/skills -s lynx-a2ui
+```
+
+安装后，兼容的 coding agent 可以自动加载 `lynx-a2ui` 规则，生成受 Catalog 约束的 A2UI 消息，并根据当前 Catalog 进行检查。
+
+## 工作方式
+
+这个 skill 遵循 Catalog 优先的工作流：
+
+1. 获取最新的 [Lynx GenUI A2UI 默认 Catalog](https://unpkg.com/@lynx-js/genui/a2ui/dist/catalog.json)；如果你提供了其他 Catalog URL 或 JSON 内容，则改用你提供的 Catalog。
+2. 读取 Catalog ID、组件与 Function Schema、必填字段、枚举值和示例。
+3. 将需求转换为数据模型和扁平组件图，并根据当前 Catalog 完成校验。
+4. 只返回格式化后的 A2UI v0.9 JSON 消息数组。
+
+生成新 Surface 时，消息会按以下顺序输出，以便 Renderer 渐进式处理：
+
+1. `createSurface`，默认使用 `main` 作为 Surface ID，并使用已获取 Catalog 中的 `catalogId`
+2. 用于初始化绑定数据的 `updateDataModel`
+3. `updateComponents`，其中恰有一个 ID 为 `root` 的组件
+
+当最新请求以 `A2UI_USER_ACTION:` 开头时，skill 会更新现有 Surface。它会优先返回尽可能小的有效补丁：只有数据变化时使用 `updateDataModel`，仅在可见结构发生变化时才添加 `updateComponents`。
+
+:::info
+Agent 必须能够先获取当前 Catalog，才能生成非简单界面。如果 Catalog 无法访问，请提供其 JSON 内容或一个可访问的 Catalog URL。
+:::
+
+## 输出约束
+
+这个 skill 会要求 Agent：
+
+- 只输出 JSON，不附加 Markdown、说明文字、注释或尾随逗号
+- 每条消息都包含 `"version": "v0.9"`
+- 在组件读取绑定路径之前创建对应数据
+- 保证组件 ID 唯一且使用 kebab-case，并通过 ID 引用子组件，而不是把子组件内联嵌套
+- 只使用最新 Catalog 中定义的组件、属性、Function、枚举值和 Action Schema
+- 不输出任意 JavaScript、HTML、CSS、脚本或其他可执行片段
+
+例如，你可以这样提问：
+
+```text
+使用 lynx-a2ui 生成一张紧凑的旅行规划卡片，展示三个通过数据模型绑定的目的地，并提供一个按钮，把选中的目的地回传给 Agent。
+```
+
+Agent 应直接返回可供 A2UI Renderer 消费的协议消息数组。
+
+## 了解更多
+
+- [ReactLynx 中的 A2UI](/react/genui/a2ui)
+- [`@lynx-js/genui/a2ui` API 参考](/api/genui/a2ui/index.html)
+- [lynx-a2ui skill 源码](https://github.com/lynx-community/skills/tree/release/skills/lynx-a2ui)
+- [GitHub 上的 lynx-community/skills](https://github.com/lynx-community/skills)
+- [Agent Skills 规范](https://agentskills.io/specification)

--- a/docs/zh/ai/skills/lynx-check-css-support.mdx
+++ b/docs/zh/ai/skills/lynx-check-css-support.mdx
@@ -1,0 +1,85 @@
+---
+description: '按照 CSS 属性、嵌套特性、渲染后端和 Lynx 版本查询兼容性。'
+---
+
+# lynx-check-css-support
+
+查询 skill 内置的 [`@lynx-js/css-defines`](https://www.npmjs.com/package/@lynx-js/css-defines) 兼容性数据，判断某个 CSS 属性或嵌套特性是否可用于指定的 Lynx 渲染后端和版本。coding agent 可以据此获得结构化证据，而不是根据浏览器行为、示例或 TypeScript 类型推测 Lynx 的支持情况。
+
+当 coding agent 需要完成以下任务时，可以使用这个 skill：
+
+- 检查 Lynx 或 ReactLynx 是否支持某个 CSS 属性或值
+- 比较数据集声明的各类后端，包括 Android、iOS、HarmonyOS、Web Lynx 和 Clay 变体
+- 查找某项能力从哪个 Lynx 版本开始支持
+- 确认计划中的样式改动是否兼容应用的目标版本
+- 查看原始兼容性定义，或检查是否已有更新的数据集
+
+## 安装
+
+```bash
+npx skills add lynx-community/skills -s lynx-check-css-support
+```
+
+这会安装 skill 及其固定版本的兼容性数据集。查询时，兼容的 coding agent 不需要下载或执行其他软件包。
+
+## 提出兼容性问题
+
+请求中应尽量包含 CSS 属性、相关的嵌套特性或取值、渲染后端以及目标 Lynx 版本。例如：
+
+```text
+使用 lynx-check-css-support 检查 Lynx 2.0 的 Android 后端是否支持 display: grid，并告诉我它从哪个版本开始支持。
+```
+
+```text
+比较 gap 在所有 Lynx 渲染后端上的支持情况，并附上数据集版本。
+```
+
+skill 会运行内置 CLI。一次完整查询如下：
+
+```bash
+node <skill-directory>/scripts/query-css-compat.mjs display \
+  --feature grid \
+  --backend android \
+  --lynx-version 2.0
+```
+
+嵌套特性的键名区分大小写，也可能包含标点。如果不知道准确键名，Agent 可以先通过 `--json` 查看该属性的原始 `compat_data`，再进行精确查询。
+
+## 理解查询结果
+
+每次回答都应包含被查询的属性和特性、后端与目标版本、数据中发布的 `version_added` 值或条件、相关说明、`partial_implementation`、废弃或实验状态，以及内置的 `@lynx-js/css-defines` 版本。
+
+CLI 会将结果归类为：
+
+- `available`：目标版本已经支持；未指定目标版本时，表示存在支持该能力的版本
+- `requires-newer-version`：需要比目标版本更新的 Lynx 版本
+- `conditional`：受非数字条件限制，例如 `targetSdkVersion` 要求
+- `unavailable`：明确不支持
+- `unknown`：数据集尚未确定支持情况
+
+如果定义中没有 `compat_data`，表示数据集未说明兼容性，不能据此判定为不支持。声明为可用也不等于与浏览器行为完全一致，且不能替代运行时行为说明。
+
+判断后端支持情况时，应以 `compat_data.__compat.support` 为准。这个 skill 不会根据定义顶层的 `version` 或某个取值的 `version` 字段推断支持情况。
+
+:::tip
+使用这个 skill 确认某项能力**是否可用以及从何时开始可用**。要了解语法、行为、布局语义和示例，请继续查阅 [CSS 参考](/api/css/properties)和 [API 大盘](/api/status)。
+:::
+
+## 保持数据集最新
+
+普通查询使用 skill 内置的数据集，不需要网络访问。当数据新鲜度很重要时，Agent 可以运行：
+
+```bash
+node <skill-directory>/scripts/query-css-compat.mjs --check-updates
+```
+
+该命令只查询公共 npm registry 中最新的数字版本号，不会下载新数据集或修改已安装的 skill。如果存在更新，请升级 skill，以使用新版本中经过评审的兼容性数据。
+
+## 了解更多
+
+- [Lynx CSS 属性参考](/api/css/properties)
+- [Lynx API 大盘](/api/status)
+- [Bundle 与 Lynx Engine 兼容性指南](/guide/compatibility)
+- [lynx-check-css-support skill 源码](https://github.com/lynx-community/skills/tree/release/skills/lynx-check-css-support)
+- [GitHub 上的 lynx-community/skills](https://github.com/lynx-community/skills)
+- [Agent Skills 规范](https://agentskills.io/specification)


### PR DESCRIPTION
## Summary

- add English and Chinese guides for `lynx-a2ui`
- add English and Chinese guides for `lynx-check-css-support`
- add both skills to the English and Chinese AI sidebars

## Why

The latest `lynx-community/skills` release includes these two skills, but the website did not yet have dedicated user-facing documentation for them. The new guides cover installation, intended workflows, output or compatibility semantics, constraints, and links to the relevant Lynx references.

## Impact

Developers can now discover and use both skills from the Lynx documentation in either locale, with guidance that matches the current released skill definitions.

## Validation

- `pnpm build`
- Prettier check
- CSpell
- zhlint
- `git diff --check`
- commit hooks: asset URL and API summary checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Document `lynx-a2ui` workflows and A2UI v0.9 output constraints in English and Chinese.
- Document `lynx-check-css-support` compatibility queries, result semantics, and dataset updates in both locales.
- Register both skills in the English and Chinese AI documentation sidebars.
- Validate documentation with build, formatting, spelling, lint, diff, and commit hook checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->