### PR TITLE
feat: add clone-element-example

### DIFF
--- a/packages/lynx-example-packages/package.json
+++ b/packages/lynx-example-packages/package.json
@@ -44,7 +44,7 @@
     "@lynx-example/overlay": "^0.6.7",
     "@lynx-example/page": "0.6.5",
     "@lynx-example/performance-api": "0.7.0",
-    "@lynx-example/react-apis": "0.1.1",
+    "@lynx-example/react-apis": "0.1.2",
     "@lynx-example/react-lifecycle": "0.5.6",
     "@lynx-example/refresh": "^0.6.9",
     "@lynx-example/scroll-coordinator": "0.6.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -383,8 +383,8 @@ importers:
         specifier: 0.7.0
         version: 0.7.0(@lynx-js/types@3.9.0)(@types/react@18.3.18)
       '@lynx-example/react-apis':
-        specifier: 0.1.1
-        version: 0.1.1(@lynx-js/types@3.9.0)(@types/react@18.3.31)
+        specifier: 0.1.2
+        version: 0.1.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
       '@lynx-example/react-lifecycle':
         specifier: 0.5.6
         version: 0.5.6(@lynx-js/types@3.9.0)(@types/react@18.3.18)
@@ -1578,8 +1578,8 @@ packages:
   '@lynx-example/performance-api@0.7.0':
     resolution: {integrity: sha512-xpdzvFc3pukN1+N6p6pVsFzgDA+73+eFYyWV3TrKmXqeeQ6wRoxczrL7/rkjjCvtBZbTEX5h0fklu/GrdvOrQQ==}
 
-  '@lynx-example/react-apis@0.1.1':
-    resolution: {integrity: sha512-MQg0rdZIMh8UbirSQNtadL5AuxVpu/FzsnKK1E3RTDVKMcOoDE4rE4D2SPXM4G5lJ3b+20Qh6+iQ7POQ7VBVxg==}
+  '@lynx-example/react-apis@0.1.2':
+    resolution: {integrity: sha512-JCA2cUKbBYI7R0Ezau0JiuWyIp6pXD8uZVGlJfgZXtMntn6N6L+GkTB021bUXyuNYZ4AEtQBAV0umfFz64LPFQ==}
     engines: {node: '>=22'}
 
   '@lynx-example/react-lifecycle@0.5.6':
@@ -1946,6 +1946,15 @@ packages:
 
   '@lynx-js/react@0.121.2':
     resolution: {integrity: sha512-Ruf5d2P0v1mXiZXbtxTOoR06Frfrs031Rp4bebnf1ZNW12PuXvnGa6n8gFi+ioJ4c1v9SUSpU40Fl/97TMgSRA==}
+    peerDependencies:
+      '@lynx-js/types': '*'
+      '@types/react': ^18
+    peerDependenciesMeta:
+      '@lynx-js/types':
+        optional: true
+
+  '@lynx-js/react@0.123.0':
+    resolution: {integrity: sha512-w/yX20jmGMdpfuNb2w7eyXN3JktSka43QdJwICvteNBZJPkZUzauvUvQ2EOqT09RHPHzMkcnk0AlpHOh7g+VoQ==}
     peerDependencies:
       '@lynx-js/types': '*'
       '@types/react': ^18
@@ -7856,9 +7865,9 @@ snapshots:
       - '@lynx-js/types'
       - '@types/react'
 
-  '@lynx-example/react-apis@0.1.1(@lynx-js/types@3.9.0)(@types/react@18.3.31)':
+  '@lynx-example/react-apis@0.1.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)':
     dependencies:
-      '@lynx-js/react': 0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.31)
+      '@lynx-js/react': 0.123.0(@lynx-js/types@3.9.0)(@types/react@18.3.31)
     transitivePeerDependencies:
       - '@lynx-js/types'
       - '@types/react'
@@ -8021,6 +8030,11 @@ snapshots:
       '@lynx-js/react': 0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18)
       '@lynx-js/types': 3.9.0
 
+  '@lynx-js/gesture-runtime@2.1.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)':
+    dependencies:
+      '@lynx-js/react': 0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
+      '@lynx-js/types': 3.9.0
+
   '@lynx-js/go-web@0.6.0(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core@0.20.4(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.13(@rspack/core@2.0.6(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@18.3.18)(micromark-util-types@2.0.1)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)':
     dependencies:
       '@douyinfe/semi-icons': 2.74.0(react@18.3.1)
@@ -8072,6 +8086,18 @@ snapshots:
       - react
       - react-dom
 
+  '@lynx-js/lynx-ui-button@3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/react': 0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
+      '@lynx-js/react-use': 0.1.3(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/types': 3.9.0
+      '@types/react': 18.3.18
+      clsx: 2.1.1
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   '@lynx-js/lynx-ui-checkbox@3.133.1(@lynx-js/react@0.114.0(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@lynx-js/lynx-ui-button': 3.133.1(@lynx-js/react@0.114.0(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -8096,6 +8122,18 @@ snapshots:
       - react
       - react-dom
 
+  '@lynx-js/lynx-ui-checkbox@3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@lynx-js/lynx-ui-button': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/react': 0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
+      '@lynx-js/types': 3.9.0
+      '@types/react': 18.3.18
+      clsx: 2.1.1
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   '@lynx-js/lynx-ui-common@3.133.1(@lynx-js/react@0.114.0(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@lynx-js/gesture-runtime': 2.1.1(@lynx-js/react@0.114.0(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)
@@ -8112,6 +8150,17 @@ snapshots:
       '@lynx-js/gesture-runtime': 2.1.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)
       '@lynx-js/react': 0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18)
       '@lynx-js/react-use': 0.1.3(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/types': 3.9.0
+      '@types/react': 18.3.18
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@lynx-js/lynx-ui-common@3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@lynx-js/gesture-runtime': 2.1.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)
+      '@lynx-js/react': 0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
+      '@lynx-js/react-use': 0.1.3(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@lynx-js/types': 3.9.0
       '@types/react': 18.3.18
     transitivePeerDependencies:
@@ -8146,6 +8195,20 @@ snapshots:
       - react
       - react-dom
 
+  '@lynx-js/lynx-ui-dialog@3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@lynx-js/lynx-ui-button': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-overlay': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-presence': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/react': 0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
+      '@lynx-js/types': 3.9.0
+      '@types/react': 18.3.18
+      clsx: 2.1.1
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   '@lynx-js/lynx-ui-draggable@3.133.1(@lynx-js/react@0.114.0(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.114.0(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -8162,6 +8225,17 @@ snapshots:
       '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@lynx-js/react': 0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18)
       '@lynx-js/react-use': 0.1.3(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/types': 3.9.0
+      '@types/react': 18.3.18
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@lynx-js/lynx-ui-draggable@3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/react': 0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
+      '@lynx-js/react-use': 0.1.3(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@lynx-js/types': 3.9.0
       '@types/react': 18.3.18
     transitivePeerDependencies:
@@ -8186,6 +8260,18 @@ snapshots:
       '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@lynx-js/lynx-ui-list': 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@lynx-js/react': 0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18)
+      '@lynx-js/types': 3.9.0
+      '@types/react': 18.3.18
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@lynx-js/lynx-ui-feed-list@3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@lynx-js/gesture-runtime': 2.1.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)
+      '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-list': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/react': 0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
       '@lynx-js/types': 3.9.0
       '@types/react': 18.3.18
     transitivePeerDependencies:
@@ -8222,6 +8308,21 @@ snapshots:
       - react
       - react-dom
 
+  '@lynx-js/lynx-ui-form@3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@lynx-js/lynx-ui-button': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-checkbox': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-input': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-radio-group': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-switch': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/react': 0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
+      '@lynx-js/types': 3.9.0
+      '@types/react': 18.3.18
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   '@lynx-js/lynx-ui-input@3.133.1(@lynx-js/react@0.114.0(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.114.0(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -8244,6 +8345,17 @@ snapshots:
       - react
       - react-dom
 
+  '@lynx-js/lynx-ui-input@3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-scroll-view': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/react': 0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
+      '@lynx-js/types': 3.9.0
+      '@types/react': 18.3.18
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   '@lynx-js/lynx-ui-lazy-component@3.133.1(@lynx-js/react@0.114.0(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.114.0(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -8258,6 +8370,16 @@ snapshots:
     dependencies:
       '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@lynx-js/react': 0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18)
+      '@lynx-js/types': 3.9.0
+      '@types/react': 18.3.18
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@lynx-js/lynx-ui-lazy-component@3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/react': 0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
       '@lynx-js/types': 3.9.0
       '@types/react': 18.3.18
     transitivePeerDependencies:
@@ -8286,6 +8408,17 @@ snapshots:
       - react
       - react-dom
 
+  '@lynx-js/lynx-ui-list@3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@lynx-js/gesture-runtime': 2.1.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)
+      '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/react': 0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
+      '@lynx-js/types': 3.9.0
+      '@types/react': 18.3.18
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   '@lynx-js/lynx-ui-overlay@3.133.1(@lynx-js/react@0.114.0(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.114.0(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -8300,6 +8433,16 @@ snapshots:
     dependencies:
       '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@lynx-js/react': 0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18)
+      '@lynx-js/types': 3.9.0
+      '@types/react': 18.3.18
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@lynx-js/lynx-ui-overlay@3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/react': 0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
       '@lynx-js/types': 3.9.0
       '@types/react': 18.3.18
     transitivePeerDependencies:
@@ -8334,6 +8477,20 @@ snapshots:
       - react
       - react-dom
 
+  '@lynx-js/lynx-ui-popover@3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@lynx-js/lynx-ui-button': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-overlay': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-presence': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/react': 0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
+      '@lynx-js/types': 3.9.0
+      '@types/react': 18.3.18
+      clsx: 2.1.1
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   '@lynx-js/lynx-ui-presence@3.133.1(@lynx-js/react@0.114.0(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.114.0(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -8349,6 +8506,17 @@ snapshots:
     dependencies:
       '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@lynx-js/react': 0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18)
+      '@lynx-js/types': 3.9.0
+      '@types/react': 18.3.18
+      clsx: 2.1.1
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@lynx-js/lynx-ui-presence@3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/react': 0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
       '@lynx-js/types': 3.9.0
       '@types/react': 18.3.18
       clsx: 2.1.1
@@ -8380,6 +8548,18 @@ snapshots:
       - react
       - react-dom
 
+  '@lynx-js/lynx-ui-radio-group@3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@lynx-js/lynx-ui-button': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/react': 0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
+      '@lynx-js/types': 3.9.0
+      '@types/react': 18.3.18
+      clsx: 2.1.1
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   '@lynx-js/lynx-ui-scroll-view@3.133.1(@lynx-js/react@0.114.0(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@lynx-js/gesture-runtime': 2.1.1(@lynx-js/react@0.114.0(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)
@@ -8398,6 +8578,18 @@ snapshots:
       '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@lynx-js/lynx-ui-lazy-component': 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@lynx-js/react': 0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18)
+      '@lynx-js/types': 3.9.0
+      '@types/react': 18.3.18
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@lynx-js/lynx-ui-scroll-view@3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@lynx-js/gesture-runtime': 2.1.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)
+      '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-lazy-component': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/react': 0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
       '@lynx-js/types': 3.9.0
       '@types/react': 18.3.18
     transitivePeerDependencies:
@@ -8436,6 +8628,22 @@ snapshots:
       - react
       - react-dom
 
+  '@lynx-js/lynx-ui-sheet@3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-dialog': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-overlay': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-presence': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/motion': 0.0.3(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/react': 0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
+      '@lynx-js/types': 3.9.0
+      '@types/react': 18.3.18
+      clsx: 2.1.1
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - react
+      - react-dom
+
   '@lynx-js/lynx-ui-slider@3.133.1(@lynx-js/react@0.114.0(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.114.0(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -8450,6 +8658,16 @@ snapshots:
     dependencies:
       '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@lynx-js/react': 0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18)
+      '@lynx-js/types': 3.9.0
+      '@types/react': 18.3.18
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@lynx-js/lynx-ui-slider@3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/react': 0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
       '@lynx-js/types': 3.9.0
       '@types/react': 18.3.18
     transitivePeerDependencies:
@@ -8478,6 +8696,17 @@ snapshots:
       - react
       - react-dom
 
+  '@lynx-js/lynx-ui-sortable@3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-draggable': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/react': 0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
+      '@lynx-js/types': 3.9.0
+      '@types/react': 18.3.18
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   '@lynx-js/lynx-ui-swipe-action@3.133.1(@lynx-js/react@0.114.0(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@lynx-js/gesture-runtime': 2.1.1(@lynx-js/react@0.114.0(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)
@@ -8494,6 +8723,17 @@ snapshots:
       '@lynx-js/gesture-runtime': 2.1.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)
       '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@lynx-js/react': 0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18)
+      '@lynx-js/types': 3.9.0
+      '@types/react': 18.3.18
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@lynx-js/lynx-ui-swipe-action@3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@lynx-js/gesture-runtime': 2.1.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)
+      '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/react': 0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
       '@lynx-js/types': 3.9.0
       '@types/react': 18.3.18
     transitivePeerDependencies:
@@ -8522,6 +8762,17 @@ snapshots:
       - react
       - react-dom
 
+  '@lynx-js/lynx-ui-swiper@3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/react': 0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
+      '@lynx-js/react-use': 0.1.3(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/types': 3.9.0
+      '@types/react': 18.3.18
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   '@lynx-js/lynx-ui-switch@3.133.1(@lynx-js/react@0.114.0(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.114.0(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -8539,6 +8790,18 @@ snapshots:
       '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@lynx-js/react': 0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18)
       '@lynx-js/react-use': 0.1.3(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/types': 3.9.0
+      '@types/react': 18.3.18
+      clsx: 2.1.1
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@lynx-js/lynx-ui-switch@3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/react': 0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
+      '@lynx-js/react-use': 0.1.3(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@lynx-js/types': 3.9.0
       '@types/react': 18.3.18
       clsx: 2.1.1
@@ -8608,26 +8871,26 @@ snapshots:
 
   '@lynx-js/lynx-ui@3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@lynx-js/lynx-ui-button': 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lynx-js/lynx-ui-checkbox': 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lynx-js/lynx-ui-dialog': 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lynx-js/lynx-ui-draggable': 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lynx-js/lynx-ui-feed-list': 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lynx-js/lynx-ui-form': 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lynx-js/lynx-ui-input': 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lynx-js/lynx-ui-lazy-component': 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lynx-js/lynx-ui-list': 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lynx-js/lynx-ui-popover': 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lynx-js/lynx-ui-presence': 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lynx-js/lynx-ui-radio-group': 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lynx-js/lynx-ui-scroll-view': 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lynx-js/lynx-ui-sheet': 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lynx-js/lynx-ui-slider': 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lynx-js/lynx-ui-sortable': 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lynx-js/lynx-ui-swipe-action': 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lynx-js/lynx-ui-swiper': 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lynx-js/lynx-ui-switch': 3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-button': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-checkbox': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-common': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-dialog': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-draggable': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-feed-list': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-form': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-input': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-lazy-component': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-list': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-popover': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-presence': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-radio-group': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-scroll-view': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-sheet': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-slider': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-sortable': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-swipe-action': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-swiper': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@lynx-js/lynx-ui-switch': 3.133.1(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@lynx-js/react': 0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
       '@lynx-js/types': 3.9.0
       '@types/react': 18.3.18
@@ -8675,6 +8938,19 @@ snapshots:
       - react
       - react-dom
 
+  '@lynx-js/motion@0.0.3(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(@lynx-js/types@3.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@lynx-js/react': 0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
+      framer-motion: 12.34.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      motion-dom: 12.23.12
+      motion-utils: 12.23.6
+    optionalDependencies:
+      '@lynx-js/types': 3.9.0
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - react
+      - react-dom
+
   '@lynx-js/react-use@0.1.3(@lynx-js/react@0.114.0(@lynx-js/types@3.9.0)(@types/react@18.3.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@lynx-js/react': 0.114.0(@lynx-js/types@3.9.0)(@types/react@18.3.18)
@@ -8698,6 +8974,16 @@ snapshots:
   '@lynx-js/react-use@0.1.3(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@lynx-js/react': 0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18)
+      immer: 10.1.1
+      nanoid: 5.1.7
+      react-use: 17.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@lynx-js/react-use@0.1.3(@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@lynx-js/react': 0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
       immer: 10.1.1
       nanoid: 5.1.7
       react-use: 17.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -8761,14 +9047,14 @@ snapshots:
     optionalDependencies:
       '@lynx-js/types': 3.9.0
 
-  '@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.31)':
+  '@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)':
     dependencies:
       '@types/react': 18.3.31
       preact: '@lynx-js/internal-preact@10.29.1-20260519060144-e6da44c'
     optionalDependencies:
       '@lynx-js/types': 3.9.0
 
-  '@lynx-js/react@0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)':
+  '@lynx-js/react@0.123.0(@lynx-js/types@3.9.0)(@types/react@18.3.31)':
     dependencies:
       '@types/react': 18.3.31
       preact: '@lynx-js/internal-preact@10.29.1-20260519060144-e6da44c'

--- a/scripts/apply-api-doc-overlays.mjs
+++ b/scripts/apply-api-doc-overlays.mjs
@@ -15,6 +15,18 @@ const localeConfig = {
 // English and Chinese API reference pages.
 const apiReferenceExamples = [
   {
+    id: 'react-clone-element-example',
+    apiReference: 'react/Function.cloneElement.mdx',
+    locales: ['en', 'zh'],
+    goProps: {
+      example: 'react-apis',
+      defaultFile: 'src/clone-element/index.tsx',
+      defaultEntryFile: 'dist/clone-element.lynx.bundle',
+      entry: 'src/clone-element',
+      defaultTab: 'web',
+    },
+  },
+  {
     id: 'react-create-element-example',
     apiReference: 'react/Function.createElement.mdx',
     locales: ['en', 'zh'],


### PR DESCRIPTION
Change-Id: Ifaa9b6272e91e05216a2d507e257569fe54c6434

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Add a clone-element example to the Lynx API reference.
- Bump `@lynx-example/react-apis` to `0.1.2`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->