### PR TITLE
ci(api-docs): run daily, open non-draft PR, sync pnpm pin from lynx-stack

### DIFF
--- a/.github/workflows/update-api-docs.yml
+++ b/.github/workflows/update-api-docs.yml
@@ -1,12 +1,12 @@
 name: Update API docs
 
-# Weekly (and on-demand) regeneration of the lynx-stack-derived API reference
-# docs, opened as a draft PR for review. Runs entirely in lynx-website and does
+# Daily (and on-demand) regeneration of the lynx-stack-derived API reference
+# docs, opened as a PR for review. Runs entirely in lynx-website and does
 # not touch the lynx-stack release pipeline or require cross-repo secrets.
 
 on:
   schedule:
-    - cron: '0 18 * * 0' # Weekly, Sunday 18:00 UTC
+    - cron: '0 18 * * *' # Daily, 18:00 UTC
   workflow_dispatch:
 
 permissions: {}
@@ -83,14 +83,14 @@ jobs:
         with:
           branch: bot/update-api-docs
           delete-branch: true
-          draft: true
           add-paths: |
             docs/en/api
             docs/zh/api
+            package.json
           commit-message: 'docs(api): sync API reference from lynx-stack main'
           title: 'docs(api): sync API reference from lynx-stack main'
           body: |
-            Automated weekly regeneration of the lynx-stack-derived API docs.
+            Automated daily regeneration of the lynx-stack-derived API docs.
 
             **Build validation:** `${{ steps.build.outcome }}` (GITHUB_TOKEN PRs don't trigger CI, so the build is run inside this job).
 
@@ -98,6 +98,7 @@ jobs:
             - `rspeedy/*` — API Extractor + API Documenter, from lynx-stack `main`.
             - `reactlynx-testing-library`, `lynx-testing-environment` — TypeDoc.
             - Targeted API reference Lynx Go examples from `scripts/apply-api-doc-overlays.mjs`.
+            - `packageManager` in `package.json` — realigned with lynx-stack's pnpm pin.
 
             **Reviewer checklist**
             - [ ] Reconcile `docs/{en,zh}/api/_meta.json` sidebar nav if API members were added/removed (not automated).

--- a/scripts/update-api-docs.sh
+++ b/scripts/update-api-docs.sh
@@ -9,6 +9,8 @@
 #                  run here in lynx-website (`pnpm run typedoc`), reading the
 #                  freshly built lynx-stack packages.
 #
+# Also syncs the `packageManager` pnpm pin in package.json from lynx-stack.
+#
 # NOT covered: docs/{en,zh}/api/react (bespoke: custom intro + projectDocuments
 # whose sources don't ship) and docs/{en,zh}/api/_meta.json (hand-curated
 # sidebar nav). Review the diff and reconcile nav when members are added/removed.
@@ -55,6 +57,35 @@ BUILD_FILTERS=(
   --filter @lynx-js/react
   --filter @lynx-js/testing-environment
 )
+
+sync_package_manager() {
+  echo "::group::Sync packageManager pin from lynx-stack"
+  # Keep lynx-website's pnpm pin aligned with lynx-stack's. This edits
+  # package.json only — the current run already installed with the old pin, so
+  # the new one takes effect on the next run.
+  node -e '
+    const fs = require("fs");
+    const [stackPkg, webPkg] = process.argv.slice(1);
+    const want = JSON.parse(fs.readFileSync(stackPkg, "utf8")).packageManager;
+    const raw = fs.readFileSync(webPkg, "utf8");
+    const have = JSON.parse(raw).packageManager;
+    if (!want) {
+      console.log("lynx-stack declares no packageManager; leaving the pin alone.");
+      process.exit(0);
+    }
+    if (!have) {
+      console.error("error: lynx-website package.json has no packageManager field to update.");
+      process.exit(1);
+    }
+    if (want === have) {
+      console.log(`packageManager already up to date: ${want}`);
+      process.exit(0);
+    }
+    fs.writeFileSync(webPkg, raw.replace(JSON.stringify(have), JSON.stringify(want)));
+    console.log(`packageManager: ${have} -> ${want}`);
+  ' "$STACK/package.json" "$WEBSITE/package.json"
+  echo "::endgroup::"
+}
 
 ensure_stack_paths_exist() {
   local missing=0
@@ -122,6 +153,8 @@ sync_api_extractor_docs() {
   done
   echo "::endgroup::"
 }
+
+sync_package_manager
 
 echo "::group::Build lynx-stack packages"
 pushd "$STACK" >/dev/null


### PR DESCRIPTION
## What

- **Schedule**: weekly (Sunday 18:00 UTC) → **daily** (18:00 UTC).
- **Draft**: dropped `draft: true` — the sync PR is now opened ready for review.
- **pnpm pin**: `scripts/update-api-docs.sh` now syncs `packageManager` in `package.json` from lynx-stack's `main` on every run, and `package.json` was added to the action's `add-paths` so the change actually lands in the PR.

## Notes

- The new pin takes effect on the **next** run — the current run already installed with the old one.
- Only `packageManager` is updated, not `pnpm-lock.yaml`. If lynx-stack ever jumps a pnpm major that changes the lockfile format, the following run's `pnpm install --frozen-lockfile` would need a manual lockfile refresh.

## Verification

Opened as draft to watch CI. The workflow itself is being validated with a `workflow_dispatch` run off this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Run API docs synchronization daily at 18:00 UTC
- Open synchronization PRs ready for review
- Sync `package.json`’s `packageManager` with `lynx-stack`’s `main` branch
- Include `package.json` in workflow path filters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->