### PR TITLE
docs(api): refresh API status data

### DIFF
--- a/packages/lynx-compat-data/api-stats.json
+++ b/packages/lynx-compat-data/api-stats.json
@@ -1,7 +1,7 @@
 {
   "summary": {
-    "total_apis": 1214,
-    "platform_api_total": 1120,
+    "total_apis": 1226,
+    "platform_api_total": 1132,
     "by_category": {
       "elements": {
         "total": 336,
@@ -40,28 +40,28 @@
         }
       },
       "css/properties": {
-        "total": 416,
+        "total": 428,
         "supported": {
-          "android": 384,
-          "ios": 384,
-          "harmony": 314,
-          "web_lynx": 336,
+          "android": 391,
+          "ios": 390,
+          "harmony": 318,
+          "web_lynx": 341,
           "clay_android": 375,
           "clay_ios": 306,
-          "clay_macos": 397,
-          "clay_windows": 401,
-          "clay": 407
+          "clay_macos": 402,
+          "clay_windows": 406,
+          "clay": 412
         },
         "coverage": {
-          "android": 92,
-          "ios": 92,
-          "harmony": 75,
-          "web_lynx": 81,
-          "clay_android": 90,
-          "clay_ios": 74,
-          "clay_macos": 95,
-          "clay_windows": 96,
-          "clay": 98
+          "android": 91,
+          "ios": 91,
+          "harmony": 74,
+          "web_lynx": 80,
+          "clay_android": 88,
+          "clay_ios": 71,
+          "clay_macos": 94,
+          "clay_windows": 95,
+          "clay": 96
         },
         "exclusive": {
           "android": 0,
@@ -72,7 +72,7 @@
           "clay_ios": 0,
           "clay_macos": 0,
           "clay_windows": 0,
-          "clay": 0
+          "clay": 4
         }
       },
       "css/at-rule": {
@@ -548,7 +548,7 @@
         "supported": {
           "android": 21,
           "ios": 21,
-          "harmony": 17,
+          "harmony": 20,
           "web_lynx": 0,
           "clay_android": 0,
           "clay_ios": 0,
@@ -559,7 +559,7 @@
         "coverage": {
           "android": 100,
           "ios": 100,
-          "harmony": 81,
+          "harmony": 95,
           "web_lynx": null,
           "clay_android": 0,
           "clay_ios": 0,
@@ -618,22 +618,22 @@
     },
     "by_platform": {
       "android": {
-        "supported_count": 1003,
-        "coverage_percent": 90,
+        "supported_count": 1010,
+        "coverage_percent": 89,
         "exclusive_count": 18
       },
       "ios": {
-        "supported_count": 1005,
-        "coverage_percent": 90,
+        "supported_count": 1011,
+        "coverage_percent": 89,
         "exclusive_count": 12
       },
       "harmony": {
-        "supported_count": 876,
+        "supported_count": 880,
         "coverage_percent": 78,
         "exclusive_count": 7
       },
       "web_lynx": {
-        "supported_count": 720,
+        "supported_count": 725,
         "coverage_percent": 64,
         "exclusive_count": 30
       },
@@ -644,23 +644,23 @@
       },
       "clay_ios": {
         "supported_count": 556,
-        "coverage_percent": 50,
+        "coverage_percent": 49,
         "exclusive_count": 0
       },
       "clay_macos": {
-        "supported_count": 988,
+        "supported_count": 993,
         "coverage_percent": 88,
         "exclusive_count": 0
       },
       "clay_windows": {
-        "supported_count": 992,
-        "coverage_percent": 89,
+        "supported_count": 997,
+        "coverage_percent": 88,
         "exclusive_count": 0
       },
       "clay": {
-        "supported_count": 1016,
-        "coverage_percent": 91,
-        "exclusive_count": 12
+        "supported_count": 1021,
+        "coverage_percent": 90,
+        "exclusive_count": 16
       }
     }
   },
@@ -21022,28 +21022,28 @@
     "css/properties": {
       "display_name": "CSS Properties",
       "stats": {
-        "total": 416,
+        "total": 428,
         "supported": {
-          "android": 384,
-          "ios": 384,
-          "harmony": 314,
-          "web_lynx": 336,
+          "android": 391,
+          "ios": 390,
+          "harmony": 318,
+          "web_lynx": 341,
           "clay_android": 375,
           "clay_ios": 306,
-          "clay_macos": 397,
-          "clay_windows": 401,
-          "clay": 407
+          "clay_macos": 402,
+          "clay_windows": 406,
+          "clay": 412
         },
         "coverage": {
-          "android": 92,
-          "ios": 92,
-          "harmony": 75,
-          "web_lynx": 81,
-          "clay_android": 90,
-          "clay_ios": 74,
-          "clay_macos": 95,
-          "clay_windows": 96,
-          "clay": 98
+          "android": 91,
+          "ios": 91,
+          "harmony": 74,
+          "web_lynx": 80,
+          "clay_android": 88,
+          "clay_ios": 71,
+          "clay_macos": 94,
+          "clay_windows": 95,
+          "clay": 96
         },
         "exclusive": {
           "android": 0,
@@ -21054,7 +21054,7 @@
           "clay_ios": 0,
           "clay_macos": 0,
           "clay_windows": 0,
-          "clay": 0
+          "clay": 4
         }
       },
       "apis": [
@@ -21062,8 +21062,14 @@
         "css/properties/-x-auto-font-size-line-ranges",
         "css/properties/-x-auto-font-size-preset-sizes",
         "css/properties/-x-auto-font-size",
+        "css/properties/-x-caret-gradient",
+        "css/properties/-x-caret-height",
+        "css/properties/-x-caret-radius",
+        "css/properties/-x-caret-width",
         "css/properties/-x-handle-color",
         "css/properties/-x-handle-size",
+        "css/properties/-x-text-decoration-gap",
+        "css/properties/-x-text-decoration-width",
         "css/properties/align-content",
         "css/properties/align-content.unsupported_value_",
         "css/properties/align-content.supported_in_flex_layout",
@@ -21413,6 +21419,7 @@
         "css/properties/margin.supported_in_linear_layout.nested_value_2",
         "css/properties/margin.supported_in_grid_layout",
         "css/properties/margin.supported_in_grid_layout.auto",
+        "css/properties/mask-composite",
         "css/properties/mask-image",
         "css/properties/mask",
         "css/properties/max-height",
@@ -21421,6 +21428,10 @@
         "css/properties/min-width",
         "css/properties/offset-distance",
         "css/properties/offset-path",
+        "css/properties/offset-path.circle()",
+        "css/properties/offset-path.inset()",
+        "css/properties/offset-path.ellipse()",
+        "css/properties/offset-path.path()",
         "css/properties/offset-rotate",
         "css/properties/opacity",
         "css/properties/order",
@@ -21466,6 +21477,7 @@
         "css/properties/row-gap.supported_in_grid_layout.grid-row-gap",
         "css/properties/row-gap.supported_in_grid_layout",
         "css/properties/text-align",
+        "css/properties/text-decoration-thickness",
         "css/properties/text-decoration",
         "css/properties/text-indent",
         "css/properties/text-overflow",
@@ -21587,6 +21599,70 @@
           }
         },
         {
+          "path": "css/properties/-x-caret-gradient",
+          "name": "-x-caret-gradient",
+          "doc_url": "api/css/properties/-x-caret-gradient",
+          "support": {
+            "android": false,
+            "ios": false,
+            "harmony": false,
+            "web_lynx": false,
+            "clay_android": false,
+            "clay_ios": false,
+            "clay_macos": "4.0",
+            "clay_windows": "4.0",
+            "clay": "4.0"
+          }
+        },
+        {
+          "path": "css/properties/-x-caret-height",
+          "name": "-x-caret-height",
+          "doc_url": "api/css/properties/-x-caret-height",
+          "support": {
+            "android": false,
+            "ios": false,
+            "harmony": false,
+            "web_lynx": false,
+            "clay_android": false,
+            "clay_ios": false,
+            "clay_macos": "4.0",
+            "clay_windows": "4.0",
+            "clay": "4.0"
+          }
+        },
+        {
+          "path": "css/properties/-x-caret-radius",
+          "name": "-x-caret-radius",
+          "doc_url": "api/css/properties/-x-caret-radius",
+          "support": {
+            "android": false,
+            "ios": false,
+            "harmony": false,
+            "web_lynx": false,
+            "clay_android": false,
+            "clay_ios": false,
+            "clay_macos": "4.0",
+            "clay_windows": "4.0",
+            "clay": "4.0"
+          }
+        },
+        {
+          "path": "css/properties/-x-caret-width",
+          "name": "-x-caret-width",
+          "doc_url": "api/css/properties/-x-caret-width",
+          "support": {
+            "android": false,
+            "ios": false,
+            "harmony": false,
+            "web_lynx": false,
+            "clay_android": false,
+            "clay_ios": false,
+            "clay_macos": "4.0",
+            "clay_windows": "4.0",
+            "clay": "4.0"
+          }
+        },
+        {
           "path": "css/properties/-x-handle-color",
           "name": "-x-handle-color",
           "doc_url": "api/css/properties/-x-handle-color",
@@ -21609,6 +21685,38 @@
           "support": {
             "android": "1.0",
             "ios": "1.0",
+            "harmony": false,
+            "web_lynx": false,
+            "clay_android": false,
+            "clay_ios": false,
+            "clay_macos": false,
+            "clay_windows": false,
+            "clay": false
+          }
+        },
+        {
+          "path": "css/properties/-x-text-decoration-gap",
+          "name": "-x-text-decoration-gap",
+          "doc_url": "api/css/properties/-x-text-decoration-gap",
+          "support": {
+            "android": "4.0",
+            "ios": "4.0",
+            "harmony": false,
+            "web_lynx": false,
+            "clay_android": false,
+            "clay_ios": false,
+            "clay_macos": false,
+            "clay_windows": false,
+            "clay": false
+          }
+        },
+        {
+          "path": "css/properties/-x-text-decoration-width",
+          "name": "-x-text-decoration-width",
+          "doc_url": "api/css/properties/-x-text-decoration-width",
+          "support": {
+            "android": "4.0",
+            "ios": "4.0",
             "harmony": false,
             "web_lynx": false,
             "clay_android": false,
@@ -27203,6 +27311,22 @@
           }
         },
         {
+          "path": "css/properties/mask-composite",
+          "name": "The mask-composite CSS property represents a compositing operation used on the current mask layer with the mask layers below it.",
+          "doc_url": "api/css/properties/mask-composite",
+          "support": {
+            "android": false,
+            "ios": false,
+            "harmony": false,
+            "web_lynx": true,
+            "clay_android": false,
+            "clay_ios": false,
+            "clay_macos": "4.0",
+            "clay_windows": "4.0",
+            "clay": "4.0"
+          }
+        },
+        {
           "path": "css/properties/mask-image",
           "name": "The mask-image CSS property sets the image that is used as mask layer for an element. By default this means the alpha channel of the mask image will be multiplied with the alpha channel of the element. This can be controlled with the mask-mode property.",
           "doc_url": "api/css/properties/mask-image",
@@ -27318,6 +27442,70 @@
           "path": "css/properties/offset-path",
           "name": "offset-path",
           "doc_url": "api/css/properties/offset-path",
+          "support": {
+            "android": "3.3",
+            "ios": "3.3",
+            "harmony": "3.8",
+            "web_lynx": true,
+            "clay_android": false,
+            "clay_ios": false,
+            "clay_macos": false,
+            "clay_windows": false,
+            "clay": false
+          }
+        },
+        {
+          "path": "css/properties/offset-path.circle()",
+          "name": "circle()",
+          "doc_url": "/api/css/properties/offset-path",
+          "support": {
+            "android": "3.3",
+            "ios": "3.3",
+            "harmony": "3.8",
+            "web_lynx": true,
+            "clay_android": false,
+            "clay_ios": false,
+            "clay_macos": false,
+            "clay_windows": false,
+            "clay": false
+          }
+        },
+        {
+          "path": "css/properties/offset-path.inset()",
+          "name": "inset()",
+          "doc_url": "/api/css/properties/offset-path",
+          "support": {
+            "android": "3.3",
+            "ios": "3.3",
+            "harmony": "3.8",
+            "web_lynx": true,
+            "clay_android": false,
+            "clay_ios": false,
+            "clay_macos": false,
+            "clay_windows": false,
+            "clay": false
+          }
+        },
+        {
+          "path": "css/properties/offset-path.ellipse()",
+          "name": "ellipse()",
+          "doc_url": "/api/css/properties/offset-path",
+          "support": {
+            "android": "3.3",
+            "ios": false,
+            "harmony": "3.8",
+            "web_lynx": true,
+            "clay_android": false,
+            "clay_ios": false,
+            "clay_macos": false,
+            "clay_windows": false,
+            "clay": false
+          }
+        },
+        {
+          "path": "css/properties/offset-path.path()",
+          "name": "path()",
+          "doc_url": "/api/css/properties/offset-path",
           "support": {
             "android": "3.3",
             "ios": "3.3",
@@ -28048,6 +28236,22 @@
             "clay_macos": "1.0",
             "clay_windows": "1.0",
             "clay": "1.0"
+          }
+        },
+        {
+          "path": "css/properties/text-decoration-thickness",
+          "name": "text-decoration-thickness",
+          "doc_url": "api/css/properties/text-decoration-thickness",
+          "support": {
+            "android": "4.0",
+            "ios": "4.0",
+            "harmony": false,
+            "web_lynx": false,
+            "clay_android": false,
+            "clay_ios": false,
+            "clay_macos": false,
+            "clay_windows": false,
+            "clay": false
           }
         },
         {
@@ -28918,6 +29122,70 @@
       "missing": {
         "android": [
           {
+            "path": "css/properties/-x-caret-gradient",
+            "name": "-x-caret-gradient",
+            "doc_url": "api/css/properties/-x-caret-gradient",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          },
+          {
+            "path": "css/properties/-x-caret-height",
+            "name": "-x-caret-height",
+            "doc_url": "api/css/properties/-x-caret-height",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          },
+          {
+            "path": "css/properties/-x-caret-radius",
+            "name": "-x-caret-radius",
+            "doc_url": "api/css/properties/-x-caret-radius",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          },
+          {
+            "path": "css/properties/-x-caret-width",
+            "name": "-x-caret-width",
+            "doc_url": "api/css/properties/-x-caret-width",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          },
+          {
             "path": "css/properties/cursor",
             "name": "The cursor CSS property controls the mouse pointer displayed when the pointer hovers over an element.",
             "doc_url": "api/css/properties/cursor",
@@ -29427,11 +29695,91 @@
               "clay_macos": false,
               "clay_windows": "3.7",
               "clay": "3.7"
+            }
+          },
+          {
+            "path": "css/properties/mask-composite",
+            "name": "The mask-composite CSS property represents a compositing operation used on the current mask layer with the mask layers below it.",
+            "doc_url": "api/css/properties/mask-composite",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
             }
           }
         ],
         "ios": [
           {
+            "path": "css/properties/-x-caret-gradient",
+            "name": "-x-caret-gradient",
+            "doc_url": "api/css/properties/-x-caret-gradient",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          },
+          {
+            "path": "css/properties/-x-caret-height",
+            "name": "-x-caret-height",
+            "doc_url": "api/css/properties/-x-caret-height",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          },
+          {
+            "path": "css/properties/-x-caret-radius",
+            "name": "-x-caret-radius",
+            "doc_url": "api/css/properties/-x-caret-radius",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          },
+          {
+            "path": "css/properties/-x-caret-width",
+            "name": "-x-caret-width",
+            "doc_url": "api/css/properties/-x-caret-width",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          },
+          {
             "path": "css/properties/cursor",
             "name": "The cursor CSS property controls the mouse pointer displayed when the pointer hovers over an element.",
             "doc_url": "api/css/properties/cursor",
@@ -29941,6 +30289,38 @@
               "clay_macos": false,
               "clay_windows": "3.7",
               "clay": "3.7"
+            }
+          },
+          {
+            "path": "css/properties/mask-composite",
+            "name": "The mask-composite CSS property represents a compositing operation used on the current mask layer with the mask layers below it.",
+            "doc_url": "api/css/properties/mask-composite",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          },
+          {
+            "path": "css/properties/offset-path.ellipse()",
+            "name": "ellipse()",
+            "doc_url": "/api/css/properties/offset-path",
+            "support": {
+              "android": "3.3",
+              "ios": false,
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
             }
           }
         ],
@@ -29994,6 +30374,70 @@
             }
           },
           {
+            "path": "css/properties/-x-caret-gradient",
+            "name": "-x-caret-gradient",
+            "doc_url": "api/css/properties/-x-caret-gradient",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          },
+          {
+            "path": "css/properties/-x-caret-height",
+            "name": "-x-caret-height",
+            "doc_url": "api/css/properties/-x-caret-height",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          },
+          {
+            "path": "css/properties/-x-caret-radius",
+            "name": "-x-caret-radius",
+            "doc_url": "api/css/properties/-x-caret-radius",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          },
+          {
+            "path": "css/properties/-x-caret-width",
+            "name": "-x-caret-width",
+            "doc_url": "api/css/properties/-x-caret-width",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          },
+          {
             "path": "css/properties/-x-handle-color",
             "name": "-x-handle-color",
             "doc_url": "api/css/properties/-x-handle-color",
@@ -30016,6 +30460,38 @@
             "support": {
               "android": "1.0",
               "ios": "1.0",
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/-x-text-decoration-gap",
+            "name": "-x-text-decoration-gap",
+            "doc_url": "api/css/properties/-x-text-decoration-gap",
+            "support": {
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/-x-text-decoration-width",
+            "name": "-x-text-decoration-width",
+            "doc_url": "api/css/properties/-x-text-decoration-width",
+            "support": {
+              "android": "4.0",
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
@@ -31082,6 +31558,22 @@
             }
           },
           {
+            "path": "css/properties/mask-composite",
+            "name": "The mask-composite CSS property represents a compositing operation used on the current mask layer with the mask layers below it.",
+            "doc_url": "api/css/properties/mask-composite",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          },
+          {
             "path": "css/properties/mask-image",
             "name": "The mask-image CSS property sets the image that is used as mask layer for an element. By default this means the alpha channel of the mask image will be multiplied with the alpha channel of the element. This can be controlled with the mask-mode property.",
             "doc_url": "api/css/properties/mask-image",
@@ -31127,6 +31619,22 @@
               "clay_macos": "2.1",
               "clay_windows": "2.1",
               "clay": "2.1"
+            }
+          },
+          {
+            "path": "css/properties/text-decoration-thickness",
+            "name": "text-decoration-thickness",
+            "doc_url": "api/css/properties/text-decoration-thickness",
+            "support": {
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
             }
           },
           {
@@ -31644,6 +32152,70 @@
             }
           },
           {
+            "path": "css/properties/-x-caret-gradient",
+            "name": "-x-caret-gradient",
+            "doc_url": "api/css/properties/-x-caret-gradient",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          },
+          {
+            "path": "css/properties/-x-caret-height",
+            "name": "-x-caret-height",
+            "doc_url": "api/css/properties/-x-caret-height",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          },
+          {
+            "path": "css/properties/-x-caret-radius",
+            "name": "-x-caret-radius",
+            "doc_url": "api/css/properties/-x-caret-radius",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          },
+          {
+            "path": "css/properties/-x-caret-width",
+            "name": "-x-caret-width",
+            "doc_url": "api/css/properties/-x-caret-width",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          },
+          {
             "path": "css/properties/-x-handle-color",
             "name": "-x-handle-color",
             "doc_url": "api/css/properties/-x-handle-color",
@@ -31666,6 +32238,38 @@
             "support": {
               "android": "1.0",
               "ios": "1.0",
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/-x-text-decoration-gap",
+            "name": "-x-text-decoration-gap",
+            "doc_url": "api/css/properties/-x-text-decoration-gap",
+            "support": {
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/-x-text-decoration-width",
+            "name": "-x-text-decoration-width",
+            "doc_url": "api/css/properties/-x-text-decoration-width",
+            "support": {
+              "android": "4.0",
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
@@ -32412,6 +33016,22 @@
             }
           },
           {
+            "path": "css/properties/text-decoration-thickness",
+            "name": "text-decoration-thickness",
+            "doc_url": "api/css/properties/text-decoration-thickness",
+            "support": {
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
             "path": "css/properties/transform.translate",
             "name": "translate",
             "doc_url": "/api/css/properties/transform",
@@ -32878,6 +33498,70 @@
             }
           },
           {
+            "path": "css/properties/-x-caret-gradient",
+            "name": "-x-caret-gradient",
+            "doc_url": "api/css/properties/-x-caret-gradient",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          },
+          {
+            "path": "css/properties/-x-caret-height",
+            "name": "-x-caret-height",
+            "doc_url": "api/css/properties/-x-caret-height",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          },
+          {
+            "path": "css/properties/-x-caret-radius",
+            "name": "-x-caret-radius",
+            "doc_url": "api/css/properties/-x-caret-radius",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          },
+          {
+            "path": "css/properties/-x-caret-width",
+            "name": "-x-caret-width",
+            "doc_url": "api/css/properties/-x-caret-width",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          },
+          {
             "path": "css/properties/-x-handle-color",
             "name": "-x-handle-color",
             "doc_url": "api/css/properties/-x-handle-color",
@@ -32900,6 +33584,38 @@
             "support": {
               "android": "1.0",
               "ios": "1.0",
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/-x-text-decoration-gap",
+            "name": "-x-text-decoration-gap",
+            "doc_url": "api/css/properties/-x-text-decoration-gap",
+            "support": {
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/-x-text-decoration-width",
+            "name": "-x-text-decoration-width",
+            "doc_url": "api/css/properties/-x-text-decoration-width",
+            "support": {
+              "android": "4.0",
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
@@ -33470,6 +34186,22 @@
             }
           },
           {
+            "path": "css/properties/mask-composite",
+            "name": "The mask-composite CSS property represents a compositing operation used on the current mask layer with the mask layers below it.",
+            "doc_url": "api/css/properties/mask-composite",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          },
+          {
             "path": "css/properties/offset-distance",
             "name": "offset-distance",
             "doc_url": "api/css/properties/offset-distance",
@@ -33502,6 +34234,70 @@
             }
           },
           {
+            "path": "css/properties/offset-path.circle()",
+            "name": "circle()",
+            "doc_url": "/api/css/properties/offset-path",
+            "support": {
+              "android": "3.3",
+              "ios": "3.3",
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/offset-path.inset()",
+            "name": "inset()",
+            "doc_url": "/api/css/properties/offset-path",
+            "support": {
+              "android": "3.3",
+              "ios": "3.3",
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/offset-path.ellipse()",
+            "name": "ellipse()",
+            "doc_url": "/api/css/properties/offset-path",
+            "support": {
+              "android": "3.3",
+              "ios": false,
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/offset-path.path()",
+            "name": "path()",
+            "doc_url": "/api/css/properties/offset-path",
+            "support": {
+              "android": "3.3",
+              "ios": "3.3",
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
             "path": "css/properties/offset-rotate",
             "name": "offset-rotate",
             "doc_url": "api/css/properties/offset-rotate",
@@ -33510,6 +34306,22 @@
               "ios": "3.3",
               "harmony": "3.8",
               "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/text-decoration-thickness",
+            "name": "text-decoration-thickness",
+            "doc_url": "api/css/properties/text-decoration-thickness",
+            "support": {
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": false,
+              "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": false,
@@ -33536,6 +34348,70 @@
             }
           },
           {
+            "path": "css/properties/-x-caret-gradient",
+            "name": "-x-caret-gradient",
+            "doc_url": "api/css/properties/-x-caret-gradient",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          },
+          {
+            "path": "css/properties/-x-caret-height",
+            "name": "-x-caret-height",
+            "doc_url": "api/css/properties/-x-caret-height",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          },
+          {
+            "path": "css/properties/-x-caret-radius",
+            "name": "-x-caret-radius",
+            "doc_url": "api/css/properties/-x-caret-radius",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          },
+          {
+            "path": "css/properties/-x-caret-width",
+            "name": "-x-caret-width",
+            "doc_url": "api/css/properties/-x-caret-width",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          },
+          {
             "path": "css/properties/-x-handle-color",
             "name": "-x-handle-color",
             "doc_url": "api/css/properties/-x-handle-color",
@@ -33558,6 +34434,38 @@
             "support": {
               "android": "1.0",
               "ios": "1.0",
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/-x-text-decoration-gap",
+            "name": "-x-text-decoration-gap",
+            "doc_url": "api/css/properties/-x-text-decoration-gap",
+            "support": {
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/-x-text-decoration-width",
+            "name": "-x-text-decoration-width",
+            "doc_url": "api/css/properties/-x-text-decoration-width",
+            "support": {
+              "android": "4.0",
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
@@ -34784,6 +35692,22 @@
             }
           },
           {
+            "path": "css/properties/mask-composite",
+            "name": "The mask-composite CSS property represents a compositing operation used on the current mask layer with the mask layers below it.",
+            "doc_url": "api/css/properties/mask-composite",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          },
+          {
             "path": "css/properties/offset-distance",
             "name": "offset-distance",
             "doc_url": "api/css/properties/offset-distance",
@@ -34816,6 +35740,70 @@
             }
           },
           {
+            "path": "css/properties/offset-path.circle()",
+            "name": "circle()",
+            "doc_url": "/api/css/properties/offset-path",
+            "support": {
+              "android": "3.3",
+              "ios": "3.3",
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/offset-path.inset()",
+            "name": "inset()",
+            "doc_url": "/api/css/properties/offset-path",
+            "support": {
+              "android": "3.3",
+              "ios": "3.3",
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/offset-path.ellipse()",
+            "name": "ellipse()",
+            "doc_url": "/api/css/properties/offset-path",
+            "support": {
+              "android": "3.3",
+              "ios": false,
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/offset-path.path()",
+            "name": "path()",
+            "doc_url": "/api/css/properties/offset-path",
+            "support": {
+              "android": "3.3",
+              "ios": "3.3",
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
             "path": "css/properties/offset-rotate",
             "name": "offset-rotate",
             "doc_url": "api/css/properties/offset-rotate",
@@ -34824,6 +35812,22 @@
               "ios": "3.3",
               "harmony": "3.8",
               "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/text-decoration-thickness",
+            "name": "text-decoration-thickness",
+            "doc_url": "api/css/properties/text-decoration-thickness",
+            "support": {
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": false,
+              "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": false,
@@ -35330,6 +36334,38 @@
             }
           },
           {
+            "path": "css/properties/-x-text-decoration-gap",
+            "name": "-x-text-decoration-gap",
+            "doc_url": "api/css/properties/-x-text-decoration-gap",
+            "support": {
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/-x-text-decoration-width",
+            "name": "-x-text-decoration-width",
+            "doc_url": "api/css/properties/-x-text-decoration-width",
+            "support": {
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
             "path": "css/properties/cursor.help",
             "name": "help",
             "doc_url": "/api/css/properties/cursor",
@@ -35570,6 +36606,70 @@
             }
           },
           {
+            "path": "css/properties/offset-path.circle()",
+            "name": "circle()",
+            "doc_url": "/api/css/properties/offset-path",
+            "support": {
+              "android": "3.3",
+              "ios": "3.3",
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/offset-path.inset()",
+            "name": "inset()",
+            "doc_url": "/api/css/properties/offset-path",
+            "support": {
+              "android": "3.3",
+              "ios": "3.3",
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/offset-path.ellipse()",
+            "name": "ellipse()",
+            "doc_url": "/api/css/properties/offset-path",
+            "support": {
+              "android": "3.3",
+              "ios": false,
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/offset-path.path()",
+            "name": "path()",
+            "doc_url": "/api/css/properties/offset-path",
+            "support": {
+              "android": "3.3",
+              "ios": "3.3",
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
             "path": "css/properties/offset-rotate",
             "name": "offset-rotate",
             "doc_url": "api/css/properties/offset-rotate",
@@ -35578,6 +36678,22 @@
               "ios": "3.3",
               "harmony": "3.8",
               "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/text-decoration-thickness",
+            "name": "text-decoration-thickness",
+            "doc_url": "api/css/properties/text-decoration-thickness",
+            "support": {
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": false,
+              "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": false,
@@ -35626,6 +36742,38 @@
             "support": {
               "android": "1.0",
               "ios": "1.0",
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/-x-text-decoration-gap",
+            "name": "-x-text-decoration-gap",
+            "doc_url": "api/css/properties/-x-text-decoration-gap",
+            "support": {
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/-x-text-decoration-width",
+            "name": "-x-text-decoration-width",
+            "doc_url": "api/css/properties/-x-text-decoration-width",
+            "support": {
+              "android": "4.0",
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
@@ -35812,6 +36960,70 @@
             }
           },
           {
+            "path": "css/properties/offset-path.circle()",
+            "name": "circle()",
+            "doc_url": "/api/css/properties/offset-path",
+            "support": {
+              "android": "3.3",
+              "ios": "3.3",
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/offset-path.inset()",
+            "name": "inset()",
+            "doc_url": "/api/css/properties/offset-path",
+            "support": {
+              "android": "3.3",
+              "ios": "3.3",
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/offset-path.ellipse()",
+            "name": "ellipse()",
+            "doc_url": "/api/css/properties/offset-path",
+            "support": {
+              "android": "3.3",
+              "ios": false,
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/offset-path.path()",
+            "name": "path()",
+            "doc_url": "/api/css/properties/offset-path",
+            "support": {
+              "android": "3.3",
+              "ios": "3.3",
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
             "path": "css/properties/offset-rotate",
             "name": "offset-rotate",
             "doc_url": "api/css/properties/offset-rotate",
@@ -35820,6 +37032,22 @@
               "ios": "3.3",
               "harmony": "3.8",
               "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/text-decoration-thickness",
+            "name": "text-decoration-thickness",
+            "doc_url": "api/css/properties/text-decoration-thickness",
+            "support": {
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": false,
+              "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": false,
@@ -35868,6 +37096,38 @@
             "support": {
               "android": "1.0",
               "ios": "1.0",
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/-x-text-decoration-gap",
+            "name": "-x-text-decoration-gap",
+            "doc_url": "api/css/properties/-x-text-decoration-gap",
+            "support": {
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/-x-text-decoration-width",
+            "name": "-x-text-decoration-width",
+            "doc_url": "api/css/properties/-x-text-decoration-width",
+            "support": {
+              "android": "4.0",
+              "ios": "4.0",
               "harmony": false,
               "web_lynx": false,
               "clay_android": false,
@@ -35958,6 +37218,70 @@
             }
           },
           {
+            "path": "css/properties/offset-path.circle()",
+            "name": "circle()",
+            "doc_url": "/api/css/properties/offset-path",
+            "support": {
+              "android": "3.3",
+              "ios": "3.3",
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/offset-path.inset()",
+            "name": "inset()",
+            "doc_url": "/api/css/properties/offset-path",
+            "support": {
+              "android": "3.3",
+              "ios": "3.3",
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/offset-path.ellipse()",
+            "name": "ellipse()",
+            "doc_url": "/api/css/properties/offset-path",
+            "support": {
+              "android": "3.3",
+              "ios": false,
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/offset-path.path()",
+            "name": "path()",
+            "doc_url": "/api/css/properties/offset-path",
+            "support": {
+              "android": "3.3",
+              "ios": "3.3",
+              "harmony": "3.8",
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
             "path": "css/properties/offset-rotate",
             "name": "offset-rotate",
             "doc_url": "api/css/properties/offset-rotate",
@@ -35966,6 +37290,22 @@
               "ios": "3.3",
               "harmony": "3.8",
               "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
+          {
+            "path": "css/properties/text-decoration-thickness",
+            "name": "text-decoration-thickness",
+            "doc_url": "api/css/properties/text-decoration-thickness",
+            "support": {
+              "android": "4.0",
+              "ios": "4.0",
+              "harmony": false,
+              "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": false,
@@ -36258,7 +37598,72 @@
         "clay_ios": [],
         "clay_macos": [],
         "clay_windows": [],
-        "clay": []
+        "clay": [
+          {
+            "path": "css/properties/-x-caret-gradient",
+            "name": "-x-caret-gradient",
+            "doc_url": "api/css/properties/-x-caret-gradient",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          },
+          {
+            "path": "css/properties/-x-caret-height",
+            "name": "-x-caret-height",
+            "doc_url": "api/css/properties/-x-caret-height",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          },
+          {
+            "path": "css/properties/-x-caret-radius",
+            "name": "-x-caret-radius",
+            "doc_url": "api/css/properties/-x-caret-radius",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          },
+          {
+            "path": "css/properties/-x-caret-width",
+            "name": "-x-caret-width",
+            "doc_url": "api/css/properties/-x-caret-width",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": "4.0",
+              "clay_windows": "4.0",
+              "clay": "4.0"
+            }
+          }
+        ]
       }
     },
     "css/at-rule": {
@@ -66354,7 +67759,7 @@
         "supported": {
           "android": 21,
           "ios": 21,
-          "harmony": 17,
+          "harmony": 20,
           "web_lynx": 0,
           "clay_android": 0,
           "clay_ios": 0,
@@ -66365,7 +67770,7 @@
         "coverage": {
           "android": 100,
           "ios": 100,
-          "harmony": 81,
+          "harmony": 95,
           "web_lynx": null,
           "clay_android": 0,
           "clay_ios": 0,
@@ -66481,7 +67886,7 @@
           "support": {
             "android": "3.0",
             "ios": "3.0",
-            "harmony": false,
+            "harmony": "4.0",
             "web_lynx": false,
             "clay_android": false,
             "clay_ios": false,
@@ -66497,7 +67902,7 @@
           "support": {
             "android": "3.0",
             "ios": "3.0",
-            "harmony": false,
+            "harmony": "4.0",
             "web_lynx": false,
             "clay_android": false,
             "clay_ios": false,
@@ -66513,7 +67918,7 @@
           "support": {
             "android": "3.0",
             "ios": "3.0",
-            "harmony": false,
+            "harmony": "4.0",
             "web_lynx": false,
             "clay_android": false,
             "clay_ios": false,
@@ -66768,54 +68173,6 @@
         "ios": [],
         "harmony": [
           {
-            "path": "devtool/logbox.notification",
-            "name": "Notification with a brief message",
-            "doc_url": "/guide/devtool/logbox",
-            "support": {
-              "android": "3.0",
-              "ios": "3.0",
-              "harmony": false,
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": false,
-              "clay_windows": false,
-              "clay": false
-            }
-          },
-          {
-            "path": "devtool/logbox.MTS Analysis",
-            "name": "MTS Analysis",
-            "doc_url": "/guide/devtool/logbox",
-            "support": {
-              "android": "3.0",
-              "ios": "3.0",
-              "harmony": false,
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": false,
-              "clay_windows": false,
-              "clay": false
-            }
-          },
-          {
-            "path": "devtool/logbox.BTS Analysis",
-            "name": "BTS Analysis",
-            "doc_url": "/guide/devtool/logbox",
-            "support": {
-              "android": "3.0",
-              "ios": "3.0",
-              "harmony": false,
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": false,
-              "clay_windows": false,
-              "clay": false
-            }
-          },
-          {
             "path": "devtool/panels.elements.preview.fullscreen",
             "name": "Fullscreen mirroring",
             "doc_url": "/guide/devtool/panels",
@@ -66904,7 +68261,7 @@
             "support": {
               "android": "3.0",
               "ios": "3.0",
-              "harmony": false,
+              "harmony": "4.0",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -66920,7 +68277,7 @@
             "support": {
               "android": "3.0",
               "ios": "3.0",
-              "harmony": false,
+              "harmony": "4.0",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -66936,7 +68293,7 @@
             "support": {
               "android": "3.0",
               "ios": "3.0",
-              "harmony": false,
+              "harmony": "4.0",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -67242,7 +68599,7 @@
             "support": {
               "android": "3.0",
               "ios": "3.0",
-              "harmony": false,
+              "harmony": "4.0",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -67258,7 +68615,7 @@
             "support": {
               "android": "3.0",
               "ios": "3.0",
-              "harmony": false,
+              "harmony": "4.0",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -67274,7 +68631,7 @@
             "support": {
               "android": "3.0",
               "ios": "3.0",
-              "harmony": false,
+              "harmony": "4.0",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -67580,7 +68937,7 @@
             "support": {
               "android": "3.0",
               "ios": "3.0",
-              "harmony": false,
+              "harmony": "4.0",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -67596,7 +68953,7 @@
             "support": {
               "android": "3.0",
               "ios": "3.0",
-              "harmony": false,
+              "harmony": "4.0",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -67612,7 +68969,7 @@
             "support": {
               "android": "3.0",
               "ios": "3.0",
-              "harmony": false,
+              "harmony": "4.0",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -67918,7 +69275,7 @@
             "support": {
               "android": "3.0",
               "ios": "3.0",
-              "harmony": false,
+              "harmony": "4.0",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -67934,7 +69291,7 @@
             "support": {
               "android": "3.0",
               "ios": "3.0",
-              "harmony": false,
+              "harmony": "4.0",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -67950,7 +69307,7 @@
             "support": {
               "android": "3.0",
               "ios": "3.0",
-              "harmony": false,
+              "harmony": "4.0",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -68256,7 +69613,7 @@
             "support": {
               "android": "3.0",
               "ios": "3.0",
-              "harmony": false,
+              "harmony": "4.0",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -68272,7 +69629,7 @@
             "support": {
               "android": "3.0",
               "ios": "3.0",
-              "harmony": false,
+              "harmony": "4.0",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -68288,7 +69645,7 @@
             "support": {
               "android": "3.0",
               "ios": "3.0",
-              "harmony": false,
+              "harmony": "4.0",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -83870,6 +85227,150 @@
     },
     {
       "id": "feature-373",
+      "query": "css/properties/-x-caret-gradient",
+      "name": "-x-caret-gradient",
+      "category": "css/properties",
+      "source_file": "css/properties/-x-caret-gradient.json",
+      "support": {
+        "android": {
+          "version_added": false
+        },
+        "ios": {
+          "version_added": false
+        },
+        "harmony": {
+          "version_added": false
+        },
+        "web_lynx": {
+          "version_added": false
+        },
+        "clay_android": {
+          "version_added": false
+        },
+        "clay_ios": {
+          "version_added": false
+        },
+        "clay_macos": {
+          "version_added": "4.0"
+        },
+        "clay_windows": {
+          "version_added": "4.0"
+        },
+        "clay": {
+          "version_added": "4.0"
+        }
+      }
+    },
+    {
+      "id": "feature-374",
+      "query": "css/properties/-x-caret-height",
+      "name": "-x-caret-height",
+      "category": "css/properties",
+      "source_file": "css/properties/-x-caret-height.json",
+      "support": {
+        "android": {
+          "version_added": false
+        },
+        "ios": {
+          "version_added": false
+        },
+        "harmony": {
+          "version_added": false
+        },
+        "web_lynx": {
+          "version_added": false
+        },
+        "clay_android": {
+          "version_added": false
+        },
+        "clay_ios": {
+          "version_added": false
+        },
+        "clay_macos": {
+          "version_added": "4.0"
+        },
+        "clay_windows": {
+          "version_added": "4.0"
+        },
+        "clay": {
+          "version_added": "4.0"
+        }
+      }
+    },
+    {
+      "id": "feature-375",
+      "query": "css/properties/-x-caret-radius",
+      "name": "-x-caret-radius",
+      "category": "css/properties",
+      "source_file": "css/properties/-x-caret-radius.json",
+      "support": {
+        "android": {
+          "version_added": false
+        },
+        "ios": {
+          "version_added": false
+        },
+        "harmony": {
+          "version_added": false
+        },
+        "web_lynx": {
+          "version_added": false
+        },
+        "clay_android": {
+          "version_added": false
+        },
+        "clay_ios": {
+          "version_added": false
+        },
+        "clay_macos": {
+          "version_added": "4.0"
+        },
+        "clay_windows": {
+          "version_added": "4.0"
+        },
+        "clay": {
+          "version_added": "4.0"
+        }
+      }
+    },
+    {
+      "id": "feature-376",
+      "query": "css/properties/-x-caret-width",
+      "name": "-x-caret-width",
+      "category": "css/properties",
+      "source_file": "css/properties/-x-caret-width.json",
+      "support": {
+        "android": {
+          "version_added": false
+        },
+        "ios": {
+          "version_added": false
+        },
+        "harmony": {
+          "version_added": false
+        },
+        "web_lynx": {
+          "version_added": false
+        },
+        "clay_android": {
+          "version_added": false
+        },
+        "clay_ios": {
+          "version_added": false
+        },
+        "clay_macos": {
+          "version_added": "4.0"
+        },
+        "clay_windows": {
+          "version_added": "4.0"
+        },
+        "clay": {
+          "version_added": "4.0"
+        }
+      }
+    },
+    {
+      "id": "feature-377",
       "query": "css/properties/-x-handle-color",
       "name": "-x-handle-color",
       "category": "css/properties",
@@ -83905,7 +85406,7 @@
       }
     },
     {
-      "id": "feature-374",
+      "id": "feature-378",
       "query": "css/properties/-x-handle-size",
       "name": "-x-handle-size",
       "category": "css/properties",
@@ -83941,7 +85442,79 @@
       }
     },
     {
-      "id": "feature-375",
+      "id": "feature-379",
+      "query": "css/properties/-x-text-decoration-gap",
+      "name": "-x-text-decoration-gap",
+      "category": "css/properties",
+      "source_file": "css/properties/-x-text-decoration-gap.json",
+      "support": {
+        "android": {
+          "version_added": "4.0"
+        },
+        "ios": {
+          "version_added": "4.0"
+        },
+        "harmony": {
+          "version_added": false
+        },
+        "web_lynx": {
+          "version_added": false
+        },
+        "clay_android": {
+          "version_added": false
+        },
+        "clay_ios": {
+          "version_added": false
+        },
+        "clay_macos": {
+          "version_added": false
+        },
+        "clay_windows": {
+          "version_added": false
+        },
+        "clay": {
+          "version_added": false
+        }
+      }
+    },
+    {
+      "id": "feature-380",
+      "query": "css/properties/-x-text-decoration-width",
+      "name": "-x-text-decoration-width",
+      "category": "css/properties",
+      "source_file": "css/properties/-x-text-decoration-width.json",
+      "support": {
+        "android": {
+          "version_added": "4.0"
+        },
+        "ios": {
+          "version_added": "4.0"
+        },
+        "harmony": {
+          "version_added": false
+        },
+        "web_lynx": {
+          "version_added": false
+        },
+        "clay_android": {
+          "version_added": false
+        },
+        "clay_ios": {
+          "version_added": false
+        },
+        "clay_macos": {
+          "version_added": false
+        },
+        "clay_windows": {
+          "version_added": false
+        },
+        "clay": {
+          "version_added": false
+        }
+      }
+    },
+    {
+      "id": "feature-381",
       "query": "css/properties/align-content",
       "name": "align-content",
       "category": "css/properties",
@@ -83977,7 +85550,7 @@
       }
     },
     {
-      "id": "feature-376",
+      "id": "feature-382",
       "query": "css/properties/align-content.unsupported_value_",
       "name": "<code>normal</code>, <code>space-evenly</code>",
       "category": "css/properties",
@@ -84013,7 +85586,7 @@
       }
     },
     {
-      "id": "feature-377",
+      "id": "feature-383",
       "query": "css/properties/align-content.supported_in_flex_layout",
       "name": "Supported in Flexible Box Layout",
       "category": "css/properties",
@@ -84049,7 +85622,7 @@
       }
     },
     {
-      "id": "feature-378",
+      "id": "feature-384",
       "query": "css/properties/align-content.supported_in_flex_layout.nested_value_1",
       "name": "<code>stretch</code>, <code>flex-start</code>, <code>flex-end</code>, <code>center</code>, <code>space-between</code> and <code>space-around</code>",
       "category": "css/properties",
@@ -84085,7 +85658,7 @@
       }
     },
     {
-      "id": "feature-379",
+      "id": "feature-385",
       "query": "css/properties/align-content.supported_in_flex_layout.nested_value_2",
       "name": "<code>start</code> and <code>end</code>",
       "category": "css/properties",
@@ -84121,7 +85694,7 @@
       }
     },
     {
-      "id": "feature-380",
+      "id": "feature-386",
       "query": "css/properties/align-content.supported_in_grid_layout",
       "name": "Supported in Grid Layout",
       "category": "css/properties",
@@ -84157,7 +85730,7 @@
       }
     },
     {
-      "id": "feature-381",
+      "id": "feature-387",
       "query": "css/properties/align-content.supported_in_grid_layout.nested_value_1",
       "name": "<code>stretch</code>, <code>flex-start</code>, <code>flex-end</code>, <code>center</code>, <code>space-between</code> and <code>space-around</code>",
       "category": "css/properties",
@@ -84193,7 +85766,7 @@
       }
     },
     {
-      "id": "feature-382",
+      "id": "feature-388",
       "query": "css/properties/align-content.supported_in_grid_layout.nested_value_2",
       "name": "<code>start</code> and <code>end</code>",
       "category": "css/properties",
@@ -84229,7 +85802,7 @@
       }
     },
     {
-      "id": "feature-383",
+      "id": "feature-389",
       "query": "css/properties/align-items",
       "name": "align-items",
       "category": "css/properties",
@@ -84265,7 +85838,7 @@
       }
     },
     {
-      "id": "feature-384",
+      "id": "feature-390",
       "query": "css/properties/align-items.supported_in_flex_layout",
       "name": "Supported in Flexible Box Layout",
       "category": "css/properties",
@@ -84301,7 +85874,7 @@
       }
     },
     {
-      "id": "feature-385",
+      "id": "feature-391",
       "query": "css/properties/align-items.supported_in_flex_layout.stretch-flex-start-flex-end-center",
       "name": "<code>stretch</code>, <code>flex-start</code>, <code>flex-end</code>, <code>center</code>",
       "category": "css/properties",
@@ -84337,7 +85910,7 @@
       }
     },
     {
-      "id": "feature-386",
+      "id": "feature-392",
       "query": "css/properties/align-items.supported_in_flex_layout.start-and-end",
       "name": "<code>start</code> and <code>end</code>",
       "category": "css/properties",
@@ -84373,7 +85946,7 @@
       }
     },
     {
-      "id": "feature-387",
+      "id": "feature-393",
       "query": "css/properties/align-items.supported_in_flex_layout.baseline",
       "name": "baseline",
       "category": "css/properties",
@@ -84409,7 +85982,7 @@
       }
     },
     {
-      "id": "feature-388",
+      "id": "feature-394",
       "query": "css/properties/align-items.supported_in_linear_layout",
       "name": "Supported in Linear Layout",
       "category": "css/properties",
@@ -84445,7 +86018,7 @@
       }
     },
     {
-      "id": "feature-389",
+      "id": "feature-395",
       "query": "css/properties/align-items.supported_in_linear_layout.flex-start-flex-end-center",
       "name": "<code>flex-start</code>, <code>flex-end</code>, <code>center</code>",
       "category": "css/properties",
@@ -84481,7 +86054,7 @@
       }
     },
     {
-      "id": "feature-390",
+      "id": "feature-396",
       "query": "css/properties/align-items.supported_in_linear_layout.start-and-end",
       "name": "<code>start</code> and <code>end</code>",
       "category": "css/properties",
@@ -84517,7 +86090,7 @@
       }
     },
     {
-      "id": "feature-391",
+      "id": "feature-397",
       "query": "css/properties/align-items.supported_in_linear_layout.baseline-and-stretch",
       "name": "<code>baseline</code> and <code>stretch</code>",
       "category": "css/properties",
@@ -84553,7 +86126,7 @@
       }
     },
     {
-      "id": "feature-392",
+      "id": "feature-398",
       "query": "css/properties/align-items.supported_in_grid_layout",
       "name": "Supported in Grid Layout",
       "category": "css/properties",
@@ -84589,7 +86162,7 @@
       }
     },
     {
-      "id": "feature-393",
+      "id": "feature-399",
       "query": "css/properties/align-items.supported_in_grid_layout.stretch-flex-start-flex-end-center",
       "name": "<code>stretch</code>, <code>flex-start</code>, <code>flex-end</code>, <code>center</code>",
       "category": "css/properties",
@@ -84625,7 +86198,7 @@
       }
     },
     {
-      "id": "feature-394",
+      "id": "feature-400",
       "query": "css/properties/align-items.supported_in_grid_layout.start-and-end",
       "name": "<code>start</code> and <code>end</code>",
       "category": "css/properties",
@@ -84661,7 +86234,7 @@
       }
     },
     {
-      "id": "feature-395",
+      "id": "feature-401",
       "query": "css/properties/align-items.supported_in_grid_layout.baseline",
       "name": "baseline",
       "category": "css/properties",
@@ -84697,7 +86270,7 @@
       }
     },
     {
-      "id": "feature-396",
+      "id": "feature-402",
       "query": "css/properties/align-items.normal",
       "name": "normal",
       "category": "css/properties",
@@ -84733,7 +86306,7 @@
       }
     },
     {
-      "id": "feature-397",
+      "id": "feature-403",
       "query": "css/properties/align-self",
       "name": "align-self",
       "category": "css/properties",
@@ -84769,7 +86342,7 @@
       }
     },
     {
-      "id": "feature-398",
+      "id": "feature-404",
       "query": "css/properties/align-self.supported_in_flex_layout",
       "name": "Supported in Flexible Box Layout",
       "category": "css/properties",
@@ -84805,7 +86378,7 @@
       }
     },
     {
-      "id": "feature-399",
+      "id": "feature-405",
       "query": "css/properties/align-self.supported_in_flex_layout.nested_value_1",
       "name": "<code>auto</code>, <code>stretch</code>, <code>flex-start</code>, <code>flex-end</code>, <code>center</code>",
       "category": "css/properties",
@@ -84841,7 +86414,7 @@
       }
     },
     {
-      "id": "feature-400",
+      "id": "feature-406",
       "query": "css/properties/align-self.supported_in_flex_layout.nested_value_3",
       "name": "<code>start</code> and <code>end</code>",
       "category": "css/properties",
@@ -84877,7 +86450,7 @@
       }
     },
     {
-      "id": "feature-401",
+      "id": "feature-407",
       "query": "css/properties/align-self.supported_in_flex_layout.baseline",
       "name": "<code>baseline</code>",
       "category": "css/properties",
@@ -84913,7 +86486,7 @@
       }
     },
     {
-      "id": "feature-402",
+      "id": "feature-408",
       "query": "css/properties/align-self.supported_in_linear_layout",
       "name": "Supported in Linear Layout",
       "category": "css/properties",
@@ -84949,7 +86522,7 @@
       }
     },
     {
-      "id": "feature-403",
+      "id": "feature-409",
       "query": "css/properties/align-self.supported_in_linear_layout.nested_value_1",
       "name": "<code>auto</code>, <code>flex-start</code>, <code>flex-end</code>, <code>center</code>",
       "category": "css/properties",
@@ -84985,7 +86558,7 @@
       }
     },
     {
-      "id": "feature-404",
+      "id": "feature-410",
       "query": "css/properties/align-self.supported_in_linear_layout.nested_value_2",
       "name": "<code>start</code> and <code>end</code>",
       "category": "css/properties",
@@ -85021,7 +86594,7 @@
       }
     },
     {
-      "id": "feature-405",
+      "id": "feature-411",
       "query": "css/properties/align-self.supported_in_linear_layout.nested_value_3",
       "name": "<code>baseline</code> and <code>stretch</code>",
       "category": "css/properties",
@@ -85057,7 +86630,7 @@
       }
     },
     {
-      "id": "feature-406",
+      "id": "feature-412",
       "query": "css/properties/align-self.supported_in_grid_layout",
       "name": "Supported in Grid Layout",
       "category": "css/properties",
@@ -85093,7 +86666,7 @@
       }
     },
     {
-      "id": "feature-407",
+      "id": "feature-413",
       "query": "css/properties/align-self.supported_in_grid_layout.nested_value_1",
       "name": "<code>auto</code>, <code>stretch</code>, <code>flex-start</code>, <code>flex-end</code>, <code>center</code>",
       "category": "css/properties",
@@ -85129,7 +86702,7 @@
       }
     },
     {
-      "id": "feature-408",
+      "id": "feature-414",
       "query": "css/properties/align-self.supported_in_grid_layout.nested_value_2",
       "name": "<code>start</code> and <code>end</code>",
       "category": "css/properties",
@@ -85165,7 +86738,7 @@
       }
     },
     {
-      "id": "feature-409",
+      "id": "feature-415",
       "query": "css/properties/align-self.supported_in_grid_layout.baseline",
       "name": "<code>baseline</code>",
       "category": "css/properties",
@@ -85201,7 +86774,7 @@
       }
     },
     {
-      "id": "feature-410",
+      "id": "feature-416",
       "query": "css/properties/align-self.normal",
       "name": "<code>normal</code>",
       "category": "css/properties",
@@ -85237,7 +86810,7 @@
       }
     },
     {
-      "id": "feature-411",
+      "id": "feature-417",
       "query": "css/properties/animation-delay",
       "name": "animation-delay",
       "category": "css/properties",
@@ -85273,7 +86846,7 @@
       }
     },
     {
-      "id": "feature-412",
+      "id": "feature-418",
       "query": "css/properties/animation-direction",
       "name": "animation-direction",
       "category": "css/properties",
@@ -85309,7 +86882,7 @@
       }
     },
     {
-      "id": "feature-413",
+      "id": "feature-419",
       "query": "css/properties/animation-duration",
       "name": "animation-duration",
       "category": "css/properties",
@@ -85345,7 +86918,7 @@
       }
     },
     {
-      "id": "feature-414",
+      "id": "feature-420",
       "query": "css/properties/animation-fill-mode",
       "name": "animation-fill-mode",
       "category": "css/properties",
@@ -85381,7 +86954,7 @@
       }
     },
     {
-      "id": "feature-415",
+      "id": "feature-421",
       "query": "css/properties/animation-iteration-count",
       "name": "animation-iteration-count",
       "category": "css/properties",
@@ -85417,7 +86990,7 @@
       }
     },
     {
-      "id": "feature-416",
+      "id": "feature-422",
       "query": "css/properties/animation-name",
       "name": "animation-name",
       "category": "css/properties",
@@ -85453,7 +87026,7 @@
       }
     },
     {
-      "id": "feature-417",
+      "id": "feature-423",
       "query": "css/properties/animation-play-state",
       "name": "animation-play-state",
       "category": "css/properties",
@@ -85489,7 +87062,7 @@
       }
     },
     {
-      "id": "feature-418",
+      "id": "feature-424",
       "query": "css/properties/animation-timing-function",
       "name": "animation-timing-function",
       "category": "css/properties",
@@ -85525,7 +87098,7 @@
       }
     },
     {
-      "id": "feature-419",
+      "id": "feature-425",
       "query": "css/properties/animation-timing-function.linear",
       "name": "linear",
       "category": "css/properties",
@@ -85561,7 +87134,7 @@
       }
     },
     {
-      "id": "feature-420",
+      "id": "feature-426",
       "query": "css/properties/animation-timing-function.ease-in",
       "name": "ease-in",
       "category": "css/properties",
@@ -85597,7 +87170,7 @@
       }
     },
     {
-      "id": "feature-421",
+      "id": "feature-427",
       "query": "css/properties/animation-timing-function.ease-out",
       "name": "ease-out",
       "category": "css/properties",
@@ -85633,7 +87206,7 @@
       }
     },
     {
-      "id": "feature-422",
+      "id": "feature-428",
       "query": "css/properties/animation-timing-function.ease-in-ease-out",
       "name": "ease-in-ease-out",
       "category": "css/properties",
@@ -85669,7 +87242,7 @@
       }
     },
     {
-      "id": "feature-423",
+      "id": "feature-429",
       "query": "css/properties/animation-timing-function.ease",
       "name": "ease",
       "category": "css/properties",
@@ -85705,7 +87278,7 @@
       }
     },
     {
-      "id": "feature-424",
+      "id": "feature-430",
       "query": "css/properties/animation-timing-function.ease-in-out",
       "name": "ease-in-out",
       "category": "css/properties",
@@ -85741,7 +87314,7 @@
       }
     },
     {
-      "id": "feature-425",
+      "id": "feature-431",
       "query": "css/properties/animation-timing-function.square-bezier",
       "name": "square-bezier",
       "category": "css/properties",
@@ -85777,7 +87350,7 @@
       }
     },
     {
-      "id": "feature-426",
+      "id": "feature-432",
       "query": "css/properties/animation-timing-function.cubic-bezier",
       "name": "cubic-bezier",
       "category": "css/properties",
@@ -85813,7 +87386,7 @@
       }
     },
     {
-      "id": "feature-427",
+      "id": "feature-433",
       "query": "css/properties/animation-timing-function.step-start",
       "name": "step-start",
       "category": "css/properties",
@@ -85849,7 +87422,7 @@
       }
     },
     {
-      "id": "feature-428",
+      "id": "feature-434",
       "query": "css/properties/animation-timing-function.step-end",
       "name": "step-end",
       "category": "css/properties",
@@ -85885,7 +87458,7 @@
       }
     },
     {
-      "id": "feature-429",
+      "id": "feature-435",
       "query": "css/properties/animation-timing-function.steps",
       "name": "steps",
       "category": "css/properties",
@@ -85921,7 +87494,7 @@
       }
     },
     {
-      "id": "feature-430",
+      "id": "feature-436",
       "query": "css/properties/animation",
       "name": "animation",
       "category": "css/properties",
@@ -85957,7 +87530,7 @@
       }
     },
     {
-      "id": "feature-431",
+      "id": "feature-437",
       "query": "css/properties/aspect-ratio",
       "name": "aspect-ratio",
       "category": "css/properties",
@@ -85993,7 +87566,7 @@
       }
     },
     {
-      "id": "feature-432",
+      "id": "feature-438",
       "query": "css/properties/aspect-ratio.auto",
       "name": "auto",
       "category": "css/properties",
@@ -86029,7 +87602,7 @@
       }
     },
     {
-      "id": "feature-433",
+      "id": "feature-439",
       "query": "css/properties/background-clip",
       "name": "background-clip",
       "category": "css/properties",
@@ -86065,7 +87638,7 @@
       }
     },
     {
-      "id": "feature-434",
+      "id": "feature-440",
       "query": "css/properties/background-clip.box",
       "name": "<code>&lt;box&gt;</code>",
       "category": "css/properties",
@@ -86101,7 +87674,7 @@
       }
     },
     {
-      "id": "feature-435",
+      "id": "feature-441",
       "query": "css/properties/background-clip.border-area",
       "name": "<code>border-area</code>",
       "category": "css/properties",
@@ -86137,7 +87710,7 @@
       }
     },
     {
-      "id": "feature-436",
+      "id": "feature-442",
       "query": "css/properties/background-color",
       "name": "background-color",
       "category": "css/properties",
@@ -86173,7 +87746,7 @@
       }
     },
     {
-      "id": "feature-437",
+      "id": "feature-443",
       "query": "css/properties/background-image",
       "name": "background-image",
       "category": "css/properties",
@@ -86209,7 +87782,7 @@
       }
     },
     {
-      "id": "feature-438",
+      "id": "feature-444",
       "query": "css/properties/background-image.conic-gradient",
       "name": "conic-gradient",
       "category": "css/properties",
@@ -86245,7 +87818,7 @@
       }
     },
     {
-      "id": "feature-439",
+      "id": "feature-445",
       "query": "css/properties/background-origin",
       "name": "background-origin",
       "category": "css/properties",
@@ -86281,7 +87854,7 @@
       }
     },
     {
-      "id": "feature-440",
+      "id": "feature-446",
       "query": "css/properties/background-position",
       "name": "background-position",
       "category": "css/properties",
@@ -86317,7 +87890,7 @@
       }
     },
     {
-      "id": "feature-441",
+      "id": "feature-447",
       "query": "css/properties/background-repeat",
       "name": "background-repeat",
       "category": "css/properties",
@@ -86353,7 +87926,7 @@
       }
     },
     {
-      "id": "feature-442",
+      "id": "feature-448",
       "query": "css/properties/background-size",
       "name": "background-size",
       "category": "css/properties",
@@ -86389,7 +87962,7 @@
       }
     },
     {
-      "id": "feature-443",
+      "id": "feature-449",
       "query": "css/properties/background",
       "name": "background",
       "category": "css/properties",
@@ -86425,7 +87998,7 @@
       }
     },
     {
-      "id": "feature-444",
+      "id": "feature-450",
       "query": "css/properties/border-bottom-color",
       "name": "border-bottom-color",
       "category": "css/properties",
@@ -86461,7 +88034,7 @@
       }
     },
     {
-      "id": "feature-445",
+      "id": "feature-451",
       "query": "css/properties/border-bottom-left-radius",
       "name": "border-bottom-left-radius",
       "category": "css/properties",
@@ -86497,7 +88070,7 @@
       }
     },
     {
-      "id": "feature-446",
+      "id": "feature-452",
       "query": "css/properties/border-bottom-right-radius",
       "name": "border-bottom-right-radius",
       "category": "css/properties",
@@ -86533,7 +88106,7 @@
       }
     },
     {
-      "id": "feature-447",
+      "id": "feature-453",
       "query": "css/properties/border-bottom-style",
       "name": "border-bottom-style",
       "category": "css/properties",
@@ -86569,7 +88142,7 @@
       }
     },
     {
-      "id": "feature-448",
+      "id": "feature-454",
       "query": "css/properties/border-bottom-width",
       "name": "border-bottom-width",
       "category": "css/properties",
@@ -86605,7 +88178,7 @@
       }
     },
     {
-      "id": "feature-449",
+      "id": "feature-455",
       "query": "css/properties/border-bottom",
       "name": "border-bottom",
       "category": "css/properties",
@@ -86641,7 +88214,7 @@
       }
     },
     {
-      "id": "feature-450",
+      "id": "feature-456",
       "query": "css/properties/border-color",
       "name": "border-color",
       "category": "css/properties",
@@ -86677,7 +88250,7 @@
       }
     },
     {
-      "id": "feature-451",
+      "id": "feature-457",
       "query": "css/properties/border-end-end-radius",
       "name": "border-end-end-radius",
       "category": "css/properties",
@@ -86713,7 +88286,7 @@
       }
     },
     {
-      "id": "feature-452",
+      "id": "feature-458",
       "query": "css/properties/border-end-start-radius",
       "name": "border-end-start-radius",
       "category": "css/properties",
@@ -86749,7 +88322,7 @@
       }
     },
     {
-      "id": "feature-453",
+      "id": "feature-459",
       "query": "css/properties/border-inline-end-color",
       "name": "border-inline-end-color",
       "category": "css/properties",
@@ -86785,7 +88358,7 @@
       }
     },
     {
-      "id": "feature-454",
+      "id": "feature-460",
       "query": "css/properties/border-inline-end-style",
       "name": "border-inline-end-style",
       "category": "css/properties",
@@ -86821,7 +88394,7 @@
       }
     },
     {
-      "id": "feature-455",
+      "id": "feature-461",
       "query": "css/properties/border-inline-end-width",
       "name": "border-inline-end-width",
       "category": "css/properties",
@@ -86857,7 +88430,7 @@
       }
     },
     {
-      "id": "feature-456",
+      "id": "feature-462",
       "query": "css/properties/border-inline-start-color",
       "name": "border-inline-start-color",
       "category": "css/properties",
@@ -86893,7 +88466,7 @@
       }
     },
     {
-      "id": "feature-457",
+      "id": "feature-463",
       "query": "css/properties/border-inline-start-style",
       "name": "border-inline-start-style",
       "category": "css/properties",
@@ -86929,7 +88502,7 @@
       }
     },
     {
-      "id": "feature-458",
+      "id": "feature-464",
       "query": "css/properties/border-inline-start-width",
       "name": "border-inline-start-width",
       "category": "css/properties",
@@ -86965,7 +88538,7 @@
       }
     },
     {
-      "id": "feature-459",
+      "id": "feature-465",
       "query": "css/properties/border-left-color",
       "name": "border-left-color",
       "category": "css/properties",
@@ -87001,7 +88574,7 @@
       }
     },
     {
-      "id": "feature-460",
+      "id": "feature-466",
       "query": "css/properties/border-left-style",
       "name": "border-left-style",
       "category": "css/properties",
@@ -87037,7 +88610,7 @@
       }
     },
     {
-      "id": "feature-461",
+      "id": "feature-467",
       "query": "css/properties/border-left-width",
       "name": "border-left-width",
       "category": "css/properties",
@@ -87073,7 +88646,7 @@
       }
     },
     {
-      "id": "feature-462",
+      "id": "feature-468",
       "query": "css/properties/border-left",
       "name": "border-left",
       "category": "css/properties",
@@ -87109,7 +88682,7 @@
       }
     },
     {
-      "id": "feature-463",
+      "id": "feature-469",
       "query": "css/properties/border-radius",
       "name": "border-radius",
       "category": "css/properties",
@@ -87145,7 +88718,7 @@
       }
     },
     {
-      "id": "feature-464",
+      "id": "feature-470",
       "query": "css/properties/border-right-color",
       "name": "border-right-color",
       "category": "css/properties",
@@ -87181,7 +88754,7 @@
       }
     },
     {
-      "id": "feature-465",
+      "id": "feature-471",
       "query": "css/properties/border-right-style",
       "name": "border-right-style",
       "category": "css/properties",
@@ -87217,7 +88790,7 @@
       }
     },
     {
-      "id": "feature-466",
+      "id": "feature-472",
       "query": "css/properties/border-right-width",
       "name": "border-right-width",
       "category": "css/properties",
@@ -87253,7 +88826,7 @@
       }
     },
     {
-      "id": "feature-467",
+      "id": "feature-473",
       "query": "css/properties/border-right",
       "name": "border-right",
       "category": "css/properties",
@@ -87289,7 +88862,7 @@
       }
     },
     {
-      "id": "feature-468",
+      "id": "feature-474",
       "query": "css/properties/border-start-end-radius",
       "name": "border-start-end-radius",
       "category": "css/properties",
@@ -87325,7 +88898,7 @@
       }
     },
     {
-      "id": "feature-469",
+      "id": "feature-475",
       "query": "css/properties/border-start-start-radius",
       "name": "border-start-start-radius",
       "category": "css/properties",
@@ -87361,7 +88934,7 @@
       }
     },
     {
-      "id": "feature-470",
+      "id": "feature-476",
       "query": "css/properties/border-style",
       "name": "border-style",
       "category": "css/properties",
@@ -87397,7 +88970,7 @@
       }
     },
     {
-      "id": "feature-471",
+      "id": "feature-477",
       "query": "css/properties/border-top-color",
       "name": "border-top-color",
       "category": "css/properties",
@@ -87433,7 +89006,7 @@
       }
     },
     {
-      "id": "feature-472",
+      "id": "feature-478",
       "query": "css/properties/border-top-left-radius",
       "name": "border-top-left-radius",
       "category": "css/properties",
@@ -87469,7 +89042,7 @@
       }
     },
     {
-      "id": "feature-473",
+      "id": "feature-479",
       "query": "css/properties/border-top-right-radius",
       "name": "border-top-right-radius",
       "category": "css/properties",
@@ -87505,7 +89078,7 @@
       }
     },
     {
-      "id": "feature-474",
+      "id": "feature-480",
       "query": "css/properties/border-top-style",
       "name": "border-top-style",
       "category": "css/properties",
@@ -87541,7 +89114,7 @@
       }
     },
     {
-      "id": "feature-475",
+      "id": "feature-481",
       "query": "css/properties/border-top-width",
       "name": "border-top-width",
       "category": "css/properties",
@@ -87577,7 +89150,7 @@
       }
     },
     {
-      "id": "feature-476",
+      "id": "feature-482",
       "query": "css/properties/border-top",
       "name": "border-top",
       "category": "css/properties",
@@ -87613,7 +89186,7 @@
       }
     },
     {
-      "id": "feature-477",
+      "id": "feature-483",
       "query": "css/properties/border-width",
       "name": "border-width",
       "category": "css/properties",
@@ -87649,7 +89222,7 @@
       }
     },
     {
-      "id": "feature-478",
+      "id": "feature-484",
       "query": "css/properties/border",
       "name": "border",
       "category": "css/properties",
@@ -87685,7 +89258,7 @@
       }
     },
     {
-      "id": "feature-479",
+      "id": "feature-485",
       "query": "css/properties/bottom",
       "name": "bottom",
       "category": "css/properties",
@@ -87721,7 +89294,7 @@
       }
     },
     {
-      "id": "feature-480",
+      "id": "feature-486",
       "query": "css/properties/box-shadow",
       "name": "box-shadow",
       "category": "css/properties",
@@ -87757,7 +89330,7 @@
       }
     },
     {
-      "id": "feature-481",
+      "id": "feature-487",
       "query": "css/properties/box-sizing",
       "name": "box-sizing",
       "category": "css/properties",
@@ -87793,7 +89366,7 @@
       }
     },
     {
-      "id": "feature-482",
+      "id": "feature-488",
       "query": "css/properties/clip-path",
       "name": "clip-path",
       "category": "css/properties",
@@ -87829,7 +89402,7 @@
       }
     },
     {
-      "id": "feature-483",
+      "id": "feature-489",
       "query": "css/properties/clip-path.circle()",
       "name": "circle()",
       "category": "css/properties",
@@ -87865,7 +89438,7 @@
       }
     },
     {
-      "id": "feature-484",
+      "id": "feature-490",
       "query": "css/properties/clip-path.inset()",
       "name": "inset()",
       "category": "css/properties",
@@ -87901,7 +89474,7 @@
       }
     },
     {
-      "id": "feature-485",
+      "id": "feature-491",
       "query": "css/properties/clip-path.ellipse()",
       "name": "ellipse()",
       "category": "css/properties",
@@ -87937,7 +89510,7 @@
       }
     },
     {
-      "id": "feature-486",
+      "id": "feature-492",
       "query": "css/properties/clip-path.path()",
       "name": "path()",
       "category": "css/properties",
@@ -87973,7 +89546,7 @@
       }
     },
     {
-      "id": "feature-487",
+      "id": "feature-493",
       "query": "css/properties/clip-path.polygon()",
       "name": "polygon()",
       "category": "css/properties",
@@ -88009,7 +89582,7 @@
       }
     },
     {
-      "id": "feature-488",
+      "id": "feature-494",
       "query": "css/properties/color",
       "name": "color",
       "category": "css/properties",
@@ -88045,7 +89618,7 @@
       }
     },
     {
-      "id": "feature-489",
+      "id": "feature-495",
       "query": "css/properties/column-gap",
       "name": "<code>column-gap</code>",
       "category": "css/properties",
@@ -88081,7 +89654,7 @@
       }
     },
     {
-      "id": "feature-490",
+      "id": "feature-496",
       "query": "css/properties/column-gap.grid-column-gap",
       "name": "<code>grid-column-gap</code>",
       "category": "css/properties",
@@ -88117,7 +89690,7 @@
       }
     },
     {
-      "id": "feature-491",
+      "id": "feature-497",
       "query": "css/properties/column-gap.supported_in_flex_layout",
       "name": "Supported in Flexible Box Layout",
       "category": "css/properties",
@@ -88153,7 +89726,7 @@
       }
     },
     {
-      "id": "feature-492",
+      "id": "feature-498",
       "query": "css/properties/column-gap.supported_in_flex_layout.nested_value_1",
       "name": "<code>column-gap</code> and <code>grid-column-gap</code>",
       "category": "css/properties",
@@ -88189,7 +89762,7 @@
       }
     },
     {
-      "id": "feature-493",
+      "id": "feature-499",
       "query": "css/properties/column-gap.supported_in_grid_layout",
       "name": "Supported in Grid Layout",
       "category": "css/properties",
@@ -88225,7 +89798,7 @@
       }
     },
     {
-      "id": "feature-494",
+      "id": "feature-500",
       "query": "css/properties/column-gap.supported_in_grid_layout.grid-column-gap",
       "name": "<code>grid-column-gap</code>",
       "category": "css/properties",
@@ -88261,7 +89834,7 @@
       }
     },
     {
-      "id": "feature-495",
+      "id": "feature-501",
       "query": "css/properties/column-gap.supported_in_grid_layout",
       "name": "<code>column-gap</code>",
       "category": "css/properties",
@@ -88297,7 +89870,7 @@
       }
     },
     {
-      "id": "feature-496",
+      "id": "feature-502",
       "query": "css/properties/css-variable",
       "name": "css-variable",
       "category": "css/properties",
@@ -88333,7 +89906,7 @@
       }
     },
     {
-      "id": "feature-497",
+      "id": "feature-503",
       "query": "css/properties/cursor",
       "name": "The cursor CSS property controls the mouse pointer displayed when the pointer hovers over an element.",
       "category": "css/properties",
@@ -88369,7 +89942,7 @@
       }
     },
     {
-      "id": "feature-498",
+      "id": "feature-504",
       "query": "css/properties/cursor.default",
       "name": "default",
       "category": "css/properties",
@@ -88405,7 +89978,7 @@
       }
     },
     {
-      "id": "feature-499",
+      "id": "feature-505",
       "query": "css/properties/cursor.none",
       "name": "none",
       "category": "css/properties",
@@ -88441,7 +90014,7 @@
       }
     },
     {
-      "id": "feature-500",
+      "id": "feature-506",
       "query": "css/properties/cursor.context-menu",
       "name": "context-menu",
       "category": "css/properties",
@@ -88477,7 +90050,7 @@
       }
     },
     {
-      "id": "feature-501",
+      "id": "feature-507",
       "query": "css/properties/cursor.help",
       "name": "help",
       "category": "css/properties",
@@ -88513,7 +90086,7 @@
       }
     },
     {
-      "id": "feature-502",
+      "id": "feature-508",
       "query": "css/properties/cursor.pointer",
       "name": "pointer",
       "category": "css/properties",
@@ -88549,7 +90122,7 @@
       }
     },
     {
-      "id": "feature-503",
+      "id": "feature-509",
       "query": "css/properties/cursor.progress",
       "name": "progress",
       "category": "css/properties",
@@ -88585,7 +90158,7 @@
       }
     },
     {
-      "id": "feature-504",
+      "id": "feature-510",
       "query": "css/properties/cursor.wait",
       "name": "wait",
       "category": "css/properties",
@@ -88621,7 +90194,7 @@
       }
     },
     {
-      "id": "feature-505",
+      "id": "feature-511",
       "query": "css/properties/cursor.crosshair",
       "name": "crosshair",
       "category": "css/properties",
@@ -88657,7 +90230,7 @@
       }
     },
     {
-      "id": "feature-506",
+      "id": "feature-512",
       "query": "css/properties/cursor.text",
       "name": "text",
       "category": "css/properties",
@@ -88693,7 +90266,7 @@
       }
     },
     {
-      "id": "feature-507",
+      "id": "feature-513",
       "query": "css/properties/cursor.vertical-text",
       "name": "vertical-text",
       "category": "css/properties",
@@ -88729,7 +90302,7 @@
       }
     },
     {
-      "id": "feature-508",
+      "id": "feature-514",
       "query": "css/properties/cursor.alias",
       "name": "alias",
       "category": "css/properties",
@@ -88765,7 +90338,7 @@
       }
     },
     {
-      "id": "feature-509",
+      "id": "feature-515",
       "query": "css/properties/cursor.copy",
       "name": "copy",
       "category": "css/properties",
@@ -88801,7 +90374,7 @@
       }
     },
     {
-      "id": "feature-510",
+      "id": "feature-516",
       "query": "css/properties/cursor.move",
       "name": "move",
       "category": "css/properties",
@@ -88837,7 +90410,7 @@
       }
     },
     {
-      "id": "feature-511",
+      "id": "feature-517",
       "query": "css/properties/cursor.no-drop",
       "name": "no-drop",
       "category": "css/properties",
@@ -88873,7 +90446,7 @@
       }
     },
     {
-      "id": "feature-512",
+      "id": "feature-518",
       "query": "css/properties/cursor.not-allowed",
       "name": "not-allowed",
       "category": "css/properties",
@@ -88909,7 +90482,7 @@
       }
     },
     {
-      "id": "feature-513",
+      "id": "feature-519",
       "query": "css/properties/cursor.grab",
       "name": "grab",
       "category": "css/properties",
@@ -88945,7 +90518,7 @@
       }
     },
     {
-      "id": "feature-514",
+      "id": "feature-520",
       "query": "css/properties/cursor.grabbing",
       "name": "grabbing",
       "category": "css/properties",
@@ -88981,7 +90554,7 @@
       }
     },
     {
-      "id": "feature-515",
+      "id": "feature-521",
       "query": "css/properties/cursor.col-resize",
       "name": "col-resize",
       "category": "css/properties",
@@ -89017,7 +90590,7 @@
       }
     },
     {
-      "id": "feature-516",
+      "id": "feature-522",
       "query": "css/properties/cursor.row-resize",
       "name": "row-resize",
       "category": "css/properties",
@@ -89053,7 +90626,7 @@
       }
     },
     {
-      "id": "feature-517",
+      "id": "feature-523",
       "query": "css/properties/cursor.n-resize",
       "name": "n-resize",
       "category": "css/properties",
@@ -89089,7 +90662,7 @@
       }
     },
     {
-      "id": "feature-518",
+      "id": "feature-524",
       "query": "css/properties/cursor.e-resize",
       "name": "e-resize",
       "category": "css/properties",
@@ -89125,7 +90698,7 @@
       }
     },
     {
-      "id": "feature-519",
+      "id": "feature-525",
       "query": "css/properties/cursor.s-resize",
       "name": "s-resize",
       "category": "css/properties",
@@ -89161,7 +90734,7 @@
       }
     },
     {
-      "id": "feature-520",
+      "id": "feature-526",
       "query": "css/properties/cursor.w-resize",
       "name": "w-resize",
       "category": "css/properties",
@@ -89197,7 +90770,7 @@
       }
     },
     {
-      "id": "feature-521",
+      "id": "feature-527",
       "query": "css/properties/cursor.ne-resize",
       "name": "ne-resize",
       "category": "css/properties",
@@ -89233,7 +90806,7 @@
       }
     },
     {
-      "id": "feature-522",
+      "id": "feature-528",
       "query": "css/properties/cursor.nw-resize",
       "name": "nw-resize",
       "category": "css/properties",
@@ -89269,7 +90842,7 @@
       }
     },
     {
-      "id": "feature-523",
+      "id": "feature-529",
       "query": "css/properties/cursor.se-resize",
       "name": "se-resize",
       "category": "css/properties",
@@ -89305,7 +90878,7 @@
       }
     },
     {
-      "id": "feature-524",
+      "id": "feature-530",
       "query": "css/properties/cursor.sw-resize",
       "name": "sw-resize",
       "category": "css/properties",
@@ -89341,7 +90914,7 @@
       }
     },
     {
-      "id": "feature-525",
+      "id": "feature-531",
       "query": "css/properties/cursor.ew-resize",
       "name": "ew-resize",
       "category": "css/properties",
@@ -89377,7 +90950,7 @@
       }
     },
     {
-      "id": "feature-526",
+      "id": "feature-532",
       "query": "css/properties/cursor.ns-resize",
       "name": "ns-resize",
       "category": "css/properties",
@@ -89413,7 +90986,7 @@
       }
     },
     {
-      "id": "feature-527",
+      "id": "feature-533",
       "query": "css/properties/cursor.nesw-resize",
       "name": "nesw-resize",
       "category": "css/properties",
@@ -89449,7 +91022,7 @@
       }
     },
     {
-      "id": "feature-528",
+      "id": "feature-534",
       "query": "css/properties/cursor.nwse-resize",
       "name": "nwse-resize",
       "category": "css/properties",
@@ -89485,7 +91058,7 @@
       }
     },
     {
-      "id": "feature-529",
+      "id": "feature-535",
       "query": "css/properties/custom-property",
       "name": "custom-property",
       "category": "css/properties",
@@ -89521,7 +91094,7 @@
       }
     },
     {
-      "id": "feature-530",
+      "id": "feature-536",
       "query": "css/properties/custom-property.In StyleSheet",
       "name": "Declare and reference variables in css files",
       "category": "css/properties",
@@ -89557,7 +91130,7 @@
       }
     },
     {
-      "id": "feature-531",
+      "id": "feature-537",
       "query": "css/properties/custom-property.In `style` attributes",
       "name": "Declare and reference variables in <code>style</code> attribute",
       "category": "css/properties",
@@ -89593,7 +91166,7 @@
       }
     },
     {
-      "id": "feature-532",
+      "id": "feature-538",
       "query": "css/properties/custom-property.Nested references",
       "name": "Nested references",
       "category": "css/properties",
@@ -89629,7 +91202,7 @@
       }
     },
     {
-      "id": "feature-533",
+      "id": "feature-539",
       "query": "css/properties/custom-property.At property rule",
       "name": "Use <code>@property</code> rule to declare custom property",
       "category": "css/properties",
@@ -89665,7 +91238,7 @@
       }
     },
     {
-      "id": "feature-534",
+      "id": "feature-540",
       "query": "css/properties/direction",
       "name": "direction",
       "category": "css/properties",
@@ -89701,7 +91274,7 @@
       }
     },
     {
-      "id": "feature-535",
+      "id": "feature-541",
       "query": "css/properties/direction.lynx-rtl",
       "name": "<code>lynx-rtl</code>",
       "category": "css/properties",
@@ -89737,7 +91310,7 @@
       }
     },
     {
-      "id": "feature-536",
+      "id": "feature-542",
       "query": "css/properties/display",
       "name": "display",
       "category": "css/properties",
@@ -89773,7 +91346,7 @@
       }
     },
     {
-      "id": "feature-537",
+      "id": "feature-543",
       "query": "css/properties/display.api1",
       "name": "<code>none</code>, <code>flex</code>, <code>linear</code>",
       "category": "css/properties",
@@ -89809,7 +91382,7 @@
       }
     },
     {
-      "id": "feature-538",
+      "id": "feature-544",
       "query": "css/properties/display.relative",
       "name": "<code>relative</code>",
       "category": "css/properties",
@@ -89845,7 +91418,7 @@
       }
     },
     {
-      "id": "feature-539",
+      "id": "feature-545",
       "query": "css/properties/display.grid",
       "name": "<code>grid</code>",
       "category": "css/properties",
@@ -89881,7 +91454,7 @@
       }
     },
     {
-      "id": "feature-540",
+      "id": "feature-546",
       "query": "css/properties/display.unsupported_value",
       "name": "<code>inline</code> and <code>block</code>",
       "category": "css/properties",
@@ -89917,7 +91490,7 @@
       }
     },
     {
-      "id": "feature-541",
+      "id": "feature-547",
       "query": "css/properties/filter",
       "name": "filter",
       "category": "css/properties",
@@ -89953,7 +91526,7 @@
       }
     },
     {
-      "id": "feature-542",
+      "id": "feature-548",
       "query": "css/properties/filter.blur",
       "name": "blur",
       "category": "css/properties",
@@ -89989,7 +91562,7 @@
       }
     },
     {
-      "id": "feature-543",
+      "id": "feature-549",
       "query": "css/properties/filter.grayscale",
       "name": "grayscale",
       "category": "css/properties",
@@ -90025,7 +91598,7 @@
       }
     },
     {
-      "id": "feature-544",
+      "id": "feature-550",
       "query": "css/properties/filter.brightness",
       "name": "brightness",
       "category": "css/properties",
@@ -90061,7 +91634,7 @@
       }
     },
     {
-      "id": "feature-545",
+      "id": "feature-551",
       "query": "css/properties/filter.contrast",
       "name": "contrast",
       "category": "css/properties",
@@ -90097,7 +91670,7 @@
       }
     },
     {
-      "id": "feature-546",
+      "id": "feature-552",
       "query": "css/properties/filter.saturate",
       "name": "saturate",
       "category": "css/properties",
@@ -90133,7 +91706,7 @@
       }
     },
     {
-      "id": "feature-547",
+      "id": "feature-553",
       "query": "css/properties/flex-basis",
       "name": "<code>flex-basis</code>",
       "category": "css/properties",
@@ -90169,7 +91742,7 @@
       }
     },
     {
-      "id": "feature-548",
+      "id": "feature-554",
       "query": "css/properties/flex-basis.unsupported_value_",
       "name": "<code>max-content</code>, <code>min-content</code>, <code>fit-content</code>",
       "category": "css/properties",
@@ -90205,7 +91778,7 @@
       }
     },
     {
-      "id": "feature-549",
+      "id": "feature-555",
       "query": "css/properties/flex-direction",
       "name": "flex-direction",
       "category": "css/properties",
@@ -90241,7 +91814,7 @@
       }
     },
     {
-      "id": "feature-550",
+      "id": "feature-556",
       "query": "css/properties/flex-flow",
       "name": "flex-flow",
       "category": "css/properties",
@@ -90277,7 +91850,7 @@
       }
     },
     {
-      "id": "feature-551",
+      "id": "feature-557",
       "query": "css/properties/flex-grow",
       "name": "flex-grow",
       "category": "css/properties",
@@ -90313,7 +91886,7 @@
       }
     },
     {
-      "id": "feature-552",
+      "id": "feature-558",
       "query": "css/properties/flex-shrink",
       "name": "flex-shrink",
       "category": "css/properties",
@@ -90349,7 +91922,7 @@
       }
     },
     {
-      "id": "feature-553",
+      "id": "feature-559",
       "query": "css/properties/flex-wrap",
       "name": "flex-wrap",
       "category": "css/properties",
@@ -90385,7 +91958,7 @@
       }
     },
     {
-      "id": "feature-554",
+      "id": "feature-560",
       "query": "css/properties/flex-wrap.nowrap",
       "name": "nowrap",
       "category": "css/properties",
@@ -90421,7 +91994,7 @@
       }
     },
     {
-      "id": "feature-555",
+      "id": "feature-561",
       "query": "css/properties/flex-wrap.wrap",
       "name": "wrap",
       "category": "css/properties",
@@ -90457,7 +92030,7 @@
       }
     },
     {
-      "id": "feature-556",
+      "id": "feature-562",
       "query": "css/properties/flex-wrap.wrap-reverse",
       "name": "wrap-reverse",
       "category": "css/properties",
@@ -90493,7 +92066,7 @@
       }
     },
     {
-      "id": "feature-557",
+      "id": "feature-563",
       "query": "css/properties/flex",
       "name": "flex",
       "category": "css/properties",
@@ -90529,7 +92102,7 @@
       }
     },
     {
-      "id": "feature-558",
+      "id": "feature-564",
       "query": "css/properties/flex.none",
       "name": "none",
       "category": "css/properties",
@@ -90565,7 +92138,7 @@
       }
     },
     {
-      "id": "feature-559",
+      "id": "feature-565",
       "query": "css/properties/font-family",
       "name": "font-family",
       "category": "css/properties",
@@ -90601,7 +92174,7 @@
       }
     },
     {
-      "id": "feature-560",
+      "id": "feature-566",
       "query": "css/properties/font-feature-settings",
       "name": "font-feature-settings",
       "category": "css/properties",
@@ -90637,7 +92210,7 @@
       }
     },
     {
-      "id": "feature-561",
+      "id": "feature-567",
       "query": "css/properties/font-optical-sizing",
       "name": "font-optical-sizing",
       "category": "css/properties",
@@ -90673,7 +92246,7 @@
       }
     },
     {
-      "id": "feature-562",
+      "id": "feature-568",
       "query": "css/properties/font-size",
       "name": "font-size",
       "category": "css/properties",
@@ -90709,7 +92282,7 @@
       }
     },
     {
-      "id": "feature-563",
+      "id": "feature-569",
       "query": "css/properties/font-style",
       "name": "font-style",
       "category": "css/properties",
@@ -90745,7 +92318,7 @@
       }
     },
     {
-      "id": "feature-564",
+      "id": "feature-570",
       "query": "css/properties/font-variation-settings",
       "name": "font-variation-settings",
       "category": "css/properties",
@@ -90781,7 +92354,7 @@
       }
     },
     {
-      "id": "feature-565",
+      "id": "feature-571",
       "query": "css/properties/font-weight",
       "name": "font-weight",
       "category": "css/properties",
@@ -90817,7 +92390,7 @@
       }
     },
     {
-      "id": "feature-566",
+      "id": "feature-572",
       "query": "css/properties/gap",
       "name": "gap",
       "category": "css/properties",
@@ -90853,7 +92426,7 @@
       }
     },
     {
-      "id": "feature-567",
+      "id": "feature-573",
       "query": "css/properties/gap.Flex",
       "name": "Supported in Flexible Box Layout",
       "category": "css/properties",
@@ -90889,7 +92462,7 @@
       }
     },
     {
-      "id": "feature-568",
+      "id": "feature-574",
       "query": "css/properties/gap.Grid",
       "name": "Supported in Grid Layout",
       "category": "css/properties",
@@ -90925,7 +92498,7 @@
       }
     },
     {
-      "id": "feature-569",
+      "id": "feature-575",
       "query": "css/properties/grid-auto-columns",
       "name": "grid-auto-columns",
       "category": "css/properties",
@@ -90961,7 +92534,7 @@
       }
     },
     {
-      "id": "feature-570",
+      "id": "feature-576",
       "query": "css/properties/grid-auto-columns.calc",
       "name": "<code>calc()</code>",
       "category": "css/properties",
@@ -90997,7 +92570,7 @@
       }
     },
     {
-      "id": "feature-571",
+      "id": "feature-577",
       "query": "css/properties/grid-auto-columns.fr",
       "name": "<code>fr</code>",
       "category": "css/properties",
@@ -91033,7 +92606,7 @@
       }
     },
     {
-      "id": "feature-572",
+      "id": "feature-578",
       "query": "css/properties/grid-auto-columns.max-content",
       "name": "<code>max-content</code>, <code>fit-content</code> and <code>minmax()</code>",
       "category": "css/properties",
@@ -91069,7 +92642,7 @@
       }
     },
     {
-      "id": "feature-573",
+      "id": "feature-579",
       "query": "css/properties/grid-auto-columns.unsupported_value1",
       "name": "<code>none</code> and <code>[linename]</code>",
       "category": "css/properties",
@@ -91105,7 +92678,7 @@
       }
     },
     {
-      "id": "feature-574",
+      "id": "feature-580",
       "query": "css/properties/grid-auto-columns.unsupported_value2",
       "name": "<code>min-content</code></code>",
       "category": "css/properties",
@@ -91141,7 +92714,7 @@
       }
     },
     {
-      "id": "feature-575",
+      "id": "feature-581",
       "query": "css/properties/grid-auto-flow",
       "name": "grid-auto-flow",
       "category": "css/properties",
@@ -91177,7 +92750,7 @@
       }
     },
     {
-      "id": "feature-576",
+      "id": "feature-582",
       "query": "css/properties/grid-auto-rows",
       "name": "grid-auto-rows",
       "category": "css/properties",
@@ -91213,7 +92786,7 @@
       }
     },
     {
-      "id": "feature-577",
+      "id": "feature-583",
       "query": "css/properties/grid-auto-rows.calc",
       "name": "<code>calc()</code>",
       "category": "css/properties",
@@ -91249,7 +92822,7 @@
       }
     },
     {
-      "id": "feature-578",
+      "id": "feature-584",
       "query": "css/properties/grid-auto-rows.fr",
       "name": "<code>fr</code>",
       "category": "css/properties",
@@ -91285,7 +92858,7 @@
       }
     },
     {
-      "id": "feature-579",
+      "id": "feature-585",
       "query": "css/properties/grid-auto-rows.max-content",
       "name": "<code>max-content</code>, <code>fit-content</code> and <code>minmax()</code>",
       "category": "css/properties",
@@ -91321,7 +92894,7 @@
       }
     },
     {
-      "id": "feature-580",
+      "id": "feature-586",
       "query": "css/properties/grid-auto-rows.unsupported_value1",
       "name": "<code>none</code> and <code>[linename]</code>",
       "category": "css/properties",
@@ -91357,7 +92930,7 @@
       }
     },
     {
-      "id": "feature-581",
+      "id": "feature-587",
       "query": "css/properties/grid-auto-rows.unsupported_value2",
       "name": "<code>min-content</code>",
       "category": "css/properties",
@@ -91393,7 +92966,7 @@
       }
     },
     {
-      "id": "feature-582",
+      "id": "feature-588",
       "query": "css/properties/grid-column-end",
       "name": "grid-column-end",
       "category": "css/properties",
@@ -91429,224 +93002,8 @@
       }
     },
     {
-      "id": "feature-583",
-      "query": "css/properties/grid-column-gap",
-      "name": "<code>column-gap</code>",
-      "category": "css/properties",
-      "source_file": "css/properties/grid-column-gap.json",
-      "support": {
-        "android": {
-          "version_added": "2.14"
-        },
-        "ios": {
-          "version_added": "2.14"
-        },
-        "harmony": {
-          "version_added": false
-        },
-        "web_lynx": {
-          "version_added": false
-        },
-        "clay_android": {
-          "version_added": "2.14"
-        },
-        "clay_ios": {
-          "version_added": false
-        },
-        "clay_macos": {
-          "version_added": "2.14"
-        },
-        "clay_windows": {
-          "version_added": "2.14"
-        },
-        "clay": {
-          "version_added": "2.14"
-        }
-      }
-    },
-    {
-      "id": "feature-584",
-      "query": "css/properties/grid-column-gap",
-      "name": "<code>grid-column-gap</code>",
-      "category": "css/properties",
-      "source_file": "css/properties/grid-column-gap.json",
-      "support": {
-        "android": {
-          "version_added": "2.1"
-        },
-        "ios": {
-          "version_added": "2.1"
-        },
-        "harmony": {
-          "version_added": false
-        },
-        "web_lynx": {
-          "version_added": false
-        },
-        "clay_android": {
-          "version_added": "2.1"
-        },
-        "clay_ios": {
-          "version_added": false
-        },
-        "clay_macos": {
-          "version_added": "2.1"
-        },
-        "clay_windows": {
-          "version_added": "2.1"
-        },
-        "clay": {
-          "version_added": "2.1"
-        }
-      }
-    },
-    {
-      "id": "feature-585",
-      "query": "css/properties/grid-column-gap.supported_in_flex_layout",
-      "name": "Supported in Flex Layout",
-      "category": "css/properties",
-      "source_file": "css/properties/grid-column-gap.json",
-      "support": {
-        "android": {
-          "version_added": "2.14"
-        },
-        "ios": {
-          "version_added": "2.14"
-        },
-        "harmony": {
-          "version_added": false
-        },
-        "web_lynx": {
-          "version_added": false
-        },
-        "clay_android": {
-          "version_added": "2.14"
-        },
-        "clay_ios": {
-          "version_added": false
-        },
-        "clay_macos": {
-          "version_added": "2.14"
-        },
-        "clay_windows": {
-          "version_added": "2.14"
-        },
-        "clay": {
-          "version_added": "2.14"
-        }
-      }
-    },
-    {
-      "id": "feature-586",
-      "query": "css/properties/grid-column-gap.supported_in_flex_layout.nested_value_1",
-      "name": "<code>column-gap</code> and <code>grid-column-gap</code>",
-      "category": "css/properties",
-      "source_file": "css/properties/grid-column-gap.json",
-      "support": {
-        "android": {
-          "version_added": "2.14"
-        },
-        "ios": {
-          "version_added": "2.14"
-        },
-        "harmony": {
-          "version_added": false
-        },
-        "web_lynx": {
-          "version_added": false
-        },
-        "clay_android": {
-          "version_added": "2.14"
-        },
-        "clay_ios": {
-          "version_added": false
-        },
-        "clay_macos": {
-          "version_added": "2.14"
-        },
-        "clay_windows": {
-          "version_added": "2.14"
-        },
-        "clay": {
-          "version_added": "2.14"
-        }
-      }
-    },
-    {
-      "id": "feature-587",
-      "query": "css/properties/grid-column-gap.supported_in_grid_layout",
-      "name": "Supported in Grid Layout",
-      "category": "css/properties",
-      "source_file": "css/properties/grid-column-gap.json",
-      "support": {
-        "android": {
-          "version_added": "2.1"
-        },
-        "ios": {
-          "version_added": "2.1"
-        },
-        "harmony": {
-          "version_added": false
-        },
-        "web_lynx": {
-          "version_added": false
-        },
-        "clay_android": {
-          "version_added": "2.1"
-        },
-        "clay_ios": {
-          "version_added": false
-        },
-        "clay_macos": {
-          "version_added": "2.1"
-        },
-        "clay_windows": {
-          "version_added": "2.1"
-        },
-        "clay": {
-          "version_added": "2.1"
-        }
-      }
-    },
-    {
-      "id": "feature-588",
-      "query": "css/properties/grid-column-gap.supported_in_grid_layout",
-      "name": "<code>grid-column-gap</code>",
-      "category": "css/properties",
-      "source_file": "css/properties/grid-column-gap.json",
-      "support": {
-        "android": {
-          "version_added": "2.1"
-        },
-        "ios": {
-          "version_added": "2.1"
-        },
-        "harmony": {
-          "version_added": false
-        },
-        "web_lynx": {
-          "version_added": false
-        },
-        "clay_android": {
-          "version_added": "2.1"
-        },
-        "clay_ios": {
-          "version_added": false
-        },
-        "clay_macos": {
-          "version_added": "2.1"
-        },
-        "clay_windows": {
-          "version_added": "2.1"
-        },
-        "clay": {
-          "version_added": "2.1"
-        }
-      }
-    },
-    {
       "id": "feature-589",
-      "query": "css/properties/grid-column-gap.supported_in_grid_layout.column-gap",
+      "query": "css/properties/grid-column-gap",
       "name": "<code>column-gap</code>",
       "category": "css/properties",
       "source_file": "css/properties/grid-column-gap.json",
@@ -91682,6 +93039,222 @@
     },
     {
       "id": "feature-590",
+      "query": "css/properties/grid-column-gap",
+      "name": "<code>grid-column-gap</code>",
+      "category": "css/properties",
+      "source_file": "css/properties/grid-column-gap.json",
+      "support": {
+        "android": {
+          "version_added": "2.1"
+        },
+        "ios": {
+          "version_added": "2.1"
+        },
+        "harmony": {
+          "version_added": false
+        },
+        "web_lynx": {
+          "version_added": false
+        },
+        "clay_android": {
+          "version_added": "2.1"
+        },
+        "clay_ios": {
+          "version_added": false
+        },
+        "clay_macos": {
+          "version_added": "2.1"
+        },
+        "clay_windows": {
+          "version_added": "2.1"
+        },
+        "clay": {
+          "version_added": "2.1"
+        }
+      }
+    },
+    {
+      "id": "feature-591",
+      "query": "css/properties/grid-column-gap.supported_in_flex_layout",
+      "name": "Supported in Flex Layout",
+      "category": "css/properties",
+      "source_file": "css/properties/grid-column-gap.json",
+      "support": {
+        "android": {
+          "version_added": "2.14"
+        },
+        "ios": {
+          "version_added": "2.14"
+        },
+        "harmony": {
+          "version_added": false
+        },
+        "web_lynx": {
+          "version_added": false
+        },
+        "clay_android": {
+          "version_added": "2.14"
+        },
+        "clay_ios": {
+          "version_added": false
+        },
+        "clay_macos": {
+          "version_added": "2.14"
+        },
+        "clay_windows": {
+          "version_added": "2.14"
+        },
+        "clay": {
+          "version_added": "2.14"
+        }
+      }
+    },
+    {
+      "id": "feature-592",
+      "query": "css/properties/grid-column-gap.supported_in_flex_layout.nested_value_1",
+      "name": "<code>column-gap</code> and <code>grid-column-gap</code>",
+      "category": "css/properties",
+      "source_file": "css/properties/grid-column-gap.json",
+      "support": {
+        "android": {
+          "version_added": "2.14"
+        },
+        "ios": {
+          "version_added": "2.14"
+        },
+        "harmony": {
+          "version_added": false
+        },
+        "web_lynx": {
+          "version_added": false
+        },
+        "clay_android": {
+          "version_added": "2.14"
+        },
+        "clay_ios": {
+          "version_added": false
+        },
+        "clay_macos": {
+          "version_added": "2.14"
+        },
+        "clay_windows": {
+          "version_added": "2.14"
+        },
+        "clay": {
+          "version_added": "2.14"
+        }
+      }
+    },
+    {
+      "id": "feature-593",
+      "query": "css/properties/grid-column-gap.supported_in_grid_layout",
+      "name": "Supported in Grid Layout",
+      "category": "css/properties",
+      "source_file": "css/properties/grid-column-gap.json",
+      "support": {
+        "android": {
+          "version_added": "2.1"
+        },
+        "ios": {
+          "version_added": "2.1"
+        },
+        "harmony": {
+          "version_added": false
+        },
+        "web_lynx": {
+          "version_added": false
+        },
+        "clay_android": {
+          "version_added": "2.1"
+        },
+        "clay_ios": {
+          "version_added": false
+        },
+        "clay_macos": {
+          "version_added": "2.1"
+        },
+        "clay_windows": {
+          "version_added": "2.1"
+        },
+        "clay": {
+          "version_added": "2.1"
+        }
+      }
+    },
+    {
+      "id": "feature-594",
+      "query": "css/properties/grid-column-gap.supported_in_grid_layout",
+      "name": "<code>grid-column-gap</code>",
+      "category": "css/properties",
+      "source_file": "css/properties/grid-column-gap.json",
+      "support": {
+        "android": {
+          "version_added": "2.1"
+        },
+        "ios": {
+          "version_added": "2.1"
+        },
+        "harmony": {
+          "version_added": false
+        },
+        "web_lynx": {
+          "version_added": false
+        },
+        "clay_android": {
+          "version_added": "2.1"
+        },
+        "clay_ios": {
+          "version_added": false
+        },
+        "clay_macos": {
+          "version_added": "2.1"
+        },
+        "clay_windows": {
+          "version_added": "2.1"
+        },
+        "clay": {
+          "version_added": "2.1"
+        }
+      }
+    },
+    {
+      "id": "feature-595",
+      "query": "css/properties/grid-column-gap.supported_in_grid_layout.column-gap",
+      "name": "<code>column-gap</code>",
+      "category": "css/properties",
+      "source_file": "css/properties/grid-column-gap.json",
+      "support": {
+        "android": {
+          "version_added": "2.14"
+        },
+        "ios": {
+          "version_added": "2.14"
+        },
+        "harmony": {
+          "version_added": false
+        },
+        "web_lynx": {
+          "version_added": false
+        },
+        "clay_android": {
+          "version_added": "2.14"
+        },
+        "clay_ios": {
+          "version_added": false
+        },
+        "clay_macos": {
+          "version_added": "2.14"
+        },
+        "clay_windows": {
+          "version_added": "2.14"
+        },
+        "clay": {
+          "version_added": "2.14"
+        }
+      }
+    },
+    {
+      "id": "feature-596",
       "query": "css/properties/grid-column-span",
       "name": "grid-column-span",
       "category": "css/properties",
@@ -91717,7 +93290,7 @@
       }
     },
     {
-      "id": "feature-591",
+      "id": "feature-597",
       "query": "css/properties/grid-column-start",
       "name": "grid-column-start",
       "category": "css/properties",
@@ -91753,7 +93326,7 @@
       }
     },
     {
-      "id": "feature-592",
+      "id": "feature-598",
       "query": "css/properties/grid-column",
       "name": "grid-column",
       "category": "css/properties",
@@ -91789,7 +93362,7 @@
       }
     },
     {
-      "id": "feature-593",
+      "id": "feature-599",
       "query": "css/properties/grid-row-end",
       "name": "grid-row-end",
       "category": "css/properties",
@@ -91825,224 +93398,8 @@
       }
     },
     {
-      "id": "feature-594",
-      "query": "css/properties/grid-row-gap",
-      "name": "<code>row-gap</code>",
-      "category": "css/properties",
-      "source_file": "css/properties/grid-row-gap.json",
-      "support": {
-        "android": {
-          "version_added": "2.14"
-        },
-        "ios": {
-          "version_added": "2.14"
-        },
-        "harmony": {
-          "version_added": false
-        },
-        "web_lynx": {
-          "version_added": false
-        },
-        "clay_android": {
-          "version_added": "2.14"
-        },
-        "clay_ios": {
-          "version_added": false
-        },
-        "clay_macos": {
-          "version_added": "2.14"
-        },
-        "clay_windows": {
-          "version_added": "2.14"
-        },
-        "clay": {
-          "version_added": "2.14"
-        }
-      }
-    },
-    {
-      "id": "feature-595",
-      "query": "css/properties/grid-row-gap",
-      "name": "<code>grid-row-gap</code>",
-      "category": "css/properties",
-      "source_file": "css/properties/grid-row-gap.json",
-      "support": {
-        "android": {
-          "version_added": "2.1"
-        },
-        "ios": {
-          "version_added": "2.1"
-        },
-        "harmony": {
-          "version_added": false
-        },
-        "web_lynx": {
-          "version_added": false
-        },
-        "clay_android": {
-          "version_added": "2.1"
-        },
-        "clay_ios": {
-          "version_added": false
-        },
-        "clay_macos": {
-          "version_added": "2.1"
-        },
-        "clay_windows": {
-          "version_added": "2.1"
-        },
-        "clay": {
-          "version_added": "2.1"
-        }
-      }
-    },
-    {
-      "id": "feature-596",
-      "query": "css/properties/grid-row-gap.supported_in_flex_layout",
-      "name": "Supported in Flex Layout",
-      "category": "css/properties",
-      "source_file": "css/properties/grid-row-gap.json",
-      "support": {
-        "android": {
-          "version_added": "2.14"
-        },
-        "ios": {
-          "version_added": "2.14"
-        },
-        "harmony": {
-          "version_added": false
-        },
-        "web_lynx": {
-          "version_added": false
-        },
-        "clay_android": {
-          "version_added": "2.14"
-        },
-        "clay_ios": {
-          "version_added": false
-        },
-        "clay_macos": {
-          "version_added": "2.14"
-        },
-        "clay_windows": {
-          "version_added": "2.14"
-        },
-        "clay": {
-          "version_added": "2.14"
-        }
-      }
-    },
-    {
-      "id": "feature-597",
-      "query": "css/properties/grid-row-gap.supported_in_flex_layout.nested_value_1",
-      "name": "<code>row-gap</code> and <code>grid-row-gap</code>",
-      "category": "css/properties",
-      "source_file": "css/properties/grid-row-gap.json",
-      "support": {
-        "android": {
-          "version_added": "2.14"
-        },
-        "ios": {
-          "version_added": "2.14"
-        },
-        "harmony": {
-          "version_added": false
-        },
-        "web_lynx": {
-          "version_added": false
-        },
-        "clay_android": {
-          "version_added": "2.14"
-        },
-        "clay_ios": {
-          "version_added": false
-        },
-        "clay_macos": {
-          "version_added": "2.14"
-        },
-        "clay_windows": {
-          "version_added": "2.14"
-        },
-        "clay": {
-          "version_added": "2.14"
-        }
-      }
-    },
-    {
-      "id": "feature-598",
-      "query": "css/properties/grid-row-gap.supported_in_grid_layout",
-      "name": "Supported in Grid Layout",
-      "category": "css/properties",
-      "source_file": "css/properties/grid-row-gap.json",
-      "support": {
-        "android": {
-          "version_added": "2.1"
-        },
-        "ios": {
-          "version_added": "2.1"
-        },
-        "harmony": {
-          "version_added": false
-        },
-        "web_lynx": {
-          "version_added": false
-        },
-        "clay_android": {
-          "version_added": "2.1"
-        },
-        "clay_ios": {
-          "version_added": false
-        },
-        "clay_macos": {
-          "version_added": "2.1"
-        },
-        "clay_windows": {
-          "version_added": "2.1"
-        },
-        "clay": {
-          "version_added": "2.1"
-        }
-      }
-    },
-    {
-      "id": "feature-599",
-      "query": "css/properties/grid-row-gap.supported_in_grid_layout",
-      "name": "<code>grid-row-gap</code>",
-      "category": "css/properties",
-      "source_file": "css/properties/grid-row-gap.json",
-      "support": {
-        "android": {
-          "version_added": "2.1"
-        },
-        "ios": {
-          "version_added": "2.1"
-        },
-        "harmony": {
-          "version_added": false
-        },
-        "web_lynx": {
-          "version_added": false
-        },
-        "clay_android": {
-          "version_added": "2.1"
-        },
-        "clay_ios": {
-          "version_added": false
-        },
-        "clay_macos": {
-          "version_added": "2.1"
-        },
-        "clay_windows": {
-          "version_added": "2.1"
-        },
-        "clay": {
-          "version_added": "2.1"
-        }
-      }
-    },
-    {
       "id": "feature-600",
-      "query": "css/properties/grid-row-gap.supported_in_grid_layout.row-gap",
+      "query": "css/properties/grid-row-gap",
       "name": "<code>row-gap</code>",
       "category": "css/properties",
       "source_file": "css/properties/grid-row-gap.json",
@@ -92078,6 +93435,222 @@
     },
     {
       "id": "feature-601",
+      "query": "css/properties/grid-row-gap",
+      "name": "<code>grid-row-gap</code>",
+      "category": "css/properties",
+      "source_file": "css/properties/grid-row-gap.json",
+      "support": {
+        "android": {
+          "version_added": "2.1"
+        },
+        "ios": {
+          "version_added": "2.1"
+        },
+        "harmony": {
+          "version_added": false
+        },
+        "web_lynx": {
+          "version_added": false
+        },
+        "clay_android": {
+          "version_added": "2.1"
+        },
+        "clay_ios": {
+          "version_added": false
+        },
+        "clay_macos": {
+          "version_added": "2.1"
+        },
+        "clay_windows": {
+          "version_added": "2.1"
+        },
+        "clay": {
+          "version_added": "2.1"
+        }
+      }
+    },
+    {
+      "id": "feature-602",
+      "query": "css/properties/grid-row-gap.supported_in_flex_layout",
+      "name": "Supported in Flex Layout",
+      "category": "css/properties",
+      "source_file": "css/properties/grid-row-gap.json",
+      "support": {
+        "android": {
+          "version_added": "2.14"
+        },
+        "ios": {
+          "version_added": "2.14"
+        },
+        "harmony": {
+          "version_added": false
+        },
+        "web_lynx": {
+          "version_added": false
+        },
+        "clay_android": {
+          "version_added": "2.14"
+        },
+        "clay_ios": {
+          "version_added": false
+        },
+        "clay_macos": {
+          "version_added": "2.14"
+        },
+        "clay_windows": {
+          "version_added": "2.14"
+        },
+        "clay": {
+          "version_added": "2.14"
+        }
+      }
+    },
+    {
+      "id": "feature-603",
+      "query": "css/properties/grid-row-gap.supported_in_flex_layout.nested_value_1",
+      "name": "<code>row-gap</code> and <code>grid-row-gap</code>",
+      "category": "css/properties",
+      "source_file": "css/properties/grid-row-gap.json",
+      "support": {
+        "android": {
+          "version_added": "2.14"
+        },
+        "ios": {
+          "version_added": "2.14"
+        },
+        "harmony": {
+          "version_added": false
+        },
+        "web_lynx": {
+          "version_added": false
+        },
+        "clay_android": {
+          "version_added": "2.14"
+        },
+        "clay_ios": {
+          "version_added": false
+        },
+        "clay_macos": {
+          "version_added": "2.14"
+        },
+        "clay_windows": {
+          "version_added": "2.14"
+        },
+        "clay": {
+          "version_added": "2.14"
+        }
+      }
+    },
+    {
+      "id": "feature-604",
+      "query": "css/properties/grid-row-gap.supported_in_grid_layout",
+      "name": "Supported in Grid Layout",
+      "category": "css/properties",
+      "source_file": "css/properties/grid-row-gap.json",
+      "support": {
+        "android": {
+          "version_added": "2.1"
+        },
+        "ios": {
+          "version_added": "2.1"
+        },
+        "harmony": {
+          "version_added": false
+        },
+        "web_lynx": {
+          "version_added": false
+        },
+        "clay_android": {
+          "version_added": "2.1"
+        },
+        "clay_ios": {
+          "version_added": false
+        },
+        "clay_macos": {
+          "version_added": "2.1"
+        },
+        "clay_windows": {
+          "version_added": "2.1"
+        },
+        "clay": {
+          "version_added": "2.1"
+        }
+      }
+    },
+    {
+      "id": "feature-605",
+      "query": "css/properties/grid-row-gap.supported_in_grid_layout",
+      "name": "<code>grid-row-gap</code>",
+      "category": "css/properties",
+      "source_file": "css/properties/grid-row-gap.json",
+      "support": {
+        "android": {
+          "version_added": "2.1"
+        },
+        "ios": {
+          "version_added": "2.1"
+        },
+        "harmony": {
+          "version_added": false
+        },
+        "web_lynx": {
+          "version_added": false
+        },
+        "clay_android": {
+          "version_added": "2.1"
+        },
+        "clay_ios": {
+          "version_added": false
+        },
+        "clay_macos": {
+          "version_added": "2.1"
+        },
+        "clay_windows": {
+          "version_added": "2.1"
+        },
+        "clay": {
+          "version_added": "2.1"
+        }
+      }
+    },
+    {
+      "id": "feature-606",
+      "query": "css/properties/grid-row-gap.supported_in_grid_layout.row-gap",
+      "name": "<code>row-gap</code>",
+      "category": "css/properties",
+      "source_file": "css/properties/grid-row-gap.json",
+      "support": {
+        "android": {
+          "version_added": "2.14"
+        },
+        "ios": {
+          "version_added": "2.14"
+        },
+        "harmony": {
+          "version_added": false
+        },
+        "web_lynx": {
+          "version_added": false
+        },
+        "clay_android": {
+          "version_added": "2.14"
+        },
+        "clay_ios": {
+          "version_added": false
+        },
+        "clay_macos": {
+          "version_added": "2.14"
+        },
+        "clay_windows": {
+          "version_added": "2.14"
+        },
+        "clay": {
+          "version_added": "2.14"
+        }
+      }
+    },
+    {
+      "id": "feature-607",
       "query": "css/properties/grid-row-span",
       "name": "grid-row-span",
       "category": "css/properties",
@@ -92113,7 +93686,7 @@
       }
     },
     {
-      "id": "feature-602",
+      "id": "feature-608",
       "query": "css/properties/grid-row-start",
       "name": "grid-row-start",
       "category": "css/properties",
@@ -92149,7 +93722,7 @@
       }
     },
     {
-      "id": "feature-603",
+      "id": "feature-609",
       "query": "css/properties/grid-row",
       "name": "grid-row",
       "category": "css/properties",
@@ -92185,7 +93758,7 @@
       }
     },
     {
-      "id": "feature-604",
+      "id": "feature-610",
       "query": "css/properties/grid-template-columns",
       "name": "grid-template-columns",
       "category": "css/properties",
@@ -92221,7 +93794,7 @@
       }
     },
     {
-      "id": "feature-605",
+      "id": "feature-611",
       "query": "css/properties/grid-template-columns.calc",
       "name": "<code>calc()</code>",
       "category": "css/properties",
@@ -92257,7 +93830,7 @@
       }
     },
     {
-      "id": "feature-606",
+      "id": "feature-612",
       "query": "css/properties/grid-template-columns.fr",
       "name": "<code>fr</code>",
       "category": "css/properties",
@@ -92293,7 +93866,7 @@
       }
     },
     {
-      "id": "feature-607",
+      "id": "feature-613",
       "query": "css/properties/grid-template-columns.max-content",
       "name": "<code>max-content</code>, <code>fit-content</code> and <code>minmax()</code>",
       "category": "css/properties",
@@ -92329,7 +93902,7 @@
       }
     },
     {
-      "id": "feature-608",
+      "id": "feature-614",
       "query": "css/properties/grid-template-columns.unsupported_value1",
       "name": "<code>min-content</code>",
       "category": "css/properties",
@@ -92365,7 +93938,7 @@
       }
     },
     {
-      "id": "feature-609",
+      "id": "feature-615",
       "query": "css/properties/grid-template-columns.unsupported_value2",
       "name": "<code>none</code> and <code>[linename]</code>",
       "category": "css/properties",
@@ -92401,7 +93974,7 @@
       }
     },
     {
-      "id": "feature-610",
+      "id": "feature-616",
       "query": "css/properties/grid-template-rows",
       "name": "grid-template-rows",
       "category": "css/properties",
@@ -92437,7 +94010,7 @@
       }
     },
     {
-      "id": "feature-611",
+      "id": "feature-617",
       "query": "css/properties/grid-template-rows.calc",
       "name": "<code>calc()</code>",
       "category": "css/properties",
@@ -92473,7 +94046,7 @@
       }
     },
     {
-      "id": "feature-612",
+      "id": "feature-618",
       "query": "css/properties/grid-template-rows.fr",
       "name": "<code>fr</code>",
       "category": "css/properties",
@@ -92509,7 +94082,7 @@
       }
     },
     {
-      "id": "feature-613",
+      "id": "feature-619",
       "query": "css/properties/grid-template-rows.max-content",
       "name": "<code>max-content</code>, <code>fit-content</code> and <code>minmax()</code>",
       "category": "css/properties",
@@ -92545,7 +94118,7 @@
       }
     },
     {
-      "id": "feature-614",
+      "id": "feature-620",
       "query": "css/properties/grid-template-rows.unsupported_value1",
       "name": "<code>none</code> and <code>[linename]</code>",
       "category": "css/properties",
@@ -92581,7 +94154,7 @@
       }
     },
     {
-      "id": "feature-615",
+      "id": "feature-621",
       "query": "css/properties/grid-template-rows.unsupported_value2",
       "name": "<code>min-content</code>",
       "category": "css/properties",
@@ -92617,7 +94190,7 @@
       }
     },
     {
-      "id": "feature-616",
+      "id": "feature-622",
       "query": "css/properties/height",
       "name": "height",
       "category": "css/properties",
@@ -92653,7 +94226,7 @@
       }
     },
     {
-      "id": "feature-617",
+      "id": "feature-623",
       "query": "css/properties/height.max-content",
       "name": "max-content",
       "category": "css/properties",
@@ -92689,7 +94262,7 @@
       }
     },
     {
-      "id": "feature-618",
+      "id": "feature-624",
       "query": "css/properties/height.fit-content",
       "name": "fit-content",
       "category": "css/properties",
@@ -92725,7 +94298,7 @@
       }
     },
     {
-      "id": "feature-619",
+      "id": "feature-625",
       "query": "css/properties/height.min-content",
       "name": "min-content",
       "category": "css/properties",
@@ -92761,7 +94334,7 @@
       }
     },
     {
-      "id": "feature-620",
+      "id": "feature-626",
       "query": "css/properties/image-rendering",
       "name": "The image-rendering CSS property sets an image scaling algorithm. The property applies to an element itself.",
       "category": "css/properties",
@@ -92797,7 +94370,7 @@
       }
     },
     {
-      "id": "feature-621",
+      "id": "feature-627",
       "query": "css/properties/inset-inline-end",
       "name": "The inset-inline-end CSS property defines the logical inline end inset of an element, which maps to a physical offset depending on the element's directionality.",
       "category": "css/properties",
@@ -92833,7 +94406,7 @@
       }
     },
     {
-      "id": "feature-622",
+      "id": "feature-628",
       "query": "css/properties/inset-inline-start",
       "name": "The inset-inline-start CSS property defines the logical inline start inset of an element, which maps to a physical offset depending on the element's directionality.",
       "category": "css/properties",
@@ -92869,7 +94442,7 @@
       }
     },
     {
-      "id": "feature-623",
+      "id": "feature-629",
       "query": "css/properties/justify-content",
       "name": "justify-content",
       "category": "css/properties",
@@ -92905,7 +94478,7 @@
       }
     },
     {
-      "id": "feature-624",
+      "id": "feature-630",
       "query": "css/properties/justify-content.supported_in_flex_layout",
       "name": "Supported in Flexible Box Layout",
       "category": "css/properties",
@@ -92941,7 +94514,7 @@
       }
     },
     {
-      "id": "feature-625",
+      "id": "feature-631",
       "query": "css/properties/justify-content.supported_in_flex_layout.nested_value_1",
       "name": "<code>flex-start</code>, <code>flex-end</code>, <code>center</code>, <code>space-between</code>, <code>space-around</code>, <code>space-evenly</code>",
       "category": "css/properties",
@@ -92977,7 +94550,7 @@
       }
     },
     {
-      "id": "feature-626",
+      "id": "feature-632",
       "query": "css/properties/justify-content.supported_in_flex_layout.nested_value_2",
       "name": "<code>start</code> and <code>end</code>",
       "category": "css/properties",
@@ -93013,7 +94586,7 @@
       }
     },
     {
-      "id": "feature-627",
+      "id": "feature-633",
       "query": "css/properties/justify-content.supported_in_linear_layout",
       "name": "Supported in Linear Layout",
       "category": "css/properties",
@@ -93049,7 +94622,7 @@
       }
     },
     {
-      "id": "feature-628",
+      "id": "feature-634",
       "query": "css/properties/justify-content.supported_in_linear_layout.nested_value_1",
       "name": "<code>flex-start</code>, <code>flex-end</code>, <code>center</code>, <code>space-between</code>, <code>start</code>, <code>end</code>",
       "category": "css/properties",
@@ -93085,7 +94658,7 @@
       }
     },
     {
-      "id": "feature-629",
+      "id": "feature-635",
       "query": "css/properties/justify-content.supported_in_grid_layout",
       "name": "Supported in Grid Layout",
       "category": "css/properties",
@@ -93121,7 +94694,7 @@
       }
     },
     {
-      "id": "feature-630",
+      "id": "feature-636",
       "query": "css/properties/justify-content.supported_in_grid_layout.nested_value_1",
       "name": "<code>flex-start</code>, <code>flex-end</code>, <code>center</code>, <code>space-between</code>, <code>space-around</code>, <code>space-evenly</code>, <code>start</code>, <code>end</code>, <code>stretch</code>",
       "category": "css/properties",
@@ -93157,7 +94730,7 @@
       }
     },
     {
-      "id": "feature-631",
+      "id": "feature-637",
       "query": "css/properties/justify-content.unsupported_value_2",
       "name": "<code>left</code> and <code>right</code>",
       "category": "css/properties",
@@ -93193,7 +94766,7 @@
       }
     },
     {
-      "id": "feature-632",
+      "id": "feature-638",
       "query": "css/properties/justify-content.normal",
       "name": "<code>normal</code>",
       "category": "css/properties",
@@ -93229,7 +94802,7 @@
       }
     },
     {
-      "id": "feature-633",
+      "id": "feature-639",
       "query": "css/properties/justify-content.baseline",
       "name": "<code>baseline</code>",
       "category": "css/properties",
@@ -93265,7 +94838,7 @@
       }
     },
     {
-      "id": "feature-634",
+      "id": "feature-640",
       "query": "css/properties/justify-items",
       "name": "defines the default justify-self for all items of the box, giving them all a default way of justifying each box along the appropriate axis.",
       "category": "css/properties",
@@ -93301,7 +94874,7 @@
       }
     },
     {
-      "id": "feature-635",
+      "id": "feature-641",
       "query": "css/properties/justify-self",
       "name": "The CSS justify-self property sets the way a box is justified inside its alignment container along the appropriate axis.",
       "category": "css/properties",
@@ -93337,7 +94910,7 @@
       }
     },
     {
-      "id": "feature-636",
+      "id": "feature-642",
       "query": "css/properties/layout-animation-create-delay",
       "name": "layout-animation-create-delay",
       "category": "css/properties",
@@ -93373,7 +94946,7 @@
       }
     },
     {
-      "id": "feature-637",
+      "id": "feature-643",
       "query": "css/properties/layout-animation-create-duration",
       "name": "layout-animation-create-duration",
       "category": "css/properties",
@@ -93409,7 +94982,7 @@
       }
     },
     {
-      "id": "feature-638",
+      "id": "feature-644",
       "query": "css/properties/layout-animation-create-property",
       "name": "layout-animation-create-property",
       "category": "css/properties",
@@ -93445,7 +95018,7 @@
       }
     },
     {
-      "id": "feature-639",
+      "id": "feature-645",
       "query": "css/properties/layout-animation-create-timing-function",
       "name": "layout-animation-create-timing-function",
       "category": "css/properties",
@@ -93481,7 +95054,7 @@
       }
     },
     {
-      "id": "feature-640",
+      "id": "feature-646",
       "query": "css/properties/layout-animation-delete-delay",
       "name": "layout-animation-delete-delay",
       "category": "css/properties",
@@ -93517,7 +95090,7 @@
       }
     },
     {
-      "id": "feature-641",
+      "id": "feature-647",
       "query": "css/properties/layout-animation-delete-duration",
       "name": "layout-animation-delete-duration",
       "category": "css/properties",
@@ -93553,7 +95126,7 @@
       }
     },
     {
-      "id": "feature-642",
+      "id": "feature-648",
       "query": "css/properties/layout-animation-delete-property",
       "name": "layout-animation-delete-property",
       "category": "css/properties",
@@ -93589,7 +95162,7 @@
       }
     },
     {
-      "id": "feature-643",
+      "id": "feature-649",
       "query": "css/properties/layout-animation-delete-timing-function",
       "name": "layout-animation-delete-timing-function",
       "category": "css/properties",
@@ -93625,7 +95198,7 @@
       }
     },
     {
-      "id": "feature-644",
+      "id": "feature-650",
       "query": "css/properties/layout-animation-update-delay",
       "name": "layout-animation-update-delay",
       "category": "css/properties",
@@ -93661,7 +95234,7 @@
       }
     },
     {
-      "id": "feature-645",
+      "id": "feature-651",
       "query": "css/properties/layout-animation-update-duration",
       "name": "layout-animation-update-duration",
       "category": "css/properties",
@@ -93697,7 +95270,7 @@
       }
     },
     {
-      "id": "feature-646",
+      "id": "feature-652",
       "query": "css/properties/layout-animation-update-timing-function",
       "name": "layout-animation-update-timing-function",
       "category": "css/properties",
@@ -93733,7 +95306,7 @@
       }
     },
     {
-      "id": "feature-647",
+      "id": "feature-653",
       "query": "css/properties/left",
       "name": "participates in setting the horizontal position of a positioned element. It has no effect on non-positioned elements.",
       "category": "css/properties",
@@ -93769,7 +95342,7 @@
       }
     },
     {
-      "id": "feature-648",
+      "id": "feature-654",
       "query": "css/properties/letter-spacing",
       "name": "letter-spacing",
       "category": "css/properties",
@@ -93805,7 +95378,7 @@
       }
     },
     {
-      "id": "feature-649",
+      "id": "feature-655",
       "query": "css/properties/line-height",
       "name": "line-height",
       "category": "css/properties",
@@ -93841,7 +95414,7 @@
       }
     },
     {
-      "id": "feature-650",
+      "id": "feature-656",
       "query": "css/properties/linear-cross-gravity",
       "name": "Set the position of the child element on the cross axis of the parent container in linear layout.",
       "category": "css/properties",
@@ -93877,7 +95450,7 @@
       }
     },
     {
-      "id": "feature-651",
+      "id": "feature-657",
       "query": "css/properties/linear-direction",
       "name": "sets how linear items are placed in the linear container defining the main axis and the direction.",
       "category": "css/properties",
@@ -93913,7 +95486,7 @@
       }
     },
     {
-      "id": "feature-652",
+      "id": "feature-658",
       "query": "css/properties/linear-direction.support_linear_direction",
       "name": "Support <code>linear-direction</code>",
       "category": "css/properties",
@@ -93949,7 +95522,7 @@
       }
     },
     {
-      "id": "feature-653",
+      "id": "feature-659",
       "query": "css/properties/linear-direction.support_linear_direction.nested_value_1",
       "name": "<code>row</code>, <code>row-reverse</code>, <code>column</code>, <code>column-reverse</code>",
       "category": "css/properties",
@@ -93985,7 +95558,7 @@
       }
     },
     {
-      "id": "feature-654",
+      "id": "feature-660",
       "query": "css/properties/linear-direction.support_linear_direction.nested_value_2",
       "name": "<code>vertical</code>, <code>horizontal</code>, <code>vertical-reverse</code>, <code>horizontal-reverse</code>",
       "category": "css/properties",
@@ -94021,7 +95594,7 @@
       }
     },
     {
-      "id": "feature-655",
+      "id": "feature-661",
       "query": "css/properties/linear-direction.support_linear_orientation",
       "name": "Supported <code>linear-orientation</code>",
       "category": "css/properties",
@@ -94057,7 +95630,7 @@
       }
     },
     {
-      "id": "feature-656",
+      "id": "feature-662",
       "query": "css/properties/linear-gravity",
       "name": "defines how distributes space between and around content items along the main-axis of a linear container.",
       "category": "css/properties",
@@ -94093,7 +95666,7 @@
       }
     },
     {
-      "id": "feature-657",
+      "id": "feature-663",
       "query": "css/properties/linear-gravity.value1",
       "name": "<code>start</code>, <code>end</code>, <code>center</code>",
       "category": "css/properties",
@@ -94129,7 +95702,7 @@
       }
     },
     {
-      "id": "feature-658",
+      "id": "feature-664",
       "query": "css/properties/linear-layout-gravity",
       "name": "The position of the child element in the linear container, perpendicular to the layout direction.",
       "category": "css/properties",
@@ -94165,7 +95738,7 @@
       }
     },
     {
-      "id": "feature-659",
+      "id": "feature-665",
       "query": "css/properties/linear-layout-gravity.value1",
       "name": "<code>stretch</code>, <code>start</code>, <code>end</code>, <code>center</code>",
       "category": "css/properties",
@@ -94201,7 +95774,7 @@
       }
     },
     {
-      "id": "feature-660",
+      "id": "feature-666",
       "query": "css/properties/linear-orientation",
       "name": "sets how linear items are placed in the linear container defining the main axis and the direction.",
       "category": "css/properties",
@@ -94237,7 +95810,7 @@
       }
     },
     {
-      "id": "feature-661",
+      "id": "feature-667",
       "query": "css/properties/linear-orientation.support_linear_orientation",
       "name": "Supported <code>linear-orientation</code>",
       "category": "css/properties",
@@ -94273,7 +95846,7 @@
       }
     },
     {
-      "id": "feature-662",
+      "id": "feature-668",
       "query": "css/properties/linear-orientation.support_linear_orientation.nested_value_1",
       "name": "<code>vertical</code>, <code>horizontal</code>, <code>vertical-reverse</code>, <code>horizontal-reverse</code>",
       "category": "css/properties",
@@ -94309,7 +95882,7 @@
       }
     },
     {
-      "id": "feature-663",
+      "id": "feature-669",
       "query": "css/properties/linear-orientation.support_linear_orientation.nested_value_2",
       "name": "<code>row</code>, <code>row-reverse</code>, <code>column</code>, <code>column-reverse</code>",
       "category": "css/properties",
@@ -94345,7 +95918,7 @@
       }
     },
     {
-      "id": "feature-664",
+      "id": "feature-670",
       "query": "css/properties/linear-orientation.support_linear_direction",
       "name": "Support <code>linear-direction</code>",
       "category": "css/properties",
@@ -94381,7 +95954,7 @@
       }
     },
     {
-      "id": "feature-665",
+      "id": "feature-671",
       "query": "css/properties/linear-orientation.support_linear_direction.nested_value_1",
       "name": "<code>vertical</code>, <code>horizontal</code>, <code>vertical-reverse</code>, <code>horizontal-reverse</code>, <code>row</code>, <code>row-reverse</code>, <code>column</code>, <code>column-reverse</code>",
       "category": "css/properties",
@@ -94417,7 +95990,7 @@
       }
     },
     {
-      "id": "feature-666",
+      "id": "feature-672",
       "query": "css/properties/linear-weight-sum",
       "name": "Child element's weight sum in linear layout.",
       "category": "css/properties",
@@ -94453,7 +96026,7 @@
       }
     },
     {
-      "id": "feature-667",
+      "id": "feature-673",
       "query": "css/properties/linear-weight",
       "name": "Child element's weight in linear layout.",
       "category": "css/properties",
@@ -94489,7 +96062,7 @@
       }
     },
     {
-      "id": "feature-668",
+      "id": "feature-674",
       "query": "css/properties/margin-bottom",
       "name": "margin-bottom",
       "category": "css/properties",
@@ -94525,7 +96098,7 @@
       }
     },
     {
-      "id": "feature-669",
+      "id": "feature-675",
       "query": "css/properties/margin-bottom.supported_in_flex_layout",
       "name": "Supported in Flexible Box Layout",
       "category": "css/properties",
@@ -94561,7 +96134,7 @@
       }
     },
     {
-      "id": "feature-670",
+      "id": "feature-676",
       "query": "css/properties/margin-bottom.supported_in_flex_layout.auto",
       "name": "<code>auto</code>",
       "category": "css/properties",
@@ -94597,7 +96170,7 @@
       }
     },
     {
-      "id": "feature-671",
+      "id": "feature-677",
       "query": "css/properties/margin-bottom.supported_in_linear_layout",
       "name": "Supported in Linear Layout",
       "category": "css/properties",
@@ -94633,7 +96206,7 @@
       }
     },
     {
-      "id": "feature-672",
+      "id": "feature-678",
       "query": "css/properties/margin-bottom.supported_in_linear_layout.nested_value_1",
       "name": "<code>auto</code> in cross-axis",
       "category": "css/properties",
@@ -94669,7 +96242,7 @@
       }
     },
     {
-      "id": "feature-673",
+      "id": "feature-679",
       "query": "css/properties/margin-bottom.supported_in_linear_layout.nested_value_2",
       "name": "<code>auto</code> in main-axis",
       "category": "css/properties",
@@ -94705,7 +96278,7 @@
       }
     },
     {
-      "id": "feature-674",
+      "id": "feature-680",
       "query": "css/properties/margin-bottom.supported_in_grid_layout",
       "name": "Supported in Grid Layout",
       "category": "css/properties",
@@ -94741,7 +96314,7 @@
       }
     },
     {
-      "id": "feature-675",
+      "id": "feature-681",
       "query": "css/properties/margin-bottom.supported_in_grid_layout.auto",
       "name": "<code>auto</code>",
       "category": "css/properties",
@@ -94777,7 +96350,7 @@
       }
     },
     {
-      "id": "feature-676",
+      "id": "feature-682",
       "query": "css/properties/margin-inline-end",
       "name": "margin-inline-end",
       "category": "css/properties",
@@ -94813,7 +96386,7 @@
       }
     },
     {
-      "id": "feature-677",
+      "id": "feature-683",
       "query": "css/properties/margin-inline-end.supported_in_flex_layout",
       "name": "Supported in Flexible Box Layout",
       "category": "css/properties",
@@ -94849,7 +96422,7 @@
       }
     },
     {
-      "id": "feature-678",
+      "id": "feature-684",
       "query": "css/properties/margin-inline-end.supported_in_flex_layout.auto",
       "name": "<code>auto</code>",
       "category": "css/properties",
@@ -94885,7 +96458,7 @@
       }
     },
     {
-      "id": "feature-679",
+      "id": "feature-685",
       "query": "css/properties/margin-inline-end.supported_in_linear_layout",
       "name": "Supported in Linear Layout",
       "category": "css/properties",
@@ -94921,7 +96494,7 @@
       }
     },
     {
-      "id": "feature-680",
+      "id": "feature-686",
       "query": "css/properties/margin-inline-end.supported_in_linear_layout.nested_value_1",
       "name": "<code>auto</code> in cross-axis",
       "category": "css/properties",
@@ -94957,7 +96530,7 @@
       }
     },
     {
-      "id": "feature-681",
+      "id": "feature-687",
       "query": "css/properties/margin-inline-end.supported_in_linear_layout.nested_value_2",
       "name": "<code>auto</code> in main-axis",
       "category": "css/properties",
@@ -94993,7 +96566,7 @@
       }
     },
     {
-      "id": "feature-682",
+      "id": "feature-688",
       "query": "css/properties/margin-inline-end.supported_in_grid_layout",
       "name": "Supported in Grid Layout",
       "category": "css/properties",
@@ -95029,7 +96602,7 @@
       }
     },
     {
-      "id": "feature-683",
+      "id": "feature-689",
       "query": "css/properties/margin-inline-end.supported_in_grid_layout.auto",
       "name": "<code>auto</code>",
       "category": "css/properties",
@@ -95065,7 +96638,7 @@
       }
     },
     {
-      "id": "feature-684",
+      "id": "feature-690",
       "query": "css/properties/margin-inline-start",
       "name": "margin-inline-start",
       "category": "css/properties",
@@ -95101,7 +96674,7 @@
       }
     },
     {
-      "id": "feature-685",
+      "id": "feature-691",
       "query": "css/properties/margin-inline-start.supported_in_flex_layout",
       "name": "Supported in Flexible Box Layout",
       "category": "css/properties",
@@ -95137,7 +96710,7 @@
       }
     },
     {
-      "id": "feature-686",
+      "id": "feature-692",
       "query": "css/properties/margin-inline-start.supported_in_flex_layout.auto",
       "name": "<code>auto</code>",
       "category": "css/properties",
@@ -95173,7 +96746,7 @@
       }
     },
     {
-      "id": "feature-687",
+      "id": "feature-693",
       "query": "css/properties/margin-inline-start.supported_in_linear_layout",
       "name": "Supported in Linear Layout",
       "category": "css/properties",
@@ -95209,7 +96782,7 @@
       }
     },
     {
-      "id": "feature-688",
+      "id": "feature-694",
       "query": "css/properties/margin-inline-start.supported_in_linear_layout.nested_value_1",
       "name": "<code>auto</code> in cross-axis",
       "category": "css/properties",
@@ -95245,7 +96818,7 @@
       }
     },
     {
-      "id": "feature-689",
+      "id": "feature-695",
       "query": "css/properties/margin-inline-start.supported_in_linear_layout.nested_value_2",
       "name": "<code>auto</code> in main-axis",
       "category": "css/properties",
@@ -95281,7 +96854,7 @@
       }
     },
     {
-      "id": "feature-690",
+      "id": "feature-696",
       "query": "css/properties/margin-inline-start.supported_in_grid_layout",
       "name": "Supported in Grid Layout",
       "category": "css/properties",
@@ -95317,7 +96890,7 @@
       }
     },
     {
-      "id": "feature-691",
+      "id": "feature-697",
       "query": "css/properties/margin-inline-start.supported_in_grid_layout.auto",
       "name": "<code>auto</code>",
       "category": "css/properties",
@@ -95353,7 +96926,7 @@
       }
     },
     {
-      "id": "feature-692",
+      "id": "feature-698",
       "query": "css/properties/margin-left",
       "name": "margin-left",
       "category": "css/properties",
@@ -95389,7 +96962,7 @@
       }
     },
     {
-      "id": "feature-693",
+      "id": "feature-699",
       "query": "css/properties/margin-left.supported_in_flex_layout",
       "name": "Supported in Flexible Box Layout",
       "category": "css/properties",
@@ -95425,7 +96998,7 @@
       }
     },
     {
-      "id": "feature-694",
+      "id": "feature-700",
       "query": "css/properties/margin-left.supported_in_flex_layout.auto",
       "name": "<code>auto</code>",
       "category": "css/properties",
@@ -95461,7 +97034,7 @@
       }
     },
     {
-      "id": "feature-695",
+      "id": "feature-701",
       "query": "css/properties/margin-left.supported_in_linear_layout",
       "name": "Supported in Linear Layout",
       "category": "css/properties",
@@ -95497,7 +97070,7 @@
       }
     },
     {
-      "id": "feature-696",
+      "id": "feature-702",
       "query": "css/properties/margin-left.supported_in_linear_layout.nested_value_1",
       "name": "<code>auto</code> in cross-axis",
       "category": "css/properties",
@@ -95533,7 +97106,7 @@
       }
     },
     {
-      "id": "feature-697",
+      "id": "feature-703",
       "query": "css/properties/margin-left.supported_in_linear_layout.nested_value_2",
       "name": "<code>auto</code> in main-axis",
       "category": "css/properties",
@@ -95569,7 +97142,7 @@
       }
     },
     {
-      "id": "feature-698",
+      "id": "feature-704",
       "query": "css/properties/margin-left.supported_in_grid_layout",
       "name": "Supported in Grid Layout",
       "category": "css/properties",
@@ -95605,7 +97178,7 @@
       }
     },
     {
-      "id": "feature-699",
+      "id": "feature-705",
       "query": "css/properties/margin-left.supported_in_grid_layout.auto",
       "name": "<code>auto</code>",
       "category": "css/properties",
@@ -95641,7 +97214,7 @@
       }
     },
     {
-      "id": "feature-700",
+      "id": "feature-706",
       "query": "css/properties/margin-right",
       "name": "margin-right",
       "category": "css/properties",
@@ -95677,7 +97250,7 @@
       }
     },
     {
-      "id": "feature-701",
+      "id": "feature-707",
       "query": "css/properties/margin-right.supported_in_flex_layout",
       "name": "Supported in Flexible Box Layout",
       "category": "css/properties",
@@ -95713,7 +97286,7 @@
       }
     },
     {
-      "id": "feature-702",
+      "id": "feature-708",
       "query": "css/properties/margin-right.supported_in_flex_layout.auto",
       "name": "<code>auto</code>",
       "category": "css/properties",
@@ -95749,7 +97322,7 @@
       }
     },
     {
-      "id": "feature-703",
+      "id": "feature-709",
       "query": "css/properties/margin-right.supported_in_linear_layout",
       "name": "Supported in Linear Layout",
       "category": "css/properties",
@@ -95785,7 +97358,7 @@
       }
     },
     {
-      "id": "feature-704",
+      "id": "feature-710",
       "query": "css/properties/margin-right.supported_in_linear_layout.nested_value_1",
       "name": "<code>auto</code> in cross-axis",
       "category": "css/properties",
@@ -95821,7 +97394,7 @@
       }
     },
     {
-      "id": "feature-705",
+      "id": "feature-711",
       "query": "css/properties/margin-right.supported_in_linear_layout.nested_value_2",
       "name": "<code>auto</code> in main-axis",
       "category": "css/properties",
@@ -95857,7 +97430,7 @@
       }
     },
     {
-      "id": "feature-706",
+      "id": "feature-712",
       "query": "css/properties/margin-right.supported_in_grid_layout",
       "name": "Supported in Grid Layout",
       "category": "css/properties",
@@ -95893,7 +97466,7 @@
       }
     },
     {
-      "id": "feature-707",
+      "id": "feature-713",
       "query": "css/properties/margin-right.supported_in_grid_layout.auto",
       "name": "<code>auto</code>",
       "category": "css/properties",
@@ -95929,7 +97502,7 @@
       }
     },
     {
-      "id": "feature-708",
+      "id": "feature-714",
       "query": "css/properties/margin-top",
       "name": "margin-top",
       "category": "css/properties",
@@ -95965,7 +97538,7 @@
       }
     },
     {
-      "id": "feature-709",
+      "id": "feature-715",
       "query": "css/properties/margin-top.supported_in_flex_layout",
       "name": "Supported in Flexible Box Layout",
       "category": "css/properties",
@@ -96001,7 +97574,7 @@
       }
     },
     {
-      "id": "feature-710",
+      "id": "feature-716",
       "query": "css/properties/margin-top.supported_in_flex_layout.auto",
       "name": "<code>auto</code>",
       "category": "css/properties",
@@ -96037,7 +97610,7 @@
       }
     },
     {
-      "id": "feature-711",
+      "id": "feature-717",
       "query": "css/properties/margin-top.supported_in_linear_layout",
       "name": "Supported in Linear Layout",
       "category": "css/properties",
@@ -96073,7 +97646,7 @@
       }
     },
     {
-      "id": "feature-712",
+      "id": "feature-718",
       "query": "css/properties/margin-top.supported_in_linear_layout.nested_value_1",
       "name": "<code>auto</code> in cross-axis",
       "category": "css/properties",
@@ -96109,7 +97682,7 @@
       }
     },
     {
-      "id": "feature-713",
+      "id": "feature-719",
       "query": "css/properties/margin-top.supported_in_linear_layout.nested_value_2",
       "name": "<code>auto</code> in main-axis",
       "category": "css/properties",
@@ -96145,7 +97718,7 @@
       }
     },
     {
-      "id": "feature-714",
+      "id": "feature-720",
       "query": "css/properties/margin-top.supported_in_grid_layout",
       "name": "Supported in Grid Layout",
       "category": "css/properties",
@@ -96181,7 +97754,7 @@
       }
     },
     {
-      "id": "feature-715",
+      "id": "feature-721",
       "query": "css/properties/margin-top.supported_in_grid_layout.auto",
       "name": "<code>auto</code>",
       "category": "css/properties",
@@ -96217,7 +97790,7 @@
       }
     },
     {
-      "id": "feature-716",
+      "id": "feature-722",
       "query": "css/properties/margin",
       "name": "margin",
       "category": "css/properties",
@@ -96253,7 +97826,7 @@
       }
     },
     {
-      "id": "feature-717",
+      "id": "feature-723",
       "query": "css/properties/margin.supported_in_flex_layout",
       "name": "Supported in Flexible Box Layout",
       "category": "css/properties",
@@ -96289,7 +97862,7 @@
       }
     },
     {
-      "id": "feature-718",
+      "id": "feature-724",
       "query": "css/properties/margin.supported_in_flex_layout.auto",
       "name": "<code>auto</code>",
       "category": "css/properties",
@@ -96325,7 +97898,7 @@
       }
     },
     {
-      "id": "feature-719",
+      "id": "feature-725",
       "query": "css/properties/margin.supported_in_linear_layout",
       "name": "Supported in Linear Layout",
       "category": "css/properties",
@@ -96361,7 +97934,7 @@
       }
     },
     {
-      "id": "feature-720",
+      "id": "feature-726",
       "query": "css/properties/margin.supported_in_linear_layout.nested_value_1",
       "name": "<code>auto</code> in cross-axis",
       "category": "css/properties",
@@ -96397,7 +97970,7 @@
       }
     },
     {
-      "id": "feature-721",
+      "id": "feature-727",
       "query": "css/properties/margin.supported_in_linear_layout.nested_value_2",
       "name": "<code>auto</code> in main-axis",
       "category": "css/properties",
@@ -96433,7 +98006,7 @@
       }
     },
     {
-      "id": "feature-722",
+      "id": "feature-728",
       "query": "css/properties/margin.supported_in_grid_layout",
       "name": "Supported in Grid Layout",
       "category": "css/properties",
@@ -96469,7 +98042,7 @@
       }
     },
     {
-      "id": "feature-723",
+      "id": "feature-729",
       "query": "css/properties/margin.supported_in_grid_layout.auto",
       "name": "<code>auto</code>",
       "category": "css/properties",
@@ -96505,7 +98078,43 @@
       }
     },
     {
-      "id": "feature-724",
+      "id": "feature-730",
+      "query": "css/properties/mask-composite",
+      "name": "The mask-composite CSS property represents a compositing operation used on the current mask layer with the mask layers below it.",
+      "category": "css/properties",
+      "source_file": "css/properties/mask-composite.json",
+      "support": {
+        "android": {
+          "version_added": false
+        },
+        "ios": {
+          "version_added": false
+        },
+        "harmony": {
+          "version_added": false
+        },
+        "web_lynx": {
+          "version_added": true
+        },
+        "clay_android": {
+          "version_added": false
+        },
+        "clay_ios": {
+          "version_added": false
+        },
+        "clay_macos": {
+          "version_added": "4.0"
+        },
+        "clay_windows": {
+          "version_added": "4.0"
+        },
+        "clay": {
+          "version_added": "4.0"
+        }
+      }
+    },
+    {
+      "id": "feature-731",
       "query": "css/properties/mask-image",
       "name": "The mask-image CSS property sets the image that is used as mask layer for an element. By default this means the alpha channel of the mask image will be multiplied with the alpha channel of the element. This can be controlled with the mask-mode property.",
       "category": "css/properties",
@@ -96541,7 +98150,7 @@
       }
     },
     {
-      "id": "feature-725",
+      "id": "feature-732",
       "query": "css/properties/mask",
       "name": "The mask CSS shorthand property hides an element (partially or fully) by masking or clipping the image at specific points.",
       "category": "css/properties",
@@ -96577,7 +98186,7 @@
       }
     },
     {
-      "id": "feature-726",
+      "id": "feature-733",
       "query": "css/properties/max-height",
       "name": "sets the maximum height of an element.",
       "category": "css/properties",
@@ -96613,7 +98222,7 @@
       }
     },
     {
-      "id": "feature-727",
+      "id": "feature-734",
       "query": "css/properties/max-width",
       "name": "sets the maximum width of an element.",
       "category": "css/properties",
@@ -96649,7 +98258,7 @@
       }
     },
     {
-      "id": "feature-728",
+      "id": "feature-735",
       "query": "css/properties/min-height",
       "name": "sets the minimum height of an element.",
       "category": "css/properties",
@@ -96685,7 +98294,7 @@
       }
     },
     {
-      "id": "feature-729",
+      "id": "feature-736",
       "query": "css/properties/min-width",
       "name": "sets the minimum width of an element.",
       "category": "css/properties",
@@ -96721,7 +98330,7 @@
       }
     },
     {
-      "id": "feature-730",
+      "id": "feature-737",
       "query": "css/properties/offset-distance",
       "name": "offset-distance",
       "category": "css/properties",
@@ -96757,7 +98366,7 @@
       }
     },
     {
-      "id": "feature-731",
+      "id": "feature-738",
       "query": "css/properties/offset-path",
       "name": "offset-path",
       "category": "css/properties",
@@ -96793,7 +98402,151 @@
       }
     },
     {
-      "id": "feature-732",
+      "id": "feature-739",
+      "query": "css/properties/offset-path.circle()",
+      "name": "circle()",
+      "category": "css/properties",
+      "source_file": "css/properties/offset-path.json",
+      "support": {
+        "android": {
+          "version_added": "3.3"
+        },
+        "ios": {
+          "version_added": "3.3"
+        },
+        "harmony": {
+          "version_added": "3.8"
+        },
+        "web_lynx": {
+          "version_added": true
+        },
+        "clay_android": {
+          "version_added": false
+        },
+        "clay_ios": {
+          "version_added": false
+        },
+        "clay_macos": {
+          "version_added": false
+        },
+        "clay_windows": {
+          "version_added": false
+        },
+        "clay": {
+          "version_added": false
+        }
+      }
+    },
+    {
+      "id": "feature-740",
+      "query": "css/properties/offset-path.inset()",
+      "name": "inset()",
+      "category": "css/properties",
+      "source_file": "css/properties/offset-path.json",
+      "support": {
+        "android": {
+          "version_added": "3.3"
+        },
+        "ios": {
+          "version_added": "3.3"
+        },
+        "harmony": {
+          "version_added": "3.8"
+        },
+        "web_lynx": {
+          "version_added": true
+        },
+        "clay_android": {
+          "version_added": false
+        },
+        "clay_ios": {
+          "version_added": false
+        },
+        "clay_macos": {
+          "version_added": false
+        },
+        "clay_windows": {
+          "version_added": false
+        },
+        "clay": {
+          "version_added": false
+        }
+      }
+    },
+    {
+      "id": "feature-741",
+      "query": "css/properties/offset-path.ellipse()",
+      "name": "ellipse()",
+      "category": "css/properties",
+      "source_file": "css/properties/offset-path.json",
+      "support": {
+        "android": {
+          "version_added": "3.3"
+        },
+        "ios": {
+          "version_added": false
+        },
+        "harmony": {
+          "version_added": "3.8"
+        },
+        "web_lynx": {
+          "version_added": true
+        },
+        "clay_android": {
+          "version_added": false
+        },
+        "clay_ios": {
+          "version_added": false
+        },
+        "clay_macos": {
+          "version_added": false
+        },
+        "clay_windows": {
+          "version_added": false
+        },
+        "clay": {
+          "version_added": false
+        }
+      }
+    },
+    {
+      "id": "feature-742",
+      "query": "css/properties/offset-path.path()",
+      "name": "path()",
+      "category": "css/properties",
+      "source_file": "css/properties/offset-path.json",
+      "support": {
+        "android": {
+          "version_added": "3.3"
+        },
+        "ios": {
+          "version_added": "3.3"
+        },
+        "harmony": {
+          "version_added": "3.8"
+        },
+        "web_lynx": {
+          "version_added": true
+        },
+        "clay_android": {
+          "version_added": false
+        },
+        "clay_ios": {
+          "version_added": false
+        },
+        "clay_macos": {
+          "version_added": false
+        },
+        "clay_windows": {
+          "version_added": false
+        },
+        "clay": {
+          "version_added": false
+        }
+      }
+    },
+    {
+      "id": "feature-743",
       "query": "css/properties/offset-rotate",
       "name": "offset-rotate",
       "category": "css/properties",
@@ -96829,7 +98582,7 @@
       }
     },
     {
-      "id": "feature-733",
+      "id": "feature-744",
       "query": "css/properties/opacity",
       "name": "opacity",
       "category": "css/properties",
@@ -96865,7 +98618,7 @@
       }
     },
     {
-      "id": "feature-734",
+      "id": "feature-745",
       "query": "css/properties/order",
       "name": "The order CSS property sets the order to lay out an item.",
       "category": "css/properties",
@@ -96901,7 +98654,7 @@
       }
     },
     {
-      "id": "feature-735",
+      "id": "feature-746",
       "query": "css/properties/overflow-x",
       "name": "overflow-x",
       "category": "css/properties",
@@ -96937,7 +98690,7 @@
       }
     },
     {
-      "id": "feature-736",
+      "id": "feature-747",
       "query": "css/properties/overflow-y",
       "name": "overflow-y",
       "category": "css/properties",
@@ -96973,7 +98726,7 @@
       }
     },
     {
-      "id": "feature-737",
+      "id": "feature-748",
       "query": "css/properties/overflow",
       "name": "overflow",
       "category": "css/properties",
@@ -97009,7 +98762,7 @@
       }
     },
     {
-      "id": "feature-738",
+      "id": "feature-749",
       "query": "css/properties/padding-bottom",
       "name": "padding-bottom",
       "category": "css/properties",
@@ -97045,7 +98798,7 @@
       }
     },
     {
-      "id": "feature-739",
+      "id": "feature-750",
       "query": "css/properties/padding-inline-end",
       "name": "padding-inline-end",
       "category": "css/properties",
@@ -97081,7 +98834,7 @@
       }
     },
     {
-      "id": "feature-740",
+      "id": "feature-751",
       "query": "css/properties/padding-inline-start",
       "name": "padding-inline-start",
       "category": "css/properties",
@@ -97117,7 +98870,7 @@
       }
     },
     {
-      "id": "feature-741",
+      "id": "feature-752",
       "query": "css/properties/padding-left",
       "name": "padding-left",
       "category": "css/properties",
@@ -97153,7 +98906,7 @@
       }
     },
     {
-      "id": "feature-742",
+      "id": "feature-753",
       "query": "css/properties/padding-right",
       "name": "padding-right",
       "category": "css/properties",
@@ -97189,7 +98942,7 @@
       }
     },
     {
-      "id": "feature-743",
+      "id": "feature-754",
       "query": "css/properties/padding-top",
       "name": "padding-top",
       "category": "css/properties",
@@ -97225,7 +98978,7 @@
       }
     },
     {
-      "id": "feature-744",
+      "id": "feature-755",
       "query": "css/properties/padding",
       "name": "padding",
       "category": "css/properties",
@@ -97261,7 +99014,7 @@
       }
     },
     {
-      "id": "feature-745",
+      "id": "feature-756",
       "query": "css/properties/perspective",
       "name": "perspective",
       "category": "css/properties",
@@ -97297,7 +99050,7 @@
       }
     },
     {
-      "id": "feature-746",
+      "id": "feature-757",
       "query": "css/properties/pointer-events",
       "name": "pointer-events",
       "category": "css/properties",
@@ -97333,7 +99086,7 @@
       }
     },
     {
-      "id": "feature-747",
+      "id": "feature-758",
       "query": "css/properties/position",
       "name": "position",
       "category": "css/properties",
@@ -97369,7 +99122,7 @@
       }
     },
     {
-      "id": "feature-748",
+      "id": "feature-759",
       "query": "css/properties/position.relative",
       "name": "relative",
       "category": "css/properties",
@@ -97405,7 +99158,7 @@
       }
     },
     {
-      "id": "feature-749",
+      "id": "feature-760",
       "query": "css/properties/position.absolute",
       "name": "absolute",
       "category": "css/properties",
@@ -97441,7 +99194,7 @@
       }
     },
     {
-      "id": "feature-750",
+      "id": "feature-761",
       "query": "css/properties/position.fixed",
       "name": "fixed",
       "category": "css/properties",
@@ -97477,7 +99230,7 @@
       }
     },
     {
-      "id": "feature-751",
+      "id": "feature-762",
       "query": "css/properties/position.sticky",
       "name": "sticky",
       "category": "css/properties",
@@ -97513,7 +99266,7 @@
       }
     },
     {
-      "id": "feature-752",
+      "id": "feature-763",
       "query": "css/properties/position.static",
       "name": "static",
       "category": "css/properties",
@@ -97549,7 +99302,7 @@
       }
     },
     {
-      "id": "feature-753",
+      "id": "feature-764",
       "query": "css/properties/relative-align-bottom",
       "name": "Specifies that the current element is aligned with the bottom edge of the parent or sibling element corresponding to id.",
       "category": "css/properties",
@@ -97585,7 +99338,7 @@
       }
     },
     {
-      "id": "feature-754",
+      "id": "feature-765",
       "query": "css/properties/relative-align-inline-end",
       "name": "Specifies that the current element is aligned with the left/right edges of the parent or sibling element corresponding to id.",
       "category": "css/properties",
@@ -97621,7 +99374,7 @@
       }
     },
     {
-      "id": "feature-755",
+      "id": "feature-766",
       "query": "css/properties/relative-align-inline-start",
       "name": "Specifies that the current element is aligned with the left/right edges of the parent or sibling element corresponding to id.",
       "category": "css/properties",
@@ -97657,7 +99410,7 @@
       }
     },
     {
-      "id": "feature-756",
+      "id": "feature-767",
       "query": "css/properties/relative-align-left",
       "name": "Specifies that the current element is aligned with the left edge of the parent or sibling element corresponding to id.",
       "category": "css/properties",
@@ -97693,7 +99446,7 @@
       }
     },
     {
-      "id": "feature-757",
+      "id": "feature-768",
       "query": "css/properties/relative-align-right",
       "name": "Specifies that the current element is aligned with the right edge of the parent or sibling element corresponding to id.",
       "category": "css/properties",
@@ -97729,7 +99482,7 @@
       }
     },
     {
-      "id": "feature-758",
+      "id": "feature-769",
       "query": "css/properties/relative-align-top",
       "name": "Specifies that the current element is aligned with the top edge of the parent or sibling element corresponding to id.",
       "category": "css/properties",
@@ -97765,7 +99518,7 @@
       }
     },
     {
-      "id": "feature-759",
+      "id": "feature-770",
       "query": "css/properties/relative-bottom-of",
       "name": "The current element is to the bottom of the sibling element specified corresponding to id.",
       "category": "css/properties",
@@ -97801,7 +99554,7 @@
       }
     },
     {
-      "id": "feature-760",
+      "id": "feature-771",
       "query": "css/properties/relative-center",
       "name": "Specifies that the current element is aligned with the bottom edge of the parent or sibling element corresponding to id.",
       "category": "css/properties",
@@ -97837,7 +99590,7 @@
       }
     },
     {
-      "id": "feature-761",
+      "id": "feature-772",
       "query": "css/properties/relative-id",
       "name": "Used to set the number of sibling elements in the relative layout.",
       "category": "css/properties",
@@ -97873,7 +99626,7 @@
       }
     },
     {
-      "id": "feature-762",
+      "id": "feature-773",
       "query": "css/properties/relative-inline-end-of",
       "name": "The current element is to the left/right of the sibling element corresponding to the specified id.",
       "category": "css/properties",
@@ -97909,7 +99662,7 @@
       }
     },
     {
-      "id": "feature-763",
+      "id": "feature-774",
       "query": "css/properties/relative-inline-start-of",
       "name": "The current element is to the left/right of the sibling element corresponding to the specified id.",
       "category": "css/properties",
@@ -97945,7 +99698,7 @@
       }
     },
     {
-      "id": "feature-764",
+      "id": "feature-775",
       "query": "css/properties/relative-layout-once",
       "name": "Used to set typesetting acceleration. When using positioning between elements at the same level, it is recommended to enable this property, and elements at the same level will only depend upwards.",
       "category": "css/properties",
@@ -97981,7 +99734,7 @@
       }
     },
     {
-      "id": "feature-765",
+      "id": "feature-776",
       "query": "css/properties/relative-left-of",
       "name": "The current element is to the left of the sibling element specified corresponding to id.",
       "category": "css/properties",
@@ -98017,7 +99770,7 @@
       }
     },
     {
-      "id": "feature-766",
+      "id": "feature-777",
       "query": "css/properties/relative-right-of",
       "name": "The current element is to the right of the sibling element specified corresponding to id.",
       "category": "css/properties",
@@ -98053,7 +99806,7 @@
       }
     },
     {
-      "id": "feature-767",
+      "id": "feature-778",
       "query": "css/properties/relative-top-of",
       "name": "The current element is to the top of the sibling element specified corresponding to id.",
       "category": "css/properties",
@@ -98089,7 +99842,7 @@
       }
     },
     {
-      "id": "feature-768",
+      "id": "feature-779",
       "query": "css/properties/right",
       "name": "participates in setting the horizontal position of a positioned element. It has no effect on non-positioned elements.",
       "category": "css/properties",
@@ -98125,7 +99878,7 @@
       }
     },
     {
-      "id": "feature-769",
+      "id": "feature-780",
       "query": "css/properties/row-gap",
       "name": "<code>row-gap</code>",
       "category": "css/properties",
@@ -98161,7 +99914,7 @@
       }
     },
     {
-      "id": "feature-770",
+      "id": "feature-781",
       "query": "css/properties/row-gap.grid-row-gap",
       "name": "<code>grid-row-gap</code>",
       "category": "css/properties",
@@ -98197,7 +99950,7 @@
       }
     },
     {
-      "id": "feature-771",
+      "id": "feature-782",
       "query": "css/properties/row-gap.supported_in_flex_layout",
       "name": "Supported in Flexible Box Layout",
       "category": "css/properties",
@@ -98233,7 +99986,7 @@
       }
     },
     {
-      "id": "feature-772",
+      "id": "feature-783",
       "query": "css/properties/row-gap.supported_in_flex_layout.nested_value_1",
       "name": "<code>row-gap</code> and <code>grid-row-gap</code>",
       "category": "css/properties",
@@ -98269,7 +100022,7 @@
       }
     },
     {
-      "id": "feature-773",
+      "id": "feature-784",
       "query": "css/properties/row-gap.supported_in_grid_layout",
       "name": "Supported in Grid Layout",
       "category": "css/properties",
@@ -98305,7 +100058,7 @@
       }
     },
     {
-      "id": "feature-774",
+      "id": "feature-785",
       "query": "css/properties/row-gap.supported_in_grid_layout.grid-row-gap",
       "name": "<code>grid-row-gap</code>",
       "category": "css/properties",
@@ -98341,7 +100094,7 @@
       }
     },
     {
-      "id": "feature-775",
+      "id": "feature-786",
       "query": "css/properties/row-gap.supported_in_grid_layout",
       "name": "<code>row-gap</code>",
       "category": "css/properties",
@@ -98377,7 +100130,7 @@
       }
     },
     {
-      "id": "feature-776",
+      "id": "feature-787",
       "query": "css/properties/text-align",
       "name": "text-align",
       "category": "css/properties",
@@ -98413,7 +100166,43 @@
       }
     },
     {
-      "id": "feature-777",
+      "id": "feature-788",
+      "query": "css/properties/text-decoration-thickness",
+      "name": "text-decoration-thickness",
+      "category": "css/properties",
+      "source_file": "css/properties/text-decoration-thickness.json",
+      "support": {
+        "android": {
+          "version_added": "4.0"
+        },
+        "ios": {
+          "version_added": "4.0"
+        },
+        "harmony": {
+          "version_added": false
+        },
+        "web_lynx": {
+          "version_added": false
+        },
+        "clay_android": {
+          "version_added": false
+        },
+        "clay_ios": {
+          "version_added": false
+        },
+        "clay_macos": {
+          "version_added": false
+        },
+        "clay_windows": {
+          "version_added": false
+        },
+        "clay": {
+          "version_added": false
+        }
+      }
+    },
+    {
+      "id": "feature-789",
       "query": "css/properties/text-decoration",
       "name": "text-decoration",
       "category": "css/properties",
@@ -98449,7 +100238,7 @@
       }
     },
     {
-      "id": "feature-778",
+      "id": "feature-790",
       "query": "css/properties/text-indent",
       "name": "text-indent",
       "category": "css/properties",
@@ -98485,7 +100274,7 @@
       }
     },
     {
-      "id": "feature-779",
+      "id": "feature-791",
       "query": "css/properties/text-overflow",
       "name": "text-overflow",
       "category": "css/properties",
@@ -98521,7 +100310,7 @@
       }
     },
     {
-      "id": "feature-780",
+      "id": "feature-792",
       "query": "css/properties/text-shadow",
       "name": "text-shadow",
       "category": "css/properties",
@@ -98557,7 +100346,7 @@
       }
     },
     {
-      "id": "feature-781",
+      "id": "feature-793",
       "query": "css/properties/text-stroke-color",
       "name": "text-stroke-color",
       "category": "css/properties",
@@ -98593,7 +100382,7 @@
       }
     },
     {
-      "id": "feature-782",
+      "id": "feature-794",
       "query": "css/properties/text-stroke-width",
       "name": "text-stroke-width",
       "category": "css/properties",
@@ -98629,7 +100418,7 @@
       }
     },
     {
-      "id": "feature-783",
+      "id": "feature-795",
       "query": "css/properties/text-stroke",
       "name": "text-stroke",
       "category": "css/properties",
@@ -98665,7 +100454,7 @@
       }
     },
     {
-      "id": "feature-784",
+      "id": "feature-796",
       "query": "css/properties/top",
       "name": "participates in setting the vertical position of a positioned element. It has no effect on non-positioned elements.",
       "category": "css/properties",
@@ -98701,7 +100490,7 @@
       }
     },
     {
-      "id": "feature-785",
+      "id": "feature-797",
       "query": "css/properties/transform-origin",
       "name": "transform-origin",
       "category": "css/properties",
@@ -98737,7 +100526,7 @@
       }
     },
     {
-      "id": "feature-786",
+      "id": "feature-798",
       "query": "css/properties/transform",
       "name": "transform",
       "category": "css/properties",
@@ -98773,7 +100562,7 @@
       }
     },
     {
-      "id": "feature-787",
+      "id": "feature-799",
       "query": "css/properties/transform.translate",
       "name": "translate",
       "category": "css/properties",
@@ -98809,7 +100598,7 @@
       }
     },
     {
-      "id": "feature-788",
+      "id": "feature-800",
       "query": "css/properties/transform.translateX",
       "name": "translateX",
       "category": "css/properties",
@@ -98845,7 +100634,7 @@
       }
     },
     {
-      "id": "feature-789",
+      "id": "feature-801",
       "query": "css/properties/transform.translateY",
       "name": "translateY",
       "category": "css/properties",
@@ -98881,7 +100670,7 @@
       }
     },
     {
-      "id": "feature-790",
+      "id": "feature-802",
       "query": "css/properties/transform.translateZ",
       "name": "translateZ",
       "category": "css/properties",
@@ -98917,7 +100706,7 @@
       }
     },
     {
-      "id": "feature-791",
+      "id": "feature-803",
       "query": "css/properties/transform.translate3d",
       "name": "translate3d",
       "category": "css/properties",
@@ -98953,7 +100742,7 @@
       }
     },
     {
-      "id": "feature-792",
+      "id": "feature-804",
       "query": "css/properties/transform.rotate",
       "name": "rotate",
       "category": "css/properties",
@@ -98989,7 +100778,7 @@
       }
     },
     {
-      "id": "feature-793",
+      "id": "feature-805",
       "query": "css/properties/transform.rotateZ",
       "name": "rotateZ",
       "category": "css/properties",
@@ -99025,7 +100814,7 @@
       }
     },
     {
-      "id": "feature-794",
+      "id": "feature-806",
       "query": "css/properties/transform.rotateX",
       "name": "rotateX",
       "category": "css/properties",
@@ -99061,7 +100850,7 @@
       }
     },
     {
-      "id": "feature-795",
+      "id": "feature-807",
       "query": "css/properties/transform.rotateY",
       "name": "rotateY",
       "category": "css/properties",
@@ -99097,7 +100886,7 @@
       }
     },
     {
-      "id": "feature-796",
+      "id": "feature-808",
       "query": "css/properties/transform.scale",
       "name": "scale",
       "category": "css/properties",
@@ -99133,7 +100922,7 @@
       }
     },
     {
-      "id": "feature-797",
+      "id": "feature-809",
       "query": "css/properties/transform.scaleX",
       "name": "scaleX",
       "category": "css/properties",
@@ -99169,7 +100958,7 @@
       }
     },
     {
-      "id": "feature-798",
+      "id": "feature-810",
       "query": "css/properties/transform.scaleY",
       "name": "scaleY",
       "category": "css/properties",
@@ -99205,7 +100994,7 @@
       }
     },
     {
-      "id": "feature-799",
+      "id": "feature-811",
       "query": "css/properties/transform.skew",
       "name": "skew",
       "category": "css/properties",
@@ -99241,7 +101030,7 @@
       }
     },
     {
-      "id": "feature-800",
+      "id": "feature-812",
       "query": "css/properties/transform.skewX",
       "name": "skewX",
       "category": "css/properties",
@@ -99277,7 +101066,7 @@
       }
     },
     {
-      "id": "feature-801",
+      "id": "feature-813",
       "query": "css/properties/transform.skewY",
       "name": "skewY",
       "category": "css/properties",
@@ -99313,7 +101102,7 @@
       }
     },
     {
-      "id": "feature-802",
+      "id": "feature-814",
       "query": "css/properties/transform.matrix",
       "name": "matrix",
       "category": "css/properties",
@@ -99349,7 +101138,7 @@
       }
     },
     {
-      "id": "feature-803",
+      "id": "feature-815",
       "query": "css/properties/transform.matrix3d",
       "name": "matrix3d",
       "category": "css/properties",
@@ -99385,7 +101174,7 @@
       }
     },
     {
-      "id": "feature-804",
+      "id": "feature-816",
       "query": "css/properties/transform.rotate3d",
       "name": "rotate3d",
       "category": "css/properties",
@@ -99421,7 +101210,7 @@
       }
     },
     {
-      "id": "feature-805",
+      "id": "feature-817",
       "query": "css/properties/transform.scale3d",
       "name": "scale3d",
       "category": "css/properties",
@@ -99457,7 +101246,7 @@
       }
     },
     {
-      "id": "feature-806",
+      "id": "feature-818",
       "query": "css/properties/transition-delay",
       "name": "transition-delay",
       "category": "css/properties",
@@ -99493,7 +101282,7 @@
       }
     },
     {
-      "id": "feature-807",
+      "id": "feature-819",
       "query": "css/properties/transition-duration",
       "name": "transition-duration",
       "category": "css/properties",
@@ -99529,7 +101318,7 @@
       }
     },
     {
-      "id": "feature-808",
+      "id": "feature-820",
       "query": "css/properties/transition-property",
       "name": "transition-property",
       "category": "css/properties",
@@ -99565,7 +101354,7 @@
       }
     },
     {
-      "id": "feature-809",
+      "id": "feature-821",
       "query": "css/properties/transition-timing-function",
       "name": "transition-timing-function",
       "category": "css/properties",
@@ -99601,7 +101390,7 @@
       }
     },
     {
-      "id": "feature-810",
+      "id": "feature-822",
       "query": "css/properties/transition-timing-function.linear",
       "name": "linear",
       "category": "css/properties",
@@ -99637,7 +101426,7 @@
       }
     },
     {
-      "id": "feature-811",
+      "id": "feature-823",
       "query": "css/properties/transition-timing-function.ease-in",
       "name": "ease-in",
       "category": "css/properties",
@@ -99673,7 +101462,7 @@
       }
     },
     {
-      "id": "feature-812",
+      "id": "feature-824",
       "query": "css/properties/transition-timing-function.ease-out",
       "name": "ease-out",
       "category": "css/properties",
@@ -99709,7 +101498,7 @@
       }
     },
     {
-      "id": "feature-813",
+      "id": "feature-825",
       "query": "css/properties/transition-timing-function.ease-in-ease-out",
       "name": "ease-in-ease-out",
       "category": "css/properties",
@@ -99745,7 +101534,7 @@
       }
     },
     {
-      "id": "feature-814",
+      "id": "feature-826",
       "query": "css/properties/transition-timing-function.ease",
       "name": "ease",
       "category": "css/properties",
@@ -99781,7 +101570,7 @@
       }
     },
     {
-      "id": "feature-815",
+      "id": "feature-827",
       "query": "css/properties/transition-timing-function.ease-in-out",
       "name": "ease-in-out",
       "category": "css/properties",
@@ -99817,7 +101606,7 @@
       }
     },
     {
-      "id": "feature-816",
+      "id": "feature-828",
       "query": "css/properties/transition-timing-function.square-bezier",
       "name": "square-bezier",
       "category": "css/properties",
@@ -99853,7 +101642,7 @@
       }
     },
     {
-      "id": "feature-817",
+      "id": "feature-829",
       "query": "css/properties/transition-timing-function.cubic-bezier",
       "name": "cubic-bezier",
       "category": "css/properties",
@@ -99889,7 +101678,7 @@
       }
     },
     {
-      "id": "feature-818",
+      "id": "feature-830",
       "query": "css/properties/transition-timing-function.step-start",
       "name": "step-start",
       "category": "css/properties",
@@ -99925,7 +101714,7 @@
       }
     },
     {
-      "id": "feature-819",
+      "id": "feature-831",
       "query": "css/properties/transition-timing-function.step-end",
       "name": "step-end",
       "category": "css/properties",
@@ -99961,7 +101750,7 @@
       }
     },
     {
-      "id": "feature-820",
+      "id": "feature-832",
       "query": "css/properties/transition-timing-function.steps",
       "name": "steps",
       "category": "css/properties",
@@ -99997,7 +101786,7 @@
       }
     },
     {
-      "id": "feature-821",
+      "id": "feature-833",
       "query": "css/properties/transition",
       "name": "transition",
       "category": "css/properties",
@@ -100033,7 +101822,7 @@
       }
     },
     {
-      "id": "feature-822",
+      "id": "feature-834",
       "query": "css/properties/vertical-align",
       "name": "vertical-align",
       "category": "css/properties",
@@ -100069,7 +101858,7 @@
       }
     },
     {
-      "id": "feature-823",
+      "id": "feature-835",
       "query": "css/properties/visibility",
       "name": "visibility",
       "category": "css/properties",
@@ -100105,7 +101894,7 @@
       }
     },
     {
-      "id": "feature-824",
+      "id": "feature-836",
       "query": "css/properties/white-space",
       "name": "white-space",
       "category": "css/properties",
@@ -100141,7 +101930,7 @@
       }
     },
     {
-      "id": "feature-825",
+      "id": "feature-837",
       "query": "css/properties/width",
       "name": "width",
       "category": "css/properties",
@@ -100177,7 +101966,7 @@
       }
     },
     {
-      "id": "feature-826",
+      "id": "feature-838",
       "query": "css/properties/width.max-content",
       "name": "max-content",
       "category": "css/properties",
@@ -100213,7 +102002,7 @@
       }
     },
     {
-      "id": "feature-827",
+      "id": "feature-839",
       "query": "css/properties/width.fit-content",
       "name": "fit-content",
       "category": "css/properties",
@@ -100249,7 +102038,7 @@
       }
     },
     {
-      "id": "feature-828",
+      "id": "feature-840",
       "query": "css/properties/width.min-content",
       "name": "min-content",
       "category": "css/properties",
@@ -100285,7 +102074,7 @@
       }
     },
     {
-      "id": "feature-829",
+      "id": "feature-841",
       "query": "css/properties/word-break",
       "name": "word-break",
       "category": "css/properties",
@@ -100321,7 +102110,7 @@
       }
     },
     {
-      "id": "feature-830",
+      "id": "feature-842",
       "query": "css/properties/z-index",
       "name": "z-index",
       "category": "css/properties",
@@ -100357,7 +102146,7 @@
       }
     },
     {
-      "id": "feature-831",
+      "id": "feature-843",
       "query": "css/at-rule/font-face",
       "name": "font-face",
       "category": "css/at-rule",
@@ -100393,7 +102182,7 @@
       }
     },
     {
-      "id": "feature-832",
+      "id": "feature-844",
       "query": "css/data-type/angle",
       "name": "<code>&lt;angle&gt;</code>",
       "category": "css/data-type",
@@ -100429,7 +102218,7 @@
       }
     },
     {
-      "id": "feature-833",
+      "id": "feature-845",
       "query": "css/data-type/angle.deg",
       "name": "deg",
       "category": "css/data-type",
@@ -100465,7 +102254,7 @@
       }
     },
     {
-      "id": "feature-834",
+      "id": "feature-846",
       "query": "css/data-type/angle.grad",
       "name": "grad",
       "category": "css/data-type",
@@ -100501,7 +102290,7 @@
       }
     },
     {
-      "id": "feature-835",
+      "id": "feature-847",
       "query": "css/data-type/angle.rad",
       "name": "rad",
       "category": "css/data-type",
@@ -100537,7 +102326,7 @@
       }
     },
     {
-      "id": "feature-836",
+      "id": "feature-848",
       "query": "css/data-type/angle.turn",
       "name": "turn",
       "category": "css/data-type",
@@ -100573,7 +102362,7 @@
       }
     },
     {
-      "id": "feature-837",
+      "id": "feature-849",
       "query": "css/data-type/color",
       "name": "<code>&lt;color&gt;</code>",
       "category": "css/data-type",
@@ -100609,7 +102398,7 @@
       }
     },
     {
-      "id": "feature-838",
+      "id": "feature-850",
       "query": "css/data-type/color.rgb()",
       "name": "<code>rgb()</code> (RGB color model)",
       "category": "css/data-type",
@@ -100645,7 +102434,7 @@
       }
     },
     {
-      "id": "feature-839",
+      "id": "feature-851",
       "query": "css/data-type/color.rgb().legacy-rgb-syntax",
       "name": "<a href='https://drafts.csswg.org/css-color/#typedef-legacy-rgb-syntax'><code>&lt;legacy-rgb-syntax&gt;</code></a>",
       "category": "css/data-type",
@@ -100681,7 +102470,7 @@
       }
     },
     {
-      "id": "feature-840",
+      "id": "feature-852",
       "query": "css/data-type/color.rgb().modern-rgb-syntax",
       "name": "<a href='https://drafts.csswg.org/css-color/#typedef-modern-rgb-syntax'><code>&lt;modern-rgb-syntax&gt;</code></a>",
       "category": "css/data-type",
@@ -100717,7 +102506,7 @@
       }
     },
     {
-      "id": "feature-841",
+      "id": "feature-853",
       "query": "css/data-type/color.rgb().legacy-rgba-syntax",
       "name": "<a href='https://drafts.csswg.org/css-color/#typedef-legacy-rgba-syntax'><code>&lt;legacy-rgba-syntax&gt;</code></a>",
       "category": "css/data-type",
@@ -100753,7 +102542,7 @@
       }
     },
     {
-      "id": "feature-842",
+      "id": "feature-854",
       "query": "css/data-type/color.rgb().modern-rgba-syntax",
       "name": "<a href='https://drafts.csswg.org/css-color/#typedef-modern-rgba-syntax'><code>&lt;modern-rgba-syntax&gt;</code></a>",
       "category": "css/data-type",
@@ -100789,7 +102578,7 @@
       }
     },
     {
-      "id": "feature-843",
+      "id": "feature-855",
       "query": "css/data-type/color.hsl",
       "name": "<code>hsl()</code> (HSL color model)",
       "category": "css/data-type",
@@ -100825,7 +102614,7 @@
       }
     },
     {
-      "id": "feature-844",
+      "id": "feature-856",
       "query": "css/data-type/fit-content",
       "name": "<code>&lt;fit-content&gt;</code>",
       "category": "css/data-type",
@@ -100861,7 +102650,7 @@
       }
     },
     {
-      "id": "feature-845",
+      "id": "feature-857",
       "query": "css/data-type/gradient",
       "name": "<code>&lt;gradient&gt;</code>",
       "category": "css/data-type",
@@ -100897,7 +102686,7 @@
       }
     },
     {
-      "id": "feature-846",
+      "id": "feature-858",
       "query": "css/data-type/gradient.linear-gradient()",
       "name": "linear-gradient()",
       "category": "css/data-type",
@@ -100933,7 +102722,7 @@
       }
     },
     {
-      "id": "feature-847",
+      "id": "feature-859",
       "query": "css/data-type/gradient.radial-gradient()",
       "name": "radial-gradient()",
       "category": "css/data-type",
@@ -100969,7 +102758,7 @@
       }
     },
     {
-      "id": "feature-848",
+      "id": "feature-860",
       "query": "css/data-type/gradient.conic-gradient()",
       "name": "conic-gradient()",
       "category": "css/data-type",
@@ -101005,7 +102794,7 @@
       }
     },
     {
-      "id": "feature-849",
+      "id": "feature-861",
       "query": "css/data-type/length-percentage",
       "name": "<code>&lt;length-percentage&gt;</code>",
       "category": "css/data-type",
@@ -101041,7 +102830,7 @@
       }
     },
     {
-      "id": "feature-850",
+      "id": "feature-862",
       "query": "css/data-type/length",
       "name": "<code>&lt;length&gt;</code>",
       "category": "css/data-type",
@@ -101077,7 +102866,7 @@
       }
     },
     {
-      "id": "feature-851",
+      "id": "feature-863",
       "query": "css/data-type/length.absolute",
       "name": "Absolute length units",
       "category": "css/data-type",
@@ -101113,7 +102902,7 @@
       }
     },
     {
-      "id": "feature-852",
+      "id": "feature-864",
       "query": "css/data-type/length.absolute.value_px",
       "name": "<code>px</code> unit",
       "category": "css/data-type",
@@ -101149,7 +102938,7 @@
       }
     },
     {
-      "id": "feature-853",
+      "id": "feature-865",
       "query": "css/data-type/length.absolute.value_ppx",
       "name": "<code>ppx</code> unit",
       "category": "css/data-type",
@@ -101185,7 +102974,7 @@
       }
     },
     {
-      "id": "feature-854",
+      "id": "feature-866",
       "query": "css/data-type/length.relative",
       "name": "Relative length units",
       "category": "css/data-type",
@@ -101221,7 +103010,7 @@
       }
     },
     {
-      "id": "feature-855",
+      "id": "feature-867",
       "query": "css/data-type/length.relative.value_rpx",
       "name": "<code>rpx</code> unit",
       "category": "css/data-type",
@@ -101257,7 +103046,7 @@
       }
     },
     {
-      "id": "feature-856",
+      "id": "feature-868",
       "query": "css/data-type/length.relative.value_rem",
       "name": "<code>rem</code> unit",
       "category": "css/data-type",
@@ -101293,7 +103082,7 @@
       }
     },
     {
-      "id": "feature-857",
+      "id": "feature-869",
       "query": "css/data-type/length.relative.value_em",
       "name": "<code>em</code> unit",
       "category": "css/data-type",
@@ -101329,7 +103118,7 @@
       }
     },
     {
-      "id": "feature-858",
+      "id": "feature-870",
       "query": "css/data-type/length.relative.value_vh",
       "name": "<code>vh</code> unit",
       "category": "css/data-type",
@@ -101365,7 +103154,7 @@
       }
     },
     {
-      "id": "feature-859",
+      "id": "feature-871",
       "query": "css/data-type/length.relative.value_vw",
       "name": "<code>vw</code> unit",
       "category": "css/data-type",
@@ -101401,7 +103190,7 @@
       }
     },
     {
-      "id": "feature-860",
+      "id": "feature-872",
       "query": "css/data-type/max-content",
       "name": "<code>&lt;max-content&gt;</code>",
       "category": "css/data-type",
@@ -101437,7 +103226,7 @@
       }
     },
     {
-      "id": "feature-861",
+      "id": "feature-873",
       "query": "css/data-type/number",
       "name": "<code>&lt;number&gt;</code>",
       "category": "css/data-type",
@@ -101473,7 +103262,7 @@
       }
     },
     {
-      "id": "feature-862",
+      "id": "feature-874",
       "query": "css/data-type/percentage",
       "name": "<code>&lt;percentage&gt;</code>",
       "category": "css/data-type",
@@ -101509,7 +103298,7 @@
       }
     },
     {
-      "id": "feature-863",
+      "id": "feature-875",
       "query": "css/data-type/string",
       "name": "<code>&lt;string&gt;</code>",
       "category": "css/data-type",
@@ -101545,7 +103334,7 @@
       }
     },
     {
-      "id": "feature-864",
+      "id": "feature-876",
       "query": "css/data-type/time",
       "name": "<code>&lt;time&gt;</code>",
       "category": "css/data-type",
@@ -101581,7 +103370,7 @@
       }
     },
     {
-      "id": "feature-865",
+      "id": "feature-877",
       "query": "lynx-api/global/SystemInfo",
       "name": "Information of the current system",
       "category": "lynx-api/global",
@@ -101617,7 +103406,7 @@
       }
     },
     {
-      "id": "feature-866",
+      "id": "feature-878",
       "query": "lynx-api/global/SystemInfo.SystemInfo.engineVersion",
       "name": "engineVersion",
       "category": "lynx-api/global",
@@ -101653,7 +103442,7 @@
       }
     },
     {
-      "id": "feature-867",
+      "id": "feature-879",
       "query": "lynx-api/global/SystemInfo.SystemInfo.lynxSdkVersion",
       "name": "lynxSdkVersion",
       "category": "lynx-api/global",
@@ -101689,7 +103478,7 @@
       }
     },
     {
-      "id": "feature-868",
+      "id": "feature-880",
       "query": "lynx-api/global/clearInterval",
       "name": "Cancels the timer set by `setInterval`.",
       "category": "lynx-api/global",
@@ -101725,7 +103514,7 @@
       }
     },
     {
-      "id": "feature-869",
+      "id": "feature-881",
       "query": "lynx-api/global/clearTimeout",
       "name": "Cancel the timer set by `setTimeout`.",
       "category": "lynx-api/global",
@@ -101761,7 +103550,7 @@
       }
     },
     {
-      "id": "feature-870",
+      "id": "feature-882",
       "query": "lynx-api/global/console/assert",
       "name": "assert failed and output error level message",
       "category": "lynx-api/global",
@@ -101797,7 +103586,7 @@
       }
     },
     {
-      "id": "feature-871",
+      "id": "feature-883",
       "query": "lynx-api/global/console/count",
       "name": "start count",
       "category": "lynx-api/global",
@@ -101833,7 +103622,7 @@
       }
     },
     {
-      "id": "feature-872",
+      "id": "feature-884",
       "query": "lynx-api/global/console/countReset",
       "name": "reset count",
       "category": "lynx-api/global",
@@ -101869,7 +103658,7 @@
       }
     },
     {
-      "id": "feature-873",
+      "id": "feature-885",
       "query": "lynx-api/global/console/debug",
       "name": "output a debug level message",
       "category": "lynx-api/global",
@@ -101905,7 +103694,7 @@
       }
     },
     {
-      "id": "feature-874",
+      "id": "feature-886",
       "query": "lynx-api/global/console/error",
       "name": "output a error level message",
       "category": "lynx-api/global",
@@ -101941,7 +103730,7 @@
       }
     },
     {
-      "id": "feature-875",
+      "id": "feature-887",
       "query": "lynx-api/global/console/group",
       "name": "start a console group",
       "category": "lynx-api/global",
@@ -101977,7 +103766,7 @@
       }
     },
     {
-      "id": "feature-876",
+      "id": "feature-888",
       "query": "lynx-api/global/console/groupCollapsed",
       "name": "start a collapsed console group",
       "category": "lynx-api/global",
@@ -102013,7 +103802,7 @@
       }
     },
     {
-      "id": "feature-877",
+      "id": "feature-889",
       "query": "lynx-api/global/console/groupEnd",
       "name": "end a console group",
       "category": "lynx-api/global",
@@ -102049,7 +103838,7 @@
       }
     },
     {
-      "id": "feature-878",
+      "id": "feature-890",
       "query": "lynx-api/global/console/info",
       "name": "output a info level message",
       "category": "lynx-api/global",
@@ -102085,7 +103874,7 @@
       }
     },
     {
-      "id": "feature-879",
+      "id": "feature-891",
       "query": "lynx-api/global/console/log",
       "name": "output a log level message",
       "category": "lynx-api/global",
@@ -102121,7 +103910,7 @@
       }
     },
     {
-      "id": "feature-880",
+      "id": "feature-892",
       "query": "lynx-api/global/console/profile",
       "name": "output a message",
       "category": "lynx-api/global",
@@ -102157,7 +103946,7 @@
       }
     },
     {
-      "id": "feature-881",
+      "id": "feature-893",
       "query": "lynx-api/global/console/profileEnd",
       "name": "end profile",
       "category": "lynx-api/global",
@@ -102193,7 +103982,7 @@
       }
     },
     {
-      "id": "feature-882",
+      "id": "feature-894",
       "query": "lynx-api/global/console/table",
       "name": "print message by table",
       "category": "lynx-api/global",
@@ -102229,7 +104018,7 @@
       }
     },
     {
-      "id": "feature-883",
+      "id": "feature-895",
       "query": "lynx-api/global/console/time",
       "name": "start a timer",
       "category": "lynx-api/global",
@@ -102265,7 +104054,7 @@
       }
     },
     {
-      "id": "feature-884",
+      "id": "feature-896",
       "query": "lynx-api/global/console/timeEnd",
       "name": "end a timer",
       "category": "lynx-api/global",
@@ -102301,7 +104090,7 @@
       }
     },
     {
-      "id": "feature-885",
+      "id": "feature-897",
       "query": "lynx-api/global/console/timeLog",
       "name": "print timer",
       "category": "lynx-api/global",
@@ -102337,7 +104126,7 @@
       }
     },
     {
-      "id": "feature-886",
+      "id": "feature-898",
       "query": "lynx-api/global/console/warn",
       "name": "output a warn level message",
       "category": "lynx-api/global",
@@ -102373,7 +104162,7 @@
       }
     },
     {
-      "id": "feature-887",
+      "id": "feature-899",
       "query": "lynx-api/global/setInterval",
       "name": "Repeatedly calls a function or executes a code fragment with a fixed time interval between each call.",
       "category": "lynx-api/global",
@@ -102409,7 +104198,7 @@
       }
     },
     {
-      "id": "feature-888",
+      "id": "feature-900",
       "query": "lynx-api/global/setTimeout",
       "name": "setTimeout",
       "category": "lynx-api/global",
@@ -102445,7 +104234,7 @@
       }
     },
     {
-      "id": "feature-889",
+      "id": "feature-901",
       "query": "lynx-api/event/AnimationEvent",
       "name": "AnimationEvent",
       "category": "lynx-api/event",
@@ -102481,7 +104270,7 @@
       }
     },
     {
-      "id": "feature-890",
+      "id": "feature-902",
       "query": "lynx-api/event/AnimationEvent.detail",
       "name": "detail",
       "category": "lynx-api/event",
@@ -102517,7 +104306,7 @@
       }
     },
     {
-      "id": "feature-891",
+      "id": "feature-903",
       "query": "lynx-api/event/AnimationEvent.animationstart",
       "name": "animationstart",
       "category": "lynx-api/event",
@@ -102553,7 +104342,7 @@
       }
     },
     {
-      "id": "feature-892",
+      "id": "feature-904",
       "query": "lynx-api/event/AnimationEvent.animationend",
       "name": "animationend",
       "category": "lynx-api/event",
@@ -102589,7 +104378,7 @@
       }
     },
     {
-      "id": "feature-893",
+      "id": "feature-905",
       "query": "lynx-api/event/AnimationEvent.animationiteration",
       "name": "animationiteration",
       "category": "lynx-api/event",
@@ -102625,7 +104414,7 @@
       }
     },
     {
-      "id": "feature-894",
+      "id": "feature-906",
       "query": "lynx-api/event/AnimationEvent.animationcancel",
       "name": "animationcancel",
       "category": "lynx-api/event",
@@ -102661,7 +104450,7 @@
       }
     },
     {
-      "id": "feature-895",
+      "id": "feature-907",
       "query": "lynx-api/event/AnimationEvent.transitionstart",
       "name": "transitionstart",
       "category": "lynx-api/event",
@@ -102697,7 +104486,7 @@
       }
     },
     {
-      "id": "feature-896",
+      "id": "feature-908",
       "query": "lynx-api/event/AnimationEvent.transitionend",
       "name": "transitionend",
       "category": "lynx-api/event",
@@ -102733,7 +104522,7 @@
       }
     },
     {
-      "id": "feature-897",
+      "id": "feature-909",
       "query": "lynx-api/event/AnimationEvent.transitioncancel",
       "name": "transitioncancel",
       "category": "lynx-api/event",
@@ -102769,7 +104558,7 @@
       }
     },
     {
-      "id": "feature-898",
+      "id": "feature-910",
       "query": "lynx-api/event/CustomEvent",
       "name": "CustomEvent",
       "category": "lynx-api/event",
@@ -102805,7 +104594,7 @@
       }
     },
     {
-      "id": "feature-899",
+      "id": "feature-911",
       "query": "lynx-api/event/CustomEvent.params",
       "name": "params",
       "category": "lynx-api/event",
@@ -102841,7 +104630,7 @@
       }
     },
     {
-      "id": "feature-900",
+      "id": "feature-912",
       "query": "lynx-api/event/CustomEvent.detail",
       "name": "detail",
       "category": "lynx-api/event",
@@ -102877,7 +104666,7 @@
       }
     },
     {
-      "id": "feature-901",
+      "id": "feature-913",
       "query": "lynx-api/event/Event",
       "name": "Event",
       "category": "lynx-api/event",
@@ -102913,7 +104702,7 @@
       }
     },
     {
-      "id": "feature-902",
+      "id": "feature-914",
       "query": "lynx-api/event/Event.TouchEvent",
       "name": "TouchEvent",
       "category": "lynx-api/event",
@@ -102949,7 +104738,7 @@
       }
     },
     {
-      "id": "feature-903",
+      "id": "feature-915",
       "query": "lynx-api/event/Event.CustomEvent",
       "name": "CustomEvent",
       "category": "lynx-api/event",
@@ -102985,7 +104774,7 @@
       }
     },
     {
-      "id": "feature-904",
+      "id": "feature-916",
       "query": "lynx-api/event/Event.AnimationEvent",
       "name": "AnimationEvent",
       "category": "lynx-api/event",
@@ -103021,7 +104810,7 @@
       }
     },
     {
-      "id": "feature-905",
+      "id": "feature-917",
       "query": "lynx-api/event/Event.type",
       "name": "type",
       "category": "lynx-api/event",
@@ -103057,7 +104846,7 @@
       }
     },
     {
-      "id": "feature-906",
+      "id": "feature-918",
       "query": "lynx-api/event/Event.timestamp",
       "name": "timestamp",
       "category": "lynx-api/event",
@@ -103093,7 +104882,7 @@
       }
     },
     {
-      "id": "feature-907",
+      "id": "feature-919",
       "query": "lynx-api/event/Event.target",
       "name": "target",
       "category": "lynx-api/event",
@@ -103129,7 +104918,7 @@
       }
     },
     {
-      "id": "feature-908",
+      "id": "feature-920",
       "query": "lynx-api/event/Event.currentTarget",
       "name": "currentTarget",
       "category": "lynx-api/event",
@@ -103165,7 +104954,7 @@
       }
     },
     {
-      "id": "feature-909",
+      "id": "feature-921",
       "query": "lynx-api/event/Event.stopPropagation",
       "name": "stopPropagation",
       "category": "lynx-api/event",
@@ -103201,7 +104990,7 @@
       }
     },
     {
-      "id": "feature-910",
+      "id": "feature-922",
       "query": "lynx-api/event/Event.stopImmediatePropagation",
       "name": "stopImmediatePropagation",
       "category": "lynx-api/event",
@@ -103237,7 +105026,7 @@
       }
     },
     {
-      "id": "feature-911",
+      "id": "feature-923",
       "query": "lynx-api/event/GlobalEvent",
       "name": "GlobalEvent",
       "category": "lynx-api/event",
@@ -103273,7 +105062,7 @@
       }
     },
     {
-      "id": "feature-912",
+      "id": "feature-924",
       "query": "lynx-api/event/GlobalEvent.keyboardstatuschanged",
       "name": "keyboardstatuschanged",
       "category": "lynx-api/event",
@@ -103309,7 +105098,7 @@
       }
     },
     {
-      "id": "feature-913",
+      "id": "feature-925",
       "query": "lynx-api/event/GlobalEvent.onWindowResize",
       "name": "onWindowResize",
       "category": "lynx-api/event",
@@ -103345,7 +105134,7 @@
       }
     },
     {
-      "id": "feature-914",
+      "id": "feature-926",
       "query": "lynx-api/event/GlobalEvent.exposure",
       "name": "exposure",
       "category": "lynx-api/event",
@@ -103381,7 +105170,7 @@
       }
     },
     {
-      "id": "feature-915",
+      "id": "feature-927",
       "query": "lynx-api/event/GlobalEvent.disexposure",
       "name": "disexposure",
       "category": "lynx-api/event",
@@ -103417,7 +105206,7 @@
       }
     },
     {
-      "id": "feature-916",
+      "id": "feature-928",
       "query": "lynx-api/event/KeyEvent",
       "name": "KeyEvent",
       "category": "lynx-api/event",
@@ -103453,7 +105242,7 @@
       }
     },
     {
-      "id": "feature-917",
+      "id": "feature-929",
       "query": "lynx-api/event/KeyEvent.key",
       "name": "key",
       "category": "lynx-api/event",
@@ -103489,7 +105278,7 @@
       }
     },
     {
-      "id": "feature-918",
+      "id": "feature-930",
       "query": "lynx-api/event/KeyEvent.repeat",
       "name": "repeat",
       "category": "lynx-api/event",
@@ -103525,7 +105314,7 @@
       }
     },
     {
-      "id": "feature-919",
+      "id": "feature-931",
       "query": "lynx-api/event/KeyEvent.altKey",
       "name": "altKey",
       "category": "lynx-api/event",
@@ -103561,7 +105350,7 @@
       }
     },
     {
-      "id": "feature-920",
+      "id": "feature-932",
       "query": "lynx-api/event/KeyEvent.ctrlKey",
       "name": "ctrlKey",
       "category": "lynx-api/event",
@@ -103597,7 +105386,7 @@
       }
     },
     {
-      "id": "feature-921",
+      "id": "feature-933",
       "query": "lynx-api/event/KeyEvent.metaKey",
       "name": "metaKey",
       "category": "lynx-api/event",
@@ -103633,7 +105422,7 @@
       }
     },
     {
-      "id": "feature-922",
+      "id": "feature-934",
       "query": "lynx-api/event/KeyEvent.shiftKey",
       "name": "shiftKey",
       "category": "lynx-api/event",
@@ -103669,7 +105458,7 @@
       }
     },
     {
-      "id": "feature-923",
+      "id": "feature-935",
       "query": "lynx-api/event/KeyEvent.keydown",
       "name": "keydown",
       "category": "lynx-api/event",
@@ -103705,7 +105494,7 @@
       }
     },
     {
-      "id": "feature-924",
+      "id": "feature-936",
       "query": "lynx-api/event/KeyEvent.keyup",
       "name": "keyup",
       "category": "lynx-api/event",
@@ -103741,7 +105530,7 @@
       }
     },
     {
-      "id": "feature-925",
+      "id": "feature-937",
       "query": "lynx-api/event/MemoryEvent",
       "name": "MemoryEvent",
       "category": "lynx-api/event",
@@ -103777,7 +105566,7 @@
       }
     },
     {
-      "id": "feature-926",
+      "id": "feature-938",
       "query": "lynx-api/event/MouseEvent",
       "name": "MouseEvent",
       "category": "lynx-api/event",
@@ -103813,7 +105602,7 @@
       }
     },
     {
-      "id": "feature-927",
+      "id": "feature-939",
       "query": "lynx-api/event/MouseEvent.button",
       "name": "button",
       "category": "lynx-api/event",
@@ -103849,7 +105638,7 @@
       }
     },
     {
-      "id": "feature-928",
+      "id": "feature-940",
       "query": "lynx-api/event/MouseEvent.buttons",
       "name": "buttons",
       "category": "lynx-api/event",
@@ -103885,7 +105674,7 @@
       }
     },
     {
-      "id": "feature-929",
+      "id": "feature-941",
       "query": "lynx-api/event/MouseEvent.x",
       "name": "x",
       "category": "lynx-api/event",
@@ -103921,7 +105710,7 @@
       }
     },
     {
-      "id": "feature-930",
+      "id": "feature-942",
       "query": "lynx-api/event/MouseEvent.y",
       "name": "y",
       "category": "lynx-api/event",
@@ -103957,7 +105746,7 @@
       }
     },
     {
-      "id": "feature-931",
+      "id": "feature-943",
       "query": "lynx-api/event/MouseEvent.pageX",
       "name": "pageX",
       "category": "lynx-api/event",
@@ -103993,7 +105782,7 @@
       }
     },
     {
-      "id": "feature-932",
+      "id": "feature-944",
       "query": "lynx-api/event/MouseEvent.pageY",
       "name": "pageY",
       "category": "lynx-api/event",
@@ -104029,7 +105818,7 @@
       }
     },
     {
-      "id": "feature-933",
+      "id": "feature-945",
       "query": "lynx-api/event/MouseEvent.clientX",
       "name": "clientX",
       "category": "lynx-api/event",
@@ -104065,7 +105854,7 @@
       }
     },
     {
-      "id": "feature-934",
+      "id": "feature-946",
       "query": "lynx-api/event/MouseEvent.clientY",
       "name": "clientY",
       "category": "lynx-api/event",
@@ -104101,7 +105890,7 @@
       }
     },
     {
-      "id": "feature-935",
+      "id": "feature-947",
       "query": "lynx-api/event/MouseEvent.mousedown",
       "name": "mousedown",
       "category": "lynx-api/event",
@@ -104137,7 +105926,7 @@
       }
     },
     {
-      "id": "feature-936",
+      "id": "feature-948",
       "query": "lynx-api/event/MouseEvent.mousemove",
       "name": "mousemove",
       "category": "lynx-api/event",
@@ -104173,7 +105962,7 @@
       }
     },
     {
-      "id": "feature-937",
+      "id": "feature-949",
       "query": "lynx-api/event/MouseEvent.mouseup",
       "name": "mouseup",
       "category": "lynx-api/event",
@@ -104209,7 +105998,7 @@
       }
     },
     {
-      "id": "feature-938",
+      "id": "feature-950",
       "query": "lynx-api/event/MouseEvent.mouseenter",
       "name": "mouseenter",
       "category": "lynx-api/event",
@@ -104245,7 +106034,7 @@
       }
     },
     {
-      "id": "feature-939",
+      "id": "feature-951",
       "query": "lynx-api/event/MouseEvent.mouseover",
       "name": "mouseover",
       "category": "lynx-api/event",
@@ -104281,7 +106070,7 @@
       }
     },
     {
-      "id": "feature-940",
+      "id": "feature-952",
       "query": "lynx-api/event/MouseEvent.mouseleave",
       "name": "mouseleave",
       "category": "lynx-api/event",
@@ -104317,7 +106106,7 @@
       }
     },
     {
-      "id": "feature-941",
+      "id": "feature-953",
       "query": "lynx-api/event/TouchEvent",
       "name": "TouchEvent",
       "category": "lynx-api/event",
@@ -104353,7 +106142,7 @@
       }
     },
     {
-      "id": "feature-942",
+      "id": "feature-954",
       "query": "lynx-api/event/TouchEvent.detail",
       "name": "detail",
       "category": "lynx-api/event",
@@ -104389,7 +106178,7 @@
       }
     },
     {
-      "id": "feature-943",
+      "id": "feature-955",
       "query": "lynx-api/event/TouchEvent.touches",
       "name": "touches",
       "category": "lynx-api/event",
@@ -104425,7 +106214,7 @@
       }
     },
     {
-      "id": "feature-944",
+      "id": "feature-956",
       "query": "lynx-api/event/TouchEvent.changedTouches",
       "name": "changedTouches",
       "category": "lynx-api/event",
@@ -104461,7 +106250,7 @@
       }
     },
     {
-      "id": "feature-945",
+      "id": "feature-957",
       "query": "lynx-api/event/TouchEvent.touchstart",
       "name": "touchstart",
       "category": "lynx-api/event",
@@ -104497,7 +106286,7 @@
       }
     },
     {
-      "id": "feature-946",
+      "id": "feature-958",
       "query": "lynx-api/event/TouchEvent.touchmove",
       "name": "touchmove",
       "category": "lynx-api/event",
@@ -104533,7 +106322,7 @@
       }
     },
     {
-      "id": "feature-947",
+      "id": "feature-959",
       "query": "lynx-api/event/TouchEvent.touchend",
       "name": "touchend",
       "category": "lynx-api/event",
@@ -104569,7 +106358,7 @@
       }
     },
     {
-      "id": "feature-948",
+      "id": "feature-960",
       "query": "lynx-api/event/TouchEvent.touchcancel",
       "name": "touchcancel",
       "category": "lynx-api/event",
@@ -104605,7 +106394,7 @@
       }
     },
     {
-      "id": "feature-949",
+      "id": "feature-961",
       "query": "lynx-api/event/TouchEvent.tap",
       "name": "tap",
       "category": "lynx-api/event",
@@ -104641,7 +106430,7 @@
       }
     },
     {
-      "id": "feature-950",
+      "id": "feature-962",
       "query": "lynx-api/event/TouchEvent.longpress",
       "name": "longpress",
       "category": "lynx-api/event",
@@ -104677,7 +106466,7 @@
       }
     },
     {
-      "id": "feature-951",
+      "id": "feature-963",
       "query": "lynx-api/event/TouchEvent.click",
       "name": "click",
       "category": "lynx-api/event",
@@ -104713,7 +106502,7 @@
       }
     },
     {
-      "id": "feature-952",
+      "id": "feature-964",
       "query": "lynx-api/event/WheelEvent",
       "name": "WheelEvent",
       "category": "lynx-api/event",
@@ -104749,7 +106538,7 @@
       }
     },
     {
-      "id": "feature-953",
+      "id": "feature-965",
       "query": "lynx-api/event/WheelEvent.deltaX",
       "name": "deltaX",
       "category": "lynx-api/event",
@@ -104785,7 +106574,7 @@
       }
     },
     {
-      "id": "feature-954",
+      "id": "feature-966",
       "query": "lynx-api/event/WheelEvent.deltaY",
       "name": "deltaY",
       "category": "lynx-api/event",
@@ -104821,7 +106610,7 @@
       }
     },
     {
-      "id": "feature-955",
+      "id": "feature-967",
       "query": "lynx-api/event/WheelEvent.wheel",
       "name": "wheel",
       "category": "lynx-api/event",
@@ -104857,7 +106646,7 @@
       }
     },
     {
-      "id": "feature-956",
+      "id": "feature-968",
       "query": "lynx-api/fetch/Headers",
       "name": "Headers",
       "category": "lynx-api/fetch",
@@ -104893,7 +106682,7 @@
       }
     },
     {
-      "id": "feature-957",
+      "id": "feature-969",
       "query": "lynx-api/fetch/Headers",
       "name": "<code>Headers()</code> constructor",
       "category": "lynx-api/fetch",
@@ -104929,7 +106718,7 @@
       }
     },
     {
-      "id": "feature-958",
+      "id": "feature-970",
       "query": "lynx-api/fetch/Headers.append",
       "name": "append",
       "category": "lynx-api/fetch",
@@ -104965,7 +106754,7 @@
       }
     },
     {
-      "id": "feature-959",
+      "id": "feature-971",
       "query": "lynx-api/fetch/Headers.delete",
       "name": "delete",
       "category": "lynx-api/fetch",
@@ -105001,7 +106790,7 @@
       }
     },
     {
-      "id": "feature-960",
+      "id": "feature-972",
       "query": "lynx-api/fetch/Headers.entries",
       "name": "entries",
       "category": "lynx-api/fetch",
@@ -105037,7 +106826,7 @@
       }
     },
     {
-      "id": "feature-961",
+      "id": "feature-973",
       "query": "lynx-api/fetch/Headers.forEach",
       "name": "forEach",
       "category": "lynx-api/fetch",
@@ -105073,7 +106862,7 @@
       }
     },
     {
-      "id": "feature-962",
+      "id": "feature-974",
       "query": "lynx-api/fetch/Headers.get",
       "name": "get",
       "category": "lynx-api/fetch",
@@ -105109,7 +106898,7 @@
       }
     },
     {
-      "id": "feature-963",
+      "id": "feature-975",
       "query": "lynx-api/fetch/Headers.getSetCookie",
       "name": "getSetCookie",
       "category": "lynx-api/fetch",
@@ -105145,7 +106934,7 @@
       }
     },
     {
-      "id": "feature-964",
+      "id": "feature-976",
       "query": "lynx-api/fetch/Headers.has",
       "name": "has",
       "category": "lynx-api/fetch",
@@ -105181,7 +106970,7 @@
       }
     },
     {
-      "id": "feature-965",
+      "id": "feature-977",
       "query": "lynx-api/fetch/Headers.keys",
       "name": "keys",
       "category": "lynx-api/fetch",
@@ -105217,7 +107006,7 @@
       }
     },
     {
-      "id": "feature-966",
+      "id": "feature-978",
       "query": "lynx-api/fetch/Headers.set",
       "name": "set",
       "category": "lynx-api/fetch",
@@ -105253,7 +107042,7 @@
       }
     },
     {
-      "id": "feature-967",
+      "id": "feature-979",
       "query": "lynx-api/fetch/Headers.values",
       "name": "values",
       "category": "lynx-api/fetch",
@@ -105289,7 +107078,7 @@
       }
     },
     {
-      "id": "feature-968",
+      "id": "feature-980",
       "query": "lynx-api/fetch/Headers.@@iterator",
       "name": "<code>[Symbol.iterator]</code>",
       "category": "lynx-api/fetch",
@@ -105325,7 +107114,7 @@
       }
     },
     {
-      "id": "feature-969",
+      "id": "feature-981",
       "query": "lynx-api/fetch/Request",
       "name": "Request",
       "category": "lynx-api/fetch",
@@ -105361,7 +107150,7 @@
       }
     },
     {
-      "id": "feature-970",
+      "id": "feature-982",
       "query": "lynx-api/fetch/Request",
       "name": "`Request()` constructor",
       "category": "lynx-api/fetch",
@@ -105397,7 +107186,7 @@
       }
     },
     {
-      "id": "feature-971",
+      "id": "feature-983",
       "query": "lynx-api/fetch/Request.cors",
       "name": "cors",
       "category": "lynx-api/fetch",
@@ -105433,7 +107222,7 @@
       }
     },
     {
-      "id": "feature-972",
+      "id": "feature-984",
       "query": "lynx-api/fetch/Request.init_attributionReporting_parameter",
       "name": "`init.attributionReporting` parameter",
       "category": "lynx-api/fetch",
@@ -105469,7 +107258,7 @@
       }
     },
     {
-      "id": "feature-973",
+      "id": "feature-985",
       "query": "lynx-api/fetch/Request.init_browsingTopics_parameter",
       "name": "`init.browsingTopics` parameter",
       "category": "lynx-api/fetch",
@@ -105505,7 +107294,7 @@
       }
     },
     {
-      "id": "feature-974",
+      "id": "feature-986",
       "query": "lynx-api/fetch/Request.init_keepalive_parameter",
       "name": "`init.keepalive` parameter",
       "category": "lynx-api/fetch",
@@ -105541,7 +107330,7 @@
       }
     },
     {
-      "id": "feature-975",
+      "id": "feature-987",
       "query": "lynx-api/fetch/Request.init_priority_parameter",
       "name": "`init.priority` parameter",
       "category": "lynx-api/fetch",
@@ -105577,7 +107366,7 @@
       }
     },
     {
-      "id": "feature-976",
+      "id": "feature-988",
       "query": "lynx-api/fetch/Request.init_referrer_parameter",
       "name": "`init.referrer` parameter",
       "category": "lynx-api/fetch",
@@ -105613,7 +107402,7 @@
       }
     },
     {
-      "id": "feature-977",
+      "id": "feature-989",
       "query": "lynx-api/fetch/Request.request_body_readablestream",
       "name": "Send `ReadableStream` in request body",
       "category": "lynx-api/fetch",
@@ -105649,7 +107438,7 @@
       }
     },
     {
-      "id": "feature-978",
+      "id": "feature-990",
       "query": "lynx-api/fetch/Request.response_body_readablestream",
       "name": "Consume `ReadableStream` as a response body",
       "category": "lynx-api/fetch",
@@ -105685,7 +107474,7 @@
       }
     },
     {
-      "id": "feature-979",
+      "id": "feature-991",
       "query": "lynx-api/fetch/Request.arrayBuffer",
       "name": "arrayBuffer",
       "category": "lynx-api/fetch",
@@ -105721,7 +107510,7 @@
       }
     },
     {
-      "id": "feature-980",
+      "id": "feature-992",
       "query": "lynx-api/fetch/Request.blob",
       "name": "blob",
       "category": "lynx-api/fetch",
@@ -105757,7 +107546,7 @@
       }
     },
     {
-      "id": "feature-981",
+      "id": "feature-993",
       "query": "lynx-api/fetch/Request.body",
       "name": "body",
       "category": "lynx-api/fetch",
@@ -105793,7 +107582,7 @@
       }
     },
     {
-      "id": "feature-982",
+      "id": "feature-994",
       "query": "lynx-api/fetch/Request.bodyUsed",
       "name": "bodyUsed",
       "category": "lynx-api/fetch",
@@ -105829,7 +107618,7 @@
       }
     },
     {
-      "id": "feature-983",
+      "id": "feature-995",
       "query": "lynx-api/fetch/Request.bytes",
       "name": "bytes",
       "category": "lynx-api/fetch",
@@ -105865,7 +107654,7 @@
       }
     },
     {
-      "id": "feature-984",
+      "id": "feature-996",
       "query": "lynx-api/fetch/Request.cache",
       "name": "cache",
       "category": "lynx-api/fetch",
@@ -105901,7 +107690,7 @@
       }
     },
     {
-      "id": "feature-985",
+      "id": "feature-997",
       "query": "lynx-api/fetch/Request.cache.only-if-cached",
       "name": "only-if-cached",
       "category": "lynx-api/fetch",
@@ -105937,7 +107726,7 @@
       }
     },
     {
-      "id": "feature-986",
+      "id": "feature-998",
       "query": "lynx-api/fetch/Request.clone",
       "name": "clone",
       "category": "lynx-api/fetch",
@@ -105973,7 +107762,7 @@
       }
     },
     {
-      "id": "feature-987",
+      "id": "feature-999",
       "query": "lynx-api/fetch/Request.credentials",
       "name": "credentials",
       "category": "lynx-api/fetch",
@@ -106009,7 +107798,7 @@
       }
     },
     {
-      "id": "feature-988",
+      "id": "feature-1000",
       "query": "lynx-api/fetch/Request.destination",
       "name": "destination",
       "category": "lynx-api/fetch",
@@ -106045,7 +107834,7 @@
       }
     },
     {
-      "id": "feature-989",
+      "id": "feature-1001",
       "query": "lynx-api/fetch/Request.duplex",
       "name": "duplex",
       "category": "lynx-api/fetch",
@@ -106081,7 +107870,7 @@
       }
     },
     {
-      "id": "feature-990",
+      "id": "feature-1002",
       "query": "lynx-api/fetch/Request.formData",
       "name": "formData",
       "category": "lynx-api/fetch",
@@ -106117,7 +107906,7 @@
       }
     },
     {
-      "id": "feature-991",
+      "id": "feature-1003",
       "query": "lynx-api/fetch/Request.headers",
       "name": "headers",
       "category": "lynx-api/fetch",
@@ -106153,7 +107942,7 @@
       }
     },
     {
-      "id": "feature-992",
+      "id": "feature-1004",
       "query": "lynx-api/fetch/Request.integrity",
       "name": "integrity",
       "category": "lynx-api/fetch",
@@ -106189,7 +107978,7 @@
       }
     },
     {
-      "id": "feature-993",
+      "id": "feature-1005",
       "query": "lynx-api/fetch/Request.isHistoryNavigation",
       "name": "isHistoryNavigation",
       "category": "lynx-api/fetch",
@@ -106225,7 +108014,7 @@
       }
     },
     {
-      "id": "feature-994",
+      "id": "feature-1006",
       "query": "lynx-api/fetch/Request.json",
       "name": "json",
       "category": "lynx-api/fetch",
@@ -106261,7 +108050,7 @@
       }
     },
     {
-      "id": "feature-995",
+      "id": "feature-1007",
       "query": "lynx-api/fetch/Request.keepalive",
       "name": "keepalive",
       "category": "lynx-api/fetch",
@@ -106297,7 +108086,7 @@
       }
     },
     {
-      "id": "feature-996",
+      "id": "feature-1008",
       "query": "lynx-api/fetch/Request.method",
       "name": "method",
       "category": "lynx-api/fetch",
@@ -106333,7 +108122,7 @@
       }
     },
     {
-      "id": "feature-997",
+      "id": "feature-1009",
       "query": "lynx-api/fetch/Request.mode",
       "name": "mode",
       "category": "lynx-api/fetch",
@@ -106369,7 +108158,7 @@
       }
     },
     {
-      "id": "feature-998",
+      "id": "feature-1010",
       "query": "lynx-api/fetch/Request.mode.navigate_mode",
       "name": "`navigate` mode",
       "category": "lynx-api/fetch",
@@ -106405,7 +108194,7 @@
       }
     },
     {
-      "id": "feature-999",
+      "id": "feature-1011",
       "query": "lynx-api/fetch/Request.redirect",
       "name": "redirect",
       "category": "lynx-api/fetch",
@@ -106441,7 +108230,7 @@
       }
     },
     {
-      "id": "feature-1000",
+      "id": "feature-1012",
       "query": "lynx-api/fetch/Request.referrer",
       "name": "referrer",
       "category": "lynx-api/fetch",
@@ -106477,7 +108266,7 @@
       }
     },
     {
-      "id": "feature-1001",
+      "id": "feature-1013",
       "query": "lynx-api/fetch/Request.referrerPolicy",
       "name": "referrerPolicy",
       "category": "lynx-api/fetch",
@@ -106513,7 +108302,7 @@
       }
     },
     {
-      "id": "feature-1002",
+      "id": "feature-1014",
       "query": "lynx-api/fetch/Request.signal",
       "name": "signal",
       "category": "lynx-api/fetch",
@@ -106549,7 +108338,7 @@
       }
     },
     {
-      "id": "feature-1003",
+      "id": "feature-1015",
       "query": "lynx-api/fetch/Request.targetAddressSpace",
       "name": "targetAddressSpace",
       "category": "lynx-api/fetch",
@@ -106585,7 +108374,7 @@
       }
     },
     {
-      "id": "feature-1004",
+      "id": "feature-1016",
       "query": "lynx-api/fetch/Request.text",
       "name": "text",
       "category": "lynx-api/fetch",
@@ -106621,7 +108410,7 @@
       }
     },
     {
-      "id": "feature-1005",
+      "id": "feature-1017",
       "query": "lynx-api/fetch/Request.url",
       "name": "url",
       "category": "lynx-api/fetch",
@@ -106657,7 +108446,7 @@
       }
     },
     {
-      "id": "feature-1006",
+      "id": "feature-1018",
       "query": "lynx-api/fetch/Response",
       "name": "Response",
       "category": "lynx-api/fetch",
@@ -106693,7 +108482,7 @@
       }
     },
     {
-      "id": "feature-1007",
+      "id": "feature-1019",
       "query": "lynx-api/fetch/Response",
       "name": "`Response()` constructor",
       "category": "lynx-api/fetch",
@@ -106729,7 +108518,7 @@
       }
     },
     {
-      "id": "feature-1008",
+      "id": "feature-1020",
       "query": "lynx-api/fetch/Response.accept_readablestream",
       "name": "body parameter accepts ReadableByteStream",
       "category": "lynx-api/fetch",
@@ -106765,7 +108554,7 @@
       }
     },
     {
-      "id": "feature-1009",
+      "id": "feature-1021",
       "query": "lynx-api/fetch/Response.body_parameter_optional",
       "name": "`body` parameter is optional",
       "category": "lynx-api/fetch",
@@ -106801,7 +108590,7 @@
       }
     },
     {
-      "id": "feature-1010",
+      "id": "feature-1022",
       "query": "lynx-api/fetch/Response.arrayBuffer",
       "name": "arrayBuffer",
       "category": "lynx-api/fetch",
@@ -106837,7 +108626,7 @@
       }
     },
     {
-      "id": "feature-1011",
+      "id": "feature-1023",
       "query": "lynx-api/fetch/Response.blob",
       "name": "blob",
       "category": "lynx-api/fetch",
@@ -106873,7 +108662,7 @@
       }
     },
     {
-      "id": "feature-1012",
+      "id": "feature-1024",
       "query": "lynx-api/fetch/Response.body",
       "name": "body",
       "category": "lynx-api/fetch",
@@ -106909,7 +108698,7 @@
       }
     },
     {
-      "id": "feature-1013",
+      "id": "feature-1025",
       "query": "lynx-api/fetch/Response.body.readable_byte_stream",
       "name": "`body` is a readable byte stream",
       "category": "lynx-api/fetch",
@@ -106945,7 +108734,7 @@
       }
     },
     {
-      "id": "feature-1014",
+      "id": "feature-1026",
       "query": "lynx-api/fetch/Response.bodyUsed",
       "name": "bodyUsed",
       "category": "lynx-api/fetch",
@@ -106981,7 +108770,7 @@
       }
     },
     {
-      "id": "feature-1015",
+      "id": "feature-1027",
       "query": "lynx-api/fetch/Response.bytes",
       "name": "bytes",
       "category": "lynx-api/fetch",
@@ -107017,7 +108806,7 @@
       }
     },
     {
-      "id": "feature-1016",
+      "id": "feature-1028",
       "query": "lynx-api/fetch/Response.clone",
       "name": "clone",
       "category": "lynx-api/fetch",
@@ -107053,7 +108842,7 @@
       }
     },
     {
-      "id": "feature-1017",
+      "id": "feature-1029",
       "query": "lynx-api/fetch/Response.error_static",
       "name": "`error()` static method",
       "category": "lynx-api/fetch",
@@ -107089,7 +108878,7 @@
       }
     },
     {
-      "id": "feature-1018",
+      "id": "feature-1030",
       "query": "lynx-api/fetch/Response.formData",
       "name": "formData",
       "category": "lynx-api/fetch",
@@ -107125,7 +108914,7 @@
       }
     },
     {
-      "id": "feature-1019",
+      "id": "feature-1031",
       "query": "lynx-api/fetch/Response.headers",
       "name": "headers",
       "category": "lynx-api/fetch",
@@ -107161,7 +108950,7 @@
       }
     },
     {
-      "id": "feature-1020",
+      "id": "feature-1032",
       "query": "lynx-api/fetch/Response.json",
       "name": "json",
       "category": "lynx-api/fetch",
@@ -107197,7 +108986,7 @@
       }
     },
     {
-      "id": "feature-1021",
+      "id": "feature-1033",
       "query": "lynx-api/fetch/Response.json_static",
       "name": "json_static",
       "category": "lynx-api/fetch",
@@ -107233,7 +109022,7 @@
       }
     },
     {
-      "id": "feature-1022",
+      "id": "feature-1034",
       "query": "lynx-api/fetch/Response.ok",
       "name": "ok",
       "category": "lynx-api/fetch",
@@ -107269,7 +109058,7 @@
       }
     },
     {
-      "id": "feature-1023",
+      "id": "feature-1035",
       "query": "lynx-api/fetch/Response.redirect_static",
       "name": "`redirect()` static method",
       "category": "lynx-api/fetch",
@@ -107305,7 +109094,7 @@
       }
     },
     {
-      "id": "feature-1024",
+      "id": "feature-1036",
       "query": "lynx-api/fetch/Response.redirected",
       "name": "redirected",
       "category": "lynx-api/fetch",
@@ -107341,7 +109130,7 @@
       }
     },
     {
-      "id": "feature-1025",
+      "id": "feature-1037",
       "query": "lynx-api/fetch/Response.status",
       "name": "status",
       "category": "lynx-api/fetch",
@@ -107377,7 +109166,7 @@
       }
     },
     {
-      "id": "feature-1026",
+      "id": "feature-1038",
       "query": "lynx-api/fetch/Response.statusText",
       "name": "statusText",
       "category": "lynx-api/fetch",
@@ -107413,7 +109202,7 @@
       }
     },
     {
-      "id": "feature-1027",
+      "id": "feature-1039",
       "query": "lynx-api/fetch/Response.text",
       "name": "text",
       "category": "lynx-api/fetch",
@@ -107449,7 +109238,7 @@
       }
     },
     {
-      "id": "feature-1028",
+      "id": "feature-1040",
       "query": "lynx-api/fetch/Response.type",
       "name": "type",
       "category": "lynx-api/fetch",
@@ -107485,7 +109274,7 @@
       }
     },
     {
-      "id": "feature-1029",
+      "id": "feature-1041",
       "query": "lynx-api/fetch/Response.url",
       "name": "url",
       "category": "lynx-api/fetch",
@@ -107521,7 +109310,7 @@
       }
     },
     {
-      "id": "feature-1030",
+      "id": "feature-1042",
       "query": "lynx-api/fetch/fetch",
       "name": "<code>fetch</code>",
       "category": "lynx-api/fetch",
@@ -107557,7 +109346,7 @@
       }
     },
     {
-      "id": "feature-1031",
+      "id": "feature-1043",
       "query": "lynx-api/lynx/accessibilityAnnounce",
       "name": "Used to have the specified text content read by the screen reader.",
       "category": "lynx-api/lynx",
@@ -107593,7 +109382,7 @@
       }
     },
     {
-      "id": "feature-1032",
+      "id": "feature-1044",
       "query": "lynx-api/lynx/addFont",
       "name": "Used for dynamically adding fonts.",
       "category": "lynx-api/lynx",
@@ -107629,7 +109418,7 @@
       }
     },
     {
-      "id": "feature-1033",
+      "id": "feature-1045",
       "query": "lynx-api/lynx/animateAPI.compat",
       "name": "Used to import modules.",
       "category": "lynx-api/lynx",
@@ -107665,7 +109454,7 @@
       }
     },
     {
-      "id": "feature-1034",
+      "id": "feature-1046",
       "query": "lynx-api/lynx/animateAPI.multiple animation implementation",
       "name": "Multiple animate",
       "category": "lynx-api/lynx",
@@ -107701,7 +109490,7 @@
       }
     },
     {
-      "id": "feature-1035",
+      "id": "feature-1047",
       "query": "lynx-api/lynx/cancelAnimationFrame",
       "name": "Cancel a `requestAnimationFrame` callback.",
       "category": "lynx-api/lynx",
@@ -107737,7 +109526,7 @@
       }
     },
     {
-      "id": "feature-1036",
+      "id": "feature-1048",
       "query": "lynx-api/lynx/cancelResourcePrefetch",
       "name": "Used to cancel the prefetch of resource.",
       "category": "lynx-api/lynx",
@@ -107773,7 +109562,7 @@
       }
     },
     {
-      "id": "feature-1037",
+      "id": "feature-1049",
       "query": "lynx-api/lynx/createIntersectionObserver",
       "name": "Create an IntersectionObserver object.",
       "category": "lynx-api/lynx",
@@ -107809,7 +109598,7 @@
       }
     },
     {
-      "id": "feature-1038",
+      "id": "feature-1050",
       "query": "lynx-api/lynx/createSelectorQuery",
       "name": " Create a `SelectorQuery` with the root node of the page as the root.",
       "category": "lynx-api/lynx",
@@ -107845,7 +109634,7 @@
       }
     },
     {
-      "id": "feature-1039",
+      "id": "feature-1051",
       "query": "lynx-api/lynx/getElementById",
       "name": "Used to import modules.",
       "category": "lynx-api/lynx",
@@ -107881,7 +109670,7 @@
       }
     },
     {
-      "id": "feature-1040",
+      "id": "feature-1052",
       "query": "lynx-api/lynx/getJSModule",
       "name": "getJSModule",
       "category": "lynx-api/lynx",
@@ -107917,7 +109706,7 @@
       }
     },
     {
-      "id": "feature-1041",
+      "id": "feature-1053",
       "query": "lynx-api/lynx/getSessionStorageItem",
       "name": "The `lynx.getSessionStorageItem` method is used to retrieve data shared across multiple LynxViews. This enables data sharing between multiple pages via `SessionStorage`. You can call [lynx.setSessionStorageItem](./lynx-set-session-storage.mdx) to set the cached data.",
       "category": "lynx-api/lynx",
@@ -107953,7 +109742,7 @@
       }
     },
     {
-      "id": "feature-1042",
+      "id": "feature-1054",
       "query": "lynx-api/lynx/getSharedData",
       "name": "Get the shared data set by `lynx.setSharedData()` used on pages belonging to the same LynxGroup.",
       "category": "lynx-api/lynx",
@@ -107989,7 +109778,7 @@
       }
     },
     {
-      "id": "feature-1043",
+      "id": "feature-1055",
       "query": "lynx-api/lynx/getTextInfo",
       "name": "Used to measure the width of text content.",
       "category": "lynx-api/lynx",
@@ -108025,7 +109814,7 @@
       }
     },
     {
-      "id": "feature-1044",
+      "id": "feature-1056",
       "query": "lynx-api/lynx/globalProps",
       "name": "global data set by client.",
       "category": "lynx-api/lynx",
@@ -108061,7 +109850,7 @@
       }
     },
     {
-      "id": "feature-1045",
+      "id": "feature-1057",
       "query": "lynx-api/lynx/lynx-before-publish-event/BeforePublishEvent",
       "name": "Used to register/remove monitoring of an element event",
       "category": "lynx-api/lynx",
@@ -108097,7 +109886,7 @@
       }
     },
     {
-      "id": "feature-1046",
+      "id": "feature-1058",
       "query": "lynx-api/lynx/lynx-before-publish-event/BeforePublishEvent.add",
       "name": "Register to listen for an element event.",
       "category": "lynx-api/lynx",
@@ -108133,7 +109922,7 @@
       }
     },
     {
-      "id": "feature-1047",
+      "id": "feature-1059",
       "query": "lynx-api/lynx/lynx-before-publish-event/BeforePublishEvent.remove",
       "name": "Remove monitoring of an element event.",
       "category": "lynx-api/lynx",
@@ -108169,7 +109958,7 @@
       }
     },
     {
-      "id": "feature-1048",
+      "id": "feature-1060",
       "query": "lynx-api/lynx/lynx-before-publish-event/add",
       "name": "Register to listen for an element event.",
       "category": "lynx-api/lynx",
@@ -108205,7 +109994,7 @@
       }
     },
     {
-      "id": "feature-1049",
+      "id": "feature-1061",
       "query": "lynx-api/lynx/lynx-before-publish-event/remove",
       "name": "Remove monitoring of an element event.",
       "category": "lynx-api/lynx",
@@ -108241,7 +110030,7 @@
       }
     },
     {
-      "id": "feature-1050",
+      "id": "feature-1062",
       "query": "lynx-api/lynx/performance.lynx.performance",
       "name": "performance",
       "category": "lynx-api/lynx",
@@ -108277,7 +110066,7 @@
       }
     },
     {
-      "id": "feature-1051",
+      "id": "feature-1063",
       "query": "lynx-api/lynx/performance.createObserver()",
       "name": "createObserver()",
       "category": "lynx-api/lynx",
@@ -108313,7 +110102,7 @@
       }
     },
     {
-      "id": "feature-1052",
+      "id": "feature-1064",
       "query": "lynx-api/lynx/performance.profileStart()",
       "name": "profileStart()",
       "category": "lynx-api/lynx",
@@ -108349,7 +110138,7 @@
       }
     },
     {
-      "id": "feature-1053",
+      "id": "feature-1065",
       "query": "lynx-api/lynx/performance.profileEnd()",
       "name": "profileEnd()",
       "category": "lynx-api/lynx",
@@ -108385,7 +110174,7 @@
       }
     },
     {
-      "id": "feature-1054",
+      "id": "feature-1066",
       "query": "lynx-api/lynx/performance.profileMark()",
       "name": "profileMark()",
       "category": "lynx-api/lynx",
@@ -108421,7 +110210,7 @@
       }
     },
     {
-      "id": "feature-1055",
+      "id": "feature-1067",
       "query": "lynx-api/lynx/performance.profileFlowId()",
       "name": "profileFlowId()",
       "category": "lynx-api/lynx",
@@ -108457,7 +110246,7 @@
       }
     },
     {
-      "id": "feature-1056",
+      "id": "feature-1068",
       "query": "lynx-api/lynx/performance.isProfileRecording()",
       "name": "isProfileRecording()",
       "category": "lynx-api/lynx",
@@ -108493,7 +110282,7 @@
       }
     },
     {
-      "id": "feature-1057",
+      "id": "feature-1069",
       "query": "lynx-api/lynx/querySelector",
       "name": "querySelector",
       "category": "lynx-api/lynx",
@@ -108529,7 +110318,7 @@
       }
     },
     {
-      "id": "feature-1058",
+      "id": "feature-1070",
       "query": "lynx-api/lynx/querySelectorAll",
       "name": "querySelectorAll",
       "category": "lynx-api/lynx",
@@ -108565,7 +110354,7 @@
       }
     },
     {
-      "id": "feature-1059",
+      "id": "feature-1071",
       "query": "lynx-api/lynx/queueMicrotask",
       "name": "insert a task into microtask queue",
       "category": "lynx-api/lynx",
@@ -108601,7 +110390,7 @@
       }
     },
     {
-      "id": "feature-1060",
+      "id": "feature-1072",
       "query": "lynx-api/lynx/registerModule",
       "name": "registerModule",
       "category": "lynx-api/lynx",
@@ -108637,7 +110426,7 @@
       }
     },
     {
-      "id": "feature-1061",
+      "id": "feature-1073",
       "query": "lynx-api/lynx/registerSharedDataObserver",
       "name": "Listen for shared data updates initiated by `lynx.setSharedData()` within pages in the same LynxGroup.",
       "category": "lynx-api/lynx",
@@ -108673,7 +110462,7 @@
       }
     },
     {
-      "id": "feature-1062",
+      "id": "feature-1074",
       "query": "lynx-api/lynx/reload",
       "name": "Reloads the current page, like the Refresh button.",
       "category": "lynx-api/lynx",
@@ -108709,7 +110498,7 @@
       }
     },
     {
-      "id": "feature-1063",
+      "id": "feature-1075",
       "query": "lynx-api/lynx/removeSharedDataObserver",
       "name": "取消使用 `lynx.registerSharedDataObserver()` 进行的监听。",
       "category": "lynx-api/lynx",
@@ -108745,7 +110534,7 @@
       }
     },
     {
-      "id": "feature-1064",
+      "id": "feature-1076",
       "query": "lynx-api/lynx/reportError",
       "name": "Used to report a JavaScript Error.",
       "category": "lynx-api/lynx",
@@ -108781,7 +110570,7 @@
       }
     },
     {
-      "id": "feature-1065",
+      "id": "feature-1077",
       "query": "lynx-api/lynx/requestAnimationFrame",
       "name": "Invoke the specified callback function at the next VSYNC.",
       "category": "lynx-api/lynx",
@@ -108817,7 +110606,7 @@
       }
     },
     {
-      "id": "feature-1066",
+      "id": "feature-1078",
       "query": "lynx-api/lynx/requestResourcePrefetch",
       "name": "Used to request the prefetch of resource.",
       "category": "lynx-api/lynx",
@@ -108853,7 +110642,7 @@
       }
     },
     {
-      "id": "feature-1067",
+      "id": "feature-1079",
       "query": "lynx-api/lynx/requireModule",
       "name": "Used to import modules and JSON.",
       "category": "lynx-api/lynx",
@@ -108889,7 +110678,7 @@
       }
     },
     {
-      "id": "feature-1068",
+      "id": "feature-1080",
       "query": "lynx-api/lynx/requireModuleAsync",
       "name": "Used to import modules.",
       "category": "lynx-api/lynx",
@@ -108925,7 +110714,7 @@
       }
     },
     {
-      "id": "feature-1069",
+      "id": "feature-1081",
       "query": "lynx-api/lynx/resumeExposure",
       "name": "Turn on exposure detection, that is, to restart the detection of the visibility of the target node, and subsequently trigger the exposure/anti-exposure event normally.",
       "category": "lynx-api/lynx",
@@ -108961,7 +110750,7 @@
       }
     },
     {
-      "id": "feature-1070",
+      "id": "feature-1082",
       "query": "lynx-api/lynx/setObserverFrameRate",
       "name": "Set the frequency of exposure detection.",
       "category": "lynx-api/lynx",
@@ -108997,7 +110786,7 @@
       }
     },
     {
-      "id": "feature-1071",
+      "id": "feature-1083",
       "query": "lynx-api/lynx/setSessionStorageItem",
       "name": "The `lynx.setSessionStorageItem` method is used to set data shared across multiple LynxViews.",
       "category": "lynx-api/lynx",
@@ -109033,7 +110822,7 @@
       }
     },
     {
-      "id": "feature-1072",
+      "id": "feature-1084",
       "query": "lynx-api/lynx/setSharedData",
       "name": "设置同 LynxGroup 的页面间的共享数据。",
       "category": "lynx-api/lynx",
@@ -109069,7 +110858,7 @@
       }
     },
     {
-      "id": "feature-1073",
+      "id": "feature-1085",
       "query": "lynx-api/lynx/stopExposure",
       "name": "Stop exposure detection, that is, the visibility of the target node will no longer be detected, and exposure/anti-exposure events will no longer be triggered in the future.",
       "category": "lynx-api/lynx",
@@ -109105,7 +110894,7 @@
       }
     },
     {
-      "id": "feature-1074",
+      "id": "feature-1086",
       "query": "lynx-api/lynx/subscribeSessionStorage",
       "name": "The `lynx.subscribeSessionStorage` method is used to listen for changes in data shared across multiple LynxViews. This enables data sharing between multiple pages via `SessionStorage`. You can call [lynx.setSessionStorageItem](./lynx-set-session-storage.mdx) to set the cached data.",
       "category": "lynx-api/lynx",
@@ -109141,7 +110930,7 @@
       }
     },
     {
-      "id": "feature-1075",
+      "id": "feature-1087",
       "query": "lynx-api/lynx/unsubscribeSessionStorage",
       "name": "The `lynx.unsubscribeSessionStorage` method is used to cancel the listener for changes in data shared across multiple LynxViews. This enables data sharing between multiple pages via `SessionStorage`. You can call [lynx.setSessionStorageItem](./lynx-set-session-storage.mdx) to set the cached data. After cancellation, the cached data corresponding to this key will no longer be listened to.",
       "category": "lynx-api/lynx",
@@ -109177,7 +110966,7 @@
       }
     },
     {
-      "id": "feature-1076",
+      "id": "feature-1088",
       "query": "lynx-api/selector-query/SelectorQuery",
       "name": "Gets a reference to the specified node in order to call its methods or get its properties.",
       "category": "lynx-api/selector-query",
@@ -109213,7 +111002,7 @@
       }
     },
     {
-      "id": "feature-1077",
+      "id": "feature-1089",
       "query": "lynx-api/selector-query/SelectorQuery.`exec`",
       "name": "Execute all submitted operations.",
       "category": "lynx-api/selector-query",
@@ -109249,7 +111038,7 @@
       }
     },
     {
-      "id": "feature-1078",
+      "id": "feature-1090",
       "query": "lynx-api/selector-query/SelectorQuery.`select`",
       "name": "Select the first node that matches the specified selector in the descendants of the root node specified in `SelectorQuery`.",
       "category": "lynx-api/selector-query",
@@ -109285,7 +111074,7 @@
       }
     },
     {
-      "id": "feature-1079",
+      "id": "feature-1091",
       "query": "lynx-api/selector-query/SelectorQuery.`selectAll`",
       "name": "Select all nodes that match the specified CSS selector under the root node specified by `SelectorQuery`.",
       "category": "lynx-api/selector-query",
@@ -109321,7 +111110,7 @@
       }
     },
     {
-      "id": "feature-1080",
+      "id": "feature-1092",
       "query": "lynx-api/selector-query/SelectorQuery.`selectRoot`",
       "name": "Select the root node specified by `SelectorQuery`.",
       "category": "lynx-api/selector-query",
@@ -109357,7 +111146,7 @@
       }
     },
     {
-      "id": "feature-1081",
+      "id": "feature-1093",
       "query": "lynx-api/selector-query/SelectorQuery.`selectUniqueID`",
       "name": "Select nodes by specifying `uid`.",
       "category": "lynx-api/selector-query",
@@ -109393,7 +111182,7 @@
       }
     },
     {
-      "id": "feature-1082",
+      "id": "feature-1094",
       "query": "lynx-api/selector-query/exec",
       "name": "Execute all submitted operations.",
       "category": "lynx-api/selector-query",
@@ -109429,7 +111218,7 @@
       }
     },
     {
-      "id": "feature-1083",
+      "id": "feature-1095",
       "query": "lynx-api/selector-query/select",
       "name": "Select the first node that matches the specified selector in the descendants of the root node specified in `SelectorQuery`.",
       "category": "lynx-api/selector-query",
@@ -109465,7 +111254,7 @@
       }
     },
     {
-      "id": "feature-1084",
+      "id": "feature-1096",
       "query": "lynx-api/selector-query/select.`selector` parameter supporting `tag` selector",
       "name": "`selector` parameter supporting `tag` selector.",
       "category": "lynx-api/selector-query",
@@ -109501,7 +111290,7 @@
       }
     },
     {
-      "id": "feature-1085",
+      "id": "feature-1097",
       "query": "lynx-api/selector-query/select.`selector` parameter supporting `attribute` selector `[attr]`, `[attr=value]",
       "name": "`selector` parameter supporting `attribute` selector `[attr]`, `[attr=value].",
       "category": "lynx-api/selector-query",
@@ -109537,7 +111326,7 @@
       }
     },
     {
-      "id": "feature-1086",
+      "id": "feature-1098",
       "query": "lynx-api/selector-query/select.`selector` parameter supporting `attribute` selector `[attr*=value]`, `[attr^=value]`, `[attr$=value]`",
       "name": "`selector` parameter supporting `attribute` selector `[attr*=value]`, `[attr^=value]`, `[attr$=value]`.",
       "category": "lynx-api/selector-query",
@@ -109573,7 +111362,7 @@
       }
     },
     {
-      "id": "feature-1087",
+      "id": "feature-1099",
       "query": "lynx-api/selector-query/selectAll",
       "name": "Select all nodes that match the specified CSS selector under the root node specified by `SelectorQuery`.",
       "category": "lynx-api/selector-query",
@@ -109609,7 +111398,7 @@
       }
     },
     {
-      "id": "feature-1088",
+      "id": "feature-1100",
       "query": "lynx-api/selector-query/selectRoot",
       "name": "Select the root node specified by `SelectorQuery`.",
       "category": "lynx-api/selector-query",
@@ -109645,7 +111434,7 @@
       }
     },
     {
-      "id": "feature-1089",
+      "id": "feature-1101",
       "query": "lynx-api/selector-query/selectUniqueID",
       "name": "Select nodes by specifying `uid`.",
       "category": "lynx-api/selector-query",
@@ -109681,7 +111470,7 @@
       }
     },
     {
-      "id": "feature-1090",
+      "id": "feature-1102",
       "query": "lynx-api/nodes-ref/NodesRef",
       "name": "Represents a reference to one or more UI nodes. It can be used to call methods, get and set properties on UI nodes.",
       "category": "lynx-api/nodes-ref",
@@ -109717,7 +111506,7 @@
       }
     },
     {
-      "id": "feature-1091",
+      "id": "feature-1103",
       "query": "lynx-api/nodes-ref/NodesRef.`fields`",
       "name": "Query the attributes of the selected node.",
       "category": "lynx-api/nodes-ref",
@@ -109753,7 +111542,7 @@
       }
     },
     {
-      "id": "feature-1092",
+      "id": "feature-1104",
       "query": "lynx-api/nodes-ref/NodesRef.`invoke`",
       "name": "Execute the UI method of the selected node.",
       "category": "lynx-api/nodes-ref",
@@ -109789,7 +111578,7 @@
       }
     },
     {
-      "id": "feature-1093",
+      "id": "feature-1105",
       "query": "lynx-api/nodes-ref/NodesRef.`path`",
       "name": "Query the path information from the node to the root node of the page.",
       "category": "lynx-api/nodes-ref",
@@ -109825,7 +111614,7 @@
       }
     },
     {
-      "id": "feature-1094",
+      "id": "feature-1106",
       "query": "lynx-api/nodes-ref/NodesRef.`setNativeProps`",
       "name": "Directly set the attributes of the selected node.",
       "category": "lynx-api/nodes-ref",
@@ -109861,7 +111650,7 @@
       }
     },
     {
-      "id": "feature-1095",
+      "id": "feature-1107",
       "query": "lynx-api/nodes-ref/fields",
       "name": "Query the attributes of the selected node.",
       "category": "lynx-api/nodes-ref",
@@ -109897,7 +111686,7 @@
       }
     },
     {
-      "id": "feature-1096",
+      "id": "feature-1108",
       "query": "lynx-api/nodes-ref/fields.`fields` parameter supporting the `attribute` property",
       "name": "`fields` parameter supporting the `attribute` property.",
       "category": "lynx-api/nodes-ref",
@@ -109933,7 +111722,7 @@
       }
     },
     {
-      "id": "feature-1097",
+      "id": "feature-1109",
       "query": "lynx-api/nodes-ref/invoke",
       "name": "Execute the UI method of the selected node.",
       "category": "lynx-api/nodes-ref",
@@ -109969,7 +111758,7 @@
       }
     },
     {
-      "id": "feature-1098",
+      "id": "feature-1110",
       "query": "lynx-api/nodes-ref/path",
       "name": "Query the path information from the node to the root node of the page.",
       "category": "lynx-api/nodes-ref",
@@ -110005,7 +111794,7 @@
       }
     },
     {
-      "id": "feature-1099",
+      "id": "feature-1111",
       "query": "lynx-api/nodes-ref/setNativeProps",
       "name": "Directly set the attributes of the selected node.",
       "category": "lynx-api/nodes-ref",
@@ -110041,7 +111830,7 @@
       }
     },
     {
-      "id": "feature-1100",
+      "id": "feature-1112",
       "query": "lynx-api/intersection-observer/IntersectionObserver",
       "name": "Observe the intersection status between the target node and the reference node and the target node and the ancestor node. When the intersection status changes, the corresponding callback is triggered. Based on this, you can monitor whether the target node is exposed/de-exposed.",
       "category": "lynx-api/intersection-observer",
@@ -110077,7 +111866,7 @@
       }
     },
     {
-      "id": "feature-1101",
+      "id": "feature-1113",
       "query": "lynx-api/intersection-observer/IntersectionObserver.relativeTo",
       "name": "Specify a reference node. The reference node is specified by id.",
       "category": "lynx-api/intersection-observer",
@@ -110113,7 +111902,7 @@
       }
     },
     {
-      "id": "feature-1102",
+      "id": "feature-1114",
       "query": "lynx-api/intersection-observer/IntersectionObserver.relativeToViewport",
       "name": "Specify a LynxView as a reference node.",
       "category": "lynx-api/intersection-observer",
@@ -110149,7 +111938,7 @@
       }
     },
     {
-      "id": "feature-1103",
+      "id": "feature-1115",
       "query": "lynx-api/intersection-observer/IntersectionObserver.relativeToScreen",
       "name": "Specify the screen as the reference node.",
       "category": "lynx-api/intersection-observer",
@@ -110185,7 +111974,7 @@
       }
     },
     {
-      "id": "feature-1104",
+      "id": "feature-1116",
       "query": "lynx-api/intersection-observer/IntersectionObserver.observe",
       "name": "Specify the target node and callback, and the target node is specified according to id.",
       "category": "lynx-api/intersection-observer",
@@ -110221,7 +112010,7 @@
       }
     },
     {
-      "id": "feature-1105",
+      "id": "feature-1117",
       "query": "lynx-api/intersection-observer/IntersectionObserver.disconnect",
       "name": "Clear the target node and callback. The target node will no longer be observed and the corresponding callback will not be triggered.",
       "category": "lynx-api/intersection-observer",
@@ -110257,7 +112046,7 @@
       }
     },
     {
-      "id": "feature-1106",
+      "id": "feature-1118",
       "query": "lynx-api/intersection-observer/disconnect",
       "name": "Clear the target node and callback. The target node will no longer be observed and the corresponding callback will not be triggered.",
       "category": "lynx-api/intersection-observer",
@@ -110293,7 +112082,7 @@
       }
     },
     {
-      "id": "feature-1107",
+      "id": "feature-1119",
       "query": "lynx-api/intersection-observer/observe",
       "name": "Specify the target node and callback, and the target node is specified according to id.",
       "category": "lynx-api/intersection-observer",
@@ -110329,7 +112118,7 @@
       }
     },
     {
-      "id": "feature-1108",
+      "id": "feature-1120",
       "query": "lynx-api/intersection-observer/relativeTo",
       "name": "Specify a reference node. The reference node is specified by id.",
       "category": "lynx-api/intersection-observer",
@@ -110365,7 +112154,7 @@
       }
     },
     {
-      "id": "feature-1109",
+      "id": "feature-1121",
       "query": "lynx-api/intersection-observer/relativeToScreen",
       "name": "Specify the screen as the reference node.",
       "category": "lynx-api/intersection-observer",
@@ -110401,7 +112190,7 @@
       }
     },
     {
-      "id": "feature-1110",
+      "id": "feature-1122",
       "query": "lynx-api/intersection-observer/relativeToViewport",
       "name": "Specify a LynxView as a reference node.",
       "category": "lynx-api/intersection-observer",
@@ -110437,7 +112226,7 @@
       }
     },
     {
-      "id": "feature-1111",
+      "id": "feature-1123",
       "query": "lynx-api/main-thread/Element",
       "name": "Represents an element in the main thread.",
       "category": "lynx-api/main-thread",
@@ -110473,7 +112262,7 @@
       }
     },
     {
-      "id": "feature-1112",
+      "id": "feature-1124",
       "query": "lynx-api/main-thread/Element.Element.animate",
       "name": "animate",
       "category": "lynx-api/main-thread",
@@ -110509,7 +112298,7 @@
       }
     },
     {
-      "id": "feature-1113",
+      "id": "feature-1125",
       "query": "lynx-api/main-thread/Element.Element.getComputedStyleProperty",
       "name": "getComputedStyleProperty",
       "category": "lynx-api/main-thread",
@@ -110545,7 +112334,7 @@
       }
     },
     {
-      "id": "feature-1114",
+      "id": "feature-1126",
       "query": "lynx-api/main-thread/ElementAnimate",
       "name": "Create An Animation in MTS",
       "category": "lynx-api/main-thread",
@@ -110581,7 +112370,7 @@
       }
     },
     {
-      "id": "feature-1115",
+      "id": "feature-1127",
       "query": "lynx-api/main-thread/ElementAnimate.Animation.play()",
       "name": "play()",
       "category": "lynx-api/main-thread",
@@ -110617,7 +112406,7 @@
       }
     },
     {
-      "id": "feature-1116",
+      "id": "feature-1128",
       "query": "lynx-api/main-thread/ElementAnimate.Animation.pause()",
       "name": "pause()",
       "category": "lynx-api/main-thread",
@@ -110653,7 +112442,7 @@
       }
     },
     {
-      "id": "feature-1117",
+      "id": "feature-1129",
       "query": "lynx-api/main-thread/ElementAnimate.Animation.cancel()",
       "name": "cancel()",
       "category": "lynx-api/main-thread",
@@ -110689,7 +112478,7 @@
       }
     },
     {
-      "id": "feature-1118",
+      "id": "feature-1130",
       "query": "lynx-api/main-thread/ElementAnimate.Animation.finish()",
       "name": "finish()",
       "category": "lynx-api/main-thread",
@@ -110725,7 +112514,7 @@
       }
     },
     {
-      "id": "feature-1119",
+      "id": "feature-1131",
       "query": "lynx-api/main-thread/ElementGetComputedStyle",
       "name": "Create An Animation in MTS",
       "category": "lynx-api/main-thread",
@@ -110761,7 +112550,7 @@
       }
     },
     {
-      "id": "feature-1120",
+      "id": "feature-1132",
       "query": "lynx-api/main-thread/MainThread-APIs",
       "name": "APIs available on the main thread.",
       "category": "lynx-api/main-thread",
@@ -110797,7 +112586,7 @@
       }
     },
     {
-      "id": "feature-1121",
+      "id": "feature-1133",
       "query": "lynx-api/main-thread/MainThread-APIs.Element",
       "name": "Element",
       "category": "lynx-api/main-thread",
@@ -110833,7 +112622,7 @@
       }
     },
     {
-      "id": "feature-1122",
+      "id": "feature-1134",
       "query": "lynx-api/main-thread/MainThread-APIs.Element.animate",
       "name": "animate",
       "category": "lynx-api/main-thread",
@@ -110869,7 +112658,7 @@
       }
     },
     {
-      "id": "feature-1123",
+      "id": "feature-1135",
       "query": "lynx-api/main-thread/MainThread-APIs.Element.getComputedStyleProperty",
       "name": "getComputedStyleProperty",
       "category": "lynx-api/main-thread",
@@ -110905,7 +112694,7 @@
       }
     },
     {
-      "id": "feature-1124",
+      "id": "feature-1136",
       "query": "lynx-api/main-thread/MainThread-APIs.lynx.getTextInfo",
       "name": "getTextInfo",
       "category": "lynx-api/main-thread",
@@ -110941,7 +112730,7 @@
       }
     },
     {
-      "id": "feature-1125",
+      "id": "feature-1137",
       "query": "lynx-api/main-thread/MainThread-APIs.lynx.querySelector",
       "name": "querySelector",
       "category": "lynx-api/main-thread",
@@ -110977,7 +112766,7 @@
       }
     },
     {
-      "id": "feature-1126",
+      "id": "feature-1138",
       "query": "lynx-api/main-thread/MainThread-APIs.lynx.querySelectorAll",
       "name": "querySelectorAll",
       "category": "lynx-api/main-thread",
@@ -111013,7 +112802,7 @@
       }
     },
     {
-      "id": "feature-1127",
+      "id": "feature-1139",
       "query": "lynx-api/main-thread/MainThread-APIs.lynx.requestAnimationFrame",
       "name": "requestAnimationFrame",
       "category": "lynx-api/main-thread",
@@ -111049,7 +112838,7 @@
       }
     },
     {
-      "id": "feature-1128",
+      "id": "feature-1140",
       "query": "lynx-api/main-thread/MainThread-APIs.lynx.__globalProps",
       "name": "__globalProps",
       "category": "lynx-api/main-thread",
@@ -111085,7 +112874,7 @@
       }
     },
     {
-      "id": "feature-1129",
+      "id": "feature-1141",
       "query": "lynx-api/performance-api/framework-pipeline-timing",
       "name": "framework-pipeline-timing",
       "category": "lynx-api/performance-api",
@@ -111121,7 +112910,7 @@
       }
     },
     {
-      "id": "feature-1130",
+      "id": "feature-1142",
       "query": "lynx-api/performance-api/host-platform-timing/android-host-platform-timing",
       "name": "android-host-platform-timing",
       "category": "lynx-api/performance-api",
@@ -111157,7 +112946,7 @@
       }
     },
     {
-      "id": "feature-1131",
+      "id": "feature-1143",
       "query": "lynx-api/performance-api/host-platform-timing/harmony-host-platform-timing",
       "name": "harmony-host-platform-timing",
       "category": "lynx-api/performance-api",
@@ -111193,7 +112982,7 @@
       }
     },
     {
-      "id": "feature-1132",
+      "id": "feature-1144",
       "query": "lynx-api/performance-api/host-platform-timing/ios-host-platform-timing",
       "name": "ios-host-platform-timing",
       "category": "lynx-api/performance-api",
@@ -111229,7 +113018,7 @@
       }
     },
     {
-      "id": "feature-1133",
+      "id": "feature-1145",
       "query": "lynx-api/performance-api/performance-entry/entry-type",
       "name": "entry-type",
       "category": "lynx-api/performance-api",
@@ -111265,7 +113054,7 @@
       }
     },
     {
-      "id": "feature-1134",
+      "id": "feature-1146",
       "query": "lynx-api/performance-api/performance-entry/init-background-runtime-entry",
       "name": "Entry for background runtime initialization performance data.",
       "category": "lynx-api/performance-api",
@@ -111301,7 +113090,7 @@
       }
     },
     {
-      "id": "feature-1135",
+      "id": "feature-1147",
       "query": "lynx-api/performance-api/performance-entry/init-container-entry",
       "name": "init-container-entry",
       "category": "lynx-api/performance-api",
@@ -111337,7 +113126,7 @@
       }
     },
     {
-      "id": "feature-1136",
+      "id": "feature-1148",
       "query": "lynx-api/performance-api/performance-entry/init-lynxview-entry",
       "name": "init-lynxview-entry",
       "category": "lynx-api/performance-api",
@@ -111373,7 +113162,7 @@
       }
     },
     {
-      "id": "feature-1137",
+      "id": "feature-1149",
       "query": "lynx-api/performance-api/performance-entry/lazy-bundle-entry",
       "name": "lazy-bundle-entry",
       "category": "lynx-api/performance-api",
@@ -111409,7 +113198,7 @@
       }
     },
     {
-      "id": "feature-1138",
+      "id": "feature-1150",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry",
       "name": "load-bundle-entry",
       "category": "lynx-api/performance-api",
@@ -111445,7 +113234,7 @@
       }
     },
     {
-      "id": "feature-1139",
+      "id": "feature-1151",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.entryType",
       "name": "entryType",
       "category": "lynx-api/performance-api",
@@ -111481,7 +113270,7 @@
       }
     },
     {
-      "id": "feature-1140",
+      "id": "feature-1152",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.name",
       "name": "name",
       "category": "lynx-api/performance-api",
@@ -111517,7 +113306,7 @@
       }
     },
     {
-      "id": "feature-1141",
+      "id": "feature-1153",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.identifier",
       "name": "identifier",
       "category": "lynx-api/performance-api",
@@ -111553,7 +113342,7 @@
       }
     },
     {
-      "id": "feature-1142",
+      "id": "feature-1154",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.loadBundleStart",
       "name": "loadBundleStart",
       "category": "lynx-api/performance-api",
@@ -111589,7 +113378,7 @@
       }
     },
     {
-      "id": "feature-1143",
+      "id": "feature-1155",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.loadBundleEnd",
       "name": "loadBundleEnd",
       "category": "lynx-api/performance-api",
@@ -111625,7 +113414,7 @@
       }
     },
     {
-      "id": "feature-1144",
+      "id": "feature-1156",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.parseStart",
       "name": "parseStart",
       "category": "lynx-api/performance-api",
@@ -111661,7 +113450,7 @@
       }
     },
     {
-      "id": "feature-1145",
+      "id": "feature-1157",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.parseEnd",
       "name": "parseEnd",
       "category": "lynx-api/performance-api",
@@ -111697,7 +113486,7 @@
       }
     },
     {
-      "id": "feature-1146",
+      "id": "feature-1158",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.loadBackgroundStart",
       "name": "loadBackgroundStart",
       "category": "lynx-api/performance-api",
@@ -111733,7 +113522,7 @@
       }
     },
     {
-      "id": "feature-1147",
+      "id": "feature-1159",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.loadBackgroundEnd",
       "name": "loadBackgroundEnd",
       "category": "lynx-api/performance-api",
@@ -111769,7 +113558,7 @@
       }
     },
     {
-      "id": "feature-1148",
+      "id": "feature-1160",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.pipelineStart",
       "name": "pipelineStart",
       "category": "lynx-api/performance-api",
@@ -111805,7 +113594,7 @@
       }
     },
     {
-      "id": "feature-1149",
+      "id": "feature-1161",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.pipelineEnd",
       "name": "pipelineEnd",
       "category": "lynx-api/performance-api",
@@ -111841,7 +113630,7 @@
       }
     },
     {
-      "id": "feature-1150",
+      "id": "feature-1162",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.mtsRenderStart",
       "name": "mtsRenderStart",
       "category": "lynx-api/performance-api",
@@ -111877,7 +113666,7 @@
       }
     },
     {
-      "id": "feature-1151",
+      "id": "feature-1163",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.mtsRenderEnd",
       "name": "mtsRenderEnd",
       "category": "lynx-api/performance-api",
@@ -111913,7 +113702,7 @@
       }
     },
     {
-      "id": "feature-1152",
+      "id": "feature-1164",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.resolveStart",
       "name": "resolveStart",
       "category": "lynx-api/performance-api",
@@ -111949,7 +113738,7 @@
       }
     },
     {
-      "id": "feature-1153",
+      "id": "feature-1165",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.resolveEnd",
       "name": "resolveEnd",
       "category": "lynx-api/performance-api",
@@ -111985,7 +113774,7 @@
       }
     },
     {
-      "id": "feature-1154",
+      "id": "feature-1166",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.layoutStart",
       "name": "layoutStart",
       "category": "lynx-api/performance-api",
@@ -112021,7 +113810,7 @@
       }
     },
     {
-      "id": "feature-1155",
+      "id": "feature-1167",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.paintingUiOperationExecuteEnd",
       "name": "paintingUiOperationExecuteEnd",
       "category": "lynx-api/performance-api",
@@ -112057,7 +113846,7 @@
       }
     },
     {
-      "id": "feature-1156",
+      "id": "feature-1168",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.layoutUiOperationExecuteStart",
       "name": "layoutUiOperationExecuteStart",
       "category": "lynx-api/performance-api",
@@ -112093,7 +113882,7 @@
       }
     },
     {
-      "id": "feature-1157",
+      "id": "feature-1169",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.layoutUiOperationExecuteEnd",
       "name": "layoutUiOperationExecuteEnd",
       "category": "lynx-api/performance-api",
@@ -112129,7 +113918,7 @@
       }
     },
     {
-      "id": "feature-1158",
+      "id": "feature-1170",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.paintEnd",
       "name": "paintEnd",
       "category": "lynx-api/performance-api",
@@ -112165,7 +113954,7 @@
       }
     },
     {
-      "id": "feature-1159",
+      "id": "feature-1171",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.frameworkPipelineTiming",
       "name": "frameworkPipelineTiming",
       "category": "lynx-api/performance-api",
@@ -112201,7 +113990,7 @@
       }
     },
     {
-      "id": "feature-1160",
+      "id": "feature-1172",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.loadCoreStart",
       "name": "loadCoreStart",
       "category": "lynx-api/performance-api",
@@ -112237,7 +114026,7 @@
       }
     },
     {
-      "id": "feature-1161",
+      "id": "feature-1173",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.loadCoreEnd",
       "name": "loadCoreEnd",
       "category": "lynx-api/performance-api",
@@ -112273,7 +114062,7 @@
       }
     },
     {
-      "id": "feature-1162",
+      "id": "feature-1174",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.openTime",
       "name": "openTime",
       "category": "lynx-api/performance-api",
@@ -112309,7 +114098,7 @@
       }
     },
     {
-      "id": "feature-1163",
+      "id": "feature-1175",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.containerInitStart",
       "name": "containerInitStart",
       "category": "lynx-api/performance-api",
@@ -112345,7 +114134,7 @@
       }
     },
     {
-      "id": "feature-1164",
+      "id": "feature-1176",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.containerInitEnd",
       "name": "containerInitEnd",
       "category": "lynx-api/performance-api",
@@ -112381,7 +114170,7 @@
       }
     },
     {
-      "id": "feature-1165",
+      "id": "feature-1177",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.prepareTemplateStart",
       "name": "prepareTemplateStart",
       "category": "lynx-api/performance-api",
@@ -112417,7 +114206,7 @@
       }
     },
     {
-      "id": "feature-1166",
+      "id": "feature-1178",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.prepareTemplateEnd",
       "name": "prepareTemplateEnd",
       "category": "lynx-api/performance-api",
@@ -112453,7 +114242,7 @@
       }
     },
     {
-      "id": "feature-1167",
+      "id": "feature-1179",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.createLynxStart",
       "name": "createLynxStart",
       "category": "lynx-api/performance-api",
@@ -112489,7 +114278,7 @@
       }
     },
     {
-      "id": "feature-1168",
+      "id": "feature-1180",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.createLynxEnd",
       "name": "createLynxEnd",
       "category": "lynx-api/performance-api",
@@ -112525,7 +114314,7 @@
       }
     },
     {
-      "id": "feature-1169",
+      "id": "feature-1181",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.fcp",
       "name": "fcp",
       "category": "lynx-api/performance-api",
@@ -112561,7 +114350,7 @@
       }
     },
     {
-      "id": "feature-1170",
+      "id": "feature-1182",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.lynxFcp",
       "name": "lynxFcp",
       "category": "lynx-api/performance-api",
@@ -112597,7 +114386,7 @@
       }
     },
     {
-      "id": "feature-1171",
+      "id": "feature-1183",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.totalFcp",
       "name": "totalFcp",
       "category": "lynx-api/performance-api",
@@ -112633,7 +114422,7 @@
       }
     },
     {
-      "id": "feature-1172",
+      "id": "feature-1184",
       "query": "lynx-api/performance-api/performance-entry/metric-actual-fmp-entry",
       "name": "metric-actual-fmp-entry",
       "category": "lynx-api/performance-api",
@@ -112669,7 +114458,7 @@
       }
     },
     {
-      "id": "feature-1173",
+      "id": "feature-1185",
       "query": "lynx-api/performance-api/performance-entry/metric-fcp-entry",
       "name": "metric-fcp-entry",
       "category": "lynx-api/performance-api",
@@ -112705,7 +114494,7 @@
       }
     },
     {
-      "id": "feature-1174",
+      "id": "feature-1186",
       "query": "lynx-api/performance-api/performance-entry/name",
       "name": "name",
       "category": "lynx-api/performance-api",
@@ -112741,7 +114530,7 @@
       }
     },
     {
-      "id": "feature-1175",
+      "id": "feature-1187",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry",
       "name": "pipeline-entry",
       "category": "lynx-api/performance-api",
@@ -112777,7 +114566,7 @@
       }
     },
     {
-      "id": "feature-1176",
+      "id": "feature-1188",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.entryType",
       "name": "entryType",
       "category": "lynx-api/performance-api",
@@ -112813,7 +114602,7 @@
       }
     },
     {
-      "id": "feature-1177",
+      "id": "feature-1189",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.name",
       "name": "name",
       "category": "lynx-api/performance-api",
@@ -112849,7 +114638,7 @@
       }
     },
     {
-      "id": "feature-1178",
+      "id": "feature-1190",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.identifier",
       "name": "identifier",
       "category": "lynx-api/performance-api",
@@ -112885,7 +114674,7 @@
       }
     },
     {
-      "id": "feature-1179",
+      "id": "feature-1191",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.pipelineStart",
       "name": "pipelineStart",
       "category": "lynx-api/performance-api",
@@ -112921,7 +114710,7 @@
       }
     },
     {
-      "id": "feature-1180",
+      "id": "feature-1192",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.pipelineEnd",
       "name": "pipelineEnd",
       "category": "lynx-api/performance-api",
@@ -112957,7 +114746,7 @@
       }
     },
     {
-      "id": "feature-1181",
+      "id": "feature-1193",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.mtsRenderStart",
       "name": "mtsRenderStart",
       "category": "lynx-api/performance-api",
@@ -112993,7 +114782,7 @@
       }
     },
     {
-      "id": "feature-1182",
+      "id": "feature-1194",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.mtsRenderEnd",
       "name": "mtsRenderEnd",
       "category": "lynx-api/performance-api",
@@ -113029,7 +114818,7 @@
       }
     },
     {
-      "id": "feature-1183",
+      "id": "feature-1195",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.resolveStart",
       "name": "resolveStart",
       "category": "lynx-api/performance-api",
@@ -113065,7 +114854,7 @@
       }
     },
     {
-      "id": "feature-1184",
+      "id": "feature-1196",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.resolveEnd",
       "name": "resolveEnd",
       "category": "lynx-api/performance-api",
@@ -113101,7 +114890,7 @@
       }
     },
     {
-      "id": "feature-1185",
+      "id": "feature-1197",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.layoutStart",
       "name": "layoutStart",
       "category": "lynx-api/performance-api",
@@ -113137,7 +114926,7 @@
       }
     },
     {
-      "id": "feature-1186",
+      "id": "feature-1198",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.paintingUiOperationExecuteEnd",
       "name": "paintingUiOperationExecuteEnd",
       "category": "lynx-api/performance-api",
@@ -113173,7 +114962,7 @@
       }
     },
     {
-      "id": "feature-1187",
+      "id": "feature-1199",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.layoutUiOperationExecuteStart",
       "name": "layoutUiOperationExecuteStart",
       "category": "lynx-api/performance-api",
@@ -113209,7 +114998,7 @@
       }
     },
     {
-      "id": "feature-1188",
+      "id": "feature-1200",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.layoutUiOperationExecuteEnd",
       "name": "layoutUiOperationExecuteEnd",
       "category": "lynx-api/performance-api",
@@ -113245,7 +115034,7 @@
       }
     },
     {
-      "id": "feature-1189",
+      "id": "feature-1201",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.paintEnd",
       "name": "paintEnd",
       "category": "lynx-api/performance-api",
@@ -113281,7 +115070,7 @@
       }
     },
     {
-      "id": "feature-1190",
+      "id": "feature-1202",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.frameworkPipelineTiming",
       "name": "frameworkPipelineTiming",
       "category": "lynx-api/performance-api",
@@ -113317,7 +115106,7 @@
       }
     },
     {
-      "id": "feature-1191",
+      "id": "feature-1203",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.hostPlatformTiming",
       "name": "hostPlatformTiming",
       "category": "lynx-api/performance-api",
@@ -113353,7 +115142,7 @@
       }
     },
     {
-      "id": "feature-1192",
+      "id": "feature-1204",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.actualFmp",
       "name": "actualFmp",
       "category": "lynx-api/performance-api",
@@ -113389,7 +115178,7 @@
       }
     },
     {
-      "id": "feature-1193",
+      "id": "feature-1205",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.lynxActualFmp",
       "name": "lynxActualFmp",
       "category": "lynx-api/performance-api",
@@ -113425,7 +115214,7 @@
       }
     },
     {
-      "id": "feature-1194",
+      "id": "feature-1206",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.totalActualFmp",
       "name": "totalActualFmp",
       "category": "lynx-api/performance-api",
@@ -113461,7 +115250,7 @@
       }
     },
     {
-      "id": "feature-1195",
+      "id": "feature-1207",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry",
       "name": "reload-bundle-entry",
       "category": "lynx-api/performance-api",
@@ -113497,7 +115286,7 @@
       }
     },
     {
-      "id": "feature-1196",
+      "id": "feature-1208",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.entryType",
       "name": "entryType",
       "category": "lynx-api/performance-api",
@@ -113533,7 +115322,7 @@
       }
     },
     {
-      "id": "feature-1197",
+      "id": "feature-1209",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.name",
       "name": "name",
       "category": "lynx-api/performance-api",
@@ -113569,7 +115358,7 @@
       }
     },
     {
-      "id": "feature-1198",
+      "id": "feature-1210",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.identifier",
       "name": "identifier",
       "category": "lynx-api/performance-api",
@@ -113605,7 +115394,7 @@
       }
     },
     {
-      "id": "feature-1199",
+      "id": "feature-1211",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.reloadBundleStart",
       "name": "reloadBundleStart",
       "category": "lynx-api/performance-api",
@@ -113641,7 +115430,7 @@
       }
     },
     {
-      "id": "feature-1200",
+      "id": "feature-1212",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.reloadBundleEnd",
       "name": "reloadBundleEnd",
       "category": "lynx-api/performance-api",
@@ -113677,7 +115466,7 @@
       }
     },
     {
-      "id": "feature-1201",
+      "id": "feature-1213",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.reloadBackgroundStart",
       "name": "reloadBackgroundStart",
       "category": "lynx-api/performance-api",
@@ -113713,7 +115502,7 @@
       }
     },
     {
-      "id": "feature-1202",
+      "id": "feature-1214",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.reloadBackgroundEnd",
       "name": "reloadBackgroundEnd",
       "category": "lynx-api/performance-api",
@@ -113749,7 +115538,7 @@
       }
     },
     {
-      "id": "feature-1203",
+      "id": "feature-1215",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.pipelineStart",
       "name": "pipelineStart",
       "category": "lynx-api/performance-api",
@@ -113785,7 +115574,7 @@
       }
     },
     {
-      "id": "feature-1204",
+      "id": "feature-1216",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.pipelineEnd",
       "name": "pipelineEnd",
       "category": "lynx-api/performance-api",
@@ -113821,7 +115610,7 @@
       }
     },
     {
-      "id": "feature-1205",
+      "id": "feature-1217",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.mtsRenderStart",
       "name": "mtsRenderStart",
       "category": "lynx-api/performance-api",
@@ -113857,7 +115646,7 @@
       }
     },
     {
-      "id": "feature-1206",
+      "id": "feature-1218",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.mtsRenderEnd",
       "name": "mtsRenderEnd",
       "category": "lynx-api/performance-api",
@@ -113893,7 +115682,7 @@
       }
     },
     {
-      "id": "feature-1207",
+      "id": "feature-1219",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.resolveStart",
       "name": "resolveStart",
       "category": "lynx-api/performance-api",
@@ -113929,7 +115718,7 @@
       }
     },
     {
-      "id": "feature-1208",
+      "id": "feature-1220",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.resolveEnd",
       "name": "resolveEnd",
       "category": "lynx-api/performance-api",
@@ -113965,7 +115754,7 @@
       }
     },
     {
-      "id": "feature-1209",
+      "id": "feature-1221",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.layoutStart",
       "name": "layoutStart",
       "category": "lynx-api/performance-api",
@@ -114001,7 +115790,7 @@
       }
     },
     {
-      "id": "feature-1210",
+      "id": "feature-1222",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.paintingUiOperationExecuteEnd",
       "name": "paintingUiOperationExecuteEnd",
       "category": "lynx-api/performance-api",
@@ -114037,7 +115826,7 @@
       }
     },
     {
-      "id": "feature-1211",
+      "id": "feature-1223",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.layoutUiOperationExecuteStart",
       "name": "layoutUiOperationExecuteStart",
       "category": "lynx-api/performance-api",
@@ -114073,7 +115862,7 @@
       }
     },
     {
-      "id": "feature-1212",
+      "id": "feature-1224",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.layoutUiOperationExecuteEnd",
       "name": "layoutUiOperationExecuteEnd",
       "category": "lynx-api/performance-api",
@@ -114109,7 +115898,7 @@
       }
     },
     {
-      "id": "feature-1213",
+      "id": "feature-1225",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.paintEnd",
       "name": "paintEnd",
       "category": "lynx-api/performance-api",
@@ -114145,7 +115934,7 @@
       }
     },
     {
-      "id": "feature-1214",
+      "id": "feature-1226",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.frameworkPipelineTiming",
       "name": "frameworkPipelineTiming",
       "category": "lynx-api/performance-api",
@@ -114181,7 +115970,7 @@
       }
     },
     {
-      "id": "feature-1215",
+      "id": "feature-1227",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.loadCoreStart",
       "name": "loadCoreStart",
       "category": "lynx-api/performance-api",
@@ -114217,7 +116006,7 @@
       }
     },
     {
-      "id": "feature-1216",
+      "id": "feature-1228",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.loadCoreEnd",
       "name": "loadCoreEnd",
       "category": "lynx-api/performance-api",
@@ -114253,7 +116042,7 @@
       }
     },
     {
-      "id": "feature-1217",
+      "id": "feature-1229",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.openTime",
       "name": "openTime",
       "category": "lynx-api/performance-api",
@@ -114289,7 +116078,7 @@
       }
     },
     {
-      "id": "feature-1218",
+      "id": "feature-1230",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.containerInitStart",
       "name": "containerInitStart",
       "category": "lynx-api/performance-api",
@@ -114325,7 +116114,7 @@
       }
     },
     {
-      "id": "feature-1219",
+      "id": "feature-1231",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.containerInitEnd",
       "name": "containerInitEnd",
       "category": "lynx-api/performance-api",
@@ -114361,7 +116150,7 @@
       }
     },
     {
-      "id": "feature-1220",
+      "id": "feature-1232",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.prepareTemplateStart",
       "name": "prepareTemplateStart",
       "category": "lynx-api/performance-api",
@@ -114397,7 +116186,7 @@
       }
     },
     {
-      "id": "feature-1221",
+      "id": "feature-1233",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.prepareTemplateEnd",
       "name": "prepareTemplateEnd",
       "category": "lynx-api/performance-api",
@@ -114433,7 +116222,7 @@
       }
     },
     {
-      "id": "feature-1222",
+      "id": "feature-1234",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.createLynxStart",
       "name": "createLynxStart",
       "category": "lynx-api/performance-api",
@@ -114469,7 +116258,7 @@
       }
     },
     {
-      "id": "feature-1223",
+      "id": "feature-1235",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.createLynxEnd",
       "name": "createLynxEnd",
       "category": "lynx-api/performance-api",
@@ -114505,7 +116294,7 @@
       }
     },
     {
-      "id": "feature-1224",
+      "id": "feature-1236",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.fcp",
       "name": "fcp",
       "category": "lynx-api/performance-api",
@@ -114541,7 +116330,7 @@
       }
     },
     {
-      "id": "feature-1225",
+      "id": "feature-1237",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.lynxFcp",
       "name": "lynxFcp",
       "category": "lynx-api/performance-api",
@@ -114577,7 +116366,7 @@
       }
     },
     {
-      "id": "feature-1226",
+      "id": "feature-1238",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.totalFcp",
       "name": "totalFcp",
       "category": "lynx-api/performance-api",
@@ -114613,7 +116402,7 @@
       }
     },
     {
-      "id": "feature-1227",
+      "id": "feature-1239",
       "query": "lynx-api/performance-api/performance-entry",
       "name": "performance-entry",
       "category": "lynx-api/performance-api",
@@ -114649,7 +116438,7 @@
       }
     },
     {
-      "id": "feature-1228",
+      "id": "feature-1240",
       "query": "lynx-api/performance-api/performance-metric",
       "name": "performance-metric",
       "category": "lynx-api/performance-api",
@@ -114685,7 +116474,7 @@
       }
     },
     {
-      "id": "feature-1229",
+      "id": "feature-1241",
       "query": "lynx-api/performance-api/performance-observer/disconnect",
       "name": "disconnect",
       "category": "lynx-api/performance-api",
@@ -114721,7 +116510,7 @@
       }
     },
     {
-      "id": "feature-1230",
+      "id": "feature-1242",
       "query": "lynx-api/performance-api/performance-observer/observe",
       "name": "observe",
       "category": "lynx-api/performance-api",
@@ -114757,7 +116546,7 @@
       }
     },
     {
-      "id": "feature-1231",
+      "id": "feature-1243",
       "query": "lynx-api/performance-api/performance-observer",
       "name": "performance-observer",
       "category": "lynx-api/performance-api",
@@ -114793,7 +116582,7 @@
       }
     },
     {
-      "id": "feature-1232",
+      "id": "feature-1244",
       "query": "lynx-api/performance-api/timing-flag",
       "name": "timing-flag",
       "category": "lynx-api/performance-api",
@@ -114829,7 +116618,7 @@
       }
     },
     {
-      "id": "feature-1233",
+      "id": "feature-1245",
       "query": "lynx-native-api/lynx-background-runtime/add-lynx-background-runtime-client",
       "name": "register lifecycle observer for background runtime",
       "category": "lynx-native-api",
@@ -114865,7 +116654,7 @@
       }
     },
     {
-      "id": "feature-1234",
+      "id": "feature-1246",
       "query": "lynx-native-api/lynx-background-runtime/call-js-function",
       "name": "invoke js function from background runtime",
       "category": "lynx-native-api",
@@ -114901,7 +116690,7 @@
       }
     },
     {
-      "id": "feature-1235",
+      "id": "feature-1247",
       "query": "lynx-native-api/lynx-background-runtime/destroy",
       "name": "manually destroy background runtime instance",
       "category": "lynx-native-api",
@@ -114937,7 +116726,7 @@
       }
     },
     {
-      "id": "feature-1236",
+      "id": "feature-1248",
       "query": "lynx-native-api/lynx-background-runtime/evaluate-java-script",
       "name": "evaluate background runtime script",
       "category": "lynx-native-api",
@@ -114973,7 +116762,7 @@
       }
     },
     {
-      "id": "feature-1237",
+      "id": "feature-1249",
       "query": "lynx-native-api/lynx-background-runtime/remove-lynx-background-runtime-client",
       "name": "remove lifecycle observer for background runtime",
       "category": "lynx-native-api",
@@ -115009,7 +116798,7 @@
       }
     },
     {
-      "id": "feature-1238",
+      "id": "feature-1250",
       "query": "lynx-native-api/lynx-background-runtime/send-global-event",
       "name": "send global event to js environment from background runtime",
       "category": "lynx-native-api",
@@ -115045,7 +116834,7 @@
       }
     },
     {
-      "id": "feature-1239",
+      "id": "feature-1251",
       "query": "lynx-native-api/lynx-background-runtime-client/on-evaluate-java-script-end",
       "name": "Called when background script evaluation finished.",
       "category": "lynx-native-api",
@@ -115081,7 +116870,7 @@
       }
     },
     {
-      "id": "feature-1240",
+      "id": "feature-1252",
       "query": "lynx-native-api/lynx-background-runtime-client/on-module-method-invoked",
       "name": "Called when a module method invocation completed in background runtime.",
       "category": "lynx-native-api",
@@ -115117,7 +116906,7 @@
       }
     },
     {
-      "id": "feature-1241",
+      "id": "feature-1253",
       "query": "lynx-native-api/lynx-background-runtime-client/on-received-error",
       "name": "Called when an error is received in background runtime.",
       "category": "lynx-native-api",
@@ -115153,7 +116942,7 @@
       }
     },
     {
-      "id": "feature-1242",
+      "id": "feature-1254",
       "query": "lynx-native-api/lynx-context/send-global-event",
       "name": "send global event to js environment",
       "category": "lynx-native-api",
@@ -115189,7 +116978,7 @@
       }
     },
     {
-      "id": "feature-1243",
+      "id": "feature-1255",
       "query": "lynx-native-api/lynx-context/set-extra-timing",
       "name": "set extra timing from outside.",
       "category": "lynx-native-api",
@@ -115225,7 +117014,7 @@
       }
     },
     {
-      "id": "feature-1244",
+      "id": "feature-1256",
       "query": "lynx-native-api/lynx-context/update-font-scale",
       "name": "update font scale of lynxView",
       "category": "lynx-native-api",
@@ -115261,7 +117050,7 @@
       }
     },
     {
-      "id": "feature-1245",
+      "id": "feature-1257",
       "query": "lynx-native-api/lynx-context/update-meta-data",
       "name": "update lynx page by new data.",
       "category": "lynx-native-api",
@@ -115297,7 +117086,7 @@
       }
     },
     {
-      "id": "feature-1246",
+      "id": "feature-1258",
       "query": "lynx-native-api/lynx-context/update-viewport",
       "name": "update viewport of lynxView",
       "category": "lynx-native-api",
@@ -115333,7 +117122,7 @@
       }
     },
     {
-      "id": "feature-1247",
+      "id": "feature-1259",
       "query": "lynx-native-api/lynx-env/trim-memory",
       "name": "dispatch memory pressure signal to registered callbacks",
       "category": "lynx-native-api",
@@ -115369,7 +117158,7 @@
       }
     },
     {
-      "id": "feature-1248",
+      "id": "feature-1260",
       "query": "lynx-native-api/lynx-extension-module",
       "name": "Desktop-only extension module entry for lifecycle hooks, NAPI binding, VSync, and native view registration.",
       "category": "lynx-native-api",
@@ -115405,7 +117194,7 @@
       }
     },
     {
-      "id": "feature-1249",
+      "id": "feature-1261",
       "query": "lynx-native-api/lynx-generic-resource-fetcher/cancel",
       "name": "Cancel the request of the requiring resource.",
       "category": "lynx-native-api",
@@ -115441,7 +117230,7 @@
       }
     },
     {
-      "id": "feature-1250",
+      "id": "feature-1262",
       "query": "lynx-native-api/lynx-generic-resource-fetcher/fetch-resource-path",
       "name": "LynxEngine internally calls this method to obtain the path of the common resource on the local disk, and the return result is required to be of String type.",
       "category": "lynx-native-api",
@@ -115477,7 +117266,7 @@
       }
     },
     {
-      "id": "feature-1251",
+      "id": "feature-1263",
       "query": "lynx-native-api/lynx-generic-resource-fetcher/fetch-resource",
       "name": "LynxEngine internally calls this method to obtain the general resource content, and the return result is required to be the resource content byte[] type.",
       "category": "lynx-native-api",
@@ -115513,7 +117302,7 @@
       }
     },
     {
-      "id": "feature-1252",
+      "id": "feature-1264",
       "query": "lynx-native-api/lynx-generic-resource-fetcher/fetch-stream",
       "name": "LynxEngine internally calls this method to obtain resource content in a streaming manner.",
       "category": "lynx-native-api",
@@ -115549,7 +117338,7 @@
       }
     },
     {
-      "id": "feature-1253",
+      "id": "feature-1265",
       "query": "lynx-native-api/lynx-load-meta",
       "name": "MetaData of LynxEngine loadProcess",
       "category": "lynx-native-api",
@@ -115585,7 +117374,7 @@
       }
     },
     {
-      "id": "feature-1254",
+      "id": "feature-1266",
       "query": "lynx-native-api/lynx-media-resource-fetcher/fetch-image",
       "name": "LynxEngine will use this method to obtain the bitmap information of the image, and the return content must be of Closeable type.",
       "category": "lynx-native-api",
@@ -115621,7 +117410,7 @@
       }
     },
     {
-      "id": "feature-1255",
+      "id": "feature-1267",
       "query": "lynx-native-api/lynx-media-resource-fetcher/is-local-resource",
       "name": "LynxEngine internally calls this method to determine whether the resource path exists on disk.",
       "category": "lynx-native-api",
@@ -115657,7 +117446,7 @@
       }
     },
     {
-      "id": "feature-1256",
+      "id": "feature-1268",
       "query": "lynx-native-api/lynx-media-resource-fetcher/should-redirect-url",
       "name": "LynxEngine redirects the image path by calling this method internally, and the return result is required to be of String type.",
       "category": "lynx-native-api",
@@ -115693,7 +117482,7 @@
       }
     },
     {
-      "id": "feature-1257",
+      "id": "feature-1269",
       "query": "lynx-native-api/lynx-service/lynx-service",
       "name": "LynxService API",
       "category": "lynx-native-api",
@@ -115729,7 +117518,7 @@
       }
     },
     {
-      "id": "feature-1258",
+      "id": "feature-1270",
       "query": "lynx-native-api/lynx-template-resource-fetcher/fetch-template",
       "name": "LynxEngine internally calls this method to obtain the contents of Bundle and Lazy Bundle. The returned result type can contain byte[] or TemplateBundle.",
       "category": "lynx-native-api",
@@ -115765,7 +117554,7 @@
       }
     },
     {
-      "id": "feature-1259",
+      "id": "feature-1271",
       "query": "lynx-native-api/lynx-update-meta",
       "name": "MetaData of LynxEngine updateProcess",
       "category": "lynx-native-api",
@@ -115801,7 +117590,7 @@
       }
     },
     {
-      "id": "feature-1260",
+      "id": "feature-1272",
       "query": "lynx-native-api/lynx-view/add-lynx-view-client",
       "name": "register lifecycle observer for lynxView",
       "category": "lynx-native-api",
@@ -115837,7 +117626,7 @@
       }
     },
     {
-      "id": "feature-1261",
+      "id": "feature-1273",
       "query": "lynx-native-api/lynx-view/destroy",
       "name": "manually destroy lynxView instance",
       "category": "lynx-native-api",
@@ -115873,7 +117662,7 @@
       }
     },
     {
-      "id": "feature-1262",
+      "id": "feature-1274",
       "query": "lynx-native-api/lynx-view/find-ui-by-id-selector",
       "name": "find ui by idselector",
       "category": "lynx-native-api",
@@ -115909,7 +117698,7 @@
       }
     },
     {
-      "id": "feature-1263",
+      "id": "feature-1275",
       "query": "lynx-native-api/lynx-view/find-ui-by-name",
       "name": "find ui by name",
       "category": "lynx-native-api",
@@ -115945,7 +117734,7 @@
       }
     },
     {
-      "id": "feature-1264",
+      "id": "feature-1276",
       "query": "lynx-native-api/lynx-view/find-view-by-id-selector",
       "name": "find view by idselector",
       "category": "lynx-native-api",
@@ -115981,7 +117770,7 @@
       }
     },
     {
-      "id": "feature-1265",
+      "id": "feature-1277",
       "query": "lynx-native-api/lynx-view/find-view-by-name",
       "name": "find view by name",
       "category": "lynx-native-api",
@@ -116017,7 +117806,7 @@
       }
     },
     {
-      "id": "feature-1266",
+      "id": "feature-1278",
       "query": "lynx-native-api/lynx-view/load-template",
       "name": "load a lynx template file by LynxView.",
       "category": "lynx-native-api",
@@ -116053,7 +117842,7 @@
       }
     },
     {
-      "id": "feature-1267",
+      "id": "feature-1279",
       "query": "lynx-native-api/lynx-view/lynx-view-custom-element",
       "name": "<code>lynx-view</code> The custom element of LynxView.",
       "category": "lynx-native-api",
@@ -116089,7 +117878,7 @@
       }
     },
     {
-      "id": "feature-1268",
+      "id": "feature-1280",
       "query": "lynx-native-api/lynx-view/reload",
       "name": "reload lynx page.",
       "category": "lynx-native-api",
@@ -116125,7 +117914,7 @@
       }
     },
     {
-      "id": "feature-1269",
+      "id": "feature-1281",
       "query": "lynx-native-api/lynx-view/remove-lynx-view-client",
       "name": "remove lifecycle observer of lynxView",
       "category": "lynx-native-api",
@@ -116161,7 +117950,7 @@
       }
     },
     {
-      "id": "feature-1270",
+      "id": "feature-1282",
       "query": "lynx-native-api/lynx-view/send-global-event",
       "name": "send global event to js environment",
       "category": "lynx-native-api",
@@ -116197,7 +117986,7 @@
       }
     },
     {
-      "id": "feature-1271",
+      "id": "feature-1283",
       "query": "lynx-native-api/lynx-view/set-extra-timing",
       "name": "set extra timing from outside.",
       "category": "lynx-native-api",
@@ -116233,7 +118022,7 @@
       }
     },
     {
-      "id": "feature-1272",
+      "id": "feature-1284",
       "query": "lynx-native-api/lynx-view/update-font-scale",
       "name": "update font scale of lynxView",
       "category": "lynx-native-api",
@@ -116269,7 +118058,7 @@
       }
     },
     {
-      "id": "feature-1273",
+      "id": "feature-1285",
       "query": "lynx-native-api/lynx-view/update-meta-data",
       "name": "update lynx page by new data.",
       "category": "lynx-native-api",
@@ -116305,7 +118094,7 @@
       }
     },
     {
-      "id": "feature-1274",
+      "id": "feature-1286",
       "query": "lynx-native-api/lynx-view/update-screen-metrics",
       "name": "update screen metrics",
       "category": "lynx-native-api",
@@ -116341,7 +118130,7 @@
       }
     },
     {
-      "id": "feature-1275",
+      "id": "feature-1287",
       "query": "lynx-native-api/lynx-view/update-viewport",
       "name": "update viewport of lynxView",
       "category": "lynx-native-api",
@@ -116377,7 +118166,7 @@
       }
     },
     {
-      "id": "feature-1276",
+      "id": "feature-1288",
       "query": "lynx-native-api/lynx-view-client/on-data-updated",
       "name": "Called when data update, but the view may not be updated.",
       "category": "lynx-native-api",
@@ -116413,7 +118202,7 @@
       }
     },
     {
-      "id": "feature-1277",
+      "id": "feature-1289",
       "query": "lynx-native-api/lynx-view-client/on-destroy",
       "name": "Called after the page is destroyed.",
       "category": "lynx-native-api",
@@ -116449,7 +118238,7 @@
       }
     },
     {
-      "id": "feature-1278",
+      "id": "feature-1290",
       "query": "lynx-native-api/lynx-view-client/on-first-load-perf-ready",
       "name": "Performance data statistics callback after the first load is completed.",
       "category": "lynx-native-api",
@@ -116485,7 +118274,7 @@
       }
     },
     {
-      "id": "feature-1279",
+      "id": "feature-1291",
       "query": "lynx-native-api/lynx-view-client/on-first-screen",
       "name": "Called when first screen layout completed.",
       "category": "lynx-native-api",
@@ -116521,7 +118310,7 @@
       }
     },
     {
-      "id": "feature-1280",
+      "id": "feature-1292",
       "query": "lynx-native-api/lynx-view-client/on-fling",
       "name": "Called when inertial scrolling starts after releasing the finger.",
       "category": "lynx-native-api",
@@ -116557,7 +118346,7 @@
       }
     },
     {
-      "id": "feature-1281",
+      "id": "feature-1293",
       "query": "lynx-native-api/lynx-view-client/on-flush-finish",
       "name": "Called when UI flush end in async render mode.",
       "category": "lynx-native-api",
@@ -116593,7 +118382,7 @@
       }
     },
     {
-      "id": "feature-1282",
+      "id": "feature-1294",
       "query": "lynx-native-api/lynx-view-client/on-key-event",
       "name": "Report all android key events with flag indicating whether has been handled.",
       "category": "lynx-native-api",
@@ -116629,7 +118418,7 @@
       }
     },
     {
-      "id": "feature-1283",
+      "id": "feature-1295",
       "query": "lynx-native-api/lynx-view-client/on-load-success",
       "name": "Called when page load finish.",
       "category": "lynx-native-api",
@@ -116665,7 +118454,7 @@
       }
     },
     {
-      "id": "feature-1284",
+      "id": "feature-1296",
       "query": "lynx-native-api/lynx-view-client/on-lynx-event",
       "name": "Report Lynx events that sended to frontend.",
       "category": "lynx-native-api",
@@ -116701,7 +118490,7 @@
       }
     },
     {
-      "id": "feature-1285",
+      "id": "feature-1297",
       "query": "lynx-native-api/lynx-view-client/on-lynx-view-and-js-runtime-destroy",
       "name": "Called when lynx view and js runtime destroy.",
       "category": "lynx-native-api",
@@ -116737,7 +118526,7 @@
       }
     },
     {
-      "id": "feature-1286",
+      "id": "feature-1298",
       "query": "lynx-native-api/lynx-view-client/on-module-method-invoked",
       "name": "Called when module method invocation completed.",
       "category": "lynx-native-api",
@@ -116773,7 +118562,7 @@
       }
     },
     {
-      "id": "feature-1287",
+      "id": "feature-1299",
       "query": "lynx-native-api/lynx-view-client/on-page-start",
       "name": "Called when page start loading.",
       "category": "lynx-native-api",
@@ -116809,7 +118598,7 @@
       }
     },
     {
-      "id": "feature-1288",
+      "id": "feature-1300",
       "query": "lynx-native-api/lynx-view-client/on-page-update",
       "name": "Called when page update.",
       "category": "lynx-native-api",
@@ -116845,7 +118634,7 @@
       }
     },
     {
-      "id": "feature-1289",
+      "id": "feature-1301",
       "query": "lynx-native-api/lynx-view-client/on-performance-event",
       "name": "Notify the client that a performance event has been sent. It will be called every time a performance event is generated, including but not limited to container initialization, engine rendering, rendering metrics update, etc.",
       "category": "lynx-native-api",
@@ -116881,7 +118670,7 @@
       }
     },
     {
-      "id": "feature-1290",
+      "id": "feature-1302",
       "query": "lynx-native-api/lynx-view-client/on-piper-invoked",
       "name": "Called when JSBridge invoked.",
       "category": "lynx-native-api",
@@ -116917,7 +118706,7 @@
       }
     },
     {
-      "id": "feature-1291",
+      "id": "feature-1303",
       "query": "lynx-native-api/lynx-view-client/on-received-error",
       "name": "Called when error received.",
       "category": "lynx-native-api",
@@ -116953,7 +118742,7 @@
       }
     },
     {
-      "id": "feature-1292",
+      "id": "feature-1304",
       "query": "lynx-native-api/lynx-view-client/on-received-java-error",
       "name": "Called when java error received.",
       "category": "lynx-native-api",
@@ -116989,7 +118778,7 @@
       }
     },
     {
-      "id": "feature-1293",
+      "id": "feature-1305",
       "query": "lynx-native-api/lynx-view-client/on-received-js-error",
       "name": "Called when JS error received.",
       "category": "lynx-native-api",
@@ -117025,7 +118814,7 @@
       }
     },
     {
-      "id": "feature-1294",
+      "id": "feature-1306",
       "query": "lynx-native-api/lynx-view-client/on-received-native-error",
       "name": "Called when C++ layer error received.",
       "category": "lynx-native-api",
@@ -117061,7 +118850,7 @@
       }
     },
     {
-      "id": "feature-1295",
+      "id": "feature-1307",
       "query": "lynx-native-api/lynx-view-client/on-report-component-info",
       "name": "Return the used component tagName.",
       "category": "lynx-native-api",
@@ -117097,7 +118886,7 @@
       }
     },
     {
-      "id": "feature-1296",
+      "id": "feature-1308",
       "query": "lynx-native-api/lynx-view-client/on-runtime-ready",
       "name": "Called when JS environment preparation completed.",
       "category": "lynx-native-api",
@@ -117133,7 +118922,7 @@
       }
     },
     {
-      "id": "feature-1297",
+      "id": "feature-1309",
       "query": "lynx-native-api/lynx-view-client/on-scroll-start",
       "name": "Called when the UI start scrolling.",
       "category": "lynx-native-api",
@@ -117169,7 +118958,7 @@
       }
     },
     {
-      "id": "feature-1298",
+      "id": "feature-1310",
       "query": "lynx-native-api/lynx-view-client/on-scroll-stop",
       "name": "Called when the UI finished scrolling.",
       "category": "lynx-native-api",
@@ -117205,7 +118994,7 @@
       }
     },
     {
-      "id": "feature-1299",
+      "id": "feature-1311",
       "query": "lynx-native-api/lynx-view-client/on-tasm-finished-by-native",
       "name": "Called when native layout finish in ui or most_on_tasm mode, or diff finish in multi_thread mode.",
       "category": "lynx-native-api",
@@ -117241,7 +119030,7 @@
       }
     },
     {
-      "id": "feature-1300",
+      "id": "feature-1312",
       "query": "lynx-native-api/lynx-view-client/on-template-bundle-ready",
       "name": "Provide a reusable TemplateBundle after template is decode.",
       "category": "lynx-native-api",
@@ -117277,7 +119066,7 @@
       }
     },
     {
-      "id": "feature-1301",
+      "id": "feature-1313",
       "query": "lynx-native-api/lynx-view-client/on-update-data-without-change",
       "name": "If there is no need to update the UI after calling updateData, this method is called back.",
       "category": "lynx-native-api",
@@ -117313,7 +119102,7 @@
       }
     },
     {
-      "id": "feature-1302",
+      "id": "feature-1314",
       "query": "lynx-native-api/lynx-view-client/on-update-perf-ready",
       "name": "Performance data statistics callback after the interface update is completed.",
       "category": "lynx-native-api",
@@ -117349,7 +119138,7 @@
       }
     },
     {
-      "id": "feature-1303",
+      "id": "feature-1315",
       "query": "lynx-native-api/template-bundle/from-template-async-with-option",
       "name": "Asynchronously creates a TemplateBundle from a template binary data with options. This method avoids blocking the main thread.",
       "category": "lynx-native-api",
@@ -117385,7 +119174,7 @@
       }
     },
     {
-      "id": "feature-1304",
+      "id": "feature-1316",
       "query": "lynx-native-api/template-bundle/from-template-async",
       "name": "Asynchronously creates a TemplateBundle from a template binary data. This method avoids blocking the main thread.",
       "category": "lynx-native-api",
@@ -117421,7 +119210,7 @@
       }
     },
     {
-      "id": "feature-1305",
+      "id": "feature-1317",
       "query": "lynx-native-api/template-bundle/from-template",
       "name": "Input Lynx template binary content and return the parsed TemplateBundle object.",
       "category": "lynx-native-api",
@@ -117457,7 +119246,7 @@
       }
     },
     {
-      "id": "feature-1306",
+      "id": "feature-1318",
       "query": "lynx-native-api/template-bundle/get-error-message",
       "name": "When TemplateBundle is an invalid object, use this method to obtain the exception information that occurred during template parsing.",
       "category": "lynx-native-api",
@@ -117493,7 +119282,7 @@
       }
     },
     {
-      "id": "feature-1307",
+      "id": "feature-1319",
       "query": "lynx-native-api/template-bundle/get-extra-info",
       "name": "Read the content of the extraInfo field configured in the pageConfig of the front-end template.",
       "category": "lynx-native-api",
@@ -117529,7 +119318,7 @@
       }
     },
     {
-      "id": "feature-1308",
+      "id": "feature-1320",
       "query": "lynx-native-api/template-bundle/get-template-size",
       "name": "Get the size of current template.",
       "category": "lynx-native-api",
@@ -117565,7 +119354,7 @@
       }
     },
     {
-      "id": "feature-1309",
+      "id": "feature-1321",
       "query": "lynx-native-api/template-bundle/is-element-bundle-valid",
       "name": "Whether the TemplateBundle contains a Valid ElementBundle.",
       "category": "lynx-native-api",
@@ -117601,7 +119390,7 @@
       }
     },
     {
-      "id": "feature-1310",
+      "id": "feature-1322",
       "query": "lynx-native-api/template-bundle/is-valid",
       "name": "Determines whether the current TemplateBundle object is valid.",
       "category": "lynx-native-api",
@@ -117637,7 +119426,7 @@
       }
     },
     {
-      "id": "feature-1311",
+      "id": "feature-1323",
       "query": "lynx-native-api/template-bundle/post-js-cache-generation-task",
       "name": "Start a sub-thread task to generate the js code cache of the current template.",
       "category": "lynx-native-api",
@@ -117673,7 +119462,7 @@
       }
     },
     {
-      "id": "feature-1312",
+      "id": "feature-1324",
       "query": "lynx-native-api/template-bundle/release",
       "name": "Release the Native memory held by the current TemplateBundle object. After executing the release method, the TemplateBundle will become the inValid state.",
       "category": "lynx-native-api",
@@ -117709,7 +119498,7 @@
       }
     },
     {
-      "id": "feature-1313",
+      "id": "feature-1325",
       "query": "lynx-native-api/template-data/constructor",
       "name": "Input data in string, key-value or json format and return the parsed TemplateData object.",
       "category": "lynx-native-api",
@@ -117745,7 +119534,7 @@
       }
     },
     {
-      "id": "feature-1314",
+      "id": "feature-1326",
       "query": "lynx-native-api/template-data/data",
       "name": "Get the data in TemplateData object.",
       "category": "lynx-native-api",
@@ -117781,7 +119570,7 @@
       }
     },
     {
-      "id": "feature-1315",
+      "id": "feature-1327",
       "query": "lynx-native-api/template-data/from-map",
       "name": "Input data in key-value format and return the parsed TemplateData object.",
       "category": "lynx-native-api",
@@ -117817,7 +119606,7 @@
       }
     },
     {
-      "id": "feature-1316",
+      "id": "feature-1328",
       "query": "lynx-native-api/template-data/from-string",
       "name": "Input data in json and return the parsed TemplateData object.",
       "category": "lynx-native-api",
@@ -117853,7 +119642,7 @@
       }
     },
     {
-      "id": "feature-1317",
+      "id": "feature-1329",
       "query": "lynx-native-api/template-data/mark-state",
       "name": "Mark the current TemplateData with the associated dataProcessor name. When this TemplateData is used in UpdateData, the corresponding dataProcessor will be found based on this name for data preprocessing.",
       "category": "lynx-native-api",
@@ -117889,7 +119678,7 @@
       }
     },
     {
-      "id": "feature-1318",
+      "id": "feature-1330",
       "query": "lynx-native-api/template-data/merge",
       "name": "Merge the incoming data with the current data.",
       "category": "lynx-native-api",
@@ -117925,7 +119714,7 @@
       }
     },
     {
-      "id": "feature-1319",
+      "id": "feature-1331",
       "query": "lynx-native-api/trace-event",
       "name": "TraceEvent",
       "category": "lynx-native-api",
@@ -117961,7 +119750,7 @@
       }
     },
     {
-      "id": "feature-1320",
+      "id": "feature-1332",
       "query": "react/main-thread/MainThread-APIs",
       "name": "APIs available on the main thread.",
       "category": "react",
@@ -117997,7 +119786,7 @@
       }
     },
     {
-      "id": "feature-1321",
+      "id": "feature-1333",
       "query": "react/main-thread/MainThread-APIs.runOnBackground",
       "name": "runOnBackground: Create a value that can be shared between main thread scripts.",
       "category": "react",
@@ -118033,7 +119822,7 @@
       }
     },
     {
-      "id": "feature-1322",
+      "id": "feature-1334",
       "query": "devtool/integration.lazy_load",
       "name": "Lazy load",
       "category": "devtool",
@@ -118069,7 +119858,7 @@
       }
     },
     {
-      "id": "feature-1323",
+      "id": "feature-1335",
       "query": "devtool/integration.switch.switchPage",
       "name": "Switch page",
       "category": "devtool",
@@ -118105,7 +119894,7 @@
       }
     },
     {
-      "id": "feature-1324",
+      "id": "feature-1336",
       "query": "devtool/integration.connection.usb",
       "name": "USB connection",
       "category": "devtool",
@@ -118141,7 +119930,7 @@
       }
     },
     {
-      "id": "feature-1325",
+      "id": "feature-1337",
       "query": "devtool/logbox",
       "name": "Shows logbox details",
       "category": "devtool",
@@ -118177,7 +119966,7 @@
       }
     },
     {
-      "id": "feature-1326",
+      "id": "feature-1338",
       "query": "devtool/logbox.notification",
       "name": "Notification with a brief message",
       "category": "devtool",
@@ -118190,7 +119979,7 @@
           "version_added": "3.0"
         },
         "harmony": {
-          "version_added": false
+          "version_added": "4.0"
         },
         "web_lynx": {
           "version_added": false
@@ -118213,7 +120002,7 @@
       }
     },
     {
-      "id": "feature-1327",
+      "id": "feature-1339",
       "query": "devtool/logbox.MTS Analysis",
       "name": "MTS Analysis",
       "category": "devtool",
@@ -118226,7 +120015,7 @@
           "version_added": "3.0"
         },
         "harmony": {
-          "version_added": false
+          "version_added": "4.0"
         },
         "web_lynx": {
           "version_added": false
@@ -118249,7 +120038,7 @@
       }
     },
     {
-      "id": "feature-1328",
+      "id": "feature-1340",
       "query": "devtool/logbox.BTS Analysis",
       "name": "BTS Analysis",
       "category": "devtool",
@@ -118262,7 +120051,7 @@
           "version_added": "3.0"
         },
         "harmony": {
-          "version_added": false
+          "version_added": "4.0"
         },
         "web_lynx": {
           "version_added": false
@@ -118285,7 +120074,7 @@
       }
     },
     {
-      "id": "feature-1329",
+      "id": "feature-1341",
       "query": "devtool/panels.elements.preview.reload",
       "name": "Reload",
       "category": "devtool",
@@ -118321,7 +120110,7 @@
       }
     },
     {
-      "id": "feature-1330",
+      "id": "feature-1342",
       "query": "devtool/panels.elements.preview.lynxview",
       "name": "LynxView mirroring",
       "category": "devtool",
@@ -118357,7 +120146,7 @@
       }
     },
     {
-      "id": "feature-1331",
+      "id": "feature-1343",
       "query": "devtool/panels.elements.preview.fullscreen",
       "name": "Fullscreen mirroring",
       "category": "devtool",
@@ -118393,7 +120182,7 @@
       }
     },
     {
-      "id": "feature-1332",
+      "id": "feature-1344",
       "query": "devtool/panels.elements.preview.box_model",
       "name": "Interact via the box model",
       "category": "devtool",
@@ -118429,7 +120218,7 @@
       }
     },
     {
-      "id": "feature-1333",
+      "id": "feature-1345",
       "query": "devtool/panels.elements.view-and-edit.element_tree",
       "name": "View and edit the element tree",
       "category": "devtool",
@@ -118465,7 +120254,7 @@
       }
     },
     {
-      "id": "feature-1334",
+      "id": "feature-1346",
       "query": "devtool/panels.elements.view-and-edit.hot_reload",
       "name": "View and edit CSS styles",
       "category": "devtool",
@@ -118501,7 +120290,7 @@
       }
     },
     {
-      "id": "feature-1335",
+      "id": "feature-1347",
       "query": "devtool/panels.console.print",
       "name": "View Logged messages",
       "category": "devtool",
@@ -118537,7 +120326,7 @@
       }
     },
     {
-      "id": "feature-1336",
+      "id": "feature-1348",
       "query": "devtool/panels.console.execution",
       "name": "Run JavaScript",
       "category": "devtool",
@@ -118573,7 +120362,7 @@
       }
     },
     {
-      "id": "feature-1337",
+      "id": "feature-1349",
       "query": "devtool/panels.sources.breakpoints.BTS",
       "name": "Background thread breakpoints",
       "category": "devtool",
@@ -118609,7 +120398,7 @@
       }
     },
     {
-      "id": "feature-1338",
+      "id": "feature-1350",
       "query": "devtool/panels.sources.breakpoints.MTS",
       "name": "Main thread breakpoints",
       "category": "devtool",
@@ -118645,7 +120434,7 @@
       }
     },
     {
-      "id": "feature-1339",
+      "id": "feature-1351",
       "query": "devtool/panels.sources.JSEngine.PrimJS",
       "name": "PrimJS",
       "category": "devtool",
@@ -118681,7 +120470,7 @@
       }
     },
     {
-      "id": "feature-1340",
+      "id": "feature-1352",
       "query": "devtool/panels.sources.JSEngine.V8",
       "name": "V8",
       "category": "devtool",
@@ -118717,7 +120506,7 @@
       }
     },
     {
-      "id": "feature-1341",
+      "id": "feature-1353",
       "query": "devtool/panels.layers",
       "name": "View page layers",
       "category": "devtool",
@@ -118753,7 +120542,7 @@
       }
     },
     {
-      "id": "feature-1342",
+      "id": "feature-1354",
       "query": "devtool/recorder",
       "name": "Lynx Recorder Support",
       "category": "devtool",
@@ -118789,7 +120578,7 @@
       }
     },
     {
-      "id": "feature-1343",
+      "id": "feature-1355",
       "query": "devtool/trace",
       "name": "Trace Tool",
       "category": "devtool",
@@ -118825,7 +120614,7 @@
       }
     },
     {
-      "id": "feature-1344",
+      "id": "feature-1356",
       "query": "errors/lynx-error",
       "name": "Structure used to represent an error",
       "category": "errors",
@@ -118879,12 +120668,12 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 686,
+          "supported": 691,
           "coverage": 61
         },
         "clay_android": {
           "supported": 490,
-          "coverage": 44
+          "coverage": 43
         },
         "clay_ios": {
           "supported": 426,
@@ -118892,15 +120681,15 @@
         },
         "clay_macos": {
           "supported": 490,
-          "coverage": 44
+          "coverage": 43
         },
         "clay_windows": {
           "supported": 490,
-          "coverage": 44
+          "coverage": 43
         },
         "clay": {
           "supported": 490,
-          "coverage": 44
+          "coverage": 43
         }
       }
     },
@@ -118921,12 +120710,12 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 686,
+          "supported": 691,
           "coverage": 61
         },
         "clay_android": {
           "supported": 490,
-          "coverage": 44
+          "coverage": 43
         },
         "clay_ios": {
           "supported": 426,
@@ -118934,15 +120723,15 @@
         },
         "clay_macos": {
           "supported": 490,
-          "coverage": 44
+          "coverage": 43
         },
         "clay_windows": {
           "supported": 490,
-          "coverage": 44
+          "coverage": 43
         },
         "clay": {
           "supported": 490,
-          "coverage": 44
+          "coverage": 43
         }
       }
     },
@@ -118956,14 +120745,14 @@
         },
         "ios": {
           "supported": 639,
-          "coverage": 57
+          "coverage": 56
         },
         "harmony": {
           "supported": 0,
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 686,
+          "supported": 691,
           "coverage": 61
         },
         "clay_android": {
@@ -118972,7 +120761,7 @@
         },
         "clay_ios": {
           "supported": 432,
-          "coverage": 39
+          "coverage": 38
         },
         "clay_macos": {
           "supported": 496,
@@ -118998,14 +120787,14 @@
         },
         "ios": {
           "supported": 639,
-          "coverage": 57
+          "coverage": 56
         },
         "harmony": {
           "supported": 0,
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 686,
+          "supported": 691,
           "coverage": 61
         },
         "clay_android": {
@@ -119014,7 +120803,7 @@
         },
         "clay_ios": {
           "supported": 432,
-          "coverage": 39
+          "coverage": 38
         },
         "clay_macos": {
           "supported": 496,
@@ -119036,18 +120825,18 @@
       "platforms": {
         "android": {
           "supported": 684,
-          "coverage": 61
+          "coverage": 60
         },
         "ios": {
           "supported": 683,
-          "coverage": 61
+          "coverage": 60
         },
         "harmony": {
           "supported": 0,
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 686,
+          "supported": 691,
           "coverage": 61
         },
         "clay_android": {
@@ -119060,11 +120849,11 @@
         },
         "clay_macos": {
           "supported": 502,
-          "coverage": 45
+          "coverage": 44
         },
         "clay_windows": {
           "supported": 502,
-          "coverage": 45
+          "coverage": 44
         },
         "clay": {
           "supported": 507,
@@ -119089,12 +120878,12 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 686,
+          "supported": 691,
           "coverage": 61
         },
         "clay_android": {
           "supported": 511,
-          "coverage": 46
+          "coverage": 45
         },
         "clay_ios": {
           "supported": 442,
@@ -119110,7 +120899,7 @@
         },
         "clay": {
           "supported": 511,
-          "coverage": 46
+          "coverage": 45
         }
       }
     },
@@ -119120,23 +120909,23 @@
       "platforms": {
         "android": {
           "supported": 746,
-          "coverage": 67
+          "coverage": 66
         },
         "ios": {
           "supported": 745,
-          "coverage": 67
+          "coverage": 66
         },
         "harmony": {
           "supported": 0,
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 686,
+          "supported": 691,
           "coverage": 61
         },
         "clay_android": {
           "supported": 511,
-          "coverage": 46
+          "coverage": 45
         },
         "clay_ios": {
           "supported": 442,
@@ -119152,7 +120941,7 @@
         },
         "clay": {
           "supported": 511,
-          "coverage": 46
+          "coverage": 45
         }
       }
     },
@@ -119162,18 +120951,18 @@
       "platforms": {
         "android": {
           "supported": 764,
-          "coverage": 68
+          "coverage": 67
         },
         "ios": {
           "supported": 763,
-          "coverage": 68
+          "coverage": 67
         },
         "harmony": {
           "supported": 0,
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 686,
+          "supported": 691,
           "coverage": 61
         },
         "clay_android": {
@@ -119182,15 +120971,15 @@
         },
         "clay_ios": {
           "supported": 447,
-          "coverage": 40
+          "coverage": 39
         },
         "clay_macos": {
           "supported": 511,
-          "coverage": 46
+          "coverage": 45
         },
         "clay_windows": {
           "supported": 511,
-          "coverage": 46
+          "coverage": 45
         },
         "clay": {
           "supported": 516,
@@ -119203,19 +120992,19 @@
       "release_date": "2025/5/26",
       "platforms": {
         "android": {
-          "supported": 772,
+          "supported": 776,
           "coverage": 69
         },
         "ios": {
-          "supported": 771,
-          "coverage": 69
+          "supported": 774,
+          "coverage": 68
         },
         "harmony": {
           "supported": 0,
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 686,
+          "supported": 691,
           "coverage": 61
         },
         "clay_android": {
@@ -119224,15 +121013,15 @@
         },
         "clay_ios": {
           "supported": 447,
-          "coverage": 40
+          "coverage": 39
         },
         "clay_macos": {
           "supported": 511,
-          "coverage": 46
+          "coverage": 45
         },
         "clay_windows": {
           "supported": 511,
-          "coverage": 46
+          "coverage": 45
         },
         "clay": {
           "supported": 516,
@@ -119245,24 +121034,24 @@
       "release_date": "2025/7/21",
       "platforms": {
         "android": {
-          "supported": 831,
+          "supported": 835,
           "coverage": 74
         },
         "ios": {
-          "supported": 830,
+          "supported": 833,
           "coverage": 74
         },
         "harmony": {
           "supported": 671,
-          "coverage": 60
+          "coverage": 59
         },
         "web_lynx": {
-          "supported": 686,
+          "supported": 691,
           "coverage": 61
         },
         "clay_android": {
           "supported": 544,
-          "coverage": 49
+          "coverage": 48
         },
         "clay_ios": {
           "supported": 475,
@@ -119278,7 +121067,7 @@
         },
         "clay": {
           "supported": 544,
-          "coverage": 49
+          "coverage": 48
         }
       }
     }


### PR DESCRIPTION
### Motivation

- Keep the API Status Dashboard in sync with the latest compatibility definitions and documented CSS features by regenerating aggregated stats.
- Surface newly documented CSS properties and finer-grained `offset-path` / caret / text-decoration entries into the global stats used by the dashboard and docs.

### Description

- Regenerated `packages/lynx-compat-data/api-stats.json` with updated totals (`total_apis` -> `1226`, `platform_api_total` -> `1132`) and refreshed category/platform aggregations.
- Added new CSS feature entries and API paths including `-x-caret-gradient`, `-x-caret-height`, `-x-caret-radius`, `-x-caret-width`, `-x-text-decoration-gap`, `-x-text-decoration-width`, `mask-composite`, `text-decoration-thickness`, and `offset-path` variants (`circle()`, `inset()`, `ellipse()`, `path()`), and included them in the `css/properties` lists and missing/unsupported groupings.
- Updated `css/properties` summary counts (`total` from `416` to `428`) and adjusted per-platform `supported`/`coverage` values; updated aggregated `by_platform` support counts and `clay` platform breakdowns.
- The regeneration produced many feature entries/IDs updates so the generated `features` array and per-feature IDs were renumbered to reflect the new snapshot.

### Testing

- Ran `pnpm --filter @lynx-js/lynx-compat-data run gen-stats` and confirmed the script completed and wrote `api-stats.json` successfully.
- Ran validation/lint with `pnpm --filter @lynx-js/lynx-compat-data run lint` which completed without errors.
- Ran unit tests with `pnpm --filter @lynx-js/lynx-compat-data test` (Vitest); test suite (`index.test.ts`) passed: 1 file, 10 tests — all passed.
- Performed `git diff --check` on `packages/lynx-compat-data/api-stats.json` to ensure no formatting/whitespace issues (no errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e6f1cd9ac8329986fe7320cbcc869)