### PR TITLE
fix(home): vertically center hero badge and show version picker [4.0]

### DIFF
--- a/theme/VersionIndicator.tsx
+++ b/theme/VersionIndicator.tsx
@@ -1,5 +1,4 @@
-import { useLocation } from '@rspress/core/runtime';
-import { SUBSITES_CONFIG } from '@site/shared-route-config';
+import { useLocation, useI18n, useLang } from '@rspress/core/runtime';
 import { useState, useEffect } from 'react';
 import {
   HoverCard,
@@ -12,8 +11,6 @@ import useIfMobile from '@site/theme/hooks/use-if-mobile';
 import { ChevronDown } from 'lucide-react';
 
 import { getLangPrefix } from '../shared-route-config';
-
-import { useI18n, useLang } from '@rspress/core/runtime';
 import versionJson from '../docs/public/version.json';
 
 const menuItemClassName =
@@ -60,14 +57,10 @@ export function VersionIndicator() {
     if (pathname.endsWith('.html')) {
       pathname = pathname.replace('.html', '');
     }
-    var homepagePaths = SUBSITES_CONFIG.flatMap((site) => [
-      site.home,
-      site.home.endsWith('/') ? site.home.slice(0, -1) : `${site.home}/`,
-    ]);
-    homepagePaths.push('/versions');
-    const specificPath =
-      homepagePaths.includes(pathname) || pathname.startsWith('/blog');
-    return !specificPath;
+    // Hide on the versions index and blog listing — those pages already
+    // surface version/context. Show on docs *and* homepage/subsite homes so
+    // visitors can switch versions without first diving into a guide page.
+    return pathname !== '/versions' && !pathname.startsWith('/blog');
   };
 
   useEffect(() => {

--- a/theme/blog-btn.scss
+++ b/theme/blog-btn.scss
@@ -7,6 +7,11 @@
   // pill. Block + line-height centering (the icon is absolutely positioned,
   // so no flexbox is needed) lets text-overflow clip it with an ellipsis;
   // `max-width` caps the pill at its container so the clip actually engages.
+  //
+  // line-height must match the border-box content height (height − 2×border),
+  // otherwise the line box sits at the top and the label looks top-heavy —
+  // the regression from #1155, which updated the mobile line-height but left
+  // desktop at the old 32px value from when flex was doing the centering.
   display: block;
   max-width: 100%;
   box-sizing: border-box;
@@ -22,7 +27,8 @@
   color: var(--home-blog-btn-color);
   font-style: normal;
   font-weight: 500;
-  line-height: 32px;
+  // content box = 36px − 2×1px border
+  line-height: 34px;
   padding-left: 43px;
   padding-right: 20px;
   transition: all 0.3s ease;
@@ -33,8 +39,7 @@
   @media (max-width: 768px) {
     font-size: 12px;
     height: 28px;
-    // Match the shorter pill so the single line stays vertically centered
-    // and isn't clipped by `overflow: hidden` (content box = 28px − 2px border).
+    // content box = 28px − 2×1px border
     line-height: 26px;
     padding-left: 38px;
     padding-right: 16px;


### PR DESCRIPTION
ellipsis, but left desktop line-height at 32px. Under border-box with a 1px border that content box is 34px, so the label sat 2px high. Match line-height to the content box (34px / 26px).

Also show the nav version picker on homepage and subsite homes — hiding it there was intentional since #464, but version switching is useful before entering docs. Still hide on /blog and /versions.