### PR TITLE
docs: fix desktop text-selection compatibility

### DIFF
--- a/packages/lynx-compat-data/api-stats.json
+++ b/packages/lynx-compat-data/api-stats.json
@@ -12,8 +12,8 @@
           "web_lynx": 182,
           "clay_android": 232,
           "clay_ios": 228,
-          "clay_macos": 241,
-          "clay_windows": 241,
+          "clay_macos": 242,
+          "clay_windows": 242,
           "clay": 259
         },
         "coverage": {
@@ -648,12 +648,12 @@
         "exclusive_count": 0
       },
       "clay_macos": {
-        "supported_count": 993,
+        "supported_count": 994,
         "coverage_percent": 88,
         "exclusive_count": 0
       },
       "clay_windows": {
-        "supported_count": 997,
+        "supported_count": 998,
         "coverage_percent": 88,
         "exclusive_count": 0
       },
@@ -695,8 +695,8 @@
           "web_lynx": 182,
           "clay_android": 232,
           "clay_ios": 228,
-          "clay_macos": 241,
-          "clay_windows": 241,
+          "clay_macos": 242,
+          "clay_windows": 242,
           "clay": 259
         },
         "coverage": {
@@ -4161,8 +4161,8 @@
             "web_lynx": false,
             "clay_android": "3.7",
             "clay_ios": "3.7",
-            "clay_macos": false,
-            "clay_windows": false,
+            "clay_macos": "3.7",
+            "clay_windows": "3.7",
             "clay": "3.7"
           }
         },
@@ -9320,8 +9320,8 @@
               "web_lynx": false,
               "clay_android": "3.7",
               "clay_ios": "3.7",
-              "clay_macos": false,
-              "clay_windows": false,
+              "clay_macos": "3.7",
+              "clay_windows": "3.7",
               "clay": "3.7"
             }
           },
@@ -11450,8 +11450,8 @@
               "web_lynx": false,
               "clay_android": "3.7",
               "clay_ios": "3.7",
-              "clay_macos": false,
-              "clay_windows": false,
+              "clay_macos": "3.7",
+              "clay_windows": "3.7",
               "clay": "3.7"
             }
           },
@@ -16870,22 +16870,6 @@
             }
           },
           {
-            "path": "elements/text.attributes.text-selection",
-            "name": "<code>text-selection</code>",
-            "doc_url": "/api/elements/built-in/text",
-            "support": {
-              "android": "3.2",
-              "ios": "3.2",
-              "harmony": false,
-              "web_lynx": false,
-              "clay_android": "3.7",
-              "clay_ios": "3.7",
-              "clay_macos": false,
-              "clay_windows": false,
-              "clay": "3.7"
-            }
-          },
-          {
             "path": "elements/text.attributes.custom-context-menu",
             "name": "<code>custom-context-menu</code>",
             "doc_url": "/api/elements/built-in/text",
@@ -18389,22 +18373,6 @@
               "clay_macos": false,
               "clay_windows": false,
               "clay": false
-            }
-          },
-          {
-            "path": "elements/text.attributes.text-selection",
-            "name": "<code>text-selection</code>",
-            "doc_url": "/api/elements/built-in/text",
-            "support": {
-              "android": "3.2",
-              "ios": "3.2",
-              "harmony": false,
-              "web_lynx": false,
-              "clay_android": "3.7",
-              "clay_ios": "3.7",
-              "clay_macos": false,
-              "clay_windows": false,
-              "clay": "3.7"
             }
           },
           {
@@ -79005,10 +78973,10 @@
           "version_added": "3.7"
         },
         "clay_macos": {
-          "version_added": false
+          "version_added": "3.7"
         },
         "clay_windows": {
-          "version_added": false
+          "version_added": "3.7"
         },
         "clay": {
           "version_added": "3.7"
@@ -121406,11 +121374,11 @@
           "coverage": 44
         },
         "clay_macos": {
-          "supported": 940,
+          "supported": 941,
           "coverage": 83
         },
         "clay_windows": {
-          "supported": 944,
+          "supported": 945,
           "coverage": 83
         },
         "clay": {
@@ -121448,11 +121416,11 @@
           "coverage": 44
         },
         "clay_macos": {
-          "supported": 942,
+          "supported": 943,
           "coverage": 83
         },
         "clay_windows": {
-          "supported": 946,
+          "supported": 947,
           "coverage": 84
         },
         "clay": {
@@ -121490,11 +121458,11 @@
           "coverage": 46
         },
         "clay_macos": {
-          "supported": 964,
+          "supported": 965,
           "coverage": 85
         },
         "clay_windows": {
-          "supported": 968,
+          "supported": 969,
           "coverage": 86
         },
         "clay": {
@@ -121532,11 +121500,11 @@
           "coverage": 49
         },
         "clay_macos": {
-          "supported": 989,
+          "supported": 990,
           "coverage": 87
         },
         "clay_windows": {
-          "supported": 993,
+          "supported": 994,
           "coverage": 88
         },
         "clay": {

--- a/packages/lynx-compat-data/elements/text.json
+++ b/packages/lynx-compat-data/elements/text.json
@@ -226,10 +226,10 @@
                 "version_added": "3.7"
               },
               "clay_windows": {
-                "version_added": false
+                "version_added": "3.7"
               },
               "clay_macos": {
-                "version_added": false
+                "version_added": "3.7"
               },
               "web_lynx": {
                 "version_added": false


### PR DESCRIPTION
## Summary

- mark `text-selection` as supported since 3.7 on Clay Windows and macOS
- regenerate compatibility statistics from the corrected source data

## Why

Clay `TextView` handles `text-selection` on desktop through mouse drag selection, keyboard copy/select-all shortcuts, and clipboard integration. The compatibility source incorrectly marked both desktop platforms as unsupported.

## Validation

- `pnpm --filter @lynx-js/lynx-compat-data run lint`
- `pnpm --filter @lynx-js/lynx-compat-data run gen-stats`
- `pnpm --filter @lynx-js/lynx-compat-data test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Mark `text-selection` as supported since version 3.7 on Clay Windows and macOS.
- Regenerate compatibility statistics from corrected source data.
- Validate `@lynx-js/lynx-compat-data` with linting, statistics generation, and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->