### PR TITLE
feat(api-status): interactive coverage version range and floating drawer

### DIFF
--- a/packages/lynx-compat-data/api-stats.json
+++ b/packages/lynx-compat-data/api-stats.json
@@ -120926,6 +120926,846 @@
   ],
   "timeline": [
     {
+      "version": "1.3",
+      "release_date": "2020/6/23",
+      "platforms": {
+        "android": {
+          "supported": 310,
+          "coverage": 27
+        },
+        "ios": {
+          "supported": 310,
+          "coverage": 27
+        },
+        "harmony": {
+          "supported": 0,
+          "coverage": 0
+        },
+        "web_lynx": {
+          "supported": 691,
+          "coverage": 61
+        },
+        "clay_android": {
+          "supported": 222,
+          "coverage": 20
+        },
+        "clay_ios": {
+          "supported": 175,
+          "coverage": 15
+        },
+        "clay_macos": {
+          "supported": 222,
+          "coverage": 20
+        },
+        "clay_windows": {
+          "supported": 222,
+          "coverage": 20
+        },
+        "clay": {
+          "supported": 222,
+          "coverage": 20
+        }
+      }
+    },
+    {
+      "version": "1.4",
+      "release_date": "2020/9/9",
+      "platforms": {
+        "android": {
+          "supported": 324,
+          "coverage": 29
+        },
+        "ios": {
+          "supported": 324,
+          "coverage": 29
+        },
+        "harmony": {
+          "supported": 0,
+          "coverage": 0
+        },
+        "web_lynx": {
+          "supported": 691,
+          "coverage": 61
+        },
+        "clay_android": {
+          "supported": 234,
+          "coverage": 21
+        },
+        "clay_ios": {
+          "supported": 187,
+          "coverage": 17
+        },
+        "clay_macos": {
+          "supported": 234,
+          "coverage": 21
+        },
+        "clay_windows": {
+          "supported": 234,
+          "coverage": 21
+        },
+        "clay": {
+          "supported": 234,
+          "coverage": 21
+        }
+      }
+    },
+    {
+      "version": "1.5",
+      "release_date": "2021/2/28",
+      "platforms": {
+        "android": {
+          "supported": 444,
+          "coverage": 39
+        },
+        "ios": {
+          "supported": 443,
+          "coverage": 39
+        },
+        "harmony": {
+          "supported": 0,
+          "coverage": 0
+        },
+        "web_lynx": {
+          "supported": 691,
+          "coverage": 61
+        },
+        "clay_android": {
+          "supported": 385,
+          "coverage": 34
+        },
+        "clay_ios": {
+          "supported": 338,
+          "coverage": 30
+        },
+        "clay_macos": {
+          "supported": 385,
+          "coverage": 34
+        },
+        "clay_windows": {
+          "supported": 385,
+          "coverage": 34
+        },
+        "clay": {
+          "supported": 385,
+          "coverage": 34
+        }
+      }
+    },
+    {
+      "version": "1.6",
+      "release_date": "2021/4/30",
+      "platforms": {
+        "android": {
+          "supported": 458,
+          "coverage": 40
+        },
+        "ios": {
+          "supported": 457,
+          "coverage": 40
+        },
+        "harmony": {
+          "supported": 0,
+          "coverage": 0
+        },
+        "web_lynx": {
+          "supported": 691,
+          "coverage": 61
+        },
+        "clay_android": {
+          "supported": 391,
+          "coverage": 35
+        },
+        "clay_ios": {
+          "supported": 344,
+          "coverage": 30
+        },
+        "clay_macos": {
+          "supported": 391,
+          "coverage": 35
+        },
+        "clay_windows": {
+          "supported": 391,
+          "coverage": 35
+        },
+        "clay": {
+          "supported": 391,
+          "coverage": 35
+        }
+      }
+    },
+    {
+      "version": "2.0",
+      "release_date": "2021/7/2",
+      "platforms": {
+        "android": {
+          "supported": 470,
+          "coverage": 42
+        },
+        "ios": {
+          "supported": 469,
+          "coverage": 41
+        },
+        "harmony": {
+          "supported": 0,
+          "coverage": 0
+        },
+        "web_lynx": {
+          "supported": 691,
+          "coverage": 61
+        },
+        "clay_android": {
+          "supported": 403,
+          "coverage": 36
+        },
+        "clay_ios": {
+          "supported": 356,
+          "coverage": 31
+        },
+        "clay_macos": {
+          "supported": 403,
+          "coverage": 36
+        },
+        "clay_windows": {
+          "supported": 403,
+          "coverage": 36
+        },
+        "clay": {
+          "supported": 403,
+          "coverage": 36
+        }
+      }
+    },
+    {
+      "version": "2.1",
+      "release_date": "2021/9/10",
+      "platforms": {
+        "android": {
+          "supported": 523,
+          "coverage": 46
+        },
+        "ios": {
+          "supported": 522,
+          "coverage": 46
+        },
+        "harmony": {
+          "supported": 0,
+          "coverage": 0
+        },
+        "web_lynx": {
+          "supported": 691,
+          "coverage": 61
+        },
+        "clay_android": {
+          "supported": 454,
+          "coverage": 40
+        },
+        "clay_ios": {
+          "supported": 401,
+          "coverage": 35
+        },
+        "clay_macos": {
+          "supported": 454,
+          "coverage": 40
+        },
+        "clay_windows": {
+          "supported": 454,
+          "coverage": 40
+        },
+        "clay": {
+          "supported": 454,
+          "coverage": 40
+        }
+      }
+    },
+    {
+      "version": "2.2",
+      "release_date": "2021/11/15",
+      "platforms": {
+        "android": {
+          "supported": 544,
+          "coverage": 48
+        },
+        "ios": {
+          "supported": 543,
+          "coverage": 48
+        },
+        "harmony": {
+          "supported": 0,
+          "coverage": 0
+        },
+        "web_lynx": {
+          "supported": 691,
+          "coverage": 61
+        },
+        "clay_android": {
+          "supported": 466,
+          "coverage": 41
+        },
+        "clay_ios": {
+          "supported": 410,
+          "coverage": 36
+        },
+        "clay_macos": {
+          "supported": 466,
+          "coverage": 41
+        },
+        "clay_windows": {
+          "supported": 466,
+          "coverage": 41
+        },
+        "clay": {
+          "supported": 466,
+          "coverage": 41
+        }
+      }
+    },
+    {
+      "version": "2.3",
+      "release_date": "2022/3/7",
+      "platforms": {
+        "android": {
+          "supported": 550,
+          "coverage": 49
+        },
+        "ios": {
+          "supported": 549,
+          "coverage": 48
+        },
+        "harmony": {
+          "supported": 0,
+          "coverage": 0
+        },
+        "web_lynx": {
+          "supported": 691,
+          "coverage": 61
+        },
+        "clay_android": {
+          "supported": 466,
+          "coverage": 41
+        },
+        "clay_ios": {
+          "supported": 410,
+          "coverage": 36
+        },
+        "clay_macos": {
+          "supported": 466,
+          "coverage": 41
+        },
+        "clay_windows": {
+          "supported": 466,
+          "coverage": 41
+        },
+        "clay": {
+          "supported": 466,
+          "coverage": 41
+        }
+      }
+    },
+    {
+      "version": "2.4",
+      "release_date": "2022/5/9",
+      "platforms": {
+        "android": {
+          "supported": 555,
+          "coverage": 49
+        },
+        "ios": {
+          "supported": 554,
+          "coverage": 49
+        },
+        "harmony": {
+          "supported": 0,
+          "coverage": 0
+        },
+        "web_lynx": {
+          "supported": 691,
+          "coverage": 61
+        },
+        "clay_android": {
+          "supported": 466,
+          "coverage": 41
+        },
+        "clay_ios": {
+          "supported": 410,
+          "coverage": 36
+        },
+        "clay_macos": {
+          "supported": 466,
+          "coverage": 41
+        },
+        "clay_windows": {
+          "supported": 466,
+          "coverage": 41
+        },
+        "clay": {
+          "supported": 466,
+          "coverage": 41
+        }
+      }
+    },
+    {
+      "version": "2.5",
+      "release_date": "2022/7/7",
+      "platforms": {
+        "android": {
+          "supported": 556,
+          "coverage": 49
+        },
+        "ios": {
+          "supported": 555,
+          "coverage": 49
+        },
+        "harmony": {
+          "supported": 0,
+          "coverage": 0
+        },
+        "web_lynx": {
+          "supported": 691,
+          "coverage": 61
+        },
+        "clay_android": {
+          "supported": 466,
+          "coverage": 41
+        },
+        "clay_ios": {
+          "supported": 410,
+          "coverage": 36
+        },
+        "clay_macos": {
+          "supported": 466,
+          "coverage": 41
+        },
+        "clay_windows": {
+          "supported": 466,
+          "coverage": 41
+        },
+        "clay": {
+          "supported": 466,
+          "coverage": 41
+        }
+      }
+    },
+    {
+      "version": "2.6",
+      "release_date": "2022/9/5",
+      "platforms": {
+        "android": {
+          "supported": 569,
+          "coverage": 50
+        },
+        "ios": {
+          "supported": 565,
+          "coverage": 50
+        },
+        "harmony": {
+          "supported": 0,
+          "coverage": 0
+        },
+        "web_lynx": {
+          "supported": 691,
+          "coverage": 61
+        },
+        "clay_android": {
+          "supported": 467,
+          "coverage": 41
+        },
+        "clay_ios": {
+          "supported": 411,
+          "coverage": 36
+        },
+        "clay_macos": {
+          "supported": 467,
+          "coverage": 41
+        },
+        "clay_windows": {
+          "supported": 467,
+          "coverage": 41
+        },
+        "clay": {
+          "supported": 467,
+          "coverage": 41
+        }
+      }
+    },
+    {
+      "version": "2.7",
+      "release_date": "2022/11/14",
+      "platforms": {
+        "android": {
+          "supported": 570,
+          "coverage": 50
+        },
+        "ios": {
+          "supported": 568,
+          "coverage": 50
+        },
+        "harmony": {
+          "supported": 0,
+          "coverage": 0
+        },
+        "web_lynx": {
+          "supported": 691,
+          "coverage": 61
+        },
+        "clay_android": {
+          "supported": 469,
+          "coverage": 41
+        },
+        "clay_ios": {
+          "supported": 413,
+          "coverage": 36
+        },
+        "clay_macos": {
+          "supported": 469,
+          "coverage": 41
+        },
+        "clay_windows": {
+          "supported": 469,
+          "coverage": 41
+        },
+        "clay": {
+          "supported": 469,
+          "coverage": 41
+        }
+      }
+    },
+    {
+      "version": "2.8",
+      "release_date": "2023/1/16",
+      "platforms": {
+        "android": {
+          "supported": 578,
+          "coverage": 51
+        },
+        "ios": {
+          "supported": 577,
+          "coverage": 51
+        },
+        "harmony": {
+          "supported": 0,
+          "coverage": 0
+        },
+        "web_lynx": {
+          "supported": 691,
+          "coverage": 61
+        },
+        "clay_android": {
+          "supported": 469,
+          "coverage": 41
+        },
+        "clay_ios": {
+          "supported": 413,
+          "coverage": 36
+        },
+        "clay_macos": {
+          "supported": 469,
+          "coverage": 41
+        },
+        "clay_windows": {
+          "supported": 469,
+          "coverage": 41
+        },
+        "clay": {
+          "supported": 469,
+          "coverage": 41
+        }
+      }
+    },
+    {
+      "version": "2.9",
+      "release_date": "2023/3/13",
+      "platforms": {
+        "android": {
+          "supported": 584,
+          "coverage": 52
+        },
+        "ios": {
+          "supported": 583,
+          "coverage": 52
+        },
+        "harmony": {
+          "supported": 0,
+          "coverage": 0
+        },
+        "web_lynx": {
+          "supported": 691,
+          "coverage": 61
+        },
+        "clay_android": {
+          "supported": 469,
+          "coverage": 41
+        },
+        "clay_ios": {
+          "supported": 413,
+          "coverage": 36
+        },
+        "clay_macos": {
+          "supported": 469,
+          "coverage": 41
+        },
+        "clay_windows": {
+          "supported": 469,
+          "coverage": 41
+        },
+        "clay": {
+          "supported": 469,
+          "coverage": 41
+        }
+      }
+    },
+    {
+      "version": "2.10",
+      "release_date": "2023/5/15",
+      "platforms": {
+        "android": {
+          "supported": 586,
+          "coverage": 52
+        },
+        "ios": {
+          "supported": 585,
+          "coverage": 52
+        },
+        "harmony": {
+          "supported": 0,
+          "coverage": 0
+        },
+        "web_lynx": {
+          "supported": 691,
+          "coverage": 61
+        },
+        "clay_android": {
+          "supported": 469,
+          "coverage": 41
+        },
+        "clay_ios": {
+          "supported": 413,
+          "coverage": 36
+        },
+        "clay_macos": {
+          "supported": 469,
+          "coverage": 41
+        },
+        "clay_windows": {
+          "supported": 469,
+          "coverage": 41
+        },
+        "clay": {
+          "supported": 469,
+          "coverage": 41
+        }
+      }
+    },
+    {
+      "version": "2.11",
+      "release_date": "2023/7/10",
+      "platforms": {
+        "android": {
+          "supported": 586,
+          "coverage": 52
+        },
+        "ios": {
+          "supported": 585,
+          "coverage": 52
+        },
+        "harmony": {
+          "supported": 0,
+          "coverage": 0
+        },
+        "web_lynx": {
+          "supported": 691,
+          "coverage": 61
+        },
+        "clay_android": {
+          "supported": 469,
+          "coverage": 41
+        },
+        "clay_ios": {
+          "supported": 413,
+          "coverage": 36
+        },
+        "clay_macos": {
+          "supported": 469,
+          "coverage": 41
+        },
+        "clay_windows": {
+          "supported": 469,
+          "coverage": 41
+        },
+        "clay": {
+          "supported": 469,
+          "coverage": 41
+        }
+      }
+    },
+    {
+      "version": "2.12",
+      "release_date": "2023/9/11",
+      "platforms": {
+        "android": {
+          "supported": 589,
+          "coverage": 52
+        },
+        "ios": {
+          "supported": 588,
+          "coverage": 52
+        },
+        "harmony": {
+          "supported": 0,
+          "coverage": 0
+        },
+        "web_lynx": {
+          "supported": 691,
+          "coverage": 61
+        },
+        "clay_android": {
+          "supported": 470,
+          "coverage": 42
+        },
+        "clay_ios": {
+          "supported": 414,
+          "coverage": 37
+        },
+        "clay_macos": {
+          "supported": 470,
+          "coverage": 42
+        },
+        "clay_windows": {
+          "supported": 470,
+          "coverage": 42
+        },
+        "clay": {
+          "supported": 470,
+          "coverage": 42
+        }
+      }
+    },
+    {
+      "version": "2.13",
+      "release_date": "2023/11/20",
+      "platforms": {
+        "android": {
+          "supported": 597,
+          "coverage": 53
+        },
+        "ios": {
+          "supported": 596,
+          "coverage": 53
+        },
+        "harmony": {
+          "supported": 0,
+          "coverage": 0
+        },
+        "web_lynx": {
+          "supported": 691,
+          "coverage": 61
+        },
+        "clay_android": {
+          "supported": 470,
+          "coverage": 42
+        },
+        "clay_ios": {
+          "supported": 414,
+          "coverage": 37
+        },
+        "clay_macos": {
+          "supported": 470,
+          "coverage": 42
+        },
+        "clay_windows": {
+          "supported": 470,
+          "coverage": 42
+        },
+        "clay": {
+          "supported": 470,
+          "coverage": 42
+        }
+      }
+    },
+    {
+      "version": "2.14",
+      "release_date": "2024/1/23",
+      "platforms": {
+        "android": {
+          "supported": 631,
+          "coverage": 56
+        },
+        "ios": {
+          "supported": 630,
+          "coverage": 56
+        },
+        "harmony": {
+          "supported": 0,
+          "coverage": 0
+        },
+        "web_lynx": {
+          "supported": 691,
+          "coverage": 61
+        },
+        "clay_android": {
+          "supported": 490,
+          "coverage": 43
+        },
+        "clay_ios": {
+          "supported": 426,
+          "coverage": 38
+        },
+        "clay_macos": {
+          "supported": 490,
+          "coverage": 43
+        },
+        "clay_windows": {
+          "supported": 490,
+          "coverage": 43
+        },
+        "clay": {
+          "supported": 490,
+          "coverage": 43
+        }
+      }
+    },
+    {
+      "version": "2.15",
+      "release_date": "2024/3/18",
+      "platforms": {
+        "android": {
+          "supported": 632,
+          "coverage": 56
+        },
+        "ios": {
+          "supported": 631,
+          "coverage": 56
+        },
+        "harmony": {
+          "supported": 0,
+          "coverage": 0
+        },
+        "web_lynx": {
+          "supported": 691,
+          "coverage": 61
+        },
+        "clay_android": {
+          "supported": 490,
+          "coverage": 43
+        },
+        "clay_ios": {
+          "supported": 426,
+          "coverage": 38
+        },
+        "clay_macos": {
+          "supported": 490,
+          "coverage": 43
+        },
+        "clay_windows": {
+          "supported": 490,
+          "coverage": 43
+        },
+        "clay": {
+          "supported": 490,
+          "coverage": 43
+        }
+      }
+    },
+    {
       "version": "2.16",
       "release_date": "2024/5/20",
       "platforms": {

--- a/packages/lynx-compat-data/scripts/generate-stats.ts
+++ b/packages/lynx-compat-data/scripts/generate-stats.ts
@@ -175,8 +175,6 @@ const PLATFORM_API_CATEGORIES = new Set(
 const RECENT_VERSIONS = ['3.9', '4.0', '4.1'];
 
 // How many version.json history entries to include in the Coverage Trend.
-const TIMELINE_VERSION_COUNT = 14;
-
 interface APIInfo {
   path: string;
   name: string;
@@ -675,8 +673,9 @@ function calculateTimeline(
   allFeatures: FeatureInfo[],
   versionHistory: Array<{ version: string; release_date?: string }>,
 ): TimelinePoint[] {
-  // Use the most recent release window so the trend chart reaches current.
-  const recentVersions = versionHistory.slice(-TIMELINE_VERSION_COUNT);
+  // Emit the full version history so the Coverage page can let users pick
+  // any from/to window. The UI defaults to a recent slice.
+  const recentVersions = versionHistory;
 
   // Only count shared features in Platform API categories (supported by at least 2 platforms)
   const relevantFeatures = allFeatures.filter((f) => {

--- a/src/components/api-status/APIStatusDashboard.tsx
+++ b/src/components/api-status/APIStatusDashboard.tsx
@@ -370,7 +370,7 @@ export const APIItem: React.FC<APIItemProps> = ({
       </DrawerTrigger>
       <DrawerContent
         className={cn(
-          isDesktop ? 'h-full' : 'max-h-[85vh]',
+          !isDesktop && 'max-h-[85vh]',
           isDesktop && 'bg-zinc-50 dark:bg-zinc-900',
         )}
       >

--- a/src/components/api-status/APIStatusPages.scss
+++ b/src/components/api-status/APIStatusPages.scss
@@ -314,6 +314,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
   gap: 12px;
   padding: 12px 16px;
   border-bottom: 1px solid color-mix(in srgb, currentColor 8%, transparent);
@@ -414,6 +415,194 @@
   color: var(--tint);
   background: color-mix(in srgb, var(--tint) 14%, transparent);
   cursor: default;
+}
+
+// ─── Coverage filters + version brush ────────────────────────────────────
+
+.aps-coverage-filters {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.aps-coverage-filters__families,
+.aps-coverage-filters__leaves {
+  flex-wrap: wrap;
+  width: fit-content;
+  max-width: 100%;
+}
+
+.aps-coverage-range {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.aps-coverage-range__field {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  color: var(--rp-c-text-3, #8e8e98);
+
+  select {
+    appearance: none;
+    padding: 3px 8px;
+    border-radius: 6px;
+    border: 1px solid color-mix(in srgb, currentColor 12%, transparent);
+    background: color-mix(in srgb, currentColor 4%, transparent);
+    color: var(--rp-c-text-1, #111113);
+    font-family: var(--rp-font-mono, ui-monospace, monospace);
+    font-size: 11px;
+    font-weight: 600;
+    cursor: pointer;
+
+    &:hover {
+      border-color: color-mix(in srgb, currentColor 22%, transparent);
+    }
+
+    &:focus {
+      outline: none;
+      border-color: color-mix(
+        in srgb,
+        var(--rp-c-brand, #ff351a) 40%,
+        transparent
+      );
+    }
+  }
+}
+
+.aps-coverage-range__sep {
+  color: var(--rp-c-text-3, #8e8e98);
+  font-size: 11px;
+}
+
+.aps-coverage-range__reset {
+  margin-left: 2px;
+  padding: 3px 8px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--rp-c-text-2, #6a6a73);
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:hover {
+    color: var(--rp-c-text-1, #111113);
+    background: color-mix(in srgb, currentColor 6%, transparent);
+  }
+}
+
+.aps-version-brush {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px 6px;
+  margin-top: 4px;
+  border-top: 1px solid color-mix(in srgb, currentColor 8%, transparent);
+}
+
+.aps-version-brush__track {
+  position: relative;
+  height: 28px;
+  border-radius: 8px;
+  background: color-mix(in srgb, currentColor 6%, transparent);
+  border: 1px solid color-mix(in srgb, currentColor 10%, transparent);
+  cursor: pointer;
+  touch-action: none;
+  user-select: none;
+}
+
+.aps-version-brush__window {
+  position: absolute;
+  top: 2px;
+  bottom: 2px;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--rp-c-brand, #ff351a) 16%, transparent);
+  border: 1px solid
+    color-mix(in srgb, var(--rp-c-brand, #ff351a) 36%, transparent);
+  cursor: grab;
+
+  &:active {
+    cursor: grabbing;
+  }
+}
+
+.aps-version-brush__handle {
+  position: absolute;
+  top: 50%;
+  width: 12px;
+  height: 22px;
+  padding: 0;
+  border: 1px solid
+    color-mix(in srgb, var(--rp-c-brand, #ff351a) 50%, transparent);
+  border-radius: 4px;
+  background: var(--rp-c-bg, #fff);
+  transform: translate(-50%, -50%);
+  cursor: ew-resize;
+  box-shadow: 0 1px 3px color-mix(in srgb, #000 12%, transparent);
+  z-index: 1;
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 5px;
+    bottom: 5px;
+    left: 50%;
+    width: 1px;
+    background: color-mix(in srgb, var(--rp-c-brand, #ff351a) 55%, transparent);
+    transform: translateX(-50%);
+  }
+}
+
+.aps-version-brush__ticks {
+  position: relative;
+  height: 16px;
+  margin: 0 2px;
+}
+
+.aps-version-brush__tick {
+  position: absolute;
+  transform: translateX(-50%);
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--rp-c-text-3, #8e8e98);
+  font-family: var(--rp-font-mono, ui-monospace, monospace);
+  font-size: 9.5px;
+  font-weight: 500;
+  line-height: 1;
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:hover {
+    color: var(--rp-c-text-1, #111113);
+  }
+}
+
+.aps-version-brush__tick--in {
+  color: var(--rp-c-text-2, #6a6a73);
+}
+
+.aps-version-brush__tick--edge {
+  color: var(--rp-c-brand, #ff351a);
+  font-weight: 700;
+}
+
+.aps-version-brush__hint {
+  margin: 0;
+  font-size: 10.5px;
+  color: var(--rp-c-text-3, #8e8e98);
+  text-align: center;
+}
+
+.aps-chart-version-label {
+  &:hover {
+    fill-opacity: 0.9;
+  }
 }
 
 // ─── Version chip ────────────────────────────────────────────────────────

--- a/src/components/api-status/pages/CoveragePage.tsx
+++ b/src/components/api-status/pages/CoveragePage.tsx
@@ -1,6 +1,12 @@
 import { cn } from '@/lib/utils';
 import { useLang } from '@rspress/core/runtime';
-import React, { useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { PLATFORM_CONFIG } from '../constants';
 import {
   CATEGORY_DISPLAY_NAMES,
@@ -26,6 +32,10 @@ const i18n = {
     deltaFrom: 'Δ from',
     noData: 'Not enough timeline data for this filter.',
     features: 'features',
+    from: 'From',
+    to: 'To',
+    resetRange: 'Recent',
+    dragHint: 'Drag the handles or click a version to set the range.',
   },
   zh: {
     exclusive: '独占',
@@ -41,8 +51,14 @@ const i18n = {
     deltaFrom: '相对',
     noData: '当前筛选条件下没有足够的时间线数据。',
     features: '个特性',
+    from: '从',
+    to: '到',
+    resetRange: '近版本',
+    dragHint: '拖动手柄或点击版本号来设置范围。',
   },
 };
+
+const DEFAULT_WINDOW = 14;
 
 /** Platform-API categories used for coverage (mirrors generate-stats.ts). */
 const PLATFORM_API_CATEGORIES = new Set([
@@ -61,7 +77,7 @@ const PLATFORM_API_CATEGORIES = new Set([
   'lynx-api/performance-api',
 ]);
 
-/** Filter chips shown above the main trend chart. */
+/** Filter chips shown above the main trend chart (majors + leaf subcategories). */
 const CATEGORY_FILTERS: Array<{ id: string; label: string; match: string[] }> =
   [
     { id: 'all', label: 'All', match: [] },
@@ -92,10 +108,49 @@ const CATEGORY_FILTERS: Array<{ id: string; label: string; match: string[] }> =
         'lynx-api/performance-api',
       ],
     },
+    { id: 'lynx-api/global', label: 'Global', match: ['lynx-api/global'] },
+    { id: 'lynx-api/event', label: 'Event', match: ['lynx-api/event'] },
+    { id: 'lynx-api/fetch', label: 'Fetch', match: ['lynx-api/fetch'] },
+    { id: 'lynx-api/lynx', label: 'lynx.*', match: ['lynx-api/lynx'] },
+    {
+      id: 'lynx-api/selector-query',
+      label: 'Selector Query',
+      match: ['lynx-api/selector-query'],
+    },
+    {
+      id: 'lynx-api/nodes-ref',
+      label: 'Nodes Ref',
+      match: ['lynx-api/nodes-ref'],
+    },
+    {
+      id: 'lynx-api/intersection-observer',
+      label: 'Intersection Observer',
+      match: ['lynx-api/intersection-observer'],
+    },
+    {
+      id: 'lynx-api/main-thread',
+      label: 'Main Thread',
+      match: ['lynx-api/main-thread'],
+    },
+    {
+      id: 'lynx-api/performance-api',
+      label: 'Performance',
+      match: ['lynx-api/performance-api'],
+    },
+    {
+      id: 'lynx-native-api',
+      label: 'Native API',
+      match: ['lynx-native-api'],
+    },
+    { id: 'react', label: 'ReactLynx', match: ['react'] },
+    { id: 'devtool', label: 'DevTool', match: ['devtool'] },
+    { id: 'errors', label: 'Errors', match: ['errors'] },
   ];
 
-/** Categories rendered as small-multiple charts. */
-const CATEGORY_CHARTS = CATEGORY_FILTERS.filter((c) => c.id !== 'all');
+/** Categories rendered as small-multiple charts (skip aggregate All / Lynx API). */
+const CATEGORY_CHARTS = CATEGORY_FILTERS.filter(
+  (c) => c.id !== 'all' && c.id !== 'lynx-api',
+);
 
 const PlatformIcon: React.FC<{
   platform: string;
@@ -456,6 +511,179 @@ const ParityChart: React.FC<ParityChartProps> = ({
   );
 };
 
+// ─── Version range brush ─────────────────────────────────────────────────
+
+interface VersionBrushProps {
+  versions: string[];
+  startIndex: number;
+  endIndex: number;
+  onChange: (start: number, end: number) => void;
+  hint: string;
+}
+
+const VersionBrush: React.FC<VersionBrushProps> = ({
+  versions,
+  startIndex,
+  endIndex,
+  onChange,
+  hint,
+}) => {
+  const trackRef = useRef<HTMLDivElement>(null);
+  const dragRef = useRef<'start' | 'end' | 'window' | null>(null);
+  const dragOriginRef = useRef<{
+    x: number;
+    start: number;
+    end: number;
+  } | null>(null);
+
+  const n = versions.length;
+  const indexFromClientX = useCallback(
+    (clientX: number) => {
+      const el = trackRef.current;
+      if (!el) return 0;
+      const rect = el.getBoundingClientRect();
+      const ratio = Math.min(
+        1,
+        Math.max(0, (clientX - rect.left) / rect.width),
+      );
+      return Math.round(ratio * (n - 1));
+    },
+    [n],
+  );
+
+  useEffect(() => {
+    const onMove = (e: PointerEvent) => {
+      const mode = dragRef.current;
+      if (!mode) return;
+      const idx = indexFromClientX(e.clientX);
+      if (mode === 'start') {
+        onChange(Math.min(idx, endIndex - 1), endIndex);
+      } else if (mode === 'end') {
+        onChange(startIndex, Math.max(idx, startIndex + 1));
+      } else if (mode === 'window' && dragOriginRef.current) {
+        const origin = dragOriginRef.current;
+        const el = trackRef.current;
+        if (!el) return;
+        const dx = e.clientX - origin.x;
+        const shift = Math.round(
+          (dx / el.getBoundingClientRect().width) * (n - 1),
+        );
+        const span = origin.end - origin.start;
+        let nextStart = origin.start + shift;
+        let nextEnd = origin.end + shift;
+        if (nextStart < 0) {
+          nextStart = 0;
+          nextEnd = span;
+        }
+        if (nextEnd > n - 1) {
+          nextEnd = n - 1;
+          nextStart = nextEnd - span;
+        }
+        onChange(nextStart, nextEnd);
+      }
+    };
+    const onUp = () => {
+      dragRef.current = null;
+      dragOriginRef.current = null;
+    };
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+    return () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+    };
+  }, [endIndex, indexFromClientX, n, onChange, startIndex]);
+
+  if (n < 2) return null;
+
+  const leftPct = (startIndex / (n - 1)) * 100;
+  const widthPct = ((endIndex - startIndex) / (n - 1)) * 100;
+
+  const tickIndexes = (() => {
+    if (n <= 14) return versions.map((_, i) => i);
+    const step = Math.ceil((n - 1) / 10);
+    const set = new Set<number>([0, n - 1, startIndex, endIndex]);
+    for (let i = step; i < n - 1; i += step) set.add(i);
+    return [...set].sort((a, b) => a - b);
+  })();
+
+  return (
+    <div className="aps-version-brush">
+      <div
+        ref={trackRef}
+        className="aps-version-brush__track"
+        onPointerDown={(e) => {
+          if (e.target !== e.currentTarget) return;
+          const idx = indexFromClientX(e.clientX);
+          if (Math.abs(idx - startIndex) <= Math.abs(idx - endIndex)) {
+            onChange(Math.min(idx, endIndex - 1), endIndex);
+          } else {
+            onChange(startIndex, Math.max(idx, startIndex + 1));
+          }
+        }}
+      >
+        <div
+          className="aps-version-brush__window"
+          style={{ left: `${leftPct}%`, width: `${widthPct}%` }}
+          onPointerDown={(e) => {
+            e.stopPropagation();
+            dragRef.current = 'window';
+            dragOriginRef.current = {
+              x: e.clientX,
+              start: startIndex,
+              end: endIndex,
+            };
+          }}
+        />
+        <button
+          type="button"
+          className="aps-version-brush__handle"
+          style={{ left: `${leftPct}%` }}
+          aria-label="Range start"
+          onPointerDown={(e) => {
+            e.stopPropagation();
+            dragRef.current = 'start';
+          }}
+        />
+        <button
+          type="button"
+          className="aps-version-brush__handle"
+          style={{ left: `${leftPct + widthPct}%` }}
+          aria-label="Range end"
+          onPointerDown={(e) => {
+            e.stopPropagation();
+            dragRef.current = 'end';
+          }}
+        />
+      </div>
+      <div className="aps-version-brush__ticks">
+        {tickIndexes.map((i) => (
+          <button
+            key={versions[i]}
+            type="button"
+            className={cn(
+              'aps-version-brush__tick',
+              i >= startIndex && i <= endIndex && 'aps-version-brush__tick--in',
+              (i === startIndex || i === endIndex) &&
+                'aps-version-brush__tick--edge',
+            )}
+            style={{ left: `${(i / (n - 1)) * 100}%` }}
+            onClick={() => {
+              if (i < startIndex) onChange(i, endIndex);
+              else if (i > endIndex) onChange(startIndex, i);
+              else if (i - startIndex <= endIndex - i) onChange(i, endIndex);
+              else onChange(startIndex, i);
+            }}
+          >
+            v{versions[i]}
+          </button>
+        ))}
+      </div>
+      <p className="aps-version-brush__hint">{hint}</p>
+    </div>
+  );
+};
+
 // ─── Page ────────────────────────────────────────────────────────────────
 
 interface CoveragePageProps {
@@ -482,30 +710,69 @@ export const CoveragePage: React.FC<CoveragePageProps> = ({
       })),
     [baseTimeline],
   );
+  const versionLabels = useMemo(
+    () => versions.map((v) => v.version),
+    [versions],
+  );
+
+  const defaultStart = Math.max(0, versions.length - DEFAULT_WINDOW);
+  const defaultEnd = Math.max(0, versions.length - 1);
+  const [startIndex, setStartIndex] = useState(defaultStart);
+  const [endIndex, setEndIndex] = useState(defaultEnd);
+
+  useEffect(() => {
+    if (versions.length < 2) return;
+    setStartIndex((s) => Math.min(Math.max(0, s), versions.length - 2));
+    setEndIndex((e) => Math.min(Math.max(1, e), versions.length - 1));
+  }, [versions.length]);
+
+  const setRange = useCallback((start: number, end: number) => {
+    const s = Math.max(0, Math.min(start, end - 1));
+    const e = Math.max(s + 1, end);
+    setStartIndex(s);
+    setEndIndex(e);
+  }, []);
+
+  const resetRange = useCallback(() => {
+    setStartIndex(Math.max(0, versions.length - DEFAULT_WINDOW));
+    setEndIndex(Math.max(0, versions.length - 1));
+  }, [versions.length]);
+
+  const windowedVersions = useMemo(
+    () => versions.slice(startIndex, endIndex + 1),
+    [versions, startIndex, endIndex],
+  );
 
   const { timeline, featureCount } = useMemo(() => {
     if (categoryFilter === 'all' && baseTimeline && baseTimeline.length >= 2) {
       // Prefer precomputed overall timeline (includes clay aggregate).
       return {
-        timeline: baseTimeline,
+        timeline: baseTimeline.slice(startIndex, endIndex + 1),
         featureCount: summary.platform_api_total,
       };
     }
-    return buildTimeline(features, versions, categoryFilter, selectedPlatforms);
+    return buildTimeline(
+      features,
+      windowedVersions,
+      categoryFilter,
+      selectedPlatforms,
+    );
   }, [
     categoryFilter,
     baseTimeline,
     features,
-    versions,
+    windowedVersions,
     selectedPlatforms,
     summary.platform_api_total,
+    startIndex,
+    endIndex,
   ]);
 
   const categoryTimelines = useMemo(() => {
     return CATEGORY_CHARTS.map((cat) => {
       const built = buildTimeline(
         features,
-        versions,
+        windowedVersions,
         cat.id,
         selectedPlatforms,
       );
@@ -520,18 +787,16 @@ export const CoveragePage: React.FC<CoveragePageProps> = ({
         ...cat,
         ...built,
         deltas,
-        label:
-          cat.id === 'lynx-api'
-            ? 'Lynx API'
-            : CATEGORY_DISPLAY_NAMES[cat.id] || cat.label,
+        label: CATEGORY_DISPLAY_NAMES[cat.id] || cat.label,
       };
     }).filter((c) => c.timeline.length >= 2 && c.featureCount > 0);
-  }, [features, versions, selectedPlatforms]);
+  }, [features, windowedVersions, selectedPlatforms]);
 
   const filterLabel =
     categoryFilter === 'all'
       ? t.allCategories
-      : CATEGORY_FILTERS.find((f) => f.id === categoryFilter)?.label ||
+      : CATEGORY_DISPLAY_NAMES[categoryFilter] ||
+        CATEGORY_FILTERS.find((f) => f.id === categoryFilter)?.label ||
         categoryFilter;
 
   return (
@@ -640,8 +905,7 @@ export const CoveragePage: React.FC<CoveragePageProps> = ({
                 }}
               >
                 {filterLabel}
-                {' · '}v{versions[0].version} → v
-                {versions[versions.length - 1].version}
+                {' · '}v{versionLabels[startIndex]} → v{versionLabels[endIndex]}
                 {featureCount > 0 && (
                   <>
                     {' · '}
@@ -651,6 +915,48 @@ export const CoveragePage: React.FC<CoveragePageProps> = ({
               </p>
             </div>
             <div className="aps-trend-controls">
+              <div className="aps-coverage-range">
+                <label className="aps-coverage-range__field">
+                  <span>{t.from}</span>
+                  <select
+                    value={versionLabels[startIndex] || ''}
+                    onChange={(e) => {
+                      const idx = versionLabels.indexOf(e.target.value);
+                      if (idx >= 0) setRange(idx, endIndex);
+                    }}
+                  >
+                    {versionLabels.map((v, i) => (
+                      <option key={v} value={v} disabled={i >= endIndex}>
+                        v{v}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <span className="aps-coverage-range__sep">—</span>
+                <label className="aps-coverage-range__field">
+                  <span>{t.to}</span>
+                  <select
+                    value={versionLabels[endIndex] || ''}
+                    onChange={(e) => {
+                      const idx = versionLabels.indexOf(e.target.value);
+                      if (idx >= 0) setRange(startIndex, idx);
+                    }}
+                  >
+                    {versionLabels.map((v, i) => (
+                      <option key={v} value={v} disabled={i <= startIndex}>
+                        v{v}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <button
+                  type="button"
+                  className="aps-coverage-range__reset"
+                  onClick={resetRange}
+                >
+                  {t.resetRange}
+                </button>
+              </div>
               <div className="aps-trend-seg" role="group" aria-label={t.yScale}>
                 <button
                   type="button"
@@ -700,11 +1006,20 @@ export const CoveragePage: React.FC<CoveragePageProps> = ({
 
           <div className="aps-plate__body" style={{ padding: '8px 8px 4px' }}>
             {timeline.length >= 2 ? (
-              <ParityChart
-                timeline={timeline}
-                selectedPlatforms={selectedPlatforms}
-                focusScale={focusScale}
-              />
+              <>
+                <ParityChart
+                  timeline={timeline}
+                  selectedPlatforms={selectedPlatforms}
+                  focusScale={focusScale}
+                />
+                <VersionBrush
+                  versions={versionLabels}
+                  startIndex={startIndex}
+                  endIndex={endIndex}
+                  onChange={setRange}
+                  hint={t.dragHint}
+                />
+              </>
             ) : (
               <p
                 style={{

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -47,13 +47,21 @@ const DrawerContent = React.forwardRef<
   const { direction } = React.useContext(DrawerContext)
   const isHorizontal = direction === "left" || direction === "right"
 
-  // For side drawers, add gap from edge and use --initial-transform for animation
-  const sideDrawerGap = 8
+  // Floating side drawers: inset from viewport edges (macOS-style) + animate past the gap
+  const sideDrawerGap = 12
   const sideDrawerStyle = isHorizontal
     ? {
         ...style,
-        // ...(direction === "right" && { right: `${sideDrawerGap}px`, top: `${sideDrawerGap}px`, bottom: `${sideDrawerGap}px` }),
-        // ...(direction === "left" && { left: `${sideDrawerGap}px`, top: `${sideDrawerGap}px`, bottom: `${sideDrawerGap}px` }),
+        ...(direction === "right" && {
+          right: `${sideDrawerGap}px`,
+          top: `${sideDrawerGap}px`,
+          bottom: `${sideDrawerGap}px`,
+        }),
+        ...(direction === "left" && {
+          left: `${sideDrawerGap}px`,
+          top: `${sideDrawerGap}px`,
+          bottom: `${sideDrawerGap}px`,
+        }),
         '--initial-transform': `calc(100% + ${sideDrawerGap}px)` as React.CSSProperties['--initial-transform'],
       } as React.CSSProperties
     : style
@@ -67,10 +75,10 @@ const DrawerContent = React.forwardRef<
           "fixed z-[100] flex flex-col bg-background outline-none",
           // Bottom drawer (default)
           !isHorizontal && "inset-x-0 bottom-0 mt-24 h-auto rounded-t-[10px] border",
-          // Right drawer - with gap from edge, no border (gap provides visual separation)
-          direction === "right" && "inset-y-0 right-2 h-full w-[600px] max-w-[90vw] rounded-[16px] shadow-lg",
-          // Left drawer - with gap from edge, no border (gap provides visual separation)
-          direction === "left" && "inset-y-0 left-2 h-full w-[600px] max-w-[90vw] rounded-[16px] shadow-lg",
+          // Right drawer - floating with gap from edge (position via inline style)
+          direction === "right" && "w-[600px] max-w-[90vw] rounded-[16px] shadow-xl",
+          // Left drawer - floating with gap from edge (position via inline style)
+          direction === "left" && "w-[600px] max-w-[90vw] rounded-[16px] shadow-xl",
           // Top drawer
           direction === "top" && "inset-x-0 top-0 mb-24 h-auto rounded-b-[10px] border",
           className


### PR DESCRIPTION
## Summary
- Coverage trend: pick any version window via brush / From–To controls (full timeline history; defaults to recent versions)
- Expand category filters to leaf subcategories (Lynx API leaves, Native API, ReactLynx, DevTool, Errors) and small-multiples
- Float the API compatibility side drawer with macOS-style inset spacing

## Test plan
- [ ] Open `/api/status` → Coverage trend; confirm default window is recent versions
- [ ] Drag brush handles / use From–To / click version ticks; chart updates
- [ ] Filter by CSS Properties, Lynx API leaves, Native API; parity + trend recompute
- [ ] Open an API chip drawer on desktop; panel floats with gap from viewport edges
- [ ] Mobile drawer still opens from bottom

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Enable interactive API coverage version-range selection with brush and From–To controls
- Expand coverage filters to include leaf subcategories
- Generate and display the full API coverage timeline
- Float the API compatibility drawer on desktop while preserving mobile bottom-sheet behavior
- Add coverage range and version brush styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->