### PR TITLE
docs: update Autolink Gradle plugin IDs

### DIFF
--- a/docs/en/guide/autolink.mdx
+++ b/docs/en/guide/autolink.mdx
@@ -19,7 +19,7 @@ Autolink covers Android and iOS native app integration, and it also covers the p
 Use Autolink tooling from the same Lynx release channel as your app. The package and plugin names are:
 
 - npm: `create-lynx-library` and `@lynx-js/autolink-codegen` (`lynx-autolink-codegen` binary)
-- Android: Gradle plugins `org.lynxsdk.library-settings` and `org.lynxsdk.library-build`
+- Android: Gradle plugins `org.lynxsdk.lynx.library-settings` and `org.lynxsdk.lynx.library-build`
 - iOS: Ruby gem `cocoapods-lynx-library`
 - Lynxtron: `create-lynx-library` can generate shared native library packages, and `@lynx-js/lynxtron-dev-plugins` provides host-side loading through `pluginLynxtron()`.
 
@@ -82,7 +82,7 @@ Enable the settings plugin in `settings.gradle` so library Android projects can 
 
 ```groovy
 plugins {
-  id 'org.lynxsdk.library-settings'
+  id 'org.lynxsdk.lynx.library-settings'
 }
 ```
 
@@ -91,7 +91,7 @@ Enable the build plugin in the Android application project so the generated regi
 ```groovy
 plugins {
   id 'com.android.application'
-  id 'org.lynxsdk.library-build'
+  id 'org.lynxsdk.lynx.library-build'
 }
 ```
 

--- a/docs/zh/guide/autolink.mdx
+++ b/docs/zh/guide/autolink.mdx
@@ -19,7 +19,7 @@ Autolink 覆盖 Android 和 iOS 原生应用接入，也覆盖 Lynxtron 原生�
 请使用与应用 Lynx SDK 同一发布渠道的 Autolink 工具。相关 package 和 plugin 名称如下：
 
 - npm：`create-lynx-library` 和 `@lynx-js/autolink-codegen`（`lynx-autolink-codegen` binary）
-- Android：Gradle plugin `org.lynxsdk.library-settings` 和 `org.lynxsdk.library-build`
+- Android：Gradle plugin `org.lynxsdk.lynx.library-settings` 和 `org.lynxsdk.lynx.library-build`
 - iOS：Ruby gem `cocoapods-lynx-library`
 - Lynxtron：`create-lynx-library` 可以生成 shared native library 包，`@lynx-js/lynxtron-dev-plugins` 通过 `pluginLynxtron()` 提供宿主侧加载能力。
 
@@ -82,7 +82,7 @@ lynx-app/
 
 ```groovy
 plugins {
-  id 'org.lynxsdk.library-settings'
+  id 'org.lynxsdk.lynx.library-settings'
 }
 ```
 
@@ -91,7 +91,7 @@ plugins {
 ```groovy
 plugins {
   id 'com.android.application'
-  id 'org.lynxsdk.library-build'
+  id 'org.lynxsdk.lynx.library-build'
 }
 ```
 


### PR DESCRIPTION
## Summary

- update the Android Autolink settings plugin ID to `org.lynxsdk.lynx.library-settings`
- update the Android Autolink build plugin ID to `org.lynxsdk.lynx.library-build`
- keep the English and Chinese guides in sync

## Why

The Gradle plugin marker IDs moved under the `org.lynxsdk.lynx` namespace so they can be published through the existing Lynx namespace. The website must use the published IDs or Android users cannot resolve the Autolink plugins.

Related code change: https://github.com/lynx-family/lynx/pull/8058

## Validation

- `node node_modules/prettier/bin/prettier.cjs --check docs/en/guide/autolink.mdx docs/zh/guide/autolink.mdx`
- `node node_modules/cspell/bin.mjs lint -c cspell.json --no-must-find-files docs/en/guide/autolink.mdx docs/zh/guide/autolink.mdx`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Update English and Chinese Autolink guides with the new Android Gradle plugin IDs under the `org.lynxsdk.lynx` namespace.
- Refresh settings and build plugin references in prerequisites and configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->