### PR TITLE
fix: backport hero first-paint unblock to release/4.0

### DIFF
--- a/docs/en/index.mdx
+++ b/docs/en/index.mdx
@@ -2,8 +2,10 @@
 pageType: home
 
 hero:
-  badge: ' ' # controlled by use-blog-btn-dom.ts
-  name: Unlock Native for More
+  # Fallback badge text for SSG; upgraded to latest blog title by use-blog-btn-dom.ts
+  badge: 'Read the Latest Blog'
+  # Structured spans so the title is visible before the typing effect hydrates
+  name: <span class="dynamic-text">Unlock</span><span class="suffix-text"> Native for More</span>
   tagline: 'Empower the web community and invite more to build across platforms'
   actions:
     - theme: brand

--- a/docs/en/react/index.mdx
+++ b/docs/en/react/index.mdx
@@ -2,7 +2,7 @@
 pageType: home
 
 hero:
-  badge: ' ' # controlled by use-blog-btn-dom.ts
+  badge: 'ReactLynx'
   name: <span class="hero-title"><span class="normal">Idiomatic </span><span class="brand-ani">React </span><span class="normal">on </span><span class="brand">Lynx</span></span>
   tagline: Develop Lynx with the familiar React
   actions:

--- a/docs/en/rspeedy/index.md
+++ b/docs/en/rspeedy/index.md
@@ -2,7 +2,7 @@
 pageType: home
 
 hero:
-  badge: ' ' # controlled by use-blog-btn-dom.ts
+  badge: 'Rspeedy'
   name: <span class="hero-title"><span class="normal">The </span><span class="brand-ani">Build Tool </span><span class="normal">for </span><span class="brand">Lynx</span></span>
   tagline: Build your Lynx application instantly with Rspack
   actions:

--- a/docs/zh/index.mdx
+++ b/docs/zh/index.mdx
@@ -2,8 +2,10 @@
 pageType: home
 
 hero:
-  badge: ' ' # controlled by use-blog-btn-dom.ts
-  name: 迈向原生体验
+  # Fallback badge text for SSG; upgraded to latest blog title by use-blog-btn-dom.ts
+  badge: '阅读最新博客'
+  # Structured spans so the title is visible before the typing effect hydrates
+  name: <span class="dynamic-text">迈向</span><span class="suffix-text">原生体验</span>
   tagline: 助力 Web 构建跨平台应用
   actions:
     - theme: brand

--- a/docs/zh/react/index.mdx
+++ b/docs/zh/react/index.mdx
@@ -2,7 +2,7 @@
 pageType: home
 
 hero:
-  badge: ' ' # controlled by use-blog-btn-dom.ts
+  badge: 'ReactLynx'
   name: <span class="hero-title"><span class="brand">Lynx </span><span class="normal">上的地道 </span><span class="brand-ani">React</span></span>
   tagline: 用熟悉的 React 心智模型开发 Lynx
   actions:

--- a/docs/zh/rspeedy/index.md
+++ b/docs/zh/rspeedy/index.md
@@ -2,7 +2,7 @@
 pageType: home
 
 hero:
-  badge: ' ' # controlled by use-blog-btn-dom.ts
+  badge: 'Rspeedy'
   name: <span class="hero-title"><span class="brand">Lynx </span><span class="brand-ani">构建工具</span></span>
   tagline: 用 Rspack，瞬息之间构建你的 Lynx 应用
   actions:

--- a/theme/blog-btn.scss
+++ b/theme/blog-btn.scss
@@ -37,10 +37,10 @@
   line-height: 34px;
   // shorthand so we fully override Rspress's padding (not just left/right)
   padding: 0 20px 0 43px;
-  transition: all 0.3s ease;
+  transition: background 0.3s ease;
   user-select: none;
-  opacity: 0;
-  transition: opacity 0.5s ease-in;
+  // Visible in SSG HTML — do not wait for client JS to reveal the badge.
+  opacity: 1;
 
   @media (max-width: 768px) {
     font-size: 12px;

--- a/theme/deferred-client.tsx
+++ b/theme/deferred-client.tsx
@@ -1,0 +1,76 @@
+import { type ComponentType, type ReactNode, useEffect, useState } from 'react';
+
+type Loader<T> = () => Promise<T>;
+
+/**
+ * Load a client-only module after mount (optionally on idle).
+ * Keeps the initial theme graph thin and avoids hydration mismatches
+ * by rendering `fallback` on both SSG and the first client paint.
+ */
+export function DeferredClient<T>({
+  loader,
+  fallback = null,
+  idle = false,
+  children,
+}: {
+  loader: Loader<T>;
+  fallback?: ReactNode;
+  idle?: boolean;
+  children: (mod: T) => ReactNode;
+}) {
+  const [mod, setMod] = useState<T | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let idleId: number | undefined;
+    let timeoutId: number | undefined;
+
+    const run = () => {
+      loader().then((resolved) => {
+        if (!cancelled) {
+          setMod(() => resolved);
+        }
+      });
+    };
+
+    if (idle && typeof requestIdleCallback === 'function') {
+      idleId = requestIdleCallback(run, { timeout: 2000 });
+    } else {
+      timeoutId = window.setTimeout(run, idle ? 200 : 0);
+    }
+
+    return () => {
+      cancelled = true;
+      if (idleId !== undefined) {
+        cancelIdleCallback(idleId);
+      }
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+    };
+  }, [loader, idle]);
+
+  if (!mod) {
+    return <>{fallback}</>;
+  }
+
+  return <>{children(mod)}</>;
+}
+
+export function DeferredComponent<P extends object>({
+  loader,
+  fallback = null,
+  idle = false,
+  props,
+}: {
+  loader: () => Promise<ComponentType<P>>;
+  fallback?: ReactNode;
+  idle?: boolean;
+  props: P;
+}) {
+  return (
+    <DeferredClient loader={loader} fallback={fallback} idle={idle}>
+      {(Comp) => <Comp {...props} />}
+    </DeferredClient>
+  );
+}

--- a/theme/hero-text.scss
+++ b/theme/hero-text.scss
@@ -1,7 +1,8 @@
 :root[data-subsite='react'],
 :root[data-subsite='rspeedy'] {
   .hero-title {
-    animation: fade-in 0.8s ease-out;
+    // Keep hero title opaque on first paint — do not fade in from opacity: 0
+    // (that blanked the LCP text until CSS animation / hydration finished).
     word-wrap: break-word;
     overflow-wrap: break-word;
     word-break: break-word;
@@ -28,7 +29,6 @@
       background-clip: text;
       animation:
         blink-caret 1s cubic-bezier(1, 0, 0, 1) infinite,
-        fade-in 0.8s ease-out,
         gradientMove 6s linear infinite;
     }
     .normal {
@@ -57,7 +57,6 @@
     margin-right: -4px;
     animation:
       blink-caret 1s cubic-bezier(1, 0, 0, 1) infinite,
-      fade-in 0.8s ease-out,
       gradientMove 6s linear infinite;
 
     @media (max-width: 640px) {
@@ -71,7 +70,6 @@
     background-color: var(--hero-normal-text-color);
     -webkit-background-clip: text;
     background-clip: text;
-    animation: fade-in 0.8s ease-out;
   }
 }
 
@@ -89,15 +87,6 @@
   50%,
   to {
     border-image: linear-gradient(to bottom, transparent, transparent) 1;
-  }
-}
-
-@keyframes fade-in {
-  0% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
   }
 }
 

--- a/theme/home-after-hero.tsx
+++ b/theme/home-after-hero.tsx
@@ -1,0 +1,11 @@
+import { Banner, Features, ShowCase } from '@/components/home-comps';
+
+export function HomeAfterHero({ routePath }: { routePath: string }) {
+  return (
+    <>
+      <Features src={routePath} />
+      {routePath === '/' && <ShowCase />}
+      {routePath === '/' && <Banner />}
+    </>
+  );
+}

--- a/theme/hooks/use-blog-btn-dom.ts
+++ b/theme/hooks/use-blog-btn-dom.ts
@@ -110,8 +110,11 @@ const useBlogBtnDom = (src: string) => {
       configKey === '/'
         ? `rp-home-hero__badge active-hover`
         : `rp-home-hero__badge`;
-    badgeElement.textContent = displayText;
-    badgeElement.style.opacity = '1';
+    // Upgrade SSG fallback copy when the latest blog title is available.
+    // Badge stays visible the whole time (opacity is 1 in CSS).
+    if (displayText) {
+      badgeElement.textContent = displayText;
+    }
 
     if (configKey === '/') {
       badgeElement.addEventListener('click', handleInteraction);

--- a/theme/index.scss
+++ b/theme/index.scss
@@ -213,7 +213,8 @@ $link-color-dark: rgba(84, 169, 255, 1);
     }
   }
 
-  // When rendering the first screen, keep the typing animation transparent when it's not enabled.
+  // Parent brand gradient is disabled so child spans (.dynamic-text / .hero-title)
+  // control paint. Those children ship in SSG HTML and stay visible without JS.
   .rp-home-hero__title-brand {
     background: none;
   }

--- a/theme/index.tsx
+++ b/theme/index.tsx
@@ -25,30 +25,41 @@ import {
 } from 'react';
 
 import './index.scss';
-import { HomeLayout as LynxUIHomeLayout } from './lynx-ui-home';
 
-import {
-  Banner,
-  Features,
-  Footer,
-  MeteorsBackground,
-  ShowCase,
-} from '@/components/home-comps';
+import { Footer } from '@/components/home-comps/footer';
 import { SUBSITES_CONFIG } from '@site/shared-route-config';
 import versionJson from '../docs/public/version.json';
 import AfterNavTitle from './AfterNavTitle';
 import BeforeSidebar from './BeforeSidebar';
+import { DeferredComponent } from './deferred-client';
+import { HomeAfterHero } from './home-after-hero';
+import { HomeLayout as LynxUIHomeLayout } from './lynx-ui-home';
 import OgHead from './OgHead';
 import { useBlogBtnDom } from './hooks/use-blog-btn-dom';
 
 const CURRENT_VERSION_BASE = `/${versionJson.current_version}`;
 
+const loadMeteorsBackground = () =>
+  import('@/components/home-comps/meteors-background').then(
+    (m) => m.MeteorsBackground,
+  );
+
+/** Delay typing so the SSG hero title can paint / count for LCP first. */
+const TYPING_START_DELAY_MS = 1600;
+
 // Match subsite by checking if any path segment exactly equals the subsite value
 const findSubsite = (pathname: string) => {
   const segments = pathname.split('/');
-  return SUBSITES_CONFIG.find((s) =>
-    segments.some((seg) => seg.replace(/\.html$/, '') === s.value),
-  );
+  return SUBSITES_CONFIG.find((s) => {
+    if (s.value === 'ui') {
+      return segments.some((seg) => {
+        const normalized = seg.replace(/\.html$/, '');
+        return normalized === s.value || normalized === 'lynx-ui';
+      });
+    }
+
+    return segments.some((seg) => seg.replace(/\.html$/, '') === s.value);
+  });
 };
 
 const NULL_BYTE_RE = /\u0000/g;
@@ -143,6 +154,7 @@ function MainHomeLayout(props: Parameters<typeof BaseHomeLayout>[0]) {
   );
   const [delta, setDelta] = useState(200);
   const [isPaused, setIsPaused] = useState(false);
+  const [typingEnabled, setTypingEnabled] = useState(false);
 
   const routePath = useMemo(() => {
     let tmp = page.routePath.replace('/zh/', '/');
@@ -172,10 +184,18 @@ function MainHomeLayout(props: Parameters<typeof BaseHomeLayout>[0]) {
     const dynamicSpan = titleTextSpan.querySelector('.dynamic-text');
     const suffixSpan = titleTextSpan.querySelector('.suffix-text');
 
+    // Prefer updating existing SSG spans so we never clear the painted title.
     if (!dynamicSpan || !suffixSpan) {
-      titleTextSpan.innerHTML = `
-        <span class="dynamic-text">${dynamicText}</span><span class="suffix-text">${suffix}</span>
-      `;
+      titleTextSpan.replaceChildren(
+        Object.assign(document.createElement('span'), {
+          className: 'dynamic-text',
+          textContent: dynamicText,
+        }),
+        Object.assign(document.createElement('span'), {
+          className: 'suffix-text',
+          textContent: suffix,
+        }),
+      );
     } else {
       dynamicSpan.textContent = dynamicText;
       suffixSpan.textContent = suffix;
@@ -208,19 +228,31 @@ function MainHomeLayout(props: Parameters<typeof BaseHomeLayout>[0]) {
       setIsPaused(false);
       setDelta(200);
       setText(isZh ? `${zhWords[0]}${zhSuffix}` : `${enWords[0]}${enSuffix}`);
+      setTypingEnabled(false);
     }
-  }, [isZh, page]); // Watch both language and path changes
+  }, [isZh, page, routePath]); // Watch both language and path changes
+
+  // Let the static SSG title paint before starting the typing loop.
+  useEffect(() => {
+    if (routePath !== '/') {
+      return;
+    }
+
+    const startId = window.setTimeout(() => {
+      setTypingEnabled(true);
+    }, TYPING_START_DELAY_MS);
+
+    return () => clearTimeout(startId);
+  }, [routePath, isZh, page]);
 
   useEffect(() => {
-    const isHomePage = routePath === '/';
-
-    if (!isHomePage) {
+    if (routePath !== '/' || !typingEnabled) {
       return;
     }
 
     const ticker = setInterval(updateText, delta);
     return () => clearInterval(ticker);
-  }, [updateText, delta, page]);
+  }, [updateText, delta, page, routePath, typingEnabled]);
 
   const { pre: PreWithCodeButtonGroup, code: Code } =
     basicGetCustomMDXComponent();
@@ -230,14 +262,9 @@ function MainHomeLayout(props: Parameters<typeof BaseHomeLayout>[0]) {
   >;
 
   // Rspress would pass `afterHero: undefined` and `afterHeroActions: undefined` props to HomeLayout,
+  // Keep afterHero on the SSG path so feature cards / showcase are in the first HTML response.
   const {
-    afterHero = (
-      <>
-        <Features src={routePath} />
-        {routePath === '/' && <ShowCase />}
-        {routePath === '/' && <Banner />}
-      </>
-    ),
+    afterHero = <HomeAfterHero routePath={routePath} />,
     afterHeroActions = (
       <>
         <div
@@ -267,7 +294,11 @@ function MainHomeLayout(props: Parameters<typeof BaseHomeLayout>[0]) {
 
   return (
     <>
-      <MeteorsBackground gridSize={120} meteorCount={3} />
+      <DeferredComponent
+        loader={loadMeteorsBackground}
+        idle
+        props={{ gridSize: 120, meteorCount: 3 }}
+      />
       <div className="home-layout-container">
         <BaseHomeLayout
           {...props}

--- a/theme/lynx-ui-home/below-hero.tsx
+++ b/theme/lynx-ui-home/below-hero.tsx
@@ -1,0 +1,27 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { LunaStudioShowcase } from '@site/src/luna';
+import { ClearAPI } from './ClearApi';
+import { ConsistencyAndPerformance } from './CombinedConsistencyAndPerformance';
+import { StartBuilding } from './StartBuildingBottom';
+
+export function LynxUIBelowHero() {
+  return (
+    <>
+      <div className="luna-studio-showcase-home mx-auto w-full max-w-screen-2xl md:px-4 lg:px-8">
+        <LunaStudioShowcase
+          className="px-4 md:px-6 lg:px-8 py-8 md:py-4"
+          defaultViewMode="lineup"
+          responsiveMode="viewport"
+        />
+      </div>
+      <div className="flex flex-col">
+        <ClearAPI />
+        <ConsistencyAndPerformance />
+        <StartBuilding />
+      </div>
+    </>
+  );
+}

--- a/theme/lynx-ui-home/hero-text.scss
+++ b/theme/lynx-ui-home/hero-text.scss
@@ -1,6 +1,6 @@
 :root[data-subsite='ui'] {
   .hero-title {
-    animation: fade-in 0.8s ease-out;
+    // Keep hero title opaque on first paint — do not fade in from opacity: 0.
     word-wrap: break-word;
     overflow-wrap: break-word;
     word-break: break-word;
@@ -37,7 +37,6 @@
       background-clip: text;
       animation:
         blink-caret 1s cubic-bezier(1, 0, 0, 1) infinite,
-        fade-in 0.8s ease-out,
         gradientMove 6s linear infinite;
     }
   }

--- a/theme/lynx-ui-home/index.tsx
+++ b/theme/lynx-ui-home/index.tsx
@@ -3,16 +3,16 @@
 // LICENSE file in the root directory of this source tree.
 
 import './index.scss';
-import { WarpBackground } from './WarpBackground';
 import {
   HomeLayout as BaseHomeLayout,
   getCustomMDXComponent as basicGetCustomMDXComponent,
 } from '@rspress/core/theme-original';
 import { useRef } from 'react';
-import { ClearAPI } from './ClearApi';
-import { ConsistencyAndPerformance } from './CombinedConsistencyAndPerformance';
-import { StartBuilding } from './StartBuildingBottom';
-import { LunaStudioShowcase } from '@site/src/luna';
+import { DeferredComponent } from '../deferred-client';
+import { LynxUIBelowHero } from './below-hero';
+
+const loadWarpBackground = () =>
+  import('./WarpBackground').then((m) => m.WarpBackground);
 
 export const HomeLayout = () => {
   const { pre: PreWithCodeButtonGroup, code: Code } =
@@ -52,37 +52,30 @@ export const HomeLayout = () => {
 
   return (
     <div className="lynx-ui-home-warp">
-      <WarpBackground
-        className="beam-background"
-        style={{
-          position: 'absolute',
-          left: 0,
-          right: 0,
-          top: 0,
-          height: '70vh',
-          pointerEvents: 'none',
-          zIndex: 0,
+      <DeferredComponent
+        loader={loadWarpBackground}
+        idle
+        props={{
+          className: 'beam-background',
+          style: {
+            position: 'absolute',
+            left: 0,
+            right: 0,
+            top: 0,
+            height: '70vh',
+            pointerEvents: 'none',
+            zIndex: 0,
+          },
+          beamSize: 0.5,
+          beamsPerSide: 7,
+          perspective: 500,
+          gridSize: 3,
+          gridLineWidth: 0.5,
         }}
-        beamSize={0.5}
-        beamsPerSide={7}
-        perspective={500}
-        gridSize={3}
-        gridLineWidth={0.5}
       />
       <div className="home-layout-container relative z-10">
         <BaseHomeLayout afterHeroActions={afterHeroActions} />
-        <div className="luna-studio-showcase-home mx-auto w-full max-w-screen-2xl md:px-4 lg:px-8">
-          <LunaStudioShowcase
-            className="px-4 md:px-6 lg:px-8 py-8 md:py-4"
-            defaultViewMode="lineup"
-            responsiveMode="viewport"
-          />
-        </div>
-        <div className="flex flex-col">
-          <ClearAPI />
-          <ConsistencyAndPerformance />
-          <StartBuilding />
-        </div>
+        <LynxUIBelowHero />
       </div>
     </div>
   );


### PR DESCRIPTION
Backport #1215 onto release/4.0 so the home hero paints from SSG HTML (badge/title visible, no fade-from-zero) and below-fold home JS is deferred.

Keep release/4.0-specific versioned blog links (CURRENT_VERSION_BASE) and Algolia indexName `lynx`. Preserve the badge vertical-padding fix from #1216.