### PR TITLE
fix(version): add urgent root redirect workaround for hydration

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -185,10 +185,10 @@
   to = "https://release-3-4--lynx-doc.netlify.app/:splat"
   status = 200
 
-# Serve the latest release entry at the site root while keeping the browser
-# location at /.
+# Redirect the site root to the latest release so the browser location matches
+# the Rspress base path used by the release build.
 [[redirects]]
   from = "/"
-  to = "/index.html"
-  status = 200
+  to = "/4.0/"
+  status = 302
   force = true


### PR DESCRIPTION
## Summary

This is an urgent workaround for the production homepage hydration failure. The 4.0 release is built with the `/4.0/` Rspress base, but Netlify serves the same output at `/`, so the client router cannot match its basename. Temporarily redirect `/` to `/4.0/` with a 302 to align the browser pathname and restore hydration. A follow-up can revisit serving the latest release at `/` by building it with a root base.

## Related Links

- https://github.com/lynx-family/lynx-website/pull/1212