### PR TITLE
fix(version): derive 4.0 base from version config

### DIFF
--- a/docs/public/version.json
+++ b/docs/public/version.json
@@ -20,14 +20,14 @@
       "type": "previous",
       "version_number": "3.9",
       "repo_branch": "release/3.9",
-      "docs_link": "/",
+      "docs_link": "/3.9",
       "release_number": "3.9.0"
     },
     {
       "type": "previous",
       "version_number": "3.8",
       "repo_branch": "release/3.8",
-      "docs_link": "/",
+      "docs_link": "/3.8",
       "release_number": "3.8.1",
       "release_blog": "/blog/lynx-3-8.html"
     },

--- a/netlify.toml
+++ b/netlify.toml
@@ -162,12 +162,15 @@
   to = "https://main--lynx-doc.netlify.app/:splat"
   status = 200
 
-# Serve released docs from their branch deploys.
+# 4.0 is canonical at the site root. Keep versioned URLs as permanent
+# compatibility redirects.
 [[redirects]]
   from = "/4.0/*"
   to = "/:splat"
-  status = 200
+  status = 301
+  force = true
 
+# Serve previous releases from their branch deploys.
 [[redirects]]
   from = "/3.9/*"
   to = "https://release-3-9--lynx-doc.netlify.app/:splat"
@@ -197,11 +200,3 @@
   from = "/3.4/*"
   to = "https://release-3-4--lynx-doc.netlify.app/:splat"
   status = 200
-
-# Redirect remaining unversioned paths to the latest release so the browser
-# location matches the Rspress base path used by the release build.
-[[redirects]]
-  from = "/*"
-  to = "/4.0/:splat"
-  status = 302
-  force = true

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -18,6 +18,7 @@ import type { Dirent } from 'node:fs';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import versionJson from './docs/public/version.json';
+import { SITE_BASE } from './shared-route-config';
 import { visit } from 'unist-util-visit';
 import { pluginGoogleAnalytics } from 'rsbuild-plugin-google-analytics';
 
@@ -110,7 +111,7 @@ export default defineConfig({
       'https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/lynx-dark-logo.svg',
     dark: 'https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/lynx-light-logo.svg',
   },
-  base: `/${versionJson.current_version}`,
+  base: SITE_BASE,
   themeConfig: {
     editLink: {
       docRepoBaseUrl:

--- a/shared-og-config.ts
+++ b/shared-og-config.ts
@@ -11,19 +11,16 @@
  *   - one shared cover per subsite per language: `/og/covers/<lang>/<value>.png`
  *   - a unique image per blog post:              `/og/blog/<lang>/<slug>.png`
  */
-import { SUBSITES_CONFIG } from './shared-route-config';
-import versionJson from './docs/public/version.json';
+import { SITE_BASE, SUBSITES_CONFIG } from './shared-route-config';
 
 /** Published site origin (no trailing slash). OG/canonical URLs are absolute. */
 export const OG_SITE_ORIGIN = 'https://lynxjs.org';
 
 /**
- * Site base path — derived from the same source as rspress.config.ts's
- * `base: \`/${versionJson.current_version}\``, so canonical/og:image URLs stay
- * correct if `current_version` changes (currently `/next`). Public asset and
- * canonical URLs are prefixed with this.
+ * Site base path shared with Rspress. Public asset and canonical URLs are
+ * prefixed with this.
  */
-export const OG_BASE = `/${versionJson.current_version}`;
+export const OG_BASE = SITE_BASE === '/' ? '' : SITE_BASE.replace(/\/$/, '');
 
 /**
  * Brand anchors. Values match the home hero gradient in theme/home-layout-var.scss

--- a/shared-route-config.ts
+++ b/shared-route-config.ts
@@ -3,8 +3,19 @@
  */
 import versionJson from './docs/public/version.json';
 
+export const SITE_BASE = versionJson.versions.find(
+  (version) => version.version_number === versionJson.current_version,
+)?.docs_link;
+
+if (!SITE_BASE) {
+  throw new Error(
+    `Missing docs_link for current version ${versionJson.current_version}`,
+  );
+}
+
 /** This build's Rspress base as a URL prefix — matches rspress.config.ts. */
-export const SITE_BASE_PREFIX = `/${versionJson.current_version}`;
+export const SITE_BASE_PREFIX =
+  SITE_BASE === '/' ? '' : SITE_BASE.replace(/\/$/, '');
 
 const developingDocsLink = versionJson.versions.find(
   (version) => version.type === 'developing',


### PR DESCRIPTION
## Summary

The 4.0 release is published at the site root, but its Rspress build still used `/4.0`, causing client asset routes to miss and hydration to fail. This derives the Rspress and canonical/OG base from the current entry's existing `docs_link` in `version.json`, removes the urgent root-to-`/4.0` 302 workaround from #1220, and keeps `/4.0/*` as a permanent compatibility redirect to the canonical root path. Existing `/next` and historical release routing remain unchanged.

## Related Links

- https://github.com/lynx-family/lynx-website/pull/1220

- https://github.com/lynx-family/lynx-website/pull/1221#pullrequestreview-4853170441
