### PR TITLE
fix(version): redirect all unversioned paths to 4.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -185,10 +185,10 @@
   to = "https://release-3-4--lynx-doc.netlify.app/:splat"
   status = 200
 
-# Redirect the site root to the latest release so the browser location matches
-# the Rspress base path used by the release build.
+# Redirect remaining unversioned paths to the latest release so the browser
+# location matches the Rspress base path used by the release build.
 [[redirects]]
-  from = "/"
-  to = "/4.0/"
+  from = "/*"
+  to = "/4.0/:splat"
   status = 302
   force = true


### PR DESCRIPTION
## Summary

#1220 redirects only the site root, so direct unversioned pages such as `/guide/start/quick-start` still keep a pathname that does not match the Rspress `/4.0/` base. Extend the final fallback rule to `/*` and preserve the splat when redirecting to `/4.0/:splat`. Existing `/4.0/*`, `/next/*`, and previous-version rules remain higher priority and keep their current behavior.


https://lynxjs.org/guide/start/quick-start -> https://lynxjs.org/4.0/guide/start/quick-start 

## Related Links

- https://github.com/lynx-family/lynx-website/pull/1220