### PR TITLE
fix(api-status): backport floating compatibility drawer to 4.0

### DIFF
--- a/src/components/api-status/APIStatusDashboard.tsx
+++ b/src/components/api-status/APIStatusDashboard.tsx
@@ -370,7 +370,7 @@ export const APIItem: React.FC<APIItemProps> = ({
       </DrawerTrigger>
       <DrawerContent
         className={cn(
-          isDesktop ? 'h-full' : 'max-h-[85vh]',
+          !isDesktop && 'max-h-[85vh]',
           isDesktop && 'bg-zinc-50 dark:bg-zinc-900',
         )}
       >

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -47,13 +47,21 @@ const DrawerContent = React.forwardRef<
   const { direction } = React.useContext(DrawerContext)
   const isHorizontal = direction === "left" || direction === "right"
 
-  // For side drawers, add gap from edge and use --initial-transform for animation
-  const sideDrawerGap = 8
+  // Floating side drawers: inset from viewport edges (macOS-style) + animate past the gap
+  const sideDrawerGap = 12
   const sideDrawerStyle = isHorizontal
     ? {
         ...style,
-        // ...(direction === "right" && { right: `${sideDrawerGap}px`, top: `${sideDrawerGap}px`, bottom: `${sideDrawerGap}px` }),
-        // ...(direction === "left" && { left: `${sideDrawerGap}px`, top: `${sideDrawerGap}px`, bottom: `${sideDrawerGap}px` }),
+        ...(direction === "right" && {
+          right: `${sideDrawerGap}px`,
+          top: `${sideDrawerGap}px`,
+          bottom: `${sideDrawerGap}px`,
+        }),
+        ...(direction === "left" && {
+          left: `${sideDrawerGap}px`,
+          top: `${sideDrawerGap}px`,
+          bottom: `${sideDrawerGap}px`,
+        }),
         '--initial-transform': `calc(100% + ${sideDrawerGap}px)` as React.CSSProperties['--initial-transform'],
       } as React.CSSProperties
     : style
@@ -67,10 +75,10 @@ const DrawerContent = React.forwardRef<
           "fixed z-[100] flex flex-col bg-background outline-none",
           // Bottom drawer (default)
           !isHorizontal && "inset-x-0 bottom-0 mt-24 h-auto rounded-t-[10px] border",
-          // Right drawer - with gap from edge, no border (gap provides visual separation)
-          direction === "right" && "inset-y-0 right-2 h-full w-[600px] max-w-[90vw] rounded-[16px] shadow-lg",
-          // Left drawer - with gap from edge, no border (gap provides visual separation)
-          direction === "left" && "inset-y-0 left-2 h-full w-[600px] max-w-[90vw] rounded-[16px] shadow-lg",
+          // Right drawer - floating with gap from edge (position via inline style)
+          direction === "right" && "w-[600px] max-w-[90vw] rounded-[16px] shadow-xl",
+          // Left drawer - floating with gap from edge (position via inline style)
+          direction === "left" && "w-[600px] max-w-[90vw] rounded-[16px] shadow-xl",
           // Top drawer
           direction === "top" && "inset-x-0 top-0 mb-24 h-auto rounded-b-[10px] border",
           className


### PR DESCRIPTION
Backports the independent floating compatibility drawer portion of #1213 to the 4.0 stable docs.

The interactive coverage-range portion is intentionally excluded because the stable branch predates its category-timeline foundation.

Changes:
- inset desktop side drawers by 12px on all viewport edges
- preserve the off-canvas animation distance
- remove the full-height override so the inset is visible

Validation:
- patch applies cleanly to `release/4.0`
- `git diff --check`
- source asset URL check from the commit hook