### PR TITLE
fix(version): redirect bare version roots with 308 `/next` -> `/next/`

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,19 @@
 [context.deploy-preview.environment]
   RSPRESS_LIGHTWEIGHT_BUILD = "true"
 
+# Version homes are directory-style URLs, so redirect `/4.0` to `/4.0/` and
+# `/next` to `/next/` instead of serving the same page at two URLs. Netlify
+# normalizes trailing slashes before evaluating redirect rules, so either
+# static redirect would also match its target and cause a loop. Edge Functions
+# run first and can inspect the original pathname.
+[[edge_functions]]
+  function = "redirect-version-root"
+  path = "/4.0"
+
+[[edge_functions]]
+  function = "redirect-version-root"
+  path = "/next"
+
 [[headers]]
   for = "/*"
   [headers.values]

--- a/netlify/edge-functions/redirect-version-root.ts
+++ b/netlify/edge-functions/redirect-version-root.ts
@@ -1,0 +1,10 @@
+export default (request: Request) => {
+  const url = new URL(request.url);
+
+  if (url.pathname.endsWith('/')) {
+    return;
+  }
+
+  url.pathname += '/';
+  return Response.redirect(url, 308);
+};


### PR DESCRIPTION
## Summary

- Redirect bare `/4.0` and `/next` version roots to their trailing-slash forms with 308 responses from a Netlify Edge Function, avoiding redirect-rule URL normalization loops.
