### PR TITLE
feat(go): wire deep-link download fallback for lynxtron

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@dugyu/luna-demo-bundles": "0.2.0",
     "@dugyu/luna-stage": "0.2.2",
     "@dugyu/luna-studio": "0.2.0",
-    "@lynx-js/go-web": "^0.6.0",
+    "@lynx-js/go-web": "^0.8.0",
     "@lynx-js/lynx-core": "^0.1.3",
     "@lynx-js/web-core": "^0.20.3",
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: 0.2.0
         version: 0.2.0(@lynx-js/web-core@0.20.4(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(motion@12.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@lynx-js/go-web':
-        specifier: ^0.6.0
-        version: 0.6.0(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core@0.20.4(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.13(@rspack/core@2.0.6(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@18.3.18)(micromark-util-types@2.0.1)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)
+        specifier: ^0.8.0
+        version: 0.8.0(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core@0.20.4(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.13(@rspack/core@2.0.6(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@18.3.18)(micromark-util-types@2.0.1)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)
       '@lynx-js/lynx-core':
         specifier: ^0.1.3
         version: 0.1.3
@@ -1686,8 +1686,8 @@ packages:
       '@lynx-js/react': '*'
       '@lynx-js/types': '*'
 
-  '@lynx-js/go-web@0.6.0':
-    resolution: {integrity: sha512-JkDQoxyKwWQS0sNxDZbr0vOx+NuEAlJWaz7fy5/6ZcIWzG/7n0+QxwQi5R7X3P2tSmisAigg4sgxu5+sN+UUnQ==}
+  '@lynx-js/go-web@0.8.0':
+    resolution: {integrity: sha512-qEUvrZy3eJYkdrFgGli6B155QCyLYhvnT+vkFzr/z2SZmPN1BFtb7pDLC0mZBcdxG9UDEubkiDPA/rqgLKsw2Q==}
     engines: {node: ^22 || ^24}
     peerDependencies:
       '@douyinfe/semi-icons': '>=2.74.0'
@@ -8294,7 +8294,7 @@ snapshots:
       '@lynx-js/react': 0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
       '@lynx-js/types': 3.9.0
 
-  '@lynx-js/go-web@0.6.0(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core@0.20.4(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.13(@rspack/core@2.0.6(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@18.3.18)(micromark-util-types@2.0.1)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)':
+  '@lynx-js/go-web@0.8.0(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core@0.20.4(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.13(@rspack/core@2.0.6(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@18.3.18)(micromark-util-types@2.0.1)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)':
     dependencies:
       '@douyinfe/semi-icons': 2.74.0(react@18.3.1)
       '@douyinfe/semi-ui': 2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/src/components/go/Go.tsx
+++ b/src/components/go/Go.tsx
@@ -26,21 +26,23 @@ const ErrorComponent = ({
   </Callout>
 );
 
-// Lynxtron Go is a desktop-only host, so `downloadUrl` needs to pick between
-// the macOS .dmg and the Windows installer. go-web's `LocalizedUrl` only
-// branches on language, so we resolve the OS here. The URL is never in the
-// SSR HTML — it only renders after a client-side 5s deep-link probe — so
-// reading `navigator` at render time is safe.
-const LYNXTRON_DOWNLOAD_URL_MAC =
-  'https://github.com/lynx-community/lynxtron-examples/releases/latest/download/lynxtron-go-darwin-arm64.dmg';
+// Lynxtron Go is a desktop-only host, so `downloadUrl` needs to distinguish
+// supported desktop platforms from mobile, Linux, ChromeOS, and SSR. The
+// Windows installer has a stable asset name. macOS user agents do not reliably
+// expose Apple Silicon vs Intel, so send macOS users to the release page rather
+// than risking an automatic download of the arm64-only .dmg.
+const LYNXTRON_RELEASE_URL =
+  'https://github.com/lynx-community/lynxtron-examples/releases/latest';
 const LYNXTRON_DOWNLOAD_URL_WIN =
   'https://github.com/lynx-community/lynxtron-examples/releases/latest/download/LynxtronGo-win-x64-Setup.exe';
 
-function resolveLynxtronDownloadUrl(): string {
-  if (typeof navigator === 'undefined') return LYNXTRON_DOWNLOAD_URL_MAC;
-  return /Windows/i.test(navigator.userAgent)
-    ? LYNXTRON_DOWNLOAD_URL_WIN
-    : LYNXTRON_DOWNLOAD_URL_MAC;
+function resolveLynxtronDownloadUrl(): string | undefined {
+  if (typeof navigator === 'undefined') return undefined;
+  const { userAgent } = navigator;
+  if (/Android|Mobile|iPhone|iPad|iPod/i.test(userAgent)) return undefined;
+  if (/Windows NT/i.test(userAgent)) return LYNXTRON_DOWNLOAD_URL_WIN;
+  if (/Macintosh|Mac OS X/i.test(userAgent)) return LYNXTRON_RELEASE_URL;
+  return undefined;
 }
 
 const baseConfig = {

--- a/src/components/go/Go.tsx
+++ b/src/components/go/Go.tsx
@@ -1,4 +1,5 @@
 import path from 'path';
+import { useMemo } from 'react';
 import { Go as GoBase, GoConfigProvider } from '@lynx-js/go-web';
 import type { GoProps } from '@lynx-js/go-web';
 import { rspressAdapter } from '@lynx-js/go-web/adapters/rspress';
@@ -25,7 +26,24 @@ const ErrorComponent = ({
   </Callout>
 );
 
-const config = {
+// Lynxtron Go is a desktop-only host, so `downloadUrl` needs to pick between
+// the macOS .dmg and the Windows installer. go-web's `LocalizedUrl` only
+// branches on language, so we resolve the OS here. The URL is never in the
+// SSR HTML — it only renders after a client-side 5s deep-link probe — so
+// reading `navigator` at render time is safe.
+const LYNXTRON_DOWNLOAD_URL_MAC =
+  'https://github.com/lynx-community/lynxtron-examples/releases/latest/download/lynxtron-go-darwin-arm64.dmg';
+const LYNXTRON_DOWNLOAD_URL_WIN =
+  'https://github.com/lynx-community/lynxtron-examples/releases/latest/download/LynxtronGo-win-x64-Setup.exe';
+
+function resolveLynxtronDownloadUrl(): string {
+  if (typeof navigator === 'undefined') return LYNXTRON_DOWNLOAD_URL_MAC;
+  return /Windows/i.test(navigator.userAgent)
+    ? LYNXTRON_DOWNLOAD_URL_WIN
+    : LYNXTRON_DOWNLOAD_URL_MAC;
+}
+
+const baseConfig = {
   ...rspressAdapter,
   exampleBasePath: '/lynx-examples',
   ssgExampleRoot: path?.join?.(__dirname, '../../docs/public/lynx-examples'),
@@ -43,6 +61,18 @@ const config = {
 };
 
 export function Go(props: GoProps) {
+  const config = useMemo(
+    () => ({
+      ...baseConfig,
+      nativeFrameworks: {
+        lynxtron: {
+          downloadUrl: resolveLynxtronDownloadUrl(),
+        },
+      },
+    }),
+    [],
+  );
+
   return (
     <GoConfigProvider config={config}>
       <GoBase {...props} />


### PR DESCRIPTION
Bump @lynx-js/go-web to 0.8.0 and supply `nativeFrameworks.lynxtron.downloadUrl` so a click that goes unanswered gets replaced by a download link instead of failing silently. Windows gets the stable installer asset directly. macOS goes to the latest release page because browser user agents do not reliably distinguish Apple Silicon from Intel; SSR, mobile, Linux, and ChromeOS omit the unsupported download fallback.

Change-Id: Ibcc88f4733931cb6ffe09ce6d34d005095cd7f51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Bump `@lynx-js/go-web` to `0.8.0`
- Configure OS-aware Lynxtron `nativeFrameworks.lynxtron.downloadUrl` fallbacks for unanswered deep-link clicks by selecting Windows installer or macOS release at render time based on the user agent (skip on SSR and on mobile/Android/iOS)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->