### PR TITLE
docs(motion): enable web preview for Basic and Spring examples

### DIFF
--- a/docs/en/ui/motion.mdx
+++ b/docs/en/ui/motion.mdx
@@ -59,7 +59,7 @@ The usual pattern is:
   defaultEntryFile="dist/basic.lynx.bundle"
   entry="src/Basic"
   highlight={motionBasicDemoMeta.highlight}
-  webPreview={false}
+  defaultTab="web"
 />
 
 ## Use Springs
@@ -72,7 +72,7 @@ Set `type: 'spring'` when a value should settle with spring physics instead of f
   defaultEntryFile="dist/spring.lynx.bundle"
   entry="src/Spring"
   highlight={motionSpringDemoMeta.highlight}
-  webPreview={false}
+  defaultTab="web"
 />
 
 ## Use Motion Values

--- a/docs/zh/ui/motion.mdx
+++ b/docs/zh/ui/motion.mdx
@@ -59,7 +59,7 @@ import { animate, motionValue, styleEffect } from '@lynx-js/motion';
   defaultEntryFile="dist/basic.lynx.bundle"
   entry="src/Basic"
   highlight={motionBasicDemoMeta.highlight}
-  webPreview={false}
+  defaultTab="web"
 />
 
 ## 使用弹簧动画
@@ -72,7 +72,7 @@ import { animate, motionValue, styleEffect } from '@lynx-js/motion';
   defaultEntryFile="dist/spring.lynx.bundle"
   entry="src/Spring"
   highlight={motionSpringDemoMeta.highlight}
-  webPreview={false}
+  defaultTab="web"
 />
 
 ## 使用 MotionValue

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@lynx-js/web-core': npm:@lynx-js/web-core-canary@0.23.1-canary-20260730-6cbcb870
+
 importers:
 
   .:
@@ -19,19 +22,19 @@ importers:
         version: 0.2.0
       '@dugyu/luna-stage':
         specifier: 0.2.2
-        version: 0.2.2(@lynx-js/web-core@0.20.4(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(motion@12.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 0.2.2(@lynx-js/web-core-canary@0.23.1-canary-20260730-6cbcb870(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(motion@12.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@dugyu/luna-studio':
         specifier: 0.2.0
-        version: 0.2.0(@lynx-js/web-core@0.20.4(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(motion@12.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 0.2.0(@lynx-js/web-core-canary@0.23.1-canary-20260730-6cbcb870(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(motion@12.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@lynx-js/go-web':
         specifier: ^0.8.0
-        version: 0.8.0(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core@0.20.4(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.13(@rspack/core@2.0.6(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@18.3.18)(micromark-util-types@2.0.1)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)
+        version: 0.8.0(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core-canary@0.23.1-canary-20260730-6cbcb870(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.13(@rspack/core@2.0.6(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@18.3.18)(micromark-util-types@2.0.1)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)
       '@lynx-js/lynx-core':
         specifier: ^0.1.3
         version: 0.1.3
       '@lynx-js/web-core':
-        specifier: ^0.20.3
-        version: 0.20.4(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)
+        specifier: npm:@lynx-js/web-core-canary@0.23.1-canary-20260730-6cbcb870
+        version: '@lynx-js/web-core-canary@0.23.1-canary-20260730-6cbcb870(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)'
       '@radix-ui/react-collapsible':
         specifier: ^1.1.12
         version: 1.1.12(@types/react-dom@18.3.7(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1992,11 +1995,11 @@ packages:
   '@lynx-js/types@3.9.0':
     resolution: {integrity: sha512-mwODjqahwrGwNUsmpG/GZ5ztccB2aZ3Do8o9KwJpH5XsaXXynaRVEzmOeq2/BsLWzs4rWj6zEwsK+CaX3DCKyA==}
 
-  '@lynx-js/web-core@0.20.4':
-    resolution: {integrity: sha512-n0lLAjUeK1ndJE7xzCzkccYQE42C1qDMOvRSxqSZ5JdcBaY4pG0ZWswXC6jiL0gaksiY5Y31wZOIWHMlRRotPw==}
+  '@lynx-js/web-core-canary@0.23.1-canary-20260730-6cbcb870':
+    resolution: {integrity: sha512-Qjo8aeBRR9g9IeCL2TW/HYPnar5WldegXG7cppW6m4Iuujjc0Jm3w+Q8Jcqv71FD6I7RfAjyO9UoDtjjkaMbqQ==}
     peerDependencies:
-      '@lynx-js/css-serializer': 0.1.6
-      '@lynx-js/lynx-core': 0.1.3
+      '@lynx-js/css-serializer': '*'
+      '@lynx-js/lynx-core': 0.1.4
       tslib: ^2.5.0
     peerDependenciesMeta:
       '@lynx-js/css-serializer':
@@ -2006,13 +2009,13 @@ packages:
       tslib:
         optional: true
 
-  '@lynx-js/web-elements@0.12.2':
-    resolution: {integrity: sha512-k6eblA01RUIt09/GRXpRx1eL4n4Ztzs4v81RAE8Pkix8MyRArwjHb5qbV9O64VWuSk/R6h6ZJjen0cfzrBZdzw==}
+  '@lynx-js/web-elements-canary@0.12.7':
+    resolution: {integrity: sha512-YZcbwBrinLGd34fF/DQl5g+xxB2CzEqy//HB1r4nsKbrPKoxbHuVdMphQQISSZ4kKIIEJBPdBoBiGghH733yMQ==}
     peerDependencies:
       tslib: ^2.5.0
 
-  '@lynx-js/web-worker-rpc@0.20.4':
-    resolution: {integrity: sha512-i4RV8f397nl02zB1wjFfEJDo/bM0c+dvzd9nIPY9gksf2lX8aSOpkXn6Kyou+05qdJAXm2EZIl8SKYiTMi/P6w==}
+  '@lynx-js/web-worker-rpc-canary@0.23.1-canary-20260730-6cbcb870':
+    resolution: {integrity: sha512-DWx38zuAsXP0J4b1t7VM9280HwIr1vvt84xRopIvHaDwcrZ7XjVgaHt2pE8OFgXi/dEo6dt4WhX1oeJdpDsW+w==}
 
   '@lynxtron-examples/file-explorer@0.0.3':
     resolution: {integrity: sha512-Lm4ll9d702dY+jiEeBkEZ/2rgfTy0ZZOIxqUJcAMDeJ0WEzfXOpdk/1EgFFf6IbWDJOzzLnMOu47n3h7GZq0hg==}
@@ -4127,6 +4130,9 @@ packages:
   dompurify@3.3.3:
     resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
 
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+
   domutils@3.2.1:
     resolution: {integrity: sha512-xWXmuRnN9OMP6ptPd2+H0cCbcYBULa5YDTbMm/2lvkWvNA3O4wcW+GvzooqBuNM8yy6pl3VIAeJTUUWUbfI5Fw==}
 
@@ -4790,6 +4796,9 @@ packages:
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
 
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
+
   lint-staged@15.5.2:
     resolution: {integrity: sha512-YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w==}
     engines: {node: '>=18.12.0'}
@@ -4863,6 +4872,10 @@ packages:
 
   markdown-it@14.1.1:
     resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+    hasBin: true
+
+  markdown-it@14.3.0:
+    resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
     hasBin: true
 
   markdown-table@3.0.4:
@@ -7394,19 +7407,19 @@ snapshots:
 
   '@dugyu/luna-demo-bundles@0.2.0': {}
 
-  '@dugyu/luna-stage@0.2.2(@lynx-js/web-core@0.20.4(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(motion@12.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+  '@dugyu/luna-stage@0.2.2(@lynx-js/web-core-canary@0.23.1-canary-20260730-6cbcb870(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(motion@12.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@dugyu/luna-core': 0.5.0
       react: 18.3.1
     optionalDependencies:
-      '@lynx-js/web-core': 0.20.4(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)
+      '@lynx-js/web-core': '@lynx-js/web-core-canary@0.23.1-canary-20260730-6cbcb870(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)'
       motion: 12.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@dugyu/luna-studio@0.2.0(@lynx-js/web-core@0.20.4(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(motion@12.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+  '@dugyu/luna-studio@0.2.0(@lynx-js/web-core-canary@0.23.1-canary-20260730-6cbcb870(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(motion@12.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@dugyu/luna-core': 0.5.0
-      '@dugyu/luna-stage': 0.2.2(@lynx-js/web-core@0.20.4(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(motion@12.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
-      '@lynx-js/web-core': 0.20.4(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)
+      '@dugyu/luna-stage': 0.2.2(@lynx-js/web-core-canary@0.23.1-canary-20260730-6cbcb870(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(motion@12.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      '@lynx-js/web-core': '@lynx-js/web-core-canary@0.23.1-canary-20260730-6cbcb870(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)'
       motion: 12.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
 
@@ -8294,11 +8307,11 @@ snapshots:
       '@lynx-js/react': 0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
       '@lynx-js/types': 3.9.0
 
-  '@lynx-js/go-web@0.8.0(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core@0.20.4(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.13(@rspack/core@2.0.6(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@18.3.18)(micromark-util-types@2.0.1)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)':
+  '@lynx-js/go-web@0.8.0(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core-canary@0.23.1-canary-20260730-6cbcb870(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.13(@rspack/core@2.0.6(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@18.3.18)(micromark-util-types@2.0.1)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)':
     dependencies:
       '@douyinfe/semi-icons': 2.74.0(react@18.3.1)
       '@douyinfe/semi-ui': 2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@lynx-js/web-core': 0.20.4(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)
+      '@lynx-js/web-core': '@lynx-js/web-core-canary@0.23.1-canary-20260730-6cbcb870(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)'
       '@shikijs/transformers': 4.0.2
       qrcode.react: 4.2.0(react@18.3.1)
       react: 18.3.1
@@ -9333,22 +9346,22 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
-  '@lynx-js/web-core@0.20.4(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)':
+  '@lynx-js/web-core-canary@0.23.1-canary-20260730-6cbcb870(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)':
     dependencies:
-      '@lynx-js/web-elements': 0.12.2(tslib@2.8.1)
-      '@lynx-js/web-worker-rpc': 0.20.4
+      '@lynx-js/web-elements': '@lynx-js/web-elements-canary@0.12.7(tslib@2.8.1)'
+      '@lynx-js/web-worker-rpc': '@lynx-js/web-worker-rpc-canary@0.23.1-canary-20260730-6cbcb870'
       wasm-feature-detect: 1.8.0
     optionalDependencies:
       '@lynx-js/lynx-core': 0.1.3
       tslib: 2.8.1
 
-  '@lynx-js/web-elements@0.12.2(tslib@2.8.1)':
+  '@lynx-js/web-elements-canary@0.12.7(tslib@2.8.1)':
     dependencies:
-      dompurify: 3.3.3
-      markdown-it: 14.1.1
+      dompurify: 3.4.12
+      markdown-it: 14.3.0
       tslib: 2.8.1
 
-  '@lynx-js/web-worker-rpc@0.20.4': {}
+  '@lynx-js/web-worker-rpc-canary@0.23.1-canary-20260730-6cbcb870': {}
 
   '@lynxtron-examples/file-explorer@0.0.3':
     dependencies:
@@ -11508,6 +11521,10 @@ snapshots:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
+  dompurify@3.4.12:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
   domutils@3.2.1:
     dependencies:
       dom-serializer: 2.0.0
@@ -12222,6 +12239,10 @@ snapshots:
     dependencies:
       uc.micro: 2.1.0
 
+  linkify-it@5.0.2:
+    dependencies:
+      uc.micro: 2.1.0
+
   lint-staged@15.5.2:
     dependencies:
       chalk: 5.6.2
@@ -12311,6 +12332,15 @@ snapshots:
       argparse: 2.0.1
       entities: 4.5.0
       linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
+  markdown-it@14.3.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.2
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,3 +29,10 @@ allowBuilds:
 # - @lynxtron-examples/*: ship prebuilt bundles; their rebuild scripts require
 #   native toolchains we don't have in CI/deploy environments.
 # - sqlite3: native module only needed by @lynxtron-examples/todolist at runtime.
+
+# Use the per-commit canary of @lynx-js/web-core until the next stable release.
+# The motion web previews need __GetComputedStyleByKey (lynx-stack#3262) and
+# the mutable MTS window wrapper (lynx-stack#3294). Pin back to a stable
+# @lynx-js/web-core (>0.23.0) once released.
+overrides:
+  '@lynx-js/web-core': 'npm:@lynx-js/web-core-canary@0.23.1-canary-20260730-6cbcb870'


### PR DESCRIPTION
## Summary

Enable the Web rendering preview for the **Basic** and **Spring** examples on `/ui/motion` (en + zh), switching `webPreview={false}` to `defaultTab="web"` to match the Motion Values and Gesture examples on the same page.

These two demos were the only ones still gated off the Web preview because they read initial keyframe values via `getComputedStyle`, which needs runtime support that has now landed in lynx-stack:

- lynx-family/lynx-stack#3262 — `__GetComputedStyleByKey` element PAPI in `@lynx-js/web-core`
- lynx-family/lynx-stack#3294 — mutable MTS `window` binding in `@lynx-js/web-core`
- lynx-family/lynx-stack#3295 — Lynx for Web globals support in `@lynx-js/motion`

## Changes

- `docs/{en,zh}/ui/motion.mdx`: `webPreview={false}` → `defaultTab="web"` for Basic and Spring.
- `pnpm-workspace.yaml` + lockfile: override `@lynx-js/web-core` to the per-commit canary `0.23.1-canary-20260730-6cbcb870` (includes all three fixes above). To be pinned back to a stable release once one ships.

## Verification

Verified locally end-to-end with this exact canary web-core + example bundles rebuilt with `@lynx-js/motion-canary@0.0.5-canary-20260730-6cbcb870`: all four previews render and animate in the Web tab (Basic rotate/scale loop, Spring physics, Motion Values, Gesture slider), with zero console errors in a fresh browser session.

Also verified the negative case: the current `@lynx-example/motion@0.2.3` bundles (built with motion 0.0.4) do **not** work even on the canary runtime — Basic/Spring throw `TypeError: Cannot read properties of undefined (reading 'MotionHandoffAnimation')` because the shim fix must be inside the bundle.

## Remaining merge gate (why draft)

`@lynx-example/motion` needs a rebuild/republish with `@lynx-js/motion` ≥ `0.0.5-canary-20260730-6cbcb870` (or the next stable ≥0.0.5), and `packages/lynx-example-packages` bumped to that version — the prebuilt `dist/*.web.bundle` in the current 0.2.3 package predate the motion shim fix. Will mark ready once that lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Enable Web previews for Basic and Spring motion examples in English and Chinese docs
- Pin `@lynx-js/web-core` to the motion-preview canary

<!-- end of auto-generated comment: release notes by coderabbit.ai -->