### PR TITLE
docs(blog): 3.9 blog review follow-ups

### DIFF
--- a/docs/en/blog/lynx-3-9.mdx
+++ b/docs/en/blog/lynx-3-9.mdx
@@ -107,7 +107,7 @@ Lynx API [`requestResourcePrefetch`](/api/lynx-api/lynx/lynx-request-resource-pr
 
 ### Performance
 
-On HarmonyOS, the new image strategy optimization improves scenarios such as `image_animation`, reducing `TotalTime` and `CPUTime` by roughly 10%.
+On HarmonyOS, the new native image pipeline is enabled by default. It moves image loading, decode caching, and animated image frame scheduling down into the image node, which reduces per-frame computation and refresh overhead. In image animation benchmarks, both total time (`TotalTime`) and CPU time (`CPUTime`) dropped by roughly 10%.
 
 ## Upgrade Guide
 

--- a/docs/en/blog/lynx-3-9.mdx
+++ b/docs/en/blog/lynx-3-9.mdx
@@ -71,6 +71,7 @@ Lynx 3.9 also adds the following CSS capabilities:
   img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/doc/css/position.jpg"
   entry="src/position"
   defaultEntryFile="dist/position.lynx.bundle"
+  defaultTab="web"
 />
 
 ## ReactLynx

--- a/docs/en/blog/lynx-3-9.mdx
+++ b/docs/en/blog/lynx-3-9.mdx
@@ -17,7 +17,7 @@ Lynx 3.9 is now officially released!
 
 This release focuses on three themes: [Autolink](/guide/autolink) for simpler native capability integration, CSS behavior that is closer to the Web platform, and ReactLynx updates around Portal, rendering, and bundle output.
 
-It also includes a set of focused updates for Elements, Lynx APIs, performance, and Lynx for AI. Let's take a look at what's new in Lynx 3.9.
+It also includes a set of focused updates for Elements, Lynx APIs, and performance. Let's take a look at what's new in Lynx 3.9.
 
 ## Autolink
 
@@ -27,7 +27,7 @@ As Lynx apps depend on more reusable native libraries, app teams often need to m
 
 For conventions, configuration, and platform integration details, continue with the [Autolink guide](/guide/autolink).
 
-## CSS Updates
+## CSS, Closer to the Web
 
 The CSS work in Lynx 3.9 is not only about adding more properties. The larger goal is to make Lynx styling closer to the syntax and behavior that Web developers already know, so migrated styles are easier to reason about and AI-generated Lynx code is less likely to misuse Web-only assumptions.
 
@@ -93,17 +93,13 @@ On the build side, the ReactLynx toolchain now supports a multi-threaded Minimiz
 
 ## Misc Updates
 
-### Lynx for AI
-
-Added the lynx-api-docs agent Skill to improve how AI uses Lynx documentation, making it easier for Agent workflows to retrieve knowledge about Lynx APIs, CSS, layout, Elements, and configuration, and reducing mistakes caused by writing Lynx code with Web assumptions.
-
 ### Element Updates
 
-[`<frame>`](/api/elements/built-in/frame) adds the `enable-multi-async-thread` boolean attribute to control whether embedded Lynx pages use multiple async threads. It also adds `preset-height` and `preset-width` for specifying dimensions before content initialization, plus a `bindloadmetrics` event for tracking frame loading and performance metrics.
+[`<frame>`](/api/elements/built-in/frame) adds the [`enable-multi-async-thread`](/api/elements/built-in/frame#enable-multi-async-thread) boolean attribute to control whether embedded Lynx pages use multiple async threads. It also adds [`preset-height`](/api/elements/built-in/frame#preset-height) and [`preset-width`](/api/elements/built-in/frame#preset-width) for specifying dimensions before content initialization, plus a [`bindloadmetrics`](/api/elements/built-in/frame#bindloadmetrics) event for tracking frame loading and performance metrics.
 
 [`<image>`](/api/elements/built-in/image) adds `region-to-decode` for region-based image decoding. This helps avoid unnecessary decode work when a page only needs to display part of a larger image.
 
-On HarmonyOS, [`<overlay>`](/api/elements/built-in/overlay) supports the `mode` attribute to control whether the current overlay layer is page-level (`page`) or top-level (`top`).
+On HarmonyOS, [`<overlay>`](/api/elements/built-in/overlay) supports the [`mode`](/api/elements/built-in/overlay#mode) attribute to control whether the current overlay layer is page-level (`page`) or top-level (`top`).
 
 ### Lynx API
 

--- a/docs/en/blog/lynx-3-9.mdx
+++ b/docs/en/blog/lynx-3-9.mdx
@@ -98,10 +98,6 @@ On the build side, the ReactLynx toolchain now supports a multi-threaded Minimiz
 
 [`<frame>`](/api/elements/built-in/frame) adds the [`enable-multi-async-thread`](/api/elements/built-in/frame#enable-multi-async-thread) boolean attribute to control whether embedded Lynx pages use multiple async threads. It also adds [`preset-height`](/api/elements/built-in/frame#preset-height) and [`preset-width`](/api/elements/built-in/frame#preset-width) for specifying dimensions before content initialization, plus a [`bindloadmetrics`](/api/elements/built-in/frame#bindloadmetrics) event for tracking frame loading and performance metrics.
 
-[`<image>`](/api/elements/built-in/image) adds `region-to-decode` for region-based image decoding. This helps avoid unnecessary decode work when a page only needs to display part of a larger image.
-
-On HarmonyOS, [`<overlay>`](/api/elements/built-in/overlay) supports the [`mode`](/api/elements/built-in/overlay#mode) attribute to control whether the current overlay layer is page-level (`page`) or top-level (`top`).
-
 ### Lynx API
 
 Lynx API [`requestResourcePrefetch`](/api/lynx-api/lynx/lynx-request-resource-prefetch) gains a new `config` parameter with `awaitComplete` and `awaitTimeout`, so callbacks can run after prefetch fully completes.

--- a/docs/zh/blog/lynx-3-9.mdx
+++ b/docs/zh/blog/lynx-3-9.mdx
@@ -71,6 +71,7 @@ Lynx 3.9 还补齐了以下 CSS 能力：
   img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/doc/css/position.jpg"
   entry="src/position"
   defaultEntryFile="dist/position.lynx.bundle"
+  defaultTab="web"
 />
 
 ## ReactLynx

--- a/docs/zh/blog/lynx-3-9.mdx
+++ b/docs/zh/blog/lynx-3-9.mdx
@@ -107,7 +107,7 @@ Lynx API，[`requestResourcePrefetch`](/api/lynx-api/lynx/lynx-request-resource-
 
 ### 性能表现
 
-HarmonyOS 端通过新的图片策略优化，在 `image_animation` 等场景中将 `TotalTime` 和 `CPUTime` 降低约 10%。
+HarmonyOS 端默认启用新版原生图片链路，将图片加载、解码缓存及动图帧调度下沉至图片节点，减少逐帧计算与刷新开销。在图片动画性能测试中，总耗时（`TotalTime`）和 CPU 耗时（`CPUTime`）均降低约 10%。
 
 ## 升级指南
 

--- a/docs/zh/blog/lynx-3-9.mdx
+++ b/docs/zh/blog/lynx-3-9.mdx
@@ -98,10 +98,6 @@ ReactLynx 在 3.9 中首先补齐了 [`createPortal`](/api/react/Function.create
 
 [`<frame>`](/api/elements/built-in/frame) 新增 [`enable-multi-async-thread`](/api/elements/built-in/frame#enable-multi-async-thread)，可控制嵌入式 Lynx 页面是否使用多个异步线程。它也新增了 [`preset-height`](/api/elements/built-in/frame#preset-height) 和 [`preset-width`](/api/elements/built-in/frame#preset-width)，用于在内容初始化前指定尺寸；同时新增 [`bindloadmetrics`](/api/elements/built-in/frame#bindloadmetrics) 事件，方便宿主或业务侧跟踪 frame 的加载与性能指标。
 
-[`<image>`](/api/elements/built-in/image) 新增 `region-to-decode`，支持按图片区域解码。对于只需要展示局部区域的大图场景，这可以帮助减少不必要的解码成本。
-
-HarmonyOS 端的 [`<overlay>`](/api/elements/built-in/overlay) 支持 [`mode`](/api/elements/built-in/overlay#mode) 属性，控制当前 overlay 的层级是页面级（`page`）还是顶层（`top`）。
-
 ### Lynx API
 
 Lynx API，[`requestResourcePrefetch`](/api/lynx-api/lynx/lynx-request-resource-prefetch) 新增 `config` 参数，支持 `awaitComplete` 和 `awaitTimeout`。如果你希望 prefetch 完全结束后再触发 callback，现在可以直接通过配置表达。

--- a/docs/zh/blog/lynx-3-9.mdx
+++ b/docs/zh/blog/lynx-3-9.mdx
@@ -17,7 +17,7 @@ Lynx 3.9 已经正式发布！
 
 这个版本围绕三条主线展开：用 [Autolink](/guide/autolink) 简化原生能力接入，用更贴近 Web 的 CSS 能力减少迁移和 AI 生成代码中的常见误用，并让 ReactLynx 在 Portal、渲染与构建表现上继续前进。
 
-此外，3.9 也带来了元件、Lynx API、性能与 Lynx for AI 的一组小而实用的更新。下面我们一起来看看 Lynx 3.9 带来了哪些新变化。
+此外，3.9 也带来了元件、Lynx API 与性能的一组小而实用的更新。下面我们一起来看看 Lynx 3.9 带来了哪些新变化。
 
 ## Autolink
 
@@ -27,13 +27,13 @@ Autolink 是 Lynx 3.9 引入的原生库自动发现与注册机制。它会在�
 
 更多约定、配置和平台接入细节，可以继续阅读 [Autolink 指南](/guide/autolink)。
 
-## CSS 能力
+## 更贴近 Web 的 CSS
 
 Lynx 3.9 的 CSS 更新重点不是简单增加属性数量，而是继续贴近 Web 社区已经熟悉的写法。这样从 Web 迁移过来的样式更容易得到一致结果，AI 或 Agent 生成 Lynx 代码时，也更少把 Web 常见写法误用成不可运行的 Lynx 样式。
 
 因此，这个版本补上了 `!important`、`flex` 简写解析等兼容性能力，也继续推进 Grid、Sticky 和 Motion Path 等标准能力补齐。
 
-### [`!important`](/api/css/selectors#important-support) 优先级支持
+### [`!important`](/api/css/selectors#important-支持) 优先级支持
 
 在 `engineVersion` 3.9 或更高版本下，可以在 CSS 值后追加 `!important`，提升该声明在层叠规则中的优先级。
 
@@ -93,17 +93,13 @@ ReactLynx 在 3.9 中首先补齐了 [`createPortal`](/api/react/Function.create
 
 ## 其他更新
 
-### Lynx for AI
-
-新增 lynx-api-docs agent Skill，优化 AI 使用 Lynx 文档的方式，让 Agent 更容易获得 Lynx API、CSS、布局、元件和配置相关知识，减少“按 Web 习惯写 Lynx 代码”带来的误用。
-
 ### 元件能力
 
-[`<frame>`](/api/elements/built-in/frame) 新增 `enable-multi-async-thread`，可控制嵌入式 Lynx 页面是否使用多个异步线程。它也新增了 `preset-height` 和 `preset-width`，用于在内容初始化前指定尺寸；同时新增 `bindloadmetrics` 事件，方便宿主或业务侧跟踪 frame 的加载与性能指标。
+[`<frame>`](/api/elements/built-in/frame) 新增 [`enable-multi-async-thread`](/api/elements/built-in/frame#enable-multi-async-thread)，可控制嵌入式 Lynx 页面是否使用多个异步线程。它也新增了 [`preset-height`](/api/elements/built-in/frame#preset-height) 和 [`preset-width`](/api/elements/built-in/frame#preset-width)，用于在内容初始化前指定尺寸；同时新增 [`bindloadmetrics`](/api/elements/built-in/frame#bindloadmetrics) 事件，方便宿主或业务侧跟踪 frame 的加载与性能指标。
 
 [`<image>`](/api/elements/built-in/image) 新增 `region-to-decode`，支持按图片区域解码。对于只需要展示局部区域的大图场景，这可以帮助减少不必要的解码成本。
 
-HarmonyOS 端的 [`<overlay>`](/api/elements/built-in/overlay) 支持 `mode` 属性，控制当前 overlay 的层级是页面级（`page`）还是顶层（`top`）。
+HarmonyOS 端的 [`<overlay>`](/api/elements/built-in/overlay) 支持 [`mode`](/api/elements/built-in/overlay#mode) 属性，控制当前 overlay 的层级是页面级（`page`）还是顶层（`top`）。
 
 ### Lynx API
 

--- a/packages/lynx-example-packages/package.json
+++ b/packages/lynx-example-packages/package.json
@@ -17,7 +17,7 @@
     "@lynx-example/blur-view": "0.1.0",
     "@lynx-example/composing-elements": "0.6.5",
     "@lynx-example/css": "0.6.5",
-    "@lynx-example/css-api": "0.10.0",
+    "@lynx-example/css-api": "0.10.2",
     "@lynx-example/design-guide": "0.4.2",
     "@lynx-example/desktop": "0.2.0",
     "@lynx-example/element-manipulation": "0.6.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,8 +302,8 @@ importers:
         specifier: 0.6.5
         version: 0.6.5(@lynx-js/types@3.9.0)(@types/react@18.3.18)
       '@lynx-example/css-api':
-        specifier: 0.10.0
-        version: 0.10.0(@lynx-js/types@3.9.0)(@types/react@18.3.18)
+        specifier: 0.10.2
+        version: 0.10.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
       '@lynx-example/design-guide':
         specifier: 0.4.2
         version: 0.4.2(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1426,8 +1426,8 @@ packages:
     resolution: {integrity: sha512-McxesZ9cBeCDE9wkfW/55UGB7Bh5Gwceq/WZ1aKONk8LmQqdtrfLF/5jwfMOu5NYUl+2g20yPmvudFW1bluT2A==}
     engines: {node: '>=18'}
 
-  '@lynx-example/css-api@0.10.0':
-    resolution: {integrity: sha512-T6ZTEtmhus3SqKrk1HafXif6yiPSykXInH6FBzZDTjyvoveoEHrWz1lrGSlSi09LgLMgjTbUiuis6//yAVyKzw==}
+  '@lynx-example/css-api@0.10.2':
+    resolution: {integrity: sha512-ckyQ2s16YI90tIdTxJk7uG5IqGcSVtD/tVbcdn1O9Gb0ujE500uNYq0z1svzS51PH3qDyfwawwF9HyhRX67RnQ==}
     engines: {node: '>=18'}
 
   '@lynx-example/css@0.6.5':
@@ -1958,6 +1958,15 @@ packages:
     peerDependencies:
       '@lynx-js/types': '*'
       '@types/react': ^18
+    peerDependenciesMeta:
+      '@lynx-js/types':
+        optional: true
+
+  '@lynx-js/react@0.123.1':
+    resolution: {integrity: sha512-wgkSly8Nv3O6tdWJ5tc+dgUHp+XpPzJdOy36dPA1np9LXUEWfwkiWs6BBkluPv620c6tyev2Vj3cEjnGHs0orw==}
+    peerDependencies:
+      '@lynx-js/types': '*'
+      '@types/react': ^18 || ^19.0.0
     peerDependenciesMeta:
       '@lynx-js/types':
         optional: true
@@ -7438,9 +7447,9 @@ snapshots:
       - '@lynx-js/types'
       - '@types/react'
 
-  '@lynx-example/css-api@0.10.0(@lynx-js/types@3.9.0)(@types/react@18.3.18)':
+  '@lynx-example/css-api@0.10.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)':
     dependencies:
-      '@lynx-js/react': 0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18)
+      '@lynx-js/react': 0.123.1(@lynx-js/types@3.9.0)(@types/react@18.3.31)
     transitivePeerDependencies:
       - '@lynx-js/types'
       - '@types/react'
@@ -9055,6 +9064,13 @@ snapshots:
       '@lynx-js/types': 3.9.0
 
   '@lynx-js/react@0.123.0(@lynx-js/types@3.9.0)(@types/react@18.3.31)':
+    dependencies:
+      '@types/react': 18.3.31
+      preact: '@lynx-js/internal-preact@10.29.1-20260519060144-e6da44c'
+    optionalDependencies:
+      '@lynx-js/types': 3.9.0
+
+  '@lynx-js/react@0.123.1(@lynx-js/types@3.9.0)(@types/react@18.3.31)':
     dependencies:
       '@types/react': 18.3.31
       preact: '@lynx-js/internal-preact@10.29.1-20260519060144-e6da44c'


### PR DESCRIPTION
Stacked on top of #1165 (`p/linyiyi/add_3_9_blog`).

## Summary

- Remove the **Lynx for AI** subsection from both `docs/zh/blog/lynx-3-9.mdx` and `docs/en/blog/lynx-3-9.mdx`, and drop the corresponding mention from the intro paragraph.
- Deep-link the `<frame>` props to their exact anchors on the docs site instead of only linking the element page: `#enable-multi-async-thread`, `#preset-height`, `#preset-width`, `#bindloadmetrics`.
- Remove the `<image>` `region-to-decode` and `<overlay>` `mode` notes — see below.
- Fix the zh `!important` link: the anchor on the Chinese selectors page is `#important-支持`, not `#important-support` (the previous link scrolled nowhere).
- Retitle the CSS section to lead with the "closer to the Web" framing:
  - zh: `## CSS 能力` → `## 更贴近 Web 的 CSS`
  - en: `## CSS Updates` → `## CSS, Closer to the Web`
- Rewrite the HarmonyOS image performance note to describe the new native image pipeline, and gloss the two metrics on first use — 总耗时 / total time (`TotalTime`) and CPU 耗时 / CPU time (`CPUTime`) — instead of leaving bare identifiers plus the internal `image_animation` test-case name.
- Enable the web preview for the CSS `position` example: bump `@lynx-example/css-api` to `0.10.2` and set `defaultTab="web"`.

## Why the image and overlay notes were removed

Both described capabilities the 3.9 docs do not back up, so there was nothing correct to link to:

- **`<image>` `region-to-decode`** does not appear on the 3.9 image API page, nor anywhere in this repo — the blog draft was its only mention.
- **`<overlay>` `mode`** exists, but is documented with `<IOSOnly />` and describes `window`/`top`/`page`/`others` for iOS, contradicting the draft's HarmonyOS `page`/`top` framing.

If either capability did ship in 3.9, the docs need updating first; the notes can then come back with working links.

## Verification

Every link in the blog was checked against the **released 3.9 docs** (`https://lynxjs.org/3.9/...`), not just local `main`:

- All internal doc pages referenced by the blog return `200` on the 3.9 site.
- All four `<frame>` anchors (`enable-multi-async-thread`, `preset-height`, `preset-width`, `bindloadmetrics`) are present in the rendered 3.9 HTML.

For the web preview:

- `@lynx-example/css-api@0.10.2` is the first release containing `dist/position.web.bundle` — `0.10.1` predates lynx-family/lynx-examples#386 and shipped only the lynx bundle. Verified by inspecting both tarballs.
- After the bump, `docs/public/lynx-examples/css-api/example-metadata.json` resolves the `position` entry with `"webFile": "dist/position.web.bundle"`, and the bundle is present on disk.

## Checks

- `pnpm exec prettier --check` — pass
- `pnpm exec cspell` — 0 issues
- `node scripts/ci/check-asset-urls.mjs` — pass