### PR TITLE
docs(api): correct createPortal return type and document its contract

### DIFF
--- a/docs/en/api/react/Function.createPortal.mdx
+++ b/docs/en/api/react/Function.createPortal.mdx
@@ -22,16 +22,27 @@ in the element tree, while keeping it in the React tree.
 `container` is a `NodesRef`, obtained either from a callback `ref` or from
 `lynx.createSelectorQuery().select(...)`.
 
+:::info Availability
+
+- Added in `@lynx-js/react` 0.121.0.
+- The declared return type is `ReactNode` since 0.123.3. In 0.123.2 and
+  earlier it is Preact's `VNode<any> | null`; there is no runtime difference.
+
+:::
+
 ## Parameters
 
-| Parameter | Type |
-| ------ | ------ |
-| `vnode` | `ComponentChild` |
-| `container` | `NodesRef` |
+| Parameter | Type | Description |
+| ------ | ------ | ------ |
+| `vnode` | `ComponentChild` | The React node to render into `container`. |
+| `container` | `NodesRef` | The `NodesRef` target to render into. |
 
 ## Returns
 
 `ReactNode`
+
+A `ReactNode` placeholder to include in the JSX at the call site;
+the rendered output goes into `container`.
 
 ## Remarks
 
@@ -48,7 +59,7 @@ from `react-dom`:
 
 ## Defined in
 
-@lynx-js/react/runtime/lib/snapshot/lynx/portals.d.ts:26
+@lynx-js/react/runtime/lib/snapshot/lynx/portals.d.ts:31
 
 {/* api-doc-overlay:react-create-portal-example:start */}
 

--- a/docs/en/api/react/Function.createPortal.mdx
+++ b/docs/en/api/react/Function.createPortal.mdx
@@ -13,10 +13,14 @@ import * as Lynx from '@lynx';
 # Function: createPortal()
 
 ```ts
-function createPortal(vnode: ComponentChild, container: NodesRef): useErrorBoundary<any> | null
+function createPortal(vnode: ComponentChild, container: NodesRef): ReactNode
 ```
 
-Create a `Portal` to continue rendering the vnode tree at a different DOM node.
+Renders `vnode` into `container` instead of the current component's position
+in the element tree, while keeping it in the React tree.
+
+`container` is a `NodesRef`, obtained either from a callback `ref` or from
+`lynx.createSelectorQuery().select(...)`.
 
 ## Parameters
 
@@ -27,11 +31,24 @@ Create a `Portal` to continue rendering the vnode tree at a different DOM node.
 
 ## Returns
 
-[`useErrorBoundary`](/api/react/Variable.useErrorBoundary.mdx)\<`any`\> \| `null`
+`ReactNode`
+
+## Remarks
+
+Context still flows across the portal boundary, and state updates inside the
+portal behave like they do in any other component. A few behaviors differ
+from `react-dom`:
+
+- Events do not bubble along the React tree. ReactLynx follows Preact's
+  approach, which has no synthetic event system, so events follow the actual
+  element structure of the page.
+- The portaled subtree renders on the background thread only, and does not
+  participate in main-thread first-screen rendering.
+- Mounting across pages or across native containers is not supported.
 
 ## Defined in
 
-@lynx-js/react/runtime/lib/snapshot/lynx/portals.d.ts:9
+@lynx-js/react/runtime/lib/snapshot/lynx/portals.d.ts:26
 
 {/* api-doc-overlay:react-create-portal-example:start */}
 

--- a/docs/en/api/react/index.mdx
+++ b/docs/en/api/react/index.mdx
@@ -65,7 +65,7 @@ At the same time, we will continue to pay attention to subsequent React advancem
 | [cloneElement](/api/react/Function.cloneElement.mdx) | - |
 | [createContext](/api/react/Function.createContext.mdx) | Lets you create a Context that components can provide or read. |
 | [createElement](/api/react/Function.createElement.mdx) | - |
-| [createPortal](/api/react/Function.createPortal.mdx) | Create a `Portal` to continue rendering the vnode tree at a different DOM node. |
+| [createPortal](/api/react/Function.createPortal.mdx) | Renders `vnode` into `container` instead of the current component's position in the element tree, while keeping it in the React tree. |
 | [createRef](/api/react/Function.createRef.mdx) | - |
 | [forwardRef](/api/react/Function.forwardRef.mdx) | Lets your component expose a DOM node to a parent component using a ref. |
 | [Fragment](/api/react/Function.Fragment.mdx) | Lets you group elements without a wrapper node. |

--- a/docs/zh/api/react/Function.createPortal.mdx
+++ b/docs/zh/api/react/Function.createPortal.mdx
@@ -16,39 +16,47 @@ import * as Lynx from '@lynx';
 function createPortal(vnode: ComponentChild, container: NodesRef): ReactNode
 ```
 
-Renders `vnode` into `container` instead of the current component's position
-in the element tree, while keeping it in the React tree.
+将 `vnode` 渲染到 `container` 中，而不是当前组件在元素树中的位置，同时让它
+仍然保留在 React 树中。
 
-`container` is a `NodesRef`, obtained either from a callback `ref` or from
-`lynx.createSelectorQuery().select(...)`.
+`container` 是一个 `NodesRef`，可以通过回调 `ref` 或
+`lynx.createSelectorQuery().select(...)` 获取。
+
+:::info 可用性
+
+- 自 `@lynx-js/react` 0.121.0 起提供。
+- 自 0.123.3 起，声明的返回类型为 `ReactNode`；在 0.123.2 及更早版本中为
+  Preact 的 `VNode<any> | null`，二者没有运行时差异。
+
+:::
 
 ## 参数
 
-| 范围 | 类型 |
-| ------ | ------ |
-| `vnode` | `ComponentChild` |
-| `container` | `NodesRef` |
+| 范围 | 类型 | 描述 |
+| ------ | ------ | ------ |
+| `vnode` | `ComponentChild` | 要渲染到 `container` 中的 React 节点。 |
+| `container` | `NodesRef` | 作为渲染目标的 `NodesRef`。 |
 
 ## 返回
 
 `ReactNode`
 
+一个 `ReactNode` 占位节点，需要包含在调用处的 JSX 中；实际渲染输出会进入
+`container`。
+
 ## 备注
 
-Context still flows across the portal boundary, and state updates inside the
-portal behave like they do in any other component. A few behaviors differ
-from `react-dom`:
+Context 仍然会跨越 portal 边界传递，portal 内的状态更新行为与其他组件一致。
+以下行为与 `react-dom` 不同：
 
-- Events do not bubble along the React tree. ReactLynx follows Preact's
-  approach, which has no synthetic event system, so events follow the actual
-  element structure of the page.
-- The portaled subtree renders on the background thread only, and does not
-  participate in main-thread first-screen rendering.
-- Mounting across pages or across native containers is not supported.
+- 事件不会沿 React 树冒泡。ReactLynx 沿用了 Preact 的实现方式，没有合成
+  事件系统，因此事件遵循页面实际的元素结构。
+- portal 中的子树只在后台线程渲染，不参与主线程首屏渲染。
+- 不支持跨页面或跨原生容器挂载。
 
 ## 定义于
 
-@lynx-js/react/runtime/lib/snapshot/lynx/portals.d.ts:26
+@lynx-js/react/runtime/lib/snapshot/lynx/portals.d.ts:31
 
 {/* api-doc-overlay:react-create-portal-example:start */}
 

--- a/docs/zh/api/react/Function.createPortal.mdx
+++ b/docs/zh/api/react/Function.createPortal.mdx
@@ -13,10 +13,14 @@ import * as Lynx from '@lynx';
 # 函数: createPortal()
 
 ```ts
-function createPortal(vnode: ComponentChild, container: NodesRef): useErrorBoundary<any> | null
+function createPortal(vnode: ComponentChild, container: NodesRef): ReactNode
 ```
 
-Create a `Portal` to continue rendering the vnode tree at a different DOM node.
+Renders `vnode` into `container` instead of the current component's position
+in the element tree, while keeping it in the React tree.
+
+`container` is a `NodesRef`, obtained either from a callback `ref` or from
+`lynx.createSelectorQuery().select(...)`.
 
 ## 参数
 
@@ -27,11 +31,24 @@ Create a `Portal` to continue rendering the vnode tree at a different DOM node.
 
 ## 返回
 
-[`useErrorBoundary`](/api/react/Variable.useErrorBoundary.mdx)\<`any`\> \| `null`
+`ReactNode`
+
+## 备注
+
+Context still flows across the portal boundary, and state updates inside the
+portal behave like they do in any other component. A few behaviors differ
+from `react-dom`:
+
+- Events do not bubble along the React tree. ReactLynx follows Preact's
+  approach, which has no synthetic event system, so events follow the actual
+  element structure of the page.
+- The portaled subtree renders on the background thread only, and does not
+  participate in main-thread first-screen rendering.
+- Mounting across pages or across native containers is not supported.
 
 ## 定义于
 
-@lynx-js/react/runtime/lib/snapshot/lynx/portals.d.ts:9
+@lynx-js/react/runtime/lib/snapshot/lynx/portals.d.ts:26
 
 {/* api-doc-overlay:react-create-portal-example:start */}
 

--- a/docs/zh/api/react/index.mdx
+++ b/docs/zh/api/react/index.mdx
@@ -65,7 +65,7 @@ React 从 [React 18](https://react.dev/blog/2022/03/29/react-v18) 开始正式�
 | [cloneElement](/api/react/Function.cloneElement.mdx) | - |
 | [createContext](/api/react/Function.createContext.mdx) | Lets you create a Context that components can provide or read. |
 | [createElement](/api/react/Function.createElement.mdx) | - |
-| [createPortal](/api/react/Function.createPortal.mdx) | Create a `Portal` to continue rendering the vnode tree at a different DOM node. |
+| [createPortal](/api/react/Function.createPortal.mdx) | 将 `vnode` 渲染到 `container` 中，而不是当前组件在元素树中的位置，同时让它仍然保留在 React 树中。 |
 | [createRef](/api/react/Function.createRef.mdx) | - |
 | [forwardRef](/api/react/Function.forwardRef.mdx) | Lets your component expose a DOM node to a parent component using a ref. |
 | [Fragment](/api/react/Function.Fragment.mdx) | Lets you group elements without a wrapper node. |


### PR DESCRIPTION
The generated page rendered the return type as `useErrorBoundary<any> | null`. TypeDoc could not resolve preact's `VNode` from the documented entry point and fell back to an unrelated reflection id. lynx-family/lynx-stack#3348 types the API as `ReactNode`, matching the rest of the public surface; this page follows.

Also adds the Remarks section carrying the behavioral contract — event bubbling, background-thread-only rendering, and no cross-page mounting.

### Why this is edited by hand

`docs/{en,zh}/api/react` is not auto-regenerated — see the reviewer checklist in `.github/workflows/update-api-docs.yml`. The wording here was taken from an actual TypeDoc run (both locales) against the rebuilt package, not written by hand, so it matches what the generator would emit.

### The daily sync will not clobber this

- `pnpm run typedoc` only writes `api/genui`, `api/reactlynx-testing-library`, `api/lynx-testing-environment`.
- The API Extractor pipeline writes `api/rspeedy`.
- `scripts/apply-api-doc-overlays.mjs` does touch this file, but only replaces content between the `api-doc-overlay` markers. Verified by running it: both files report "already up to date" with a zero diff.

The `@generated` header and the `import * as Lynx from '@lynx';` line must stay — the overlay script refuses to process a file that is missing either.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Update English and Chinese `createPortal` API documentation.
- Return `ReactNode` from `createPortal`.
- Document event bubbling, background-thread-only rendering, and cross-page mounting restrictions.
- Refresh availability metadata, parameter descriptions, index summaries, and generated declaration references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->