### PR TITLE
docs(autolink): lead with the problem and split the mechanism per platform

### DIFF
--- a/docs/en/guide/autolink.mdx
+++ b/docs/en/guide/autolink.mdx
@@ -2,9 +2,11 @@ import { PlatformTabs } from '@lynx';
 
 # Native Libraries and Autolink
 
-A Lynx native library is an npm package that ships any combination of Elements, Native Modules, and Services for a host Lynx app to consume. Autolink is the integration mechanism that lets the host app discover libraries installed under `node_modules` and register their capabilities automatically on Android and iOS, instead of wiring each Element, Native Module, or Service by hand.
+A Lynx native library is an npm package that ships any combination of Elements, Native Modules, and Services for a host Lynx app to consume. Before this, those capabilities had to be wired up once per host app, with a separate pass for Android and iOS. Autolink is the companion integration mechanism that lets the host app discover libraries installed under `node_modules` and register their capabilities automatically on Android and iOS, instead of wiring each Element, Native Module, or Service by hand.
 
 Autolink currently covers native Android and iOS libraries only. It does not generate Web or HarmonyOS integration code.
+
+This page has two halves: to use an existing library in your app, start from [Consuming a Library](#consuming-a-library); to publish your own native capability as a library, start from [Authoring a Library](#authoring-a-library). For the mental model first, read [How Autolink Works](#how-autolink-works).
 
 :::info Prerequisites
 
@@ -476,4 +478,9 @@ Publish the library like any other npm package: pick a name, often scoped as `@e
 
 ## How Autolink Works
 
-Autolink runs at build time. It scans every npm package under `node_modules` for a `lynx.lib.json` manifest, then generates a per-app registry that lists every Element, Native Module, and Service the installed libraries expose. Android registry generation runs through the Gradle settings and build plugins; iOS registry generation runs through the CocoaPods plugin and emits a registry pod. The host app loads the generated registry once during `LynxEnv` initialization, which is why no per-library wiring code lives in the host.
+Autolink runs at build time. It scans every npm package under `node_modules` for a `lynx.lib.json` manifest, then generates a per-app registry that lists every Element, Native Module, and Service the installed libraries expose. Generation works differently per platform:
+
+- **Android**: registry generation runs through the Gradle settings and build plugins.
+- **iOS**: registry generation runs through the CocoaPods plugin and emits a registry pod.
+
+The host app loads the generated registry once during `LynxEnv` initialization, which is why no per-library wiring code lives in the host.

--- a/docs/zh/guide/autolink.mdx
+++ b/docs/zh/guide/autolink.mdx
@@ -2,9 +2,11 @@ import { PlatformTabs } from '@lynx';
 
 # 原生库与 Autolink
 
-Lynx 原生库是一个 npm 包，可以打包元件、原生模块和 Service 中的任意组合，供宿主 Lynx 应用消费。Autolink 是一种集成机制，让宿主应用自动发现 `node_modules` 中安装的库，并在 Android 和 iOS 上自动注册它们的能力，避免为每个元件、原生模块或 Service 手动写注册代码。
+Lynx 原生库是一个 npm 包，可以打包元件、原生模块和 Service 中的任意组合，供宿主 Lynx 应用消费。在此之前，这些能力只能在每个宿主应用里各接一次，Android 和 iOS 还要分别写一遍。Autolink 是配套的集成机制，让宿主应用自动发现 `node_modules` 中安装的库，并在 Android 和 iOS 上自动注册它们的能力，避免为每个元件、原生模块或 Service 手动写注册代码。
 
 Autolink 当前只覆盖 Android 和 iOS 原生库，不生成 Web 或 HarmonyOS 的接入代码。
+
+本页分为两部分：要在应用里用上一个已有的库，从[使用库](#使用库)开始；要把自己的原生能力发布成库，从[开发库](#开发库)开始。想先建立整体印象，可以直接看 [Autolink 工作原理](#autolink-工作原理)。
 
 :::info 开始前的准备
 
@@ -476,4 +478,9 @@ NS_ASSUME_NONNULL_END
 
 ## Autolink 工作原理
 
-Autolink 在构建期运行。它会扫描 `node_modules` 中每个 npm 包的 `lynx.lib.json` manifest，然后生成一份对应当前应用的 registry，列出所有已安装库暴露的元件、原生模块和 Service。Android 侧的 registry 生成由 Gradle settings plugin 和 build plugin 配合完成；iOS 侧由 CocoaPods plugin 完成并产出 registry pod。宿主应用在初始化 `LynxEnv` 时会一次性加载生成的 registry，因此宿主代码中不需要任何逐库的接入逻辑。
+Autolink 在构建期运行。它会扫描 `node_modules` 中每个 npm 包的 `lynx.lib.json` manifest，然后生成一份对应当前应用的 registry，列出所有已安装库暴露的元件、原生模块和 Service。各平台的生成方式如下：
+
+- **Android**：由 Gradle settings plugin 和 build plugin 配合完成 registry 生成。
+- **iOS**：由 CocoaPods plugin 完成，并产出 registry pod。
+
+宿主应用在初始化 `LynxEnv` 时会一次性加载生成的 registry，因此宿主代码中不需要任何逐库的接入逻辑。


### PR DESCRIPTION
Port of #1241 to `release/3.9`.

## Why this is a port, not a cherry-pick

`release/3.9` and `main` have diverged on this page, so `git cherry-pick` would conflict on every hunk and, worse, would drag main's wording backwards into the release branch:

| | `main` | `release/3.9` |
|---|---|---|
| Element terminology | 元素 | **元件** |
| Platforms covered | Android, iOS, HarmonyOS, Lynxtron | **Android, iOS only** |
| Opening paragraph | rewritten in e861621 | original wording |

So the three changes were re-expressed in this branch's own wording. 元件 is preserved, and both the motivation sentence and the per-platform split name only Android and iOS.

## What changed

1. **One sentence of motivation folded into the opening paragraph.** The page opened on a definition, so a reader arriving cold learned what a native library is but never why it exists.

   > Lynx 原生库是一个 npm 包，……供宿主 Lynx 应用消费。**在此之前，这些能力只能在每个宿主应用里各接一次，Android 和 iOS 还要分别写一遍。**Autolink 是配套的集成机制，……

2. **A reading map** below the scope paragraph, pointing at the consume half, the author half, and the mechanism.

3. **`Autolink 工作原理` split into one bullet per platform**, with the shared "loaded once during `LynxEnv` initialization" conclusion kept as the closing line.

No claim about how Autolink behaves is added or changed. 18 insertions, 4 deletions across the two language files.

## Checks

- `prettier --check` — pass
- `cspell` — 0 issues
- The three in-page anchors used by the reading map (`#使用库`, `#开发库`, `#autolink-工作原理`, and the English equivalents) all resolve against headings in this branch's files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVdDv5kxo9CgBZqTNuQeY7)_