### PR TITLE
feat(blog): add author Group concept and ReactLynx Team

### DIFF
--- a/src/components/blog-avatar/authors.json
+++ b/src/components/blog-avatar/authors.json
@@ -406,6 +406,34 @@
     }
   },
   {
+    "id": "hzy",
+    "name": "Zhiyuan Hong",
+    "name_zh": "Zhiyuan Hong",
+    "title": "Engineering @ Lynx",
+    "title_zh": "工程师 @ Lynx",
+    "image": "https://github.com/hzy.png",
+    "socials": {
+      "github": {
+        "username": "hzy",
+        "link": "https://github.com/hzy"
+      }
+    }
+  },
+  {
+    "id": "Yradex",
+    "name": "Ziqi",
+    "name_zh": "Ziqi",
+    "title": "Engineering @ Lynx",
+    "title_zh": "工程师 @ Lynx",
+    "image": "https://github.com/Yradex.png",
+    "socials": {
+      "github": {
+        "username": "Yradex",
+        "link": "https://github.com/Yradex"
+      }
+    }
+  },
+  {
     "id": "Neilcc",
     "name": "Chengcheng Zhu",
     "name_zh": "朱承丞",

--- a/src/components/blog-avatar/groups.json
+++ b/src/components/blog-avatar/groups.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "reactlynx",
+    "name": "ReactLynx Team",
+    "name_zh": "ReactLynx 团队",
+    "members": [
+      "upupming",
+      "HuJean",
+      "huxpro",
+      "colinaaa",
+      "gaoachao",
+      "hzy",
+      "Yradex"
+    ]
+  }
+]

--- a/src/components/blog-avatar/index.module.less
+++ b/src/components/blog-avatar/index.module.less
@@ -82,20 +82,16 @@
   }
 }
 
-/* ── Compact mode for blog index cards ── */
-.compact-authors {
+/* ── Stacked avatars, shared by groups and compact mode ── */
+.stacked-avatars {
   display: flex;
   align-items: center;
-  gap: 8px;
-}
-
-.compact-avatars {
-  display: flex;
   flex-shrink: 0;
 
   /* Stack avatars with overlap */
-  > :global(.semi-avatar) {
-    border: 2px solid var(--home-features-item-bg, #fff);
+  > :global(.semi-avatar),
+  > .stacked-avatar-overflow {
+    border: 2px solid var(--rp-c-bg, #fff);
     border-radius: 50%;
     margin-left: -6px;
 
@@ -105,8 +101,67 @@
   }
 }
 
-.compact-avatar {
+.stacked-avatar {
   pointer-events: none;
+}
+
+.stacked-avatar-overflow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: content-box;
+  width: 24px;
+  height: 24px;
+  font-size: 0.625rem;
+  font-weight: 500;
+  line-height: 1;
+  color: var(--rp-c-text-2);
+  background-color: var(--rp-c-bg-mute, rgba(127, 127, 127, 0.16));
+  pointer-events: none;
+}
+
+/* ── Group hover card ── */
+.group-members {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  max-width: 320px;
+  padding: 8px 4px;
+}
+
+.group-members-avatars {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 6px;
+}
+
+.group-member-img {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  object-fit: cover;
+  pointer-events: none;
+}
+
+.group-members-names {
+  font-size: 0.8125rem;
+  line-height: 1.4;
+  text-align: center;
+  color: var(--rp-c-text-1);
+}
+
+/* ── Compact mode for blog index cards ── */
+.compact-authors {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  .stacked-avatars > :global(.semi-avatar),
+  .stacked-avatars > .stacked-avatar-overflow {
+    border-color: var(--home-features-item-bg, #fff);
+  }
 }
 
 .compact-names {

--- a/src/components/blog-avatar/index.module.less
+++ b/src/components/blog-avatar/index.module.less
@@ -80,6 +80,21 @@
   .avatar-item:hover .avatar-socials {
     opacity: 1;
   }
+
+  /* Match the 36px single-author avatar so a group sits flush in the row */
+  .stacked-avatars {
+    > :global(.semi-avatar),
+    > .stacked-avatar-overflow {
+      box-sizing: border-box;
+      width: 36px;
+      height: 36px;
+      margin-left: -10px;
+    }
+
+    > .stacked-avatar-overflow {
+      font-size: 0.75rem;
+    }
+  }
 }
 
 /* ── Stacked avatars, shared by groups and compact mode ── */

--- a/src/components/blog-avatar/index.module.less
+++ b/src/components/blog-avatar/index.module.less
@@ -168,15 +168,17 @@
 }
 
 /* ── Compact mode for blog index cards ── */
+/*
+ * The ring separating overlapping avatars must be an OPAQUE surface color.
+ * --home-features-item-bg (the card's own background) is white@50% in light
+ * mode and white@3% in dark, so using it here let the avatar underneath show
+ * through and read as a dark outline. The card sits on the page background,
+ * so --rp-c-bg from .stacked-avatars is the right stand-in for both themes.
+ */
 .compact-authors {
   display: flex;
   align-items: center;
   gap: 8px;
-
-  .stacked-avatars > :global(.semi-avatar),
-  .stacked-avatars > .stacked-avatar-overflow {
-    border-color: var(--home-features-item-bg, #fff);
-  }
 }
 
 .compact-names {

--- a/src/components/blog-avatar/index.module.less
+++ b/src/components/blog-avatar/index.module.less
@@ -83,13 +83,8 @@
 
   /* Match the 36px single-author avatar so a group sits flush in the row */
   .stacked-avatars {
-    > :global(.semi-avatar),
-    > .stacked-avatar-overflow {
-      box-sizing: border-box;
-      width: 36px;
-      height: 36px;
-      margin-left: -10px;
-    }
+    --stack-size: 36px;
+    --stack-overlap: 10px;
 
     > .stacked-avatar-overflow {
       font-size: 0.75rem;
@@ -98,20 +93,54 @@
 }
 
 /* ── Stacked avatars, shared by groups and compact mode ── */
+/*
+ * The separation between overlapping avatars is cut OUT of the lower avatar
+ * rather than drawn on top of it. A ring painted with a surface color has to
+ * name the exact surface it sits on, and there is no single right answer:
+ * the page is --rp-c-bg, but a blog card is --home-features-item-bg composited
+ * over it (white@50% in light, white@3% in dark), so any fixed choice reads
+ * too dark on one of them. Masking a circle out of each avatar where the next
+ * one lands lets the real background show through on any surface, in either
+ * theme, with no token to keep in sync.
+ */
 .stacked-avatars {
+  --stack-size: 24px;
+  --stack-overlap: 6px;
+  --stack-gap: 2px;
+
   display: flex;
   align-items: center;
   flex-shrink: 0;
 
-  /* Stack avatars with overlap */
   > :global(.semi-avatar),
   > .stacked-avatar-overflow {
-    border: 2px solid var(--rp-c-bg, #fff);
+    box-sizing: border-box;
+    width: var(--stack-size);
+    height: var(--stack-size);
     border-radius: 50%;
-    margin-left: -6px;
+    margin-left: calc(-1 * var(--stack-overlap));
 
     &:first-child {
       margin-left: 0;
+    }
+
+    /* Bite out where the next avatar overlaps. Its center sits one full
+     * avatar minus the overlap to the right of this one's left edge, plus
+     * half an avatar; the radius adds --stack-gap for the visible gutter. */
+    &:not(:last-child) {
+      --stack-bite-x: calc(var(--stack-size) * 1.5 - var(--stack-overlap));
+      --stack-bite-r: calc(var(--stack-size) / 2 + var(--stack-gap));
+
+      -webkit-mask-image: radial-gradient(
+        circle var(--stack-bite-r) at var(--stack-bite-x) 50%,
+        transparent 99%,
+        #000 100%
+      );
+      mask-image: radial-gradient(
+        circle var(--stack-bite-r) at var(--stack-bite-x) 50%,
+        transparent 99%,
+        #000 100%
+      );
     }
   }
 }
@@ -124,9 +153,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  box-sizing: content-box;
-  width: 24px;
-  height: 24px;
   font-size: 0.625rem;
   font-weight: 500;
   line-height: 1;
@@ -168,13 +194,6 @@
 }
 
 /* ── Compact mode for blog index cards ── */
-/*
- * The ring separating overlapping avatars must be an OPAQUE surface color.
- * --home-features-item-bg (the card's own background) is white@50% in light
- * mode and white@3% in dark, so using it here let the avatar underneath show
- * through and read as a dark outline. The card sits on the page background,
- * so --rp-c-bg from .stacked-avatars is the right stand-in for both themes.
- */
 .compact-authors {
   display: flex;
   align-items: center;

--- a/src/components/blog-avatar/index.tsx
+++ b/src/components/blog-avatar/index.tsx
@@ -5,10 +5,11 @@ import {
   IconTiktokLogo,
   IconUserCircle,
 } from '@douyinfe/semi-icons';
-import { Avatar } from '@douyinfe/semi-ui';
+import { Avatar, Popover } from '@douyinfe/semi-ui';
 import { useLang } from '@rspress/core/runtime';
 import { useMemo } from 'react';
 import originListData from './authors.json';
+import originGroupData from './groups.json';
 import styles from './index.module.less';
 
 const brandSpList = {
@@ -30,10 +31,23 @@ const brandSpList = {
 } as const;
 
 type BrandKey = keyof typeof brandSpList;
+type Author = (typeof originListData)[0];
+type Group = (typeof originGroupData)[0];
 
-const HoverCard = ({ author }: { author: (typeof originListData)[0] }) => {
+/** A group renders as a single stacked-avatar entry standing in for its members. */
+type Entry =
+  | { kind: 'author'; id: string; author: Author }
+  | { kind: 'group'; id: string; group: Group; members: Author[] };
+
+/** Number of avatars shown before collapsing the rest into a `+N` bubble. */
+const MAX_STACKED_AVATARS = 4;
+
+const getDisplayName = (author: Author, lang: string) =>
+  lang === 'zh' ? author.name_zh : author.name;
+
+const HoverCard = ({ author }: { author: Author }) => {
   const lang = useLang();
-  const displayName = lang === 'zh' ? author.name_zh : author.name;
+  const displayName = getDisplayName(author, lang);
   const role = lang === 'zh' ? author.title_zh : author.title;
 
   return (
@@ -81,32 +95,138 @@ const HoverCard = ({ author }: { author: (typeof originListData)[0] }) => {
   );
 };
 
-const CompactAvatar = ({
-  authors,
-}: {
-  authors: (typeof originListData)[0][];
-}) => {
+const StackedAvatars = ({ members }: { members: Author[] }) => {
+  const lang = useLang();
+  const shown = members.slice(0, MAX_STACKED_AVATARS);
+  const overflow = members.length - shown.length;
+
+  return (
+    <span className={styles['stacked-avatars']}>
+      {shown.map((member) => (
+        <Avatar
+          key={member.id}
+          className={styles['stacked-avatar']}
+          src={member.image}
+          alt={getDisplayName(member, lang)}
+          size="extra-small"
+          // @ts-ignore
+          zoom={undefined}
+          onMouseEnter={undefined}
+          onClick={undefined}
+          onMouseLeave={undefined}
+        />
+      ))}
+      {overflow > 0 && (
+        <span className={styles['stacked-avatar-overflow']}>+{overflow}</span>
+      )}
+    </span>
+  );
+};
+
+const GroupMembersCard = ({ members }: { members: Author[] }) => {
   const lang = useLang();
 
   return (
-    <span className={styles['compact-authors']}>
-      <span className={styles['compact-avatars']}>
-        {authors.map((author) => (
-          <Avatar
-            key={author.id}
-            className={styles['compact-avatar']}
-            src={author?.image}
-            size="extra-small"
-            // @ts-ignore
-            zoom={undefined}
-            onMouseEnter={undefined}
-            onClick={undefined}
-            onMouseLeave={undefined}
+    <div className={styles['group-members']}>
+      <div className={styles['group-members-avatars']}>
+        {members.map((member) => (
+          <img
+            key={member.id}
+            className={styles['group-member-img']}
+            src={member.image}
+            alt={getDisplayName(member, lang)}
           />
         ))}
+      </div>
+      <div className={styles['group-members-names']}>
+        {members.map((member) => getDisplayName(member, lang)).join(', ')}
+      </div>
+    </div>
+  );
+};
+
+const GroupCard = ({ group, members }: { group: Group; members: Author[] }) => {
+  const lang = useLang();
+  const displayName = lang === 'zh' ? group.name_zh : group.name;
+  const memberCount =
+    lang === 'zh'
+      ? `${members.length} 位成员`
+      : `${members.length} member${members.length === 1 ? '' : 's'}`;
+
+  return (
+    <Popover
+      showArrow
+      position="top"
+      trigger="hover"
+      content={<GroupMembersCard members={members} />}
+    >
+      <span className={styles['avatar-item']}>
+        <StackedAvatars members={members} />
+        <div className={styles['avatar-text']}>
+          <span className={styles['avatar-name-row']}>
+            <span className={styles['avatar-name']}>{displayName}</span>
+          </span>
+          <span className={styles['avatar-role']}>{memberCount}</span>
+        </div>
       </span>
+    </Popover>
+  );
+};
+
+const CompactEntry = ({ entry }: { entry: Entry }) => {
+  const lang = useLang();
+
+  if (entry.kind === 'group') {
+    return (
+      <>
+        <StackedAvatars members={entry.members} />
+        <span className={styles['compact-names']}>
+          {lang === 'zh' ? entry.group.name_zh : entry.group.name}
+        </span>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <StackedAvatars members={[entry.author]} />
       <span className={styles['compact-names']}>
-        {authors.map((a) => (lang === 'zh' ? a.name_zh : a.name)).join(', ')}
+        {getDisplayName(entry.author, lang)}
+      </span>
+    </>
+  );
+};
+
+const CompactAvatar = ({ entries }: { entries: Entry[] }) => {
+  const lang = useLang();
+
+  // A lone group keeps the group's own label; a mixed/plain list stacks every
+  // avatar together and joins the names, matching the previous behavior.
+  if (entries.length === 1 && entries[0].kind === 'group') {
+    return (
+      <span className={styles['compact-authors']}>
+        <CompactEntry entry={entries[0]} />
+      </span>
+    );
+  }
+
+  const authors = entries.flatMap((entry) =>
+    entry.kind === 'group' ? entry.members : [entry.author],
+  );
+
+  return (
+    <span className={styles['compact-authors']}>
+      <StackedAvatars members={authors} />
+      <span className={styles['compact-names']}>
+        {entries
+          .map((entry) =>
+            entry.kind === 'group'
+              ? lang === 'zh'
+                ? entry.group.name_zh
+                : entry.group.name
+              : getDisplayName(entry.author, lang),
+          )
+          .join(', ')}
       </span>
     </span>
   );
@@ -121,35 +241,71 @@ const BlogAvatar = ({
   className?: string;
   compact?: boolean;
 }) => {
-  const filteredAuthors = useMemo(() => {
-    // Create a map of authors by id for O(1) lookup
+  const lang = useLang();
+
+  const entries = useMemo<Entry[]>(() => {
+    // Create maps by id for O(1) lookup
     const authorMap = new Map(
       originListData.map((author) => [author.id, author]),
     );
+    const groupMap = new Map(originGroupData.map((group) => [group.id, group]));
 
-    // Map the list order to authors, filtering out any invalid ids
+    const collator = new Intl.Collator(lang);
+    const sortMembers = (members: Author[]) =>
+      [...members].sort((a, b) =>
+        collator.compare(getDisplayName(a, lang), getDisplayName(b, lang)),
+      );
+
+    // Map the list order to authors/groups, filtering out any invalid ids
     return list
-      .map((id) => authorMap.get(id))
-      .filter((author): author is (typeof originListData)[0] => author != null);
-  }, [list]);
+      .map((id): Entry | null => {
+        const author = authorMap.get(id);
+        if (author) {
+          return { kind: 'author', id, author };
+        }
 
-  if (filteredAuthors.length === 0) {
+        const group = groupMap.get(id);
+        if (group) {
+          const members = sortMembers(
+            group.members
+              .map((memberId) => authorMap.get(memberId))
+              .filter((member): member is Author => member != null),
+          );
+          return members.length > 0
+            ? { kind: 'group', id, group, members }
+            : null;
+        }
+
+        return null;
+      })
+      .filter((entry): entry is Entry => entry != null);
+  }, [list, lang]);
+
+  if (entries.length === 0) {
     return <></>;
   }
 
   if (compact) {
     return (
       <div className={className || ''}>
-        <CompactAvatar authors={filteredAuthors} />
+        <CompactAvatar entries={entries} />
       </div>
     );
   }
 
   return (
     <div className={`${styles['blog-avatar-frame']} ${className || ''}`}>
-      {filteredAuthors.map((author) => {
-        return <HoverCard author={author} key={author.id} />;
-      })}
+      {entries.map((entry) =>
+        entry.kind === 'group' ? (
+          <GroupCard
+            key={entry.id}
+            group={entry.group}
+            members={entry.members}
+          />
+        ) : (
+          <HoverCard key={entry.id} author={entry.author} />
+        ),
+      )}
     </div>
   );
 };

--- a/src/components/blog-avatar/index.tsx
+++ b/src/components/blog-avatar/index.tsx
@@ -256,6 +256,13 @@ const BlogAvatar = ({
         collator.compare(getDisplayName(a, lang), getDisplayName(b, lang)),
       );
 
+    // Nobody is credited twice in one byline. Naming an author individually
+    // takes precedence over their membership in a group, whichever order the
+    // two appear in, so `['Yradex', 'reactlynx']` reads as "Ziqi, then the
+    // rest of the ReactLynx Team". Groups listed later likewise skip anyone an
+    // earlier group already showed.
+    const claimed = new Set(list.filter((id) => authorMap.has(id)));
+
     // Map the list order to authors/groups, filtering out any invalid ids
     return list
       .map((id): Entry | null => {
@@ -268,9 +275,11 @@ const BlogAvatar = ({
         if (group) {
           const members = sortMembers(
             group.members
+              .filter((memberId) => !claimed.has(memberId))
               .map((memberId) => authorMap.get(memberId))
               .filter((member): member is Author => member != null),
           );
+          members.forEach((member) => claimed.add(member.id));
           return members.length > 0
             ? { kind: 'group', id, group, members }
             : null;


### PR DESCRIPTION
## Overview

A blog post's `authors` frontmatter can now name a **group** as well as an individual. A group is a name plus an array of author ids, and it renders as a single entry — stacked avatars, the group name, and the member count — instead of expanding into one row per person.

`src/components/blog-avatar/groups.json`:

```json
{
  "id": "reactlynx",
  "name": "ReactLynx Team",
  "name_zh": "ReactLynx 团队",
  "members": ["upupming", "HuJean", "huxpro", "colinaaa", "gaoachao", "hzy", "Yradex"]
}
```

Used the same way as an individual: `authors: ['reactlynx']`, or mixed — `authors: ['liushouqun', 'reactlynx']`.

## Rendering

**Post header (full mode)** — up to four stacked avatars, then a `+N` bubble, followed by the group name and `7 members` / `7 位成员`. Hovering opens a card with every member's avatar and full name list.

**Blog index card (compact mode)** — stacked avatars plus the group name. Stacking is now capped at four for plain author lists too, so long author lists no longer push the names out of the card.

Members are sorted alphabetically at render time by their display name in the active locale (`Intl.Collator`), so the source order in `groups.json` doesn't matter and `zh` gets pinyin ordering.

Unknown ids are dropped, as before; a group whose members all fail to resolve is dropped too.

## Author entries added

`hzy` (Zhiyuan Hong) and `Yradex` (Ziqi) were not in `authors.json` and are needed for the ReactLynx Team roster.

Two placeholders to correct before this leaves draft:

- `name_zh` for both is set to the English name — the Chinese names weren't available to confirm, and guessing at someone's characters seemed worse than falling back.
- `Yradex` is listed as `Ziqi` only; the full name is unknown.

## Verification

Typechecked (`tsc --noEmit` — no new errors in `blog-avatar`) and rendered against the dev server: post header, hover card, and blog index all verified by screenshot.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CzfaaQBfP5TyQHePBcdWQx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Support author groups in blog frontmatter with localized names and member IDs.
- Render groups with stacked avatars, member counts, hover cards, and compact layouts.
- Sort localized group members, exclude unknown or duplicate authors, and cap avatar stacks at four.
- Add ReactLynx Team membership and missing author records.
- Apply theme-safe avatar masking and background styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->