### PR TITLE
docs: close the 3.9 release-blog review blockers

### DIFF
--- a/docs/en/api/css/properties/flex.mdx
+++ b/docs/en/api/css/properties/flex.mdx
@@ -3,7 +3,7 @@ title: flex
 api: css/properties/flex
 ---
 
-import { APISummary, APITable, Go } from '@lynx';
+import { APISummary, APITable, Go, VersionBadge } from '@lynx';
 
 <APISummary />
 ## Introduction
@@ -27,7 +27,7 @@ flex: none;
 flex: auto;
 
 /* One value, unitless number: flex-grow
-flex-basis is then equal to 0. */
+flex-basis is then equal to 0% (0 before Lynx 3.9). */
 flex: 2;
 
 /* One value, width/height: flex-basis */
@@ -47,13 +47,13 @@ flex: 2 2 10%;
 The `flex` property may be specified using one, two, or three values.
 
 - **One-value syntax**:
-  - A unitless [`<number>`](/api/css/data-type/number.mdx), which will be used as the value of [`<flex-grow>`](./flex-grow.mdx), then the shorthand expands to `flex: <flex-grow> 1 0`.
+  - A unitless [`<number>`](/api/css/data-type/number.mdx), which will be used as the value of [`<flex-grow>`](./flex-grow.mdx), then the shorthand expands to `flex: <flex-grow> 1 0%`. <VersionBadge>3.9</VersionBadge> Before 3.9 the omitted `flex-basis` expanded to a unitless `0`; browsers use `0%`, so this was aligned with the Web. See [Flex basis 0 vs 0%](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/flex-basis#flex_basis_0_vs_0).
   - A valid [`<length>`](/api/css/data-type/length.mdx) or [`<percentage>`](/api/css/data-type/percentage.mdx) or key word `auto`, it will be used as the value of [`<flex-basis>`](./flex-basis.mdx), then the shorthand expands to `flex: 1 1 <flex-basis>`.
 
 - **Two-value syntax**:
   - The first value must be a valid value for [`<flex-grow>`](./flex-grow.mdx).
   - The second value must be one of:
-    - A unitless [`<number>`](/api/css/data-type/number.mdx), which will be used as the value of [`<flex-shrink>`](./flex-shrink.mdx), then the shorthand expands to `flex: <flex-grow> <flex-shrink> 0`.
+    - A unitless [`<number>`](/api/css/data-type/number.mdx), which will be used as the value of [`<flex-shrink>`](./flex-shrink.mdx), then the shorthand expands to `flex: <flex-grow> <flex-shrink> 0%`. <VersionBadge>3.9</VersionBadge> Before 3.9 this was a unitless `0`.
     - A valid [`<length>`](/api/css/data-type/length.mdx) or [`<percentage>`](/api/css/data-type/percentage.mdx) or key word `auto`, it will be used as the value of [`<flex-basis>`](./flex-basis.mdx), then the shorthand expands to `flex: <flex-grow> 1 <flex-basis>`.
 
 - Three-value syntax: the values must be in the following order:

--- a/docs/en/api/css/properties/position.mdx
+++ b/docs/en/api/css/properties/position.mdx
@@ -3,7 +3,7 @@ title: position
 api: css/properties/position
 ---
 
-import { APISummary, APITable, Go } from '@lynx';
+import { APISummary, APITable, Go, VersionBadge } from '@lynx';
 
 <APISummary />
 ## Introduction
@@ -62,7 +62,15 @@ The element is will be treated as a direct child of root node with the property 
 
 #### `sticky`
 
-`sticky` is only supported on the children elements of a `scroll-view`. Is The element is positioned according to the normal flow of the document, and then offset relative to its parent scroll-view and containing block (nearest block-level ancestor), based on the values of top, right, bottom, and left. The offset does not affect the position of any other elements.
+`sticky` is only supported on the children elements of a `scroll-view`. The element is positioned according to the normal flow of the document, and then offset relative to its parent scroll-view and containing block (nearest block-level ancestor), based on the values of top, right, bottom, and left. The offset does not affect the position of any other elements.
+
+:::info Standard sticky behavior <VersionBadge>3.9</VersionBadge>
+
+The above describes Lynx's original sticky behavior, which only applies to direct children of a `scroll-view`. From 3.9 onwards, the `enableNewSticky` page config switch enables standard `position: sticky` behavior matching the Web: the element is laid out in normal flow and then offset relative to its nearest scrolling container and containing block, without having to be a direct child of a `scroll-view`.
+
+The switch is off by default so that existing pages keep their current behavior.
+
+:::
 
 ## Formal definition
 

--- a/docs/en/blog/lynx-3-9.mdx
+++ b/docs/en/blog/lynx-3-9.mdx
@@ -111,7 +111,7 @@ Context still flows across the portal boundary and state updates behave as they 
 
 - **Event bubbling follows Preact's behavior.** ReactLynx's `createPortal` builds on Preact, which has no synthetic event system, so events bubble along the page's actual element structure rather than the React component tree.
 - **The portal subtree does not take part in [Instant First-Frame Rendering (IFR)](/guide/interaction/ifr)** — it renders on the background thread only.
-- **Mounting across pages or containers is not supported.** For those cases, reach for Lynx UI's [`Overlay`](/ui/components/overlay) component, or the [`<overlay>`](/api/elements/built-in/overlay) [XElement](/guide/ui/elements-components#xelement) directly.
+- **Mounting across pages or across native containers is not supported.** For those cases, reach for Lynx UI's [`Overlay`](/ui/components/overlay) component, or the [`<overlay>`](/api/elements/built-in/overlay) [XElement](/guide/ui/elements-components#xelement) directly.
 
 The [`createPortal` notes](/api/react/Function.createPortal#remarks) cover all three in full.
 
@@ -137,7 +137,7 @@ Lynx API [`requestResourcePrefetch`](/api/lynx-api/lynx/lynx-request-resource-pr
 
 ### Performance
 
-On HarmonyOS, the new native image pipeline is enabled by default. It moves image loading, decode caching, and animated image frame scheduling down into the image node, which reduces per-frame computation and refresh overhead. In image animation benchmarks, both total time (`TotalTime`) and CPU time (`CPUTime`) dropped by roughly 10%.
+On HarmonyOS, the new native image pipeline is enabled by default. It moves image loading, decode caching, and animated image frame scheduling down into the image node, which reduces per-frame computation and refresh overhead. In our internal image-animation benchmark both total time (`TotalTime`) and CPU time (`CPUTime`) came down measurably. How much you see depends on image dimensions, device and page structure, so measure your own scenario.
 
 ## Upgrade Guide
 

--- a/docs/en/blog/lynx-3-9.mdx
+++ b/docs/en/blog/lynx-3-9.mdx
@@ -111,7 +111,7 @@ Context still flows across the portal boundary and state updates behave as they 
 
 - **Event bubbling follows Preact's behavior.** ReactLynx's `createPortal` builds on Preact, which has no synthetic event system, so events bubble along the page's actual element structure rather than the React component tree.
 - **The portal subtree does not take part in [Instant First-Frame Rendering (IFR)](/guide/interaction/ifr)** — it renders on the background thread only.
-- **Mounting across pages or across native containers is not supported.** For those cases, reach for Lynx UI's [`Overlay`](/ui/components/overlay) component, or the [`<overlay>`](/api/elements/built-in/overlay) [XElement](/guide/ui/elements-components#xelement) directly.
+- **Mounting across pages or across native containers is not supported.** For those cases, reach for lynx-ui's [`Overlay`](/ui/components/overlay) component, or the [`<overlay>`](/api/elements/built-in/overlay) [XElement](/guide/ui/elements-components#xelement) directly.
 
 The [`createPortal` notes](/api/react/Function.createPortal#remarks) cover all three in full.
 

--- a/docs/zh/api/css/properties/flex.mdx
+++ b/docs/zh/api/css/properties/flex.mdx
@@ -2,7 +2,7 @@
 api: css/properties/flex
 ---
 
-import { APISummary, APITable, Go } from '@lynx';
+import { APISummary, APITable, Go, VersionBadge } from '@lynx';
 
 # flex
 
@@ -29,7 +29,7 @@ flex: auto;
 flex: none;
 
 /* 单值，无单位数字：flex-grow
-flex-basis 此时等于 0。 */
+flex-basis 此时等于 0%（3.9 之前为 0）。 */
 flex: 2;
 
 /* 单值，宽度/高度：flex-basis */
@@ -49,13 +49,13 @@ flex: 2 2 10%;
 可以使用一个，两个或三个值来指定 `flex` 属性。
 
 - **单值语法**：值必须是以下之一：
-  - 一个无单位数 [`<number>`](/api/css/data-type/number.mdx)，它会被当作 [`<flex-grow>`] 的值。此时简写会扩展为 `flex: <flex-grow> 1 0`。
+  - 一个无单位数 [`<number>`](/api/css/data-type/number.mdx)，它会被当作 [`<flex-grow>`] 的值。此时简写会扩展为 `flex: <flex-grow> 1 0%`。<VersionBadge>3.9</VersionBadge> 3.9 之前省略的 `flex-basis` 会扩展为无单位的 `0`；浏览器使用的是 `0%`，这次调整是为了对齐 Web。差异参见 [Flex basis 0 vs 0%](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/flex-basis#flex_basis_0_vs_0)。
   - 一个有效的长度 [`<length>`](/api/css/data-type/length.mdx) 值或百分比 [`<percentage>`](/api/css/data-type/percentage.mdx) 或关键字 `auto`，它会被当作 [`<flex-basis>`](./flex-basis.mdx) 的值。此时简写会扩展为 `flex: 1 1 <flex-basis>`。
 
 - **双值语法**：
   - 第一个值必须是一个 [`<flex-grow>`] 的有效值。
   - 第二个值必须是以下之一：
-    - 一个无单位数 [`<number>`](/api/css/data-type/number.mdx)，它会被当作 [`<flex-shrink>`](./flex-shrink.mdx) 的值。此时简写会扩展为 `flex: <flex-grow> <flex-shrink> 0`。
+    - 一个无单位数 [`<number>`](/api/css/data-type/number.mdx)，它会被当作 [`<flex-shrink>`](./flex-shrink.mdx) 的值。此时简写会扩展为 `flex: <flex-grow> <flex-shrink> 0%`。<VersionBadge>3.9</VersionBadge> 3.9 之前为无单位的 `0`。
     - 一个有效的长度 [`<length>`](/api/css/data-type/length.mdx) 值或百分比 [`<percentage>`](/api/css/data-type/percentage.mdx) 或关键字 `auto`，它会被当作 [`<flex-basis>`](./flex-basis.mdx) 的值。此时简写会扩展为 `flex: <flex-grow> 1 <flex-basis>`。
 
 - **三值语法**：值必须按照以下顺序指定：

--- a/docs/zh/api/css/properties/position.mdx
+++ b/docs/zh/api/css/properties/position.mdx
@@ -2,7 +2,7 @@
 api: css/properties/position
 ---
 
-import { APISummary, APITable, Go } from '@lynx';
+import { APISummary, APITable, Go, VersionBadge } from '@lynx';
 
 # position
 
@@ -67,7 +67,15 @@ position: sticky;
 
 #### `sticky`
 
-当前元件将参与父节点布局，当该元件的父节点为 `scroll view` 的时候该属性才有意义。当该节点因父节点的 scroll 产生位移时，该节点会与父节点的 view port 至少保持 top 等属性所规定的距离。list 用大度的吸顶元件。
+当前元件将参与父节点布局，当该元件的父节点为 `scroll view` 的时候该属性才有意义。当该节点因父节点的 scroll 产生位移时，该节点会与父节点的 view port 至少保持 top 等属性所规定的距离。
+
+:::info 标准 sticky 行为 <VersionBadge>3.9</VersionBadge>
+
+上述是 Lynx 早期的 sticky 行为，仅对 `scroll-view` 的直接子节点生效。从 3.9 起，可以通过页面配置开关 `enableNewSticky` 启用与 Web 一致的标准 `position: sticky` 行为：元件先按正常流布局，再相对最近的滚动容器和包含块产生偏移，且不再要求它是 `scroll-view` 的直接子节点。
+
+该开关默认关闭，以保证既有页面的行为不变。
+
+:::
 
 ## 形式定义
 

--- a/docs/zh/blog/lynx-3-9.mdx
+++ b/docs/zh/blog/lynx-3-9.mdx
@@ -111,7 +111,7 @@ Context 仍然跨越 Portal 边界传递，状态更新也和普通组件一致�
 
 - **事件冒泡遵循 Preact 的行为。** ReactLynx 的 `createPortal` 沿用 Preact 的实现，没有 React 的合成事件系统，因此事件沿页面实际的元件结构冒泡，而不是 React 组件树。
 - **Portal 子树不参与[首帧直出（IFR）](/guide/interaction/ifr)**，只在后台线程渲染。
-- **不支持跨页面、跨容器挂载。** 这类场景请改用 Lynx UI 的 [`Overlay`](/ui/components/overlay) 组件，或直接使用 [`<overlay>`](/api/elements/built-in/overlay) 这个 [XElement](/guide/ui/elements-components#xelement)。
+- **不支持跨页面或跨原生容器挂载。** 这类场景请改用 Lynx UI 的 [`Overlay`](/ui/components/overlay) 组件，或直接使用 [`<overlay>`](/api/elements/built-in/overlay) 这个 [XElement](/guide/ui/elements-components#xelement)。
 
 以上限制的完整说明见 [`createPortal` 的备注](/api/react/Function.createPortal#备注)。
 
@@ -137,7 +137,7 @@ Lynx API，[`requestResourcePrefetch`](/api/lynx-api/lynx/lynx-request-resource-
 
 ### 性能表现
 
-HarmonyOS 端默认启用新版原生图片链路，将图片加载、解码缓存及动图帧调度下沉至图片节点，减少逐帧计算与刷新开销。在图片动画性能测试中，总耗时（`TotalTime`）和 CPU 耗时（`CPUTime`）均降低约 10%。
+HarmonyOS 端默认启用新版原生图片链路，将图片加载、解码缓存及动图帧调度下沉至图片节点，减少逐帧计算与刷新开销。在我们内部的图片动画基准场景中，总耗时（`TotalTime`）和 CPU 耗时（`CPUTime`）都有可观测的下降；具体幅度取决于图片规格、设备和页面结构，请以你自己场景的实测为准。
 
 ## 升级指南
 

--- a/docs/zh/blog/lynx-3-9.mdx
+++ b/docs/zh/blog/lynx-3-9.mdx
@@ -111,7 +111,7 @@ Context 仍然跨越 Portal 边界传递，状态更新也和普通组件一致�
 
 - **事件冒泡遵循 Preact 的行为。** ReactLynx 的 `createPortal` 沿用 Preact 的实现，没有 React 的合成事件系统，因此事件沿页面实际的元件结构冒泡，而不是 React 组件树。
 - **Portal 子树不参与[首帧直出（IFR）](/guide/interaction/ifr)**，只在后台线程渲染。
-- **不支持跨页面或跨原生容器挂载。** 这类场景请改用 Lynx UI 的 [`Overlay`](/ui/components/overlay) 组件，或直接使用 [`<overlay>`](/api/elements/built-in/overlay) 这个 [XElement](/guide/ui/elements-components#xelement)。
+- **不支持跨页面或跨原生容器挂载。** 这类场景请改用 lynx-ui 的 [`Overlay`](/ui/components/overlay) 组件，或直接使用 [`<overlay>`](/api/elements/built-in/overlay) 这个 [XElement](/guide/ui/elements-components#xelement)。
 
 以上限制的完整说明见 [`createPortal` 的备注](/api/react/Function.createPortal#备注)。
 


### PR DESCRIPTION
Stacked on `p/linyiyi/add_3_9_blog`, addressing the four blockers in the [CHANGES_REQUESTED review on #1165](https://github.com/lynx-family/lynx-website/pull/1165#pullrequestreview-4838246978).

## 1. Portal limitation said "containers" where it meant native containers

Correct catch — the shortened wording was ambiguous against the section's own usage example, since every portal mounts into *some* element container.

> zh: 不支持跨页面、跨容器挂载 → **不支持跨页面或跨原生容器挂载**
> en: across pages or containers → **across pages or across native containers**

Now matches the `createPortal` contract exactly.

## 2. `flex` contradicted the linked canonical page

The blog was the only place the `0` → `0%` change was written down. Both locales of `/api/css/properties/flex` now version it:

> …the shorthand expands to `flex: <flex-grow> 1 0%`. <VersionBadge>3.9</VersionBadge> Before 3.9 the omitted `flex-basis` expanded to a unitless `0`; browsers use `0%`, so this was aligned with the Web.

Applied to both the one-value and two-value expansions, plus the syntax comment. `VersionBadge` was not previously imported on these pages; it is now.

## 3. `enableNewSticky` was undocumented

`/api/css/properties/position` described only the legacy `scroll-view`-child behavior. Both locales now carry an info block on `#### sticky`: the 3.9 switch name, what standard sticky changes (normal-flow layout, offset against the nearest scrolling container, no longer requiring a direct `scroll-view` child), and that it is **off by default** so existing pages are unaffected.

The EN page also had a typo in that paragraph ("Is The element is positioned"), fixed in passing.

## 4. Performance figure was not reproducible

Removed the bare "roughly 10%" `TotalTime`/`CPUTime` claim rather than dressing it up. Without a published workload, device, build and sample size the number cannot be acted on, so the post now states the direction and tells readers to measure their own scenario.

> 在我们内部的图片动画基准场景中，总耗时（`TotalTime`）和 CPU 耗时（`CPUTime`）都有可观测的下降；具体幅度取决于图片规格、设备和页面结构，请以你自己场景的实测为准。

The Snapshot production counts (`175→123`, `76→25`) were already removed when that section was rewritten in #1243.

## Not addressed

**Dual-thread Minimizer availability metadata.** The review asks which `@lynx-js/react-rsbuild-plugin` / `@lynx-js/rspeedy` versions first support it. That is not derivable from this repository — the API pages document signatures only, and nothing here records the first supporting release. Rather than guess a version floor into a reference page, leaving it for someone with the release history. The blog paragraph makes no version claim, so nothing there is wrong today.

## Checks

- `prettier --check` — pass
- `cspell` — 0 issues
- `node scripts/ci/check-asset-urls.mjs` — pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVdDv5kxo9CgBZqTNuQeY7)_