### PR TITLE
docs(blog): tighten the 3.9 post after a full read-through

### DIFF
--- a/docs/en/blog/lynx-3-9.mdx
+++ b/docs/en/blog/lynx-3-9.mdx
@@ -71,7 +71,7 @@ Lynx 3.9 also adds the following CSS capabilities:
 
 - New [`grid-row`](/api/css/properties/grid-row) and [`grid-column`](/api/css/properties/grid-column) shorthands for setting the corresponding `grid-*-start` and `grid-*-end` values. For example, `grid-row: 1 / span 2` is equivalent to `grid-row-start: 1; grid-row-end: span 2`.
 - Standard `position: sticky` behavior, enabled through the [`enableNewSticky`](/api/css/properties/position#sticky) page switch.
-- HarmonyOS support for more [Motion Path](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_motion_path) features, including [`offset-path`](/api/css/properties/offset-path), [`offset-distance`](/api/css/properties/offset-distance), and [`offset-rotate`](/api/css/properties/offset-rotate).
+- HarmonyOS support for more [Motion Path](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Motion_path) features, including [`offset-path`](/api/css/properties/offset-path), [`offset-distance`](/api/css/properties/offset-distance), and [`offset-rotate`](/api/css/properties/offset-rotate).
 
 <Go
   example="css-api"
@@ -87,11 +87,11 @@ Lynx 3.9 also adds the following CSS capabilities:
 
 ReactLynx brings `createPortal` and an optimization that reduces both the depth and the number of Snapshots, plus a dual-thread Minimizer on the build side.
 
-### [Portal](https://react.dev/reference/react-dom/createPortal)
+### Portal
 
-In React, a Portal renders a component subtree into a container elsewhere in the element tree while keeping it in the React tree — the usual answer for overlays, dialogs, and anything that has to escape its surrounding layout. Since `@lynx-js/react` 0.121.0, Portal is available in ReactLynx through [`createPortal`](/api/react/Function.createPortal).
+In React, a [Portal](https://react.dev/reference/react-dom/createPortal) renders a component subtree into a container elsewhere in the element tree while keeping it in the React tree — the usual answer for overlays, dialogs, and anything that has to escape its surrounding layout. Since `@lynx-js/react` 0.121.0, Portal is available in ReactLynx through [`createPortal`](/api/react/Function.createPortal).
 
-Unlike React DOM, ReactLynx takes a [`NodesRef`](/api/lynx-api/nodes-ref) as the Portal container: attach a ref to the hosting element to obtain its `NodesRef`, then pass that as `createPortal`'s second argument. For the other ways to obtain a node reference, see [Manipulating Elements](/guide/interaction/event-handling/manipulating-element.react).
+Where React DOM's Portal takes a DOM node as its container, ReactLynx takes a node reference — a [`NodesRef`](/api/lynx-api/nodes-ref). Attach a ref to the hosting element to obtain its `NodesRef`, then pass that as `createPortal`'s second argument. For the other ways to obtain a node reference, see [Manipulating Elements](/guide/interaction/event-handling/manipulating-element.react).
 
 <Go
   example="react-apis"
@@ -102,15 +102,15 @@ Unlike React DOM, ReactLynx takes a [`NodesRef`](/api/lynx-api/nodes-ref) as the
   highlight="{7,34-37}"
 />
 
-React Context still flows across the Portal boundary and state updates behave as they do in any other component. Three [notes](/api/react/Function.createPortal#remarks) differ from the Web:
+A Portal only changes where an element is physically placed. In every other way the JSX you render into it behaves as a child of the component that renders it: React Context from the parent tree still reaches it, and state updates behave as they do in any other component. Three [notes](/api/react/Function.createPortal#remarks) differ from the Web:
 
-- **Event bubbling follows Preact's behavior.** ReactLynx's `createPortal` builds on Preact, which has no synthetic event system, so events bubble along the page's actual element structure rather than the React component tree.
+- **Event bubbling follows Preact's behavior.** ReactLynx's `createPortal` builds on Preact, where [events do not bubble up through Portal components](https://preactjs.com/guide/v10/differences-to-react/#main-differences), so events follow the page's actual element structure rather than the React tree.
 - **The portal subtree does not take part in [Instant First-Frame Rendering (IFR)](/guide/interaction/ifr)** — it renders on the background thread only.
 - **Mounting across pages or across native containers is not supported.** For those cases, reach for lynx-ui's [`Overlay`](/ui/components/overlay) component, or the [`<overlay>`](/api/elements/built-in/overlay) [XElement](/guide/ui/elements-components#xelement) directly.
 
 ### Snapshot depth and count optimization
 
-At compile time ReactLynx extracts the static element structure of your JSX into a **Snapshot**, so at runtime only the dynamic parts inside it need updating. (We will deep dive into Snapshots in a later post.)
+At compile time ReactLynx extracts the static element structure of your JSX into a **Snapshot**, so at runtime only the dynamic parts inside it need updating. (We will cover Snapshots in detail in a later post.)
 
 In [`@lynx-js/react` 0.120.0](https://github.com/lynx-family/lynx-stack/blob/main/packages/react/CHANGELOG.md#01200) we [extended Preact's diff algorithm](https://github.com/lynx-family/internal-preact/pull/1) so a child can declare which slot of its parent it belongs to. That lets the compiler [drop the intermediate nodes](https://github.com/lynx-family/lynx-stack/pull/1764) it used to need, leaving a shallower element tree and fewer Snapshots — less work to render. It is on by default and needs no app-side changes.
 

--- a/docs/en/blog/lynx-3-9.mdx
+++ b/docs/en/blog/lynx-3-9.mdx
@@ -15,9 +15,7 @@ import { BlogHeader, Go } from '@lynx';
 
 Lynx 3.9 is now officially released!
 
-This release focuses on three themes: [Autolink](/guide/autolink), which makes a native capability something you can package, publish, and install; CSS behavior that is closer to the Web platform; and ReactLynx updates around Portal, rendering, and bundle output.
-
-It also includes a set of focused updates for Elements, Lynx APIs, and performance. Let's take a look at what's new in Lynx 3.9.
+This release focuses on three themes: [Autolink](/guide/autolink), which makes a native capability something you can package, publish, and install; CSS behavior that is closer to the Web platform; and ReactLynx updates around Portal, rendering, and bundle output. It also includes a set of focused updates for Elements, Lynx APIs, and performance. Let's take a look at what's new in Lynx 3.9.
 
 ## Autolink
 
@@ -49,9 +47,7 @@ The CSS work in Lynx 3.9 is not about adding more properties. The goal is to mak
 
 ### [`!important`](/api/css/selectors#important-support) priority support
 
-With `engineVersion` 3.9 or later, you can append `!important` to a CSS value to increase that declaration's priority in the cascade.
-
-For example:
+With `engineVersion` 3.9 or later, you can append `!important` to a CSS value to increase that declaration's priority in the cascade. For example, the `color` of `<view className="foo" />` below resolves to `red` rather than `blue`:
 
 ```css
 .foo {
@@ -62,8 +58,6 @@ view.foo {
   color: blue;
 }
 ```
-
-The `color` of `<view className="foo" />` is now `red` instead of `blue`.
 
 ### [`flex`](/api/css/properties/flex) shorthand parsing
 
@@ -76,8 +70,8 @@ Although the CSS specification defines `0` as the default, browsers commonly par
 Lynx 3.9 also adds the following CSS capabilities:
 
 - New [`grid-row`](/api/css/properties/grid-row) and [`grid-column`](/api/css/properties/grid-column) shorthands for setting the corresponding `grid-*-start` and `grid-*-end` values. For example, `grid-row: 1 / span 2` is equivalent to `grid-row-start: 1; grid-row-end: span 2`.
-- Standard [`position: sticky`](/api/css/properties/position) behavior, enabled through the `enableNewSticky` page switch.
-- HarmonyOS support for [`offset-path`](/api/css/properties/offset-path), [`offset-distance`](/api/css/properties/offset-distance), and [`offset-rotate`](/api/css/properties/offset-rotate).
+- Standard `position: sticky` behavior, enabled through the [`enableNewSticky`](/api/css/properties/position#sticky) page switch.
+- HarmonyOS support for more [Motion Path](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_motion_path) features, including [`offset-path`](/api/css/properties/offset-path), [`offset-distance`](/api/css/properties/offset-distance), and [`offset-rotate`](/api/css/properties/offset-rotate).
 
 <Go
   example="css-api"
@@ -86,17 +80,18 @@ Lynx 3.9 also adds the following CSS capabilities:
   entry="src/position"
   defaultEntryFile="dist/position.lynx.bundle"
   defaultTab="web"
+  highlight="{139-142,166-168}"
 />
 
 ## ReactLynx
 
 ReactLynx brings `createPortal` and an optimization that reduces both the depth and the number of Snapshots, plus a dual-thread Minimizer on the build side.
 
-### `createPortal`
+### [Portal](https://react.dev/reference/react-dom/createPortal)
 
-[`createPortal`](/api/react/Function.createPortal) renders a component subtree into a container outside the current component hierarchy. It suits overlays, dialogs, and other UI that needs to escape the surrounding layout: components stay organized around React data flow, while the final render location is delegated to the target container. The API is available from `@lynx-js/react` 0.121.0.
+In React, a Portal renders a component subtree into a container elsewhere in the element tree while keeping it in the React tree — the usual answer for overlays, dialogs, and anything that has to escape its surrounding layout. Since `@lynx-js/react` 0.121.0, Portal is available in ReactLynx through [`createPortal`](/api/react/Function.createPortal).
 
-The container reaches `createPortal` as a [`NodesRef`](/api/lynx-api/nodes-ref): attach a ref to the hosting node to obtain its `NodesRef`, then pass that as the second argument. For the other ways to obtain a node reference, see [Manipulating Elements](/guide/interaction/event-handling/manipulating-element.react).
+Unlike React DOM, ReactLynx takes a [`NodesRef`](/api/lynx-api/nodes-ref) as the Portal container: attach a ref to the hosting element to obtain its `NodesRef`, then pass that as `createPortal`'s second argument. For the other ways to obtain a node reference, see [Manipulating Elements](/guide/interaction/event-handling/manipulating-element.react).
 
 <Go
   example="react-apis"
@@ -107,19 +102,17 @@ The container reaches `createPortal` as a [`NodesRef`](/api/lynx-api/nodes-ref):
   highlight="{7,34-37}"
 />
 
-Context still flows across the portal boundary and state updates behave as they do in any other component. Three things differ from `react-dom`:
+React Context still flows across the Portal boundary and state updates behave as they do in any other component. Three [notes](/api/react/Function.createPortal#remarks) differ from the Web:
 
 - **Event bubbling follows Preact's behavior.** ReactLynx's `createPortal` builds on Preact, which has no synthetic event system, so events bubble along the page's actual element structure rather than the React component tree.
 - **The portal subtree does not take part in [Instant First-Frame Rendering (IFR)](/guide/interaction/ifr)** — it renders on the background thread only.
 - **Mounting across pages or across native containers is not supported.** For those cases, reach for lynx-ui's [`Overlay`](/ui/components/overlay) component, or the [`<overlay>`](/api/elements/built-in/overlay) [XElement](/guide/ui/elements-components#xelement) directly.
 
-The [`createPortal` notes](/api/react/Function.createPortal#remarks) cover all three in full.
-
 ### Snapshot depth and count optimization
 
-At compile time ReactLynx extracts the static element structure of your JSX into a **Snapshot**, so at runtime only the dynamic parts inside it need updating. How many nodes a dynamic part renders is not fixed, and Preact's diff sees only a flat list of children, with no way to tell which child belongs to which dynamic part. The only way to keep the counts aligned was to enclose every dynamic part in an extra intermediate node that collapsed a variable number of children into exactly one — at the cost of a level in the element tree that nothing in your JSX asked for, and sometimes an extra Snapshot split on top of it.
+At compile time ReactLynx extracts the static element structure of your JSX into a **Snapshot**, so at runtime only the dynamic parts inside it need updating. (We will deep dive into Snapshots in a later post.)
 
-In [`@lynx-js/react` 0.120.0](https://github.com/lynx-family/lynx-stack/blob/main/packages/react/CHANGELOG.md#01200) we [extended Preact's diff algorithm](https://github.com/lynx-family/internal-preact/pull/1) so a child declares which slot of its parent it belongs to. With that membership written down, [the intermediate node is no longer needed](https://github.com/lynx-family/lynx-stack/pull/1764), and structures that used to be split can merge into fewer Snapshots. The optimization is on by default and needs no app-side changes.
+In [`@lynx-js/react` 0.120.0](https://github.com/lynx-family/lynx-stack/blob/main/packages/react/CHANGELOG.md#01200) we [extended Preact's diff algorithm](https://github.com/lynx-family/internal-preact/pull/1) so a child can declare which slot of its parent it belongs to. That lets the compiler [drop the intermediate nodes](https://github.com/lynx-family/lynx-stack/pull/1764) it used to need, leaving a shallower element tree and fewer Snapshots — less work to render. It is on by default and needs no app-side changes.
 
 ### Dual-thread Minimizer
 
@@ -137,12 +130,10 @@ Lynx API [`requestResourcePrefetch`](/api/lynx-api/lynx/lynx-request-resource-pr
 
 ### Performance
 
-On HarmonyOS, the new native image pipeline is enabled by default. It moves image loading, decode caching, and animated image frame scheduling down into the image node, which reduces per-frame computation and refresh overhead. In our internal image-animation benchmark both total time (`TotalTime`) and CPU time (`CPUTime`) came down measurably. How much you see depends on image dimensions, device and page structure, so measure your own scenario.
+On HarmonyOS, the new native image pipeline is enabled by default. It moves image loading, decode caching, and animated image frame scheduling down into the image node, which reduces per-frame computation and refresh overhead. In our internal image animation benchmark, both total time (`TotalTime`) and CPU time (`CPUTime`) dropped by roughly 10%.
 
 ## Upgrade Guide
 
 To upgrade to Lynx 3.9, follow the official [integration guide](https://lynxjs.org/3.9/guide/start/integrate-with-existing-apps.html) and update your Lynx dependency versions.
 
-Lynx 3.9 includes some breaking changes. Before upgrading, validate the affected platforms, `engineVersion`, page switches, and host integration path for your app.
-
-If you are upgrading to 3.9, start with Autolink integration, CSS compatibility behavior, and ReactLynx Portal usage, then evaluate the Element, Lynx API, and performance updates that apply to your app. We will keep the monthly releases smaller, focused, and easier to adopt.
+Lynx 3.9 includes some breaking changes, so validate the affected platforms, `engineVersion`, page switches, and host integration path for your app before upgrading. We will keep the monthly releases smaller, focused, and easier to adopt.

--- a/docs/zh/blog/lynx-3-9.mdx
+++ b/docs/zh/blog/lynx-3-9.mdx
@@ -15,9 +15,7 @@ import { BlogHeader, Go } from '@lynx';
 
 Lynx 3.9 已经正式发布！
 
-这个版本围绕三条主线展开：用 [Autolink](/guide/autolink) 让原生能力可以被打包成库、被安装和复用，用更贴近 Web 的 CSS 能力减少迁移和 AI 生成代码中的常见误用，并让 ReactLynx 在 Portal、渲染与构建表现上继续前进。
-
-此外，3.9 也带来了元件、Lynx API 与性能的一组小而实用的更新。下面我们一起来看看 Lynx 3.9 带来了哪些新变化。
+这个版本围绕三条主线展开：用 [Autolink](/guide/autolink) 让原生能力可以被打包成库、被安装和复用，用更贴近 Web 的 CSS 能力减少迁移和 AI 生成代码中的常见误用，并让 ReactLynx 在 Portal、渲染与构建表现上继续前进。此外，3.9 也带来了元件、Lynx API 与性能的一组小而实用的更新。下面我们一起来看看 Lynx 3.9 带来了哪些新变化。
 
 ## Autolink
 
@@ -49,9 +47,7 @@ Lynx 3.9 的 CSS 更新重点不是增加属性数量，而是继续贴近 Web �
 
 ### [`!important`](/api/css/selectors#important-支持) 优先级支持
 
-在 `engineVersion` 3.9 或更高版本下，可以在 CSS 值后追加 `!important`，提升该声明在层叠规则中的优先级。
-
-例如：
+在 `engineVersion` 3.9 或更高版本下，可以在 CSS 值后追加 `!important`，提升该声明在层叠规则中的优先级。例如下面这段样式中，`<view className="foo" />` 的 `color` 会被应用为 `red` 而不是 `blue`：
 
 ```css
 .foo {
@@ -62,8 +58,6 @@ view.foo {
   color: blue;
 }
 ```
-
-现在 `<view className="foo" />` 中的 `color` 会被应用为 `red`，而不是 `blue`。
 
 ### [`flex`](/api/css/properties/flex) 简写解析
 
@@ -76,8 +70,8 @@ view.foo {
 Lynx 3.9 还补齐了以下 CSS 能力：
 
 - 新增 [`grid-row`](/api/css/properties/grid-row) 和 [`grid-column`](/api/css/properties/grid-column) 简写，可通过它们设置 `grid-*-start` 和 `grid-*-end` 的值。例如 `grid-row: 1 / span 2` 等价于 `grid-row-start: 1; grid-row-end: span 2`。
-- 支持标准 [`position: sticky`](/api/css/properties/position) 行为，可通过 `enableNewSticky` 页面开关启用。
-- HarmonyOS 端支持 [`offset-path`](/api/css/properties/offset-path)、[`offset-distance`](/api/css/properties/offset-distance) 和 [`offset-rotate`](/api/css/properties/offset-rotate)。
+- 支持标准 `position: sticky` 行为，可通过 [`enableNewSticky`](/api/css/properties/position#sticky) 页面开关启用。
+- HarmonyOS 端补齐了更多 [Motion Path](https://developer.mozilla.org/zh-CN/docs/Web/CSS/CSS_motion_path) 能力，包括 [`offset-path`](/api/css/properties/offset-path)、[`offset-distance`](/api/css/properties/offset-distance) 和 [`offset-rotate`](/api/css/properties/offset-rotate)。
 
 <Go
   example="css-api"
@@ -86,17 +80,18 @@ Lynx 3.9 还补齐了以下 CSS 能力：
   entry="src/position"
   defaultEntryFile="dist/position.lynx.bundle"
   defaultTab="web"
+  highlight="{139-142,166-168}"
 />
 
 ## ReactLynx
 
 ReactLynx 带来了 `createPortal` 与 Snapshot 层级和数量优化，并在构建侧新增了双线程 Minimizer。
 
-### `createPortal`
+### [Portal](https://react.dev/reference/react-dom/createPortal)
 
-[`createPortal`](/api/react/Function.createPortal) 可以把一段组件树渲染到当前组件层级之外的指定容器中，适合浮层、弹窗这类需要脱离当前布局层级的 UI：组件仍然按照 React 的数据流组织，但最终的渲染位置交给目标容器。该 API 自 `@lynx-js/react` 0.121.0 起提供。
+在 React 中，Portal 用于把一段组件树渲染到元件树上的另一个容器里，同时让它仍然留在 React 树中——浮层、弹窗这类需要脱离当前布局层级的 UI 通常都靠它。自 `@lynx-js/react` 0.121.0 起，ReactLynx 通过 [`createPortal`](/api/react/Function.createPortal) 提供 Portal。
 
-容器要通过 [`NodesRef`](/api/lynx-api/nodes-ref) 传给 `createPortal`：在承载节点上挂一个 ref 拿到它的 `NodesRef`，再作为第二个参数传入。获取节点引用的更多方式见[直接操作节点](/guide/interaction/event-handling/manipulating-element.react)。
+与 React DOM 不同的是，ReactLynx 用 [`NodesRef`](/api/lynx-api/nodes-ref) 作为 Portal 容器：在承载元件上挂一个 ref 拿到它的 `NodesRef`，再作为 `createPortal` 的第二个参数传入。获取节点引用的更多方式见[直接操作节点](/guide/interaction/event-handling/manipulating-element.react)。
 
 <Go
   example="react-apis"
@@ -107,19 +102,17 @@ ReactLynx 带来了 `createPortal` 与 Snapshot 层级和数量优化，并在�
   highlight="{7,34-37}"
 />
 
-Context 仍然跨越 Portal 边界传递，状态更新也和普通组件一致。有三点与 `react-dom` 不同：
+React Context 仍然跨越 Portal 边界传递，状态更新也和普通组件一致。有三点[需要注意](/api/react/Function.createPortal#备注)的地方与 Web 不同：
 
 - **事件冒泡遵循 Preact 的行为。** ReactLynx 的 `createPortal` 沿用 Preact 的实现，没有 React 的合成事件系统，因此事件沿页面实际的元件结构冒泡，而不是 React 组件树。
 - **Portal 子树不参与[首帧直出（IFR）](/guide/interaction/ifr)**，只在后台线程渲染。
 - **不支持跨页面或跨原生容器挂载。** 这类场景请改用 lynx-ui 的 [`Overlay`](/ui/components/overlay) 组件，或直接使用 [`<overlay>`](/api/elements/built-in/overlay) 这个 [XElement](/guide/ui/elements-components#xelement)。
 
-以上限制的完整说明见 [`createPortal` 的备注](/api/react/Function.createPortal#备注)。
-
 ### Snapshot 层级和数量优化
 
-ReactLynx 在编译期会把 JSX 中的静态元件结构提取成 **Snapshot**，运行时只更新其中的动态部分。一处动态内容会渲染出几个节点是不确定的，而 Preact 的 diff 只看到一个扁平的子节点列表，分不清哪个子节点属于哪一处。过去只能在每处动态内容外面额外套一层中间节点，把数量不定的子节点收拢成恰好一个，让数量对得上——代价是元件树上凭空多出一层，有时还要为此多切一层 Snapshot。
+ReactLynx 在编译期会把 JSX 中的静态元件结构提取成 **Snapshot**，运行时只更新其中的动态部分。（Snapshot 的机制我们会在后续文章中展开。）
 
-[`@lynx-js/react` 0.120.0](https://github.com/lynx-family/lynx-stack/blob/main/packages/react/CHANGELOG.md#01200) 中我们[扩展了 Preact 的 diff 算法](https://github.com/lynx-family/internal-preact/pull/1)，让子节点直接声明自己属于父节点的哪个槽位。归属既然写明了，[那层中间节点就不再需要](https://github.com/lynx-family/lynx-stack/pull/1764)，原本被拆开的静态结构也能合并成更少的 Snapshot。该优化默认启用，业务代码无需修改。
+[`@lynx-js/react` 0.120.0](https://github.com/lynx-family/lynx-stack/blob/main/packages/react/CHANGELOG.md#01200) 中我们[扩展了 Preact 的 diff 算法](https://github.com/lynx-family/internal-preact/pull/1)，让子节点可以直接声明自己属于父节点的哪个槽位。编译产物因此可以[去掉原先必需的中间节点](https://github.com/lynx-family/lynx-stack/pull/1764)，元件树更浅、Snapshot 更少，渲染时要做的工作也更少。该优化默认启用，业务代码无需修改。
 
 ### 双线程 Minimizer
 
@@ -137,12 +130,10 @@ Lynx API，[`requestResourcePrefetch`](/api/lynx-api/lynx/lynx-request-resource-
 
 ### 性能表现
 
-HarmonyOS 端默认启用新版原生图片链路，将图片加载、解码缓存及动图帧调度下沉至图片节点，减少逐帧计算与刷新开销。在我们内部的图片动画基准场景中，总耗时（`TotalTime`）和 CPU 耗时（`CPUTime`）都有可观测的下降；具体幅度取决于图片规格、设备和页面结构，请以你自己场景的实测为准。
+HarmonyOS 端默认启用新版原生图片链路，将图片加载、解码缓存及动图帧调度下沉至图片节点，减少逐帧计算与刷新开销。在我们内部的图片动画基准测试中，总耗时（`TotalTime`）和 CPU 耗时（`CPUTime`）均降低约 10%。
 
 ## 升级指南
 
 参照官网[接入 Lynx 到现有应用](https://lynxjs.org/3.9/zh/guide/start/integrate-with-existing-apps.html)，更新 Lynx 依赖版本，即可完成 Lynx 3.9 版本升级。
 
-Lynx 3.9 包含部分破坏性变更。升级前请结合你的目标平台、`engineVersion`、页面开关和宿主集成方式进行验证。
-
-如果你正在升级到 3.9，建议优先关注 Autolink 接入、CSS 兼容性行为和 ReactLynx Portal 使用场景，再结合业务需要评估元件、Lynx API 与性能相关更新。感谢每一位持续试用新版本、反馈问题并推动 Lynx 生态发展的开发者。我们会继续保持更小、更聚焦的月度发布节奏。
+Lynx 3.9 包含部分破坏性变更，升级前请结合你的目标平台、`engineVersion`、页面开关和宿主集成方式进行验证。感谢每一位持续试用新版本、反馈问题并推动 Lynx 生态发展的开发者，我们会继续保持更小、更聚焦的月度发布节奏。

--- a/docs/zh/blog/lynx-3-9.mdx
+++ b/docs/zh/blog/lynx-3-9.mdx
@@ -71,7 +71,7 @@ Lynx 3.9 还补齐了以下 CSS 能力：
 
 - 新增 [`grid-row`](/api/css/properties/grid-row) 和 [`grid-column`](/api/css/properties/grid-column) 简写，可通过它们设置 `grid-*-start` 和 `grid-*-end` 的值。例如 `grid-row: 1 / span 2` 等价于 `grid-row-start: 1; grid-row-end: span 2`。
 - 支持标准 `position: sticky` 行为，可通过 [`enableNewSticky`](/api/css/properties/position#sticky) 页面开关启用。
-- HarmonyOS 端补齐了更多 [Motion Path](https://developer.mozilla.org/zh-CN/docs/Web/CSS/CSS_motion_path) 能力，包括 [`offset-path`](/api/css/properties/offset-path)、[`offset-distance`](/api/css/properties/offset-distance) 和 [`offset-rotate`](/api/css/properties/offset-rotate)。
+- HarmonyOS 端补齐了更多 [Motion Path](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Motion_path) 能力，包括 [`offset-path`](/api/css/properties/offset-path)、[`offset-distance`](/api/css/properties/offset-distance) 和 [`offset-rotate`](/api/css/properties/offset-rotate)。
 
 <Go
   example="css-api"
@@ -87,11 +87,11 @@ Lynx 3.9 还补齐了以下 CSS 能力：
 
 ReactLynx 带来了 `createPortal` 与 Snapshot 层级和数量优化，并在构建侧新增了双线程 Minimizer。
 
-### [Portal](https://react.dev/reference/react-dom/createPortal)
+### Portal
 
-在 React 中，Portal 用于把一段组件树渲染到元件树上的另一个容器里，同时让它仍然留在 React 树中——浮层、弹窗这类需要脱离当前布局层级的 UI 通常都靠它。自 `@lynx-js/react` 0.121.0 起，ReactLynx 通过 [`createPortal`](/api/react/Function.createPortal) 提供 Portal。
+在 React 中，[Portal](https://react.dev/reference/react-dom/createPortal) 用于把一段组件树渲染到元件树上的另一个容器里，同时让它仍然留在 React 树中——浮层、弹窗这类需要脱离当前布局层级的 UI 通常都靠它。自 `@lynx-js/react` 0.121.0 起，ReactLynx 通过 [`createPortal`](/api/react/Function.createPortal) 提供 Portal。
 
-与 React DOM 不同的是，ReactLynx 用 [`NodesRef`](/api/lynx-api/nodes-ref) 作为 Portal 容器：在承载元件上挂一个 ref 拿到它的 `NodesRef`，再作为 `createPortal` 的第二个参数传入。获取节点引用的更多方式见[直接操作节点](/guide/interaction/event-handling/manipulating-element.react)。
+与 React DOM 中的 Portal 接受一个 DOM 节点作为容器不同，在 ReactLynx 中我们使用一个节点引用（[`NodesRef`](/api/lynx-api/nodes-ref)）作为 Portal 容器：在承载元件上挂一个 ref 拿到它的 `NodesRef`，再作为 `createPortal` 的第二个参数传入。获取节点引用的更多方式见[直接操作节点](/guide/interaction/event-handling/manipulating-element.react)。
 
 <Go
   example="react-apis"
@@ -102,15 +102,15 @@ ReactLynx 带来了 `createPortal` 与 Snapshot 层级和数量优化，并在�
   highlight="{7,34-37}"
 />
 
-React Context 仍然跨越 Portal 边界传递，状态更新也和普通组件一致。有三点[需要注意](/api/react/Function.createPortal#备注)的地方与 Web 不同：
+Portal 只改变元件在页面上的物理位置。除此之外，渲染进 Portal 的 JSX 表现得就像渲染它的那个组件的子节点：父树提供的 React Context 依然能拿到，状态更新也和普通组件一致。有三点[需要注意](/api/react/Function.createPortal#备注)的地方与 Web 不同：
 
-- **事件冒泡遵循 Preact 的行为。** ReactLynx 的 `createPortal` 沿用 Preact 的实现，没有 React 的合成事件系统，因此事件沿页面实际的元件结构冒泡，而不是 React 组件树。
+- **事件冒泡遵循 Preact 的行为。** ReactLynx 的 `createPortal` 沿用 Preact 的实现，而 [Preact 中事件不会穿过 Portal 组件向上冒泡](https://preactjs.com/guide/v10/differences-to-react/#main-differences)，因此事件沿页面实际的元件结构冒泡，而不是 React 树。
 - **Portal 子树不参与[首帧直出（IFR）](/guide/interaction/ifr)**，只在后台线程渲染。
 - **不支持跨页面或跨原生容器挂载。** 这类场景请改用 lynx-ui 的 [`Overlay`](/ui/components/overlay) 组件，或直接使用 [`<overlay>`](/api/elements/built-in/overlay) 这个 [XElement](/guide/ui/elements-components#xelement)。
 
 ### Snapshot 层级和数量优化
 
-ReactLynx 在编译期会把 JSX 中的静态元件结构提取成 **Snapshot**，运行时只更新其中的动态部分。（Snapshot 的机制我们会在后续文章中展开。）
+ReactLynx 在编译期会把 JSX 中的静态元件结构提取成 **Snapshot**，运行时只更新其中的动态部分。（Snapshot 我们会在后续博客中详细介绍。）
 
 [`@lynx-js/react` 0.120.0](https://github.com/lynx-family/lynx-stack/blob/main/packages/react/CHANGELOG.md#01200) 中我们[扩展了 Preact 的 diff 算法](https://github.com/lynx-family/internal-preact/pull/1)，让子节点可以直接声明自己属于父节点的哪个槽位。编译产物因此可以[去掉原先必需的中间节点](https://github.com/lynx-family/lynx-stack/pull/1764)，元件树更浅、Snapshot 更少，渲染时要做的工作也更少。该优化默认启用，业务代码无需修改。
 


### PR DESCRIPTION
Stacked on `p/linyiyi/add_3_9_blog`. Nine edits from a read-through of the English post, mirrored in Chinese.

| # | Change |
|---|---|
| 0 | Restore the **roughly 10%** HarmonyOS figure |
| 1 | Fold "It also includes…" into the opening paragraph |
| 2 | `!important`: state the outcome **before** the snippet |
| 3 | Link `enableNewSticky` to its docs section |
| 4 | Gloss **Motion Path** with MDN, say "more Motion Path features" |
| 5 | Highlight the sticky lines in the `position` example |
| 6 | Retitle to **Portal**, link react.dev, restructure the intro |
| 7 | Portal notes: inline the link, drop the trailing sentence |
| 8 | Snapshot: keep the idea, defer the mechanics |
| 9 | Drop the odd "start with X, then evaluate Y" closing advice |

## Notes on a few of them

**0 — the 10% figure comes back.** The sentence already scopes it to our own benchmark, so the hedged rewrite was longer without being more honest. Reverted to `dropped by roughly 10%` / `均降低约 10%`.

**5 — sticky highlight.** `highlight="{139-142,166-168}"` covers the `stickyHeader` rule (`position: "sticky"`, `top`, `zIndex`) and the element that uses it, verified against `src/position/App.tsx`.

**6 — Portal.** Now leads with what a Portal is in React, linked to [react.dev](https://react.dev/reference/react-dom/createPortal), then when ReactLynx got one, then the single thing that differs:

> Since `@lynx-js/react` 0.121.0, Portal is available in ReactLynx through [`createPortal`](/api/react/Function.createPortal).
>
> Unlike React DOM, ReactLynx takes a [`NodesRef`](/api/lynx-api/nodes-ref) as the Portal container…

**7 —** now reads `React Context still flows across the Portal boundary… Three [notes](/api/react/Function.createPortal#remarks) differ from the Web:` with the link inside the sentence, and the standalone pointer after the bullets removed.

**8 — Snapshot** drops the diff-alignment explanation, which was the part that wanted a guide page rather than a release post:

> At compile time ReactLynx extracts the static element structure of your JSX into a **Snapshot**… (We will deep dive into Snapshots in a later post.)
>
> In `@lynx-js/react` 0.120.0 we extended Preact's diff algorithm so a child can declare which slot of its parent it belongs to. That lets the compiler drop the intermediate nodes it used to need, leaving a shallower element tree and fewer Snapshots — less work to render.

## Checks

- `prettier --check` — pass
- `cspell` — 0 issues
- `node scripts/ci/check-asset-urls.mjs` — pass
- `#sticky` resolves on both locales of the position page; highlight ranges verified against the example source.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVdDv5kxo9CgBZqTNuQeY7)_