### PR TITLE
docs: add Autolink Gradle plugin versions

### DIFF
--- a/docs/en/guide/autolink.mdx
+++ b/docs/en/guide/autolink.mdx
@@ -90,7 +90,7 @@ Enable the settings plugin in `settings.gradle` so library Android projects can 
 
 ```groovy
 plugins {
-  id 'org.lynxsdk.lynx.library-settings'
+  id 'org.lynxsdk.lynx.library-settings' version '4.0.1'
 }
 ```
 
@@ -99,7 +99,7 @@ Enable the build plugin in the Android application project so the generated regi
 ```groovy
 plugins {
   id 'com.android.application'
-  id 'org.lynxsdk.lynx.library-build'
+  id 'org.lynxsdk.lynx.library-build' version '4.0.1'
 }
 ```
 

--- a/docs/zh/guide/autolink.mdx
+++ b/docs/zh/guide/autolink.mdx
@@ -90,7 +90,7 @@ lynx-app/
 
 ```groovy
 plugins {
-  id 'org.lynxsdk.lynx.library-settings'
+  id 'org.lynxsdk.lynx.library-settings' version '4.0.1'
 }
 ```
 
@@ -99,7 +99,7 @@ plugins {
 ```groovy
 plugins {
   id 'com.android.application'
-  id 'org.lynxsdk.lynx.library-build'
+  id 'org.lynxsdk.lynx.library-build' version '4.0.1'
 }
 ```
 


### PR DESCRIPTION
## Summary

- Pin the Android Autolink settings and build plugins to the published `4.0.1` release.
- Keep the English and Chinese setup examples aligned.

## Validation

- `pnpm exec prettier --check docs/en/guide/autolink.mdx docs/zh/guide/autolink.mdx`
- `pnpm exec cspell lint -c cspell.json --no-must-find-files docs/en/guide/autolink.mdx docs/zh/guide/autolink.mdx`
- `git diff --check`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Pin Android Autolink settings and build plugins to `4.0.1` in English and Chinese documentation.
- Validate formatting, spelling, whitespace, and site builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->