### PR TITLE
docs: update Harmony demo links to release 4.0

### DIFF
--- a/docs/en/blog/lynx-harmony.mdx
+++ b/docs/en/blog/lynx-harmony.mdx
@@ -104,7 +104,7 @@ Lynx designed a complete event system that captures and responds to gestures and
 
 ## Create Your First Lynx on HarmonyOS
 
-Lynx's official website offers [development documentation](/guide/start/integrate-with-existing-apps.html?platform=harmony) and [demo code](https://github.com/lynx-family/integrating-lynx-demo-projects/tree/main/harmony/HarmonyEmptyProject) for developers to get started quickly and efficiently.
+Lynx's official website offers [development documentation](/guide/start/integrate-with-existing-apps.html?platform=harmony) and [demo code](https://github.com/lynx-family/integrating-lynx-demo-projects/tree/release/4.0/harmony/HarmonyEmptyProject) for developers to get started quickly and efficiently.
 
 1. **Use the Pre-built Lynx Explorer**: For the easiest development setup, follow the [Quick Start](/guide/start/quick-start.html) to install the Lynx Explorer hap package and begin Lynx development.
 

--- a/docs/en/guide/start/fragments/harmony/integrating-lynx-with-existing-app-harmony.mdx
+++ b/docs/en/guide/start/fragments/harmony/integrating-lynx-with-existing-app-harmony.mdx
@@ -6,7 +6,7 @@ import { Steps } from '@theme';
 <Info title="Lynx for Harmony">
 
 - This article assumes that you are familiar with the basic concepts of native Harmony application development.
-- You can refer to the project: [integrating-lynx-demo-projects](https://github.com/lynx-family/integrating-lynx-demo-projects/tree/main/harmony/HarmonyEmptyProject) for all the code mentioned below.
+- You can refer to the project: [integrating-lynx-demo-projects](https://github.com/lynx-family/integrating-lynx-demo-projects/tree/release/4.0/harmony/HarmonyEmptyProject) for all the code mentioned below.
 
 </Info>
 

--- a/docs/zh/blog/lynx-harmony.mdx
+++ b/docs/zh/blog/lynx-harmony.mdx
@@ -107,7 +107,7 @@ Lynx 在 HarmonyOS 构建了一套完整的事件处理机制，能在复杂交�
 
 ## 在 HarmonyOS 创建第一个 Lynx 应用
 
-在 Lynx 官网中已经准备好了详细的[开发文档](/guide/start/integrate-with-existing-apps.html)和[示例代码](https://github.com/lynx-family/integrating-lynx-demo-projects/tree/main/harmony/HarmonyEmptyProject)，帮助开发者快速上手。
+在 Lynx 官网中已经准备好了详细的[开发文档](/guide/start/integrate-with-existing-apps.html)和[示例代码](https://github.com/lynx-family/integrating-lynx-demo-projects/tree/release/4.0/harmony/HarmonyEmptyProject)，帮助开发者快速上手。
 
 1. **使用预构建的 Lynx Explorer**：若希望以最便捷的方式开启开发，可以按照[快速上手](/guide/start/quick-start.html)描述的步骤操作安装 Lynx Explorer hap 包上手 Lynx 开发。
 

--- a/docs/zh/guide/start/fragments/harmony/integrating-lynx-with-existing-app-harmony.mdx
+++ b/docs/zh/guide/start/fragments/harmony/integrating-lynx-with-existing-app-harmony.mdx
@@ -6,7 +6,7 @@ import { Steps } from '@theme';
 <Info title="Lynx for Harmony">
 
 - 本文假设你已熟悉原生 Harmony 应用开发的基本概念。
-- 下文中的所有代码，你都可以参考项目：[integrating-lynx-demo-projects](https://github.com/lynx-family/integrating-lynx-demo-projects/tree/main/harmony/HarmonyEmptyProject)。
+- 下文中的所有代码，你都可以参考项目：[integrating-lynx-demo-projects](https://github.com/lynx-family/integrating-lynx-demo-projects/tree/release/4.0/harmony/HarmonyEmptyProject)。
 
 </Info>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Update HarmonyOS demo links in English and Chinese documentation.
- Point demo references from `main` to `release/4.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->