### PR TITLE
docs: state the shipped behavior for page-config-gated features

### DIFF
--- a/docs/en/api/css/properties/flex.mdx
+++ b/docs/en/api/css/properties/flex.mdx
@@ -47,7 +47,7 @@ flex: 2 2 10%;
 The `flex` property may be specified using one, two, or three values.
 
 - **One-value syntax**:
-  - A unitless [`<number>`](/api/css/data-type/number.mdx), which will be used as the value of [`<flex-grow>`](./flex-grow.mdx), then the shorthand expands to `flex: <flex-grow> 1 0%`. <VersionBadge>3.9</VersionBadge> Before 3.9 the omitted `flex-basis` expanded to a unitless `0`; browsers use `0%`, so this was aligned with the Web. See [Flex basis 0 vs 0%](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/flex-basis#flex_basis_0_vs_0).
+  - A unitless [`<number>`](/api/css/data-type/number.mdx), which will be used as the value of [`<flex-grow>`](./flex-grow.mdx), then the shorthand expands to `flex: <flex-grow> 1 0%`. <VersionBadge>3.9</VersionBadge> Before 3.9 it expanded to a unitless `0`; see [Flex basis 0 vs 0%](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/flex-basis#flex_basis_0_vs_0) for the difference.
   - A valid [`<length>`](/api/css/data-type/length.mdx) or [`<percentage>`](/api/css/data-type/percentage.mdx) or key word `auto`, it will be used as the value of [`<flex-basis>`](./flex-basis.mdx), then the shorthand expands to `flex: 1 1 <flex-basis>`.
 
 - **Two-value syntax**:

--- a/docs/en/api/css/properties/position.mdx
+++ b/docs/en/api/css/properties/position.mdx
@@ -3,7 +3,7 @@ title: position
 api: css/properties/position
 ---
 
-import { APISummary, APITable, Go, VersionBadge } from '@lynx';
+import { APISummary, APITable, Go } from '@lynx';
 
 <APISummary />
 ## Introduction
@@ -62,15 +62,9 @@ The element is will be treated as a direct child of root node with the property 
 
 #### `sticky`
 
-`sticky` is only supported on the children elements of a `scroll-view`. The element is positioned according to the normal flow of the document, and then offset relative to its parent scroll-view and containing block (nearest block-level ancestor), based on the values of top, right, bottom, and left. The offset does not affect the position of any other elements.
+The element is positioned according to the normal flow of the document, then offset relative to its nearest scrolling container and containing block, based on the values of [`top`](./top.mdx), [`right`](./right.mdx), [`bottom`](./bottom.mdx) and [`left`](./left.mdx). The offset does not affect the position of any other element.
 
-:::info Standard sticky behavior <VersionBadge>3.9</VersionBadge>
-
-The above describes Lynx's original sticky behavior, which only applies to direct children of a `scroll-view`. From 3.9 onwards, the `enableNewSticky` page config switch enables standard `position: sticky` behavior matching the Web: the element is laid out in normal flow and then offset relative to its nearest scrolling container and containing block, without having to be a direct child of a `scroll-view`.
-
-The switch is off by default so that existing pages keep their current behavior.
-
-:::
+Before 3.9, `sticky` only applied to direct children of a `scroll-view`.
 
 ## Formal definition
 
@@ -94,7 +88,6 @@ import { PropertyDefinition } from '@/components/PropertyDefinition';
 [mdn:position](https://developer.mozilla.org/en-US/docs/Web/CSS/position)
 
 1. Lynx does not support `static` and default value is `relative`.
-2. `sticky` is only supported on the children elements of a `scroll-view`
 
 ## Compatibility
 

--- a/docs/en/api/lynx-api/intersection-observer.mdx
+++ b/docs/en/api/lynx-api/intersection-observer.mdx
@@ -63,9 +63,8 @@ observer.disconnect();
 
 ## Precautions
 
-- It is recommended to set the page switch `enableNewIntersectionObserver` to `true`, otherwise the scrollable container needs to be bound to the corresponding scroll event (such as `scroll`) to trigger the corresponding callback.
 - When using `relativeTo` and `observe` methods, you need to pay attention to the calling timing and ensure that the reference node and target node have been created when calling. Otherwise, the observation will be invalid, that is, the corresponding callback will never be triggered.
-- When `enableNewIntersectionObserver` is enabled, child nodes of a scroll-view on Android will not trigger corresponding callbacks when scrolling. You need to set [`flatten`](../elements/built-in/view.mdx#flatten) to `false` on the child node to trigger the callback.
+- On Android, child nodes of a horizontally scrolling `scroll-view` do not trigger callbacks while scrolling. Set [`flatten`](../elements/built-in/view.mdx#flatten) to `false` on the child node to trigger them.
 
 ## Compatibility
 

--- a/docs/en/blog/lynx-3-9.mdx
+++ b/docs/en/blog/lynx-3-9.mdx
@@ -70,7 +70,7 @@ Although the CSS specification defines `0` as the default, browsers commonly par
 Lynx 3.9 also adds the following CSS capabilities:
 
 - New [`grid-row`](/api/css/properties/grid-row) and [`grid-column`](/api/css/properties/grid-column) shorthands for setting the corresponding `grid-*-start` and `grid-*-end` values. For example, `grid-row: 1 / span 2` is equivalent to `grid-row-start: 1; grid-row-end: span 2`.
-- Standard `position: sticky` behavior, enabled through the [`enableNewSticky`](/api/css/properties/position#sticky) page switch.
+- Standard [`position: sticky`](/api/css/properties/position#sticky) behavior, matching the Web.
 - HarmonyOS support for more [Motion Path](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Motion_path) features, including [`offset-path`](/api/css/properties/offset-path), [`offset-distance`](/api/css/properties/offset-distance), and [`offset-rotate`](/api/css/properties/offset-rotate).
 
 <Go

--- a/docs/zh/api/css/properties/flex.mdx
+++ b/docs/zh/api/css/properties/flex.mdx
@@ -49,7 +49,7 @@ flex: 2 2 10%;
 可以使用一个，两个或三个值来指定 `flex` 属性。
 
 - **单值语法**：值必须是以下之一：
-  - 一个无单位数 [`<number>`](/api/css/data-type/number.mdx)，它会被当作 [`<flex-grow>`] 的值。此时简写会扩展为 `flex: <flex-grow> 1 0%`。<VersionBadge>3.9</VersionBadge> 3.9 之前省略的 `flex-basis` 会扩展为无单位的 `0`；浏览器使用的是 `0%`，这次调整是为了对齐 Web。差异参见 [Flex basis 0 vs 0%](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/flex-basis#flex_basis_0_vs_0)。
+  - 一个无单位数 [`<number>`](/api/css/data-type/number.mdx)，它会被当作 [`<flex-grow>`] 的值。此时简写会扩展为 `flex: <flex-grow> 1 0%`。<VersionBadge>3.9</VersionBadge> 3.9 之前扩展为无单位的 `0`，两者的差异参见 [Flex basis 0 vs 0%](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/flex-basis#flex_basis_0_vs_0)。
   - 一个有效的长度 [`<length>`](/api/css/data-type/length.mdx) 值或百分比 [`<percentage>`](/api/css/data-type/percentage.mdx) 或关键字 `auto`，它会被当作 [`<flex-basis>`](./flex-basis.mdx) 的值。此时简写会扩展为 `flex: 1 1 <flex-basis>`。
 
 - **双值语法**：

--- a/docs/zh/api/css/properties/position.mdx
+++ b/docs/zh/api/css/properties/position.mdx
@@ -2,7 +2,7 @@
 api: css/properties/position
 ---
 
-import { APISummary, APITable, Go, VersionBadge } from '@lynx';
+import { APISummary, APITable, Go } from '@lynx';
 
 # position
 
@@ -67,15 +67,9 @@ position: sticky;
 
 #### `sticky`
 
-当前元件将参与父节点布局，当该元件的父节点为 `scroll view` 的时候该属性才有意义。当该节点因父节点的 scroll 产生位移时，该节点会与父节点的 view port 至少保持 top 等属性所规定的距离。
+当前元件先按正常流布局，再相对最近的滚动容器和包含块产生偏移，偏移量由 [`top`](./top.mdx)、[`right`](./right.mdx)、[`bottom`](./bottom.mdx)、[`left`](./left.mdx) 决定。该偏移不会影响其他元件的位置。
 
-:::info 标准 sticky 行为 <VersionBadge>3.9</VersionBadge>
-
-上述是 Lynx 早期的 sticky 行为，仅对 `scroll-view` 的直接子节点生效。从 3.9 起，可以通过页面配置开关 `enableNewSticky` 启用与 Web 一致的标准 `position: sticky` 行为：元件先按正常流布局，再相对最近的滚动容器和包含块产生偏移，且不再要求它是 `scroll-view` 的直接子节点。
-
-该开关默认关闭，以保证既有页面的行为不变。
-
-:::
+3.9 之前，`sticky` 仅对 `scroll-view` 的直接子节点生效。
 
 ## 形式定义
 

--- a/docs/zh/api/lynx-api/intersection-observer.mdx
+++ b/docs/zh/api/lynx-api/intersection-observer.mdx
@@ -62,9 +62,8 @@ observer.disconnect();
 
 ## 注意事项
 
-- 推荐设置页面开关 `enableNewIntersectionObserver` 为 `true`，否则需要可滚动容器绑定相应滚动事件（如 `scroll`）才能触发相应的回调
 - 使用 `relativeTo` 和 `observe` 方法需要注意调用时机，确保调用时候参照节点和目标节点已经创建，否则会导致观察失效，即始终无法触发相应回调
-- 开启 `enableNewIntersectionObserver` 时，Android 端的横滑 `scroll-view` 的子节点在滑动时无法触发相应回调，需要在子节点上设置 [`flatten`](../elements/built-in/view.mdx#flatten) 为 `false` 才能触发回调。
+- Android 端横滑 `scroll-view` 的子节点在滑动时无法触发相应回调，需要在子节点上设置 [`flatten`](../elements/built-in/view.mdx#flatten) 为 `false` 才能触发回调。
 
 ## 兼容性
 

--- a/docs/zh/blog/lynx-3-9.mdx
+++ b/docs/zh/blog/lynx-3-9.mdx
@@ -70,7 +70,7 @@ view.foo {
 Lynx 3.9 还补齐了以下 CSS 能力：
 
 - 新增 [`grid-row`](/api/css/properties/grid-row) 和 [`grid-column`](/api/css/properties/grid-column) 简写，可通过它们设置 `grid-*-start` 和 `grid-*-end` 的值。例如 `grid-row: 1 / span 2` 等价于 `grid-row-start: 1; grid-row-end: span 2`。
-- 支持标准 `position: sticky` 行为，可通过 [`enableNewSticky`](/api/css/properties/position#sticky) 页面开关启用。
+- 支持与 Web 一致的标准 [`position: sticky`](/api/css/properties/position#sticky) 行为。
 - HarmonyOS 端补齐了更多 [Motion Path](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Motion_path) 能力，包括 [`offset-path`](/api/css/properties/offset-path)、[`offset-distance`](/api/css/properties/offset-distance) 和 [`offset-rotate`](/api/css/properties/offset-rotate)。
 
 <Go


### PR DESCRIPTION
Two pages described page-config-gated CSS behavior as something the reader has to switch on. With the Lynx toolchain they never do, so the pages now describe the behavior they actually get.

## Where the facts come from

[`@lynx-js/template-webpack-plugin`](``https://github.com/lynx-family/lynx-stack/blob/b10899281e7b6c5a95b79b557ccdc892bd5f6222/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts#L1028-L1046)`` writes eight page config values as literal `true` when it encodes a template:

```ts
lepusStrict, useNewSwiper, enableNewIntersectionObserver, enableNativeList,
enableNewSticky, flexBasisZeroPercent, enableGridPlacementShorthands, syncXElementRegistry
```

`enableNewSticky` and `flexBasisZeroPercent` each appear exactly once in the whole lynx-stack source — that line. They take no plugin option.

Distinct from the neighbouring `compilerOptions` block, where `defaultDisplayLinear`, `enableCSSSelector`, `enableRemoveCSSScope` and `defaultOverflowVisible` **are** fed from plugin options. Those are genuinely configurable and the pages documenting them are correct as-is.

## Changes

**`css/properties/position`** — `sticky` now describes standard sticky positioning directly, with the pre-3.9 restriction as a following sentence. Previously it led with the legacy `scroll-view`-child behavior and then said the standard behavior was available behind a switch that is "off by default", which is backwards.

> The element is positioned according to the normal flow of the document, then offset relative to its nearest scrolling container and containing block, based on the values of `top`, `right`, `bottom` and `left`. The offset does not affect the position of any other element.
>
> Before 3.9, `sticky` only applied to direct children of a `scroll-view`.

The EN-only "Difference with the Web" bullet — "`sticky` is only supported on the children elements of a `scroll-view`" — is dropped. Post-3.9 that is no longer a difference from the Web (sticky is relative to the nearest scrolling container there too), and the value section already carries the version boundary. This also removes a zh/en divergence: the zh page never had the bullet.

No `3.9` badge on the value: per `lynx-compat-data`, `position: sticky` has existed since **1.4** (3.4 on HarmonyOS), which the page's `<APITable />` already renders. What changed in 3.9 is the behavior, and the prose says so.

**`lynx-api/intersection-observer`** — dropped the bullet recommending `enableNewIntersectionObserver: true` and describing the fallback for when it is off; that path is unreachable. The Android caveat that followed was conditioned on the switch and is now stated unconditionally.

**`css/properties/flex`** — keeps the versioned `0%` expansion, drops the sentence explaining which config drives it. The page documents the property; the toolchain does not belong in it.

**`blog/lynx-3-9`** — "enabled through the `enableNewSticky` page switch" → "Standard `position: sticky` behavior, matching the Web."

No page names a page-config key or the plugin: `template-webpack-plugin` now appears 0 times under `docs/`.

## Sweep

All eight hardcoded keys plus the configurable neighbours, across `docs/`:

| key | files | outcome |
|---|---|---|
| `enableNewSticky` | 4 | rewritten (position ×2, blog ×2) |
| `enableNewIntersectionObserver` | 2 | obsolete guidance removed |
| `flexBasisZeroPercent` | 0 | left unnamed — not something a reader sets |
| `enableGridPlacementShorthands` | 0 | blog documents the shorthands with no switch — correct |
| `useNewSwiper`, `enableNativeList`, `syncXElementRegistry`, `lepusStrict` | 0 | nothing to correct |
| `defaultDisplayLinear` | 2 | correct as-is — genuinely configurable |

Net: **12 insertions, 27 deletions**.

## Checks

- `prettier --check` — pass
- `cspell` — 0 issues
- `node scripts/ci/check-asset-urls.mjs` — pass
- `top` / `right` / `bottom` / `left` link targets exist in both locales


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Align page-configuration documentation with `@lynx-js/template-webpack-plugin` defaults.
- Document standard `position: sticky` behavior and pre-3.9 limitations.
- Remove obsolete configuration guidance for intersection observers and flex basis handling.
- State that Rspeedy enables standard sticky behavior by default.
- Report successful Prettier, cspell, asset URL, and link-target checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->