### PR TITLE
docs(3.9): state the shipped behavior for page-config-gated features

### DIFF
--- a/docs/en/api/css/properties/flex.mdx
+++ b/docs/en/api/css/properties/flex.mdx
@@ -3,7 +3,7 @@ title: flex
 api: css/properties/flex
 ---
 
-import { APISummary, APITable, Go } from '@lynx';
+import { APISummary, APITable, Go, VersionBadge } from '@lynx';
 
 <APISummary />
 ## Introduction
@@ -27,7 +27,7 @@ flex: none;
 flex: auto;
 
 /* One value, unitless number: flex-grow
-flex-basis is then equal to 0. */
+flex-basis is then equal to 0% (0 before Lynx 3.9). */
 flex: 2;
 
 /* One value, width/height: flex-basis */
@@ -47,13 +47,13 @@ flex: 2 2 10%;
 The `flex` property may be specified using one, two, or three values.
 
 - **One-value syntax**:
-  - A unitless [`<number>`](/api/css/data-type/number.mdx), which will be used as the value of [`<flex-grow>`](./flex-grow.mdx), then the shorthand expands to `flex: <flex-grow> 1 0`.
+  - A unitless [`<number>`](/api/css/data-type/number.mdx), which will be used as the value of [`<flex-grow>`](./flex-grow.mdx), then the shorthand expands to `flex: <flex-grow> 1 0%`. <VersionBadge>3.9</VersionBadge> Before 3.9 it expanded to a unitless `0`; see [Flex basis 0 vs 0%](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/flex-basis#flex_basis_0_vs_0) for the difference.
   - A valid [`<length>`](/api/css/data-type/length.mdx) or [`<percentage>`](/api/css/data-type/percentage.mdx) or key word `auto`, it will be used as the value of [`<flex-basis>`](./flex-basis.mdx), then the shorthand expands to `flex: 1 1 <flex-basis>`.
 
 - **Two-value syntax**:
   - The first value must be a valid value for [`<flex-grow>`](./flex-grow.mdx).
   - The second value must be one of:
-    - A unitless [`<number>`](/api/css/data-type/number.mdx), which will be used as the value of [`<flex-shrink>`](./flex-shrink.mdx), then the shorthand expands to `flex: <flex-grow> <flex-shrink> 0`.
+    - A unitless [`<number>`](/api/css/data-type/number.mdx), which will be used as the value of [`<flex-shrink>`](./flex-shrink.mdx), then the shorthand expands to `flex: <flex-grow> <flex-shrink> 0%`. <VersionBadge>3.9</VersionBadge> Before 3.9 this was a unitless `0`.
     - A valid [`<length>`](/api/css/data-type/length.mdx) or [`<percentage>`](/api/css/data-type/percentage.mdx) or key word `auto`, it will be used as the value of [`<flex-basis>`](./flex-basis.mdx), then the shorthand expands to `flex: <flex-grow> 1 <flex-basis>`.
 
 - Three-value syntax: the values must be in the following order:

--- a/docs/en/api/css/properties/position.mdx
+++ b/docs/en/api/css/properties/position.mdx
@@ -62,7 +62,9 @@ The element is will be treated as a direct child of root node with the property 
 
 #### `sticky`
 
-`sticky` is only supported on the children elements of a `scroll-view`. Is The element is positioned according to the normal flow of the document, and then offset relative to its parent scroll-view and containing block (nearest block-level ancestor), based on the values of top, right, bottom, and left. The offset does not affect the position of any other elements.
+The element is positioned according to the normal flow of the document, then offset relative to its nearest scrolling container and containing block, based on the values of [`top`](./top.mdx), [`right`](./right.mdx), [`bottom`](./bottom.mdx) and [`left`](./left.mdx). The offset does not affect the position of any other element.
+
+Before 3.9, `sticky` only applied to direct children of a `scroll-view`.
 
 ## Formal definition
 
@@ -86,7 +88,6 @@ import { PropertyDefinition } from '@/components/PropertyDefinition';
 [mdn:position](https://developer.mozilla.org/en-US/docs/Web/CSS/position)
 
 1. Lynx does not support `static` and default value is `relative`.
-2. `sticky` is only supported on the children elements of a `scroll-view`
 
 ## Compatibility
 

--- a/docs/en/api/lynx-api/intersection-observer.mdx
+++ b/docs/en/api/lynx-api/intersection-observer.mdx
@@ -63,9 +63,8 @@ observer.disconnect();
 
 ## Precautions
 
-- It is recommended to set the page switch `enableNewIntersectionObserver` to `true`, otherwise the scrollable container needs to be bound to the corresponding scroll event (such as `scroll`) to trigger the corresponding callback.
 - When using `relativeTo` and `observe` methods, you need to pay attention to the calling timing and ensure that the reference node and target node have been created when calling. Otherwise, the observation will be invalid, that is, the corresponding callback will never be triggered.
-- When `enableNewIntersectionObserver` is enabled, child nodes of a scroll-view on Android will not trigger corresponding callbacks when scrolling. You need to set [`flatten`](../elements/built-in/view.mdx#flatten) to `false` on the child node to trigger the callback.
+- On Android, child nodes of a horizontally scrolling `scroll-view` do not trigger callbacks while scrolling. Set [`flatten`](../elements/built-in/view.mdx#flatten) to `false` on the child node to trigger them.
 
 ## Compatibility
 

--- a/docs/zh/api/css/properties/flex.mdx
+++ b/docs/zh/api/css/properties/flex.mdx
@@ -2,7 +2,7 @@
 api: css/properties/flex
 ---
 
-import { APISummary, APITable, Go } from '@lynx';
+import { APISummary, APITable, Go, VersionBadge } from '@lynx';
 
 # flex
 
@@ -29,7 +29,7 @@ flex: auto;
 flex: none;
 
 /* 单值，无单位数字：flex-grow
-flex-basis 此时等于 0。 */
+flex-basis 此时等于 0%（3.9 之前为 0）。 */
 flex: 2;
 
 /* 单值，宽度/高度：flex-basis */
@@ -49,13 +49,13 @@ flex: 2 2 10%;
 可以使用一个，两个或三个值来指定 `flex` 属性。
 
 - **单值语法**：值必须是以下之一：
-  - 一个无单位数 [`<number>`](/api/css/data-type/number.mdx)，它会被当作 [`<flex-grow>`] 的值。此时简写会扩展为 `flex: <flex-grow> 1 0`。
+  - 一个无单位数 [`<number>`](/api/css/data-type/number.mdx)，它会被当作 [`<flex-grow>`] 的值。此时简写会扩展为 `flex: <flex-grow> 1 0%`。<VersionBadge>3.9</VersionBadge> 3.9 之前扩展为无单位的 `0`，两者的差异参见 [Flex basis 0 vs 0%](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/flex-basis#flex_basis_0_vs_0)。
   - 一个有效的长度 [`<length>`](/api/css/data-type/length.mdx) 值或百分比 [`<percentage>`](/api/css/data-type/percentage.mdx) 或关键字 `auto`，它会被当作 [`<flex-basis>`](./flex-basis.mdx) 的值。此时简写会扩展为 `flex: 1 1 <flex-basis>`。
 
 - **双值语法**：
   - 第一个值必须是一个 [`<flex-grow>`] 的有效值。
   - 第二个值必须是以下之一：
-    - 一个无单位数 [`<number>`](/api/css/data-type/number.mdx)，它会被当作 [`<flex-shrink>`](./flex-shrink.mdx) 的值。此时简写会扩展为 `flex: <flex-grow> <flex-shrink> 0`。
+    - 一个无单位数 [`<number>`](/api/css/data-type/number.mdx)，它会被当作 [`<flex-shrink>`](./flex-shrink.mdx) 的值。此时简写会扩展为 `flex: <flex-grow> <flex-shrink> 0%`。<VersionBadge>3.9</VersionBadge> 3.9 之前为无单位的 `0`。
     - 一个有效的长度 [`<length>`](/api/css/data-type/length.mdx) 值或百分比 [`<percentage>`](/api/css/data-type/percentage.mdx) 或关键字 `auto`，它会被当作 [`<flex-basis>`](./flex-basis.mdx) 的值。此时简写会扩展为 `flex: <flex-grow> 1 <flex-basis>`。
 
 - **三值语法**：值必须按照以下顺序指定：

--- a/docs/zh/api/css/properties/position.mdx
+++ b/docs/zh/api/css/properties/position.mdx
@@ -46,6 +46,7 @@ import { APISummary, APITable, Go } from '@lynx';
 position: relative;
 position: fixed;
 position: absolute;
+position: sticky;
 ```
 
 ### 取值
@@ -66,7 +67,9 @@ position: absolute;
 
 #### `sticky`
 
-当前元件将参与父节点布局，当该元件的父节点为 `scroll view` 的时候该属性才有意义。当该节点因父节点的 scroll 产生位移时，该节点会与父节点的 view port 至少保持 top 等属性所规定的距离。list 用大度的吸顶元件。
+当前元件先按正常流布局，再相对最近的滚动容器和包含块产生偏移，偏移量由 [`top`](./top.mdx)、[`right`](./right.mdx)、[`bottom`](./bottom.mdx)、[`left`](./left.mdx) 决定。该偏移不会影响其他元件的位置。
+
+3.9 之前，`sticky` 仅对 `scroll-view` 的直接子节点生效。
 
 ## 形式定义
 

--- a/docs/zh/api/lynx-api/intersection-observer.mdx
+++ b/docs/zh/api/lynx-api/intersection-observer.mdx
@@ -62,9 +62,8 @@ observer.disconnect();
 
 ## 注意事项
 
-- 推荐设置页面开关 `enableNewIntersectionObserver` 为 `true`，否则需要可滚动容器绑定相应滚动事件（如 `scroll`）才能触发相应的回调
 - 使用 `relativeTo` 和 `observe` 方法需要注意调用时机，确保调用时候参照节点和目标节点已经创建，否则会导致观察失效，即始终无法触发相应回调
-- 开启 `enableNewIntersectionObserver` 时，Android 端的横滑 `scroll-view` 的子节点在滑动时无法触发相应回调，需要在子节点上设置 [`flatten`](../elements/built-in/view.mdx#flatten) 为 `false` 才能触发回调。
+- Android 端横滑 `scroll-view` 的子节点在滑动时无法触发相应回调，需要在子节点上设置 [`flatten`](../elements/built-in/view.mdx#flatten) 为 `false` 才能触发回调。
 
 ## 兼容性
 


### PR DESCRIPTION
Backport of #1260 to `release/3.9`.

Not a literal cherry-pick — `release/3.9` never received the intermediate edits that #1260 corrects, so these six files are brought straight to the same end state `main` now has. The blog files in #1260 are omitted: `blog/lynx-3-9.mdx` does not exist on this branch.

## Why

[`@lynx-js/template-webpack-plugin`](``https://github.com/lynx-family/lynx-stack/blob/b10899281e7b6c5a95b79b557ccdc892bd5f6222/packages/webpack/template-webpack-plugin/src/LynxTemplatePlugin.ts#L1028-L1046)`` writes eight page config values as literal `true` when it encodes a template:

```ts
lepusStrict, useNewSwiper, enableNewIntersectionObserver, enableNativeList,
enableNewSticky, flexBasisZeroPercent, enableGridPlacementShorthands, syncXElementRegistry
```

Every Rspeedy app builds through it, and none of these is exposed as a plugin option — `enableNewSticky` and `flexBasisZeroPercent` each appear exactly once in the whole lynx-stack source, on that line. So the behavior they gate is simply the behavior, bounded by engine version rather than by anything the reader configures. The pages say so directly instead of naming switches.

(Distinct from the adjacent `compilerOptions` block — `defaultDisplayLinear`, `enableCSSSelector`, `enableRemoveCSSScope`, `defaultOverflowVisible` — which *is* fed from plugin options and is documented as configurable, correctly.)

## Changes

**`css/properties/position`** — `sticky` describes standard sticky positioning, with the version boundary as a following sentence:

> The element is positioned according to the normal flow of the document, then offset relative to its nearest scrolling container and containing block, based on the values of `top`, `right`, `bottom` and `left`. The offset does not affect the position of any other element.
>
> Before 3.9, `sticky` only applied to direct children of a `scroll-view`.

The EN-only "Difference with the Web" bullet — "`sticky` is only supported on the children elements of a `scroll-view`" — is dropped: from 3.9 that is no longer a difference from the Web, and the zh page never had the bullet, so this also removes a locale divergence. The stray `Is` in the EN sentence and the trailing `list 用大度的吸顶元件。` fragment in zh go with it; zh gains `position: sticky;` in the syntax block, which was missing.

**`lynx-api/intersection-observer`** — the bullet recommending `enableNewIntersectionObserver: true`, and describing the fallback for when it is off, is removed; that path is unreachable. The Android horizontal-scroll caveat that followed was conditioned on the switch and is now stated unconditionally.

**`css/properties/flex`** — the shorthand expands to `0%`, badged `3.9`, with the pre-3.9 `0` and an MDN link for the difference. Also fixes the syntax-block comment, which still said `flex-basis is then equal to 0`.

No page names a page-config key or the toolchain.

## Checks

- `prettier`, `cspell`, `check-asset-urls`, `check-api-summary` — pass (pre-commit)
- `VersionBadge` is exported from `@lynx` on this branch and already used by other API pages
- `top` / `right` / `bottom` / `left` link targets exist in both locales


---
_Generated by [Claude Code](https://claude.ai/code/session_01FVdDv5kxo9CgBZqTNuQeY7)_