### PR TITLE
chore(deps): bump @lynx-js/go-web to ^0.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@dugyu/luna-demo-bundles": "0.2.0",
     "@dugyu/luna-stage": "0.2.2",
     "@dugyu/luna-studio": "0.2.0",
-    "@lynx-js/go-web": "^0.8.0",
+    "@lynx-js/go-web": "^0.8.1",
     "@lynx-js/lynx-core": "^0.1.3",
     "@lynx-js/web-core": "^0.20.3",
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 0.2.0
         version: 0.2.0(@lynx-js/web-core-canary@0.23.1-canary-20260730-6cbcb870(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(motion@12.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@lynx-js/go-web':
-        specifier: ^0.8.0
-        version: 0.8.0(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core-canary@0.23.1-canary-20260730-6cbcb870(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.13(@rspack/core@2.0.6(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@18.3.18)(micromark-util-types@2.0.1)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)
+        specifier: ^0.8.1
+        version: 0.8.1(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core-canary@0.23.1-canary-20260730-6cbcb870(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.13(@rspack/core@2.0.6(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@18.3.18)(micromark-util-types@2.0.1)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)
       '@lynx-js/lynx-core':
         specifier: ^0.1.3
         version: 0.1.3
@@ -1689,8 +1689,8 @@ packages:
       '@lynx-js/react': '*'
       '@lynx-js/types': '*'
 
-  '@lynx-js/go-web@0.8.0':
-    resolution: {integrity: sha512-qEUvrZy3eJYkdrFgGli6B155QCyLYhvnT+vkFzr/z2SZmPN1BFtb7pDLC0mZBcdxG9UDEubkiDPA/rqgLKsw2Q==}
+  '@lynx-js/go-web@0.8.1':
+    resolution: {integrity: sha512-qc9uPIfJv4iRQJLgfOlFh1cz3AwEW4DgovdjQOMMbftSt9xG3Rr5F4Wqe/xD9MM0ahIHSVrHbkJE3q48798Brg==}
     engines: {node: ^22 || ^24}
     peerDependencies:
       '@douyinfe/semi-icons': '>=2.74.0'
@@ -8321,7 +8321,7 @@ snapshots:
       '@lynx-js/react': 0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
       '@lynx-js/types': 3.9.0
 
-  '@lynx-js/go-web@0.8.0(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core-canary@0.23.1-canary-20260730-6cbcb870(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.13(@rspack/core@2.0.6(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@18.3.18)(micromark-util-types@2.0.1)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)':
+  '@lynx-js/go-web@0.8.1(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core-canary@0.23.1-canary-20260730-6cbcb870(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.13(@rspack/core@2.0.6(@swc/helpers@0.5.23))(@types/mdast@4.0.4)(@types/react@18.3.18)(micromark-util-types@2.0.1)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)':
     dependencies:
       '@douyinfe/semi-icons': 2.74.0(react@18.3.1)
       '@douyinfe/semi-ui': 2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)


### PR DESCRIPTION
Change-Id: Iab0cb1aeced2af84ed2959557bd85c4287c29cd7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Update the `@lynx-js/go-web` dependency to `^0.8.1`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->