### PR TITLE
fix(home): make the hero badge announce the real latest release

### DIFF
--- a/docs/en/index.mdx
+++ b/docs/en/index.mdx
@@ -2,7 +2,9 @@
 pageType: home
 
 hero:
-  badge: ' ' # controlled by use-blog-btn-dom.ts
+  # Fallback copy rendered in the SSG HTML; use-blog-btn-dom.ts swaps in the
+  # latest blog post's text once it is available.
+  badge: 'Read the Latest Blog'
   name: Unlock Native for More
   tagline: 'Empower the web community and invite more to build across platforms'
   actions:

--- a/docs/zh/index.mdx
+++ b/docs/zh/index.mdx
@@ -2,7 +2,9 @@
 pageType: home
 
 hero:
-  badge: ' ' # controlled by use-blog-btn-dom.ts
+  # Fallback copy rendered in the SSG HTML; use-blog-btn-dom.ts swaps in the
+  # latest blog post's text once it is available.
+  badge: '阅读最新博客'
   name: 迈向原生体验
   tagline: 助力 Web 构建跨平台应用
   actions:

--- a/shared-og-config.ts
+++ b/shared-og-config.ts
@@ -11,7 +11,7 @@
  *   - one shared cover per subsite per language: `/og/covers/<lang>/<value>.png`
  *   - a unique image per blog post:              `/og/blog/<lang>/<slug>.png`
  */
-import { SITE_BASE, SUBSITES_CONFIG } from './shared-route-config';
+import { SITE_BASE_PREFIX, SUBSITES_CONFIG } from './shared-route-config';
 
 /** Published site origin (no trailing slash). OG/canonical URLs are absolute. */
 export const OG_SITE_ORIGIN = 'https://lynxjs.org';
@@ -20,7 +20,7 @@ export const OG_SITE_ORIGIN = 'https://lynxjs.org';
  * Site base path shared with Rspress. Public asset and canonical URLs are
  * prefixed with this.
  */
-export const OG_BASE = SITE_BASE === '/' ? '' : SITE_BASE.replace(/\/$/, '');
+export const OG_BASE = SITE_BASE_PREFIX;
 
 /**
  * Brand anchors. Values match the home hero gradient in theme/home-layout-var.scss

--- a/shared-route-config.ts
+++ b/shared-route-config.ts
@@ -13,6 +13,40 @@ if (!SITE_BASE) {
   );
 }
 
+/** A `docs_link` as a URL prefix: `/` becomes `''`, `/next/` becomes `/next`. */
+const toBasePrefix = (docsLink: string) =>
+  docsLink === '/' ? '' : docsLink.replace(/\/$/, '');
+
+/** {@link SITE_BASE} as a prefix, safe to concatenate with a rooted path. */
+export const SITE_BASE_PREFIX = toBasePrefix(SITE_BASE);
+
+const developingDocsLink = versionJson.versions.find(
+  (version) => version.type === 'developing',
+)?.docs_link;
+
+if (!developingDocsLink) {
+  throw new Error('Missing docs_link for the developing version');
+}
+
+/**
+ * Base prefix for blog links, on every version of the site.
+ *
+ * The blog is not versioned content: release branches are cut before a
+ * release post lands, and posts are never backported, so a release build's
+ * own copy of the blog is missing everything published after the cut. Every
+ * version therefore links to the developing version's blog, which is the
+ * single source of truth. Derived from `version.json` rather than hardcoded
+ * so it follows the developing entry if `next` is ever renamed.
+ */
+export const BLOG_BASE = toBasePrefix(developingDocsLink);
+
+/**
+ * Whether this build's blog links leave its own base. False on the
+ * developing build, where {@link BLOG_BASE} is its own base — in-app
+ * routing works and there is nothing to fetch cross-version.
+ */
+export const BLOG_IS_CROSS_VERSION = BLOG_BASE !== SITE_BASE_PREFIX;
+
 /**
  * Metadata for each subsites. This is used to
  * - generate the sidebar subsite selector dropdown UI.

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,4 +4,5 @@ export {
   type LatestBlogConfig,
   type LatestBlogResult,
 } from './use-latest-blog';
+export { useCanonicalLatestBlog } from './use-canonical-latest-blog';
 export { useTiltEffect } from './use-tilt-effect';

--- a/src/hooks/use-canonical-latest-blog.ts
+++ b/src/hooks/use-canonical-latest-blog.ts
@@ -1,0 +1,115 @@
+import { useEffect, useState } from 'react';
+import { useLang } from '@rspress/core/runtime';
+import { BLOG_BASE, BLOG_IS_CROSS_VERSION } from '@site/shared-route-config';
+import { toLatestBlogPath } from '@site/src/lib/utils';
+import {
+  useLatestBlog,
+  type LatestBlogConfig,
+  type LatestBlogResult,
+} from './use-latest-blog';
+
+/**
+ * The developing build's blog feed, which lists every published post. Served
+ * from the same origin as every other version, so this is a plain fetch.
+ */
+const feedUrl = (lang: string) =>
+  `${BLOG_BASE}/rss/blog-rss${lang === 'zh' ? '-zh' : ''}.xml`;
+
+/**
+ * First entry of an RSS feed, as `{ text, link }`.
+ *
+ * The feed carries a post's `title`, not its `badge_text`, so a badge fed
+ * from here shows the full title. That is the deliberate trade: the
+ * alternative is a build announcing a months-old release because its own
+ * bundled content stops at the branch cut.
+ *
+ * `guid` is the site-relative route (`/blog/lynx-3-9`). `link` is absolute
+ * and, because the feed's `siteUrl` carries no version prefix, points at an
+ * unversioned path — so either form still has to be re-based.
+ */
+function parseFirstFeedEntry(
+  xml: string,
+): { text: string; link: string } | null {
+  const item = new DOMParser()
+    .parseFromString(xml, 'application/xml')
+    .querySelector('item');
+  const text = item?.querySelector('title')?.textContent?.trim();
+  if (!text) return null;
+
+  const guid = item?.querySelector('guid')?.textContent?.trim();
+  const path = guid?.startsWith('/')
+    ? guid
+    : pathnameOf(item?.querySelector('link')?.textContent?.trim());
+  if (!path) return null;
+
+  return { text, link: toLatestBlogPath(path) };
+}
+
+function pathnameOf(href?: string) {
+  if (!href) return undefined;
+  try {
+    return new URL(href).pathname;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The latest blog post, read from the canonical blog rather than from this
+ * build's own copy of it.
+ *
+ * Release builds are cut before a release post lands, and posts are never
+ * backported, so their bundled page data is missing everything published
+ * since the cut — {@link useLatestBlog} alone would announce a months-old
+ * post. On the developing build there is nothing to cross-check and this is
+ * exactly {@link useLatestBlog}.
+ *
+ * Falls back to the local result while the feed is in flight and if it can't
+ * be read, so the caller always has something to render.
+ */
+export const useCanonicalLatestBlog = (
+  config?: LatestBlogConfig,
+): LatestBlogResult => {
+  const local = useLatestBlog(config);
+  const lang = useLang();
+  const [canonical, setCanonical] = useState<LatestBlogResult | null>(null);
+
+  // A pinned post or an external link is an explicit choice — leave it alone.
+  const pinned = Boolean(config?.filename || config?.externalLink);
+  const skip = !BLOG_IS_CROSS_VERSION || pinned;
+
+  useEffect(() => {
+    if (skip) return;
+
+    const controller = new AbortController();
+
+    fetch(feedUrl(lang), { signal: controller.signal })
+      .then((res) => (res.ok ? res.text() : Promise.reject(res.status)))
+      .then((xml) => {
+        const entry = parseFirstFeedEntry(xml);
+        if (entry) {
+          setCanonical({
+            blog: null,
+            text: entry.text,
+            link: entry.link,
+            isExternal: false,
+          });
+        }
+      })
+      .catch(() => {
+        // Aborted, offline, feed missing, or unparseable — keep the local result.
+      });
+
+    return () => controller.abort();
+  }, [skip, lang]);
+
+  // `link` is returned in the form its consumer needs: a base-relative route
+  // for in-app navigation on the developing build, and a fully based path
+  // when it points at another version and only a page load can get there.
+  const fallback =
+    BLOG_IS_CROSS_VERSION && !local.isExternal && local.link
+      ? { ...local, link: toLatestBlogPath(local.link) }
+      : local;
+
+  return canonical ?? fallback;
+};

--- a/src/hooks/use-canonical-latest-blog.ts
+++ b/src/hooks/use-canonical-latest-blog.ts
@@ -79,6 +79,12 @@ export const useCanonicalLatestBlog = (
   const skip = !BLOG_IS_CROSS_VERSION || pinned;
 
   useEffect(() => {
+    // Anything already fetched belongs to the previous language (or to a
+    // config that has since pinned a post), so drop it before deciding what
+    // to do — otherwise switching locale keeps announcing the old locale's
+    // title until the new feed lands, and a newly pinned post never wins.
+    setCanonical(null);
+
     if (skip) return;
 
     const controller = new AbortController();

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,6 @@
-import { withBase } from '@rspress/core/runtime';
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
+import { BLOG_BASE } from '@site/shared-route-config';
 
 const VERSION_PREFIX_RE = /^\/(?:next|\d+\.\d+)(?=\/|$)/;
 
@@ -8,28 +8,34 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-function withCurrentVersionBase(link: string) {
+/**
+ * Point a blog path at the canonical blog rather than at this build's own
+ * copy of it. See {@link BLOG_BASE} for why the blog is not versioned
+ * alongside the docs.
+ */
+function withBlogBase(link: string) {
   const normalizedLink = link.startsWith('/') ? link : `/${link}`;
 
+  // Already carries a version prefix — respect the caller's choice.
   if (VERSION_PREFIX_RE.test(normalizedLink)) {
     return normalizedLink;
   }
 
-  return withBase(normalizedLink);
+  return `${BLOG_BASE}${normalizedLink}`;
 }
 
 export function toLatestBlogPath(link?: string) {
   if (!link) {
-    return withCurrentVersionBase('/blog/');
+    return withBlogBase('/blog/');
   }
 
   if (/^(https?:)?\/\//.test(link)) {
     return link;
   }
 
-  return withCurrentVersionBase(link);
+  return withBlogBase(link);
 }
 
 export function getLatestBlogIndexPath(lang: string) {
-  return withCurrentVersionBase(lang === 'zh' ? '/zh/blog/' : '/blog/');
+  return withBlogBase(lang === 'zh' ? '/zh/blog/' : '/blog/');
 }

--- a/theme/blog-btn.scss
+++ b/theme/blog-btn.scss
@@ -8,10 +8,13 @@
   // so no flexbox is needed) lets text-overflow clip it with an ellipsis;
   // `max-width` caps the pill at its container so the clip actually engages.
   //
-  // line-height must match the border-box content height (height − 2×border),
-  // otherwise the line box sits at the top and the label looks top-heavy —
-  // the regression from #1155, which updated the mobile line-height but left
-  // desktop at the old 32px value from when flex was doing the centering.
+  // line-height must match the border-box content height
+  // (height − 2×border − vertical padding), otherwise the line box sits at the
+  // top of the content box and the label looks off-centre. Write the padding as
+  // a shorthand: Rspress's own `.rp-home-hero__badge` rule sets
+  // `padding: .5rem 1rem`, and longhand `padding-left`/`padding-right` here
+  // leave its 8px top/bottom in place — which pushed the text 8px low and let
+  // `overflow: hidden` clip the descenders.
   display: block;
   max-width: 100%;
   box-sizing: border-box;
@@ -29,8 +32,7 @@
   font-weight: 500;
   // content box = 36px − 2×1px border
   line-height: 34px;
-  padding-left: 43px;
-  padding-right: 20px;
+  padding: 0 20px 0 43px;
   transition: all 0.3s ease;
   user-select: none;
   opacity: 0;
@@ -41,8 +43,7 @@
     height: 28px;
     // content box = 28px − 2×1px border
     line-height: 26px;
-    padding-left: 38px;
-    padding-right: 16px;
+    padding: 0 16px 0 38px;
   }
 
   &.active-hover {

--- a/theme/blog-btn.scss
+++ b/theme/blog-btn.scss
@@ -33,10 +33,15 @@
   // content box = 36px − 2×1px border
   line-height: 34px;
   padding: 0 20px 0 43px;
-  transition: all 0.3s ease;
+  // Only the hover gradient animates. The `all` this replaces was dead
+  // anyway — the `transition: opacity` that used to follow it overrode the
+  // whole shorthand.
+  transition: background 0.3s ease;
   user-select: none;
-  opacity: 0;
-  transition: opacity 0.5s ease-in;
+  // Rendered in the SSG HTML with the frontmatter's fallback copy, so the
+  // badge is readable before (and without) client JS; `use-blog-btn-dom`
+  // swaps in the latest post's text once it has it.
+  opacity: 1;
 
   @media (max-width: 768px) {
     font-size: 12px;

--- a/theme/hooks/use-blog-btn-dom.ts
+++ b/theme/hooks/use-blog-btn-dom.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import { useLang, useNavigate, usePageData } from '@rspress/core/runtime';
-import { useLatestBlog, type LatestBlogConfig } from '@site/src/hooks';
+import { useCanonicalLatestBlog, type LatestBlogConfig } from '@site/src/hooks';
+import { BLOG_IS_CROSS_VERSION } from '@site/shared-route-config';
 
 type ConfigKey = '/' | '/react/' | '/rspeedy/' | '/lynxtron/';
 
@@ -78,13 +79,17 @@ const useBlogBtnDom = (src: string) => {
     text: blogText,
     link: blogLink,
     isExternal,
-  } = useLatestBlog(latestBlogConfig);
+  } = useCanonicalLatestBlog(latestBlogConfig);
 
   const handleInteraction = useCallback(() => {
     if (!blogLink) return;
 
     if (isExternal) {
       window.open(blogLink, '_blank');
+    } else if (BLOG_IS_CROSS_VERSION) {
+      // The blog lives under another version's base, outside this app's
+      // router — `navigate` would resolve it against the wrong base.
+      window.location.assign(blogLink);
     } else {
       navigate(blogLink);
     }

--- a/theme/hooks/use-blog-btn-dom.ts
+++ b/theme/hooks/use-blog-btn-dom.ts
@@ -123,8 +123,13 @@ const useBlogBtnDom = (src: string) => {
       configKey === '/'
         ? `rp-home-hero__badge active-hover`
         : `rp-home-hero__badge`;
-    badgeElement.textContent = displayText;
-    badgeElement.style.opacity = '1';
+    // Upgrade the SSG fallback copy once the post's text is known. The badge
+    // is visible the whole time (`opacity: 1` in CSS), so an empty
+    // `displayText` must leave the rendered fallback alone rather than blank
+    // the pill.
+    if (displayText) {
+      badgeElement.textContent = displayText;
+    }
 
     if (configKey === '/') {
       badgeElement.addEventListener('click', handleInteraction);

--- a/theme/index.tsx
+++ b/theme/index.tsx
@@ -4,7 +4,6 @@ import {
   useLang,
   useLocation,
   usePageData,
-  withBase,
 } from '@rspress/core/runtime';
 import {
   HomeLayout as BaseHomeLayout,
@@ -37,7 +36,11 @@ import {
   MeteorsBackground,
   ShowCase,
 } from '@/components/home-comps';
-import { SUBSITES_CONFIG } from '@site/shared-route-config';
+import {
+  BLOG_BASE,
+  BLOG_IS_CROSS_VERSION,
+  SUBSITES_CONFIG,
+} from '@site/shared-route-config';
 import AfterNavTitle from './AfterNavTitle';
 import BeforeSidebar from './BeforeSidebar';
 import OgHead from './OgHead';
@@ -387,10 +390,31 @@ const Link = forwardRef<HTMLAnchorElement, BaseLinkProps>((props, ref) => {
   }
 
   if (normalizedHref?.startsWith(`${getLangPrefix(lang)}/blog`)) {
+    const blogHref = `${BLOG_BASE}${removeBase(normalizedHref)}`;
+    const blogClassName = className ? `rp-link ${className}` : 'rp-link';
+
+    // On a release build the blog sits under another version's base, outside
+    // this app: `BaseLink` would re-apply its own base to the href and then
+    // intercept the click into a route that doesn't exist here. A plain
+    // anchor does the page load that actually gets there.
+    if (BLOG_IS_CROSS_VERSION) {
+      return (
+        <a
+          href={blogHref}
+          className={blogClassName}
+          ref={ref}
+          style={style}
+          {...(safeRestProps as React.AnchorHTMLAttributes<HTMLAnchorElement>)}
+        >
+          {children}
+        </a>
+      );
+    }
+
     return (
       <BaseLink
-        href={withBase(removeBase(normalizedHref))}
-        className={className ? `rp-link ${className}` : 'rp-link'}
+        href={blogHref}
+        className={blogClassName}
         ref={ref}
         style={style as any}
         {...safeRestProps}


### PR DESCRIPTION
Four commits behind one symptom: the homepage badge is off-centre on every version, and on released versions it announces the wrong post entirely — `/3.9/` says "Generative UI on Lynx with A2UI" (2026-06-08) and `/4.0/` says Rspack 2.0. Neither has ever said 3.9.

Release-branch counterparts: #1271 (`release/3.9`), #1270 (`release/4.0`).

## 1. `fix(home): drop Rspress's vertical padding from the hero badge`

#1205 matched the badge's `line-height` to what it computed as the content box (`height − 2×border`), but Rspress's own `.rp-home-hero__badge` rule declares `padding: .5rem 1rem`. Our overrides were longhand `padding-left` / `padding-right`, so that 8px top/bottom survived the cascade — measured on the running dev server, `padding: 8px 20px 8px 43px`. The content box was 18px, not 34px, so the 34px line box started below it and the label sat 8px low with its descenders clipped by `overflow: hidden`.

Writing the padding as a shorthand leaves nothing vertical to inherit. Visible in the production CSS bundle, ours winning on source order:

```css
.rp-home-hero__badge{...padding:.5rem 1rem;...display:inline-flex}          /* Rspress */
.rp-home-hero__badge{...opacity:1;...padding:0 20px 0 43px...}              /* ours */
```

## 2. `fix(blog): keep blog links on the developing version's base`

The blog is not versioned content: release branches are cut before the release post lands, and posts are never backported. So a release build's own copy of the blog stops at the branch cut — `/3.9/blog/` is missing `lynx-3-9` and `lynx-rspack-2`, and `/4.0/blog/lynx-3-9` is a 404.

Pointing every version's blog links at the developing docs is what made one blog the source of truth. #1268 replaced that with `withBase()`, which re-versions it — visible on the live sites right now: `/3.9/blog/` (still on the old code) links every card to `/next/blog/...`, while `/4.0/blog/` (already carrying the change) links to `/4.0/blog/...`.

This restores the pinning, but derives the base from `version.json`'s `developing` entry rather than hardcoding `/next` again, so it follows a rename. `SITE_BASE_PREFIX` replaces the normalization `OG_BASE` was open-coding.

One new interaction to handle: now that a release build's base is versioned (`/3.9` rather than `/`), the theme's `Link` override can't hand a cross-version blog href to `BaseLink` — it re-applies its own base (`/3.9/next/blog/...`) and intercepts the click into a route this app doesn't have. Verified both, then fixed by rendering a plain anchor in that case.

## 3. `fix(home): read the hero badge's post from the canonical blog`

The badge takes the newest post from `usePages()` — the build's own bundled page data, which has the same branch-cut problem. It now reads the first entry of the developing build's RSS feed, same-origin from every version.

The feed carries `title`, not `badge_text`, so a release build's badge shows the full post title. That's a deliberate trade: naming the right release matters more than the shorter wording. The developing build has nothing to cross-check — it keeps using its own page data, still shows `badge_text`, and makes no request at all.

The local result stays the fallback while the feed is in flight and if it can't be read. A pinned `filename` or an `externalLink` is left alone.

## 4. `fix(home): render the hero badge in the SSG HTML`

`release/4.0` already carries this and it never came back to main. The badge was `opacity: 0` until client JS revealed it, and the frontmatter's `badge` was a single space — so the pill was invisible until hydration and empty without JS entirely. Real fallback copy in the frontmatter, `opacity: 1`, and `use-blog-btn-dom` upgrades the text rather than blanking the pill when it has none.

Also drops the dead `transition: all` — the `transition: opacity` that followed it overrode the whole shorthand, so only opacity ever animated.

## Verification

`rspress dev` plus a real browser; and a full production build (`built in 3m 29.6s`, sitemap for 3087 pages) to check the SSG output.

**Developing build** (`base: /next`) — no request, `badge_text` preserved:

| | badge text | click target | feed |
|---|---|---|---|
| en home | `Lynx 3.9 is released!` | `/next/blog/lynx-3-9` | none |
| zh home | `Lynx 3.9 发布了!` | `/next/zh/blog/lynx-3-9` | none |

Computed badge box: `padding 0px 0px`, `line-height 34px`, `height 36px`. Blog index links all `/next/blog/...` (17 anchors). Built HTML now carries the fallback copy:

```html
<div class="rp-home-hero__badge">Read the Latest Blog</div>
<div class="rp-home-hero__badge">阅读最新博客</div>
```

**Simulated release build** (`current_version` temporarily `3.9`, so `base: /3.9`), with the **real** `/next/` feeds served through request interception:

| scenario | badge text | click target |
|---|---|---|
| en, feed ok | `Lynx 3.9: Autolink, Web-Aligned CSS, and ReactLynx Portal` | `/next/blog/lynx-3-9` |
| zh, feed ok | `Lynx 3.9：Autolink、更贴近 Web 的 CSS、ReactLynx Portal` | `/next/zh/blog/lynx-3-9` |
| feed returns 500 | `Lynx 3.9 is released!` (local fallback) | `/next/blog/lynx-3-9` |
| feed returns malformed XML | `Lynx 3.9 is released!` (local fallback) | `/next/blog/lynx-3-9` |

Blog index cards on that build resolve to `/next/blog/...` with no doubled base, and clicking the badge does a full page load rather than an SPA navigation.

Not touched: the `rel="alternate"` language link still points within the current version (`/3.9/zh/blog/index.html`), which matches today's live behaviour and is what hreflang wants.

## Related

- #1268 / #1221 — where the blog's `/next` pinning was replaced with `withBase()`. The base fix there is right and needed; only the blog's base needs to stay separate.
- The `/next/` RSS feed's item links are absolute and unversioned (`https://lynxjs.org/blog/lynx-3-9`), which 302s to `/4.0/` and 404s. This PR re-bases what it reads out of the feed, but the feed's own `siteUrl` is still worth fixing for actual subscribers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Restore homepage hero badge alignment and preserve SSG fallback text.
- Route blog links through the canonical blog base across versions.
- Fetch the canonical latest blog post for cross-version builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->