### PR TITLE
fix(version): derive site base from version config

### DIFF
--- a/docs/public/version.json
+++ b/docs/public/version.json
@@ -20,14 +20,14 @@
       "type": "previous",
       "version_number": "3.9",
       "repo_branch": "release/3.9",
-      "docs_link": "/",
+      "docs_link": "/3.9",
       "release_number": "3.9.0"
     },
     {
       "type": "previous",
       "version_number": "3.8",
       "repo_branch": "release/3.8",
-      "docs_link": "/",
+      "docs_link": "/3.8",
       "release_number": "3.8.1",
       "release_blog": "/blog/lynx-3-8.html"
     },

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -18,6 +18,7 @@ import type { Dirent } from 'node:fs';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import versionJson from './docs/public/version.json';
+import { SITE_BASE } from './shared-route-config';
 import { visit } from 'unist-util-visit';
 import { pluginGoogleAnalytics } from 'rsbuild-plugin-google-analytics';
 
@@ -105,7 +106,7 @@ export default defineConfig({
       'https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/lynx-dark-logo.svg',
     dark: 'https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/lynx-light-logo.svg',
   },
-  base: `/${versionJson.current_version}`,
+  base: SITE_BASE,
   themeConfig: {
     editLink: {
       docRepoBaseUrl:

--- a/shared-og-config.ts
+++ b/shared-og-config.ts
@@ -11,19 +11,16 @@
  *   - one shared cover per subsite per language: `/og/covers/<lang>/<value>.png`
  *   - a unique image per blog post:              `/og/blog/<lang>/<slug>.png`
  */
-import { SUBSITES_CONFIG } from './shared-route-config';
-import versionJson from './docs/public/version.json';
+import { SITE_BASE, SUBSITES_CONFIG } from './shared-route-config';
 
 /** Published site origin (no trailing slash). OG/canonical URLs are absolute. */
 export const OG_SITE_ORIGIN = 'https://lynxjs.org';
 
 /**
- * Site base path — derived from the same source as rspress.config.ts's
- * `base: \`/${versionJson.current_version}\``, so canonical/og:image URLs stay
- * correct if `current_version` changes (currently `/next`). Public asset and
- * canonical URLs are prefixed with this.
+ * Site base path shared with Rspress. Public asset and canonical URLs are
+ * prefixed with this.
  */
-export const OG_BASE = `/${versionJson.current_version}`;
+export const OG_BASE = SITE_BASE === '/' ? '' : SITE_BASE.replace(/\/$/, '');
 
 /**
  * Brand anchors. Values match the home hero gradient in theme/home-layout-var.scss

--- a/shared-route-config.ts
+++ b/shared-route-config.ts
@@ -1,6 +1,17 @@
 /**
  * Sub-sites and shared docs configuration
  */
+import versionJson from './docs/public/version.json';
+
+export const SITE_BASE = versionJson.versions.find(
+  (version) => version.version_number === versionJson.current_version,
+)?.docs_link;
+
+if (!SITE_BASE) {
+  throw new Error(
+    `Missing docs_link for current version ${versionJson.current_version}`,
+  );
+}
 
 /**
  * Metadata for each subsites. This is used to

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,22 +1,35 @@
+import { withBase } from '@rspress/core/runtime';
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
+
+const VERSION_PREFIX_RE = /^\/(?:next|\d+\.\d+)(?=\/|$)/;
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export function toLatestBlogPath(link?: string) {
-  if (!link) {
-    return '/next/blog/';
+function withCurrentVersionBase(link: string) {
+  const normalizedLink = link.startsWith('/') ? link : `/${link}`;
+
+  if (VERSION_PREFIX_RE.test(normalizedLink)) {
+    return normalizedLink;
   }
 
-  if (/^(https?:)?\/\//.test(link) || link.startsWith('/next/')) {
+  return withBase(normalizedLink);
+}
+
+export function toLatestBlogPath(link?: string) {
+  if (!link) {
+    return withCurrentVersionBase('/blog/');
+  }
+
+  if (/^(https?:)?\/\//.test(link)) {
     return link;
   }
 
-  return `/next${link.startsWith('/') ? link : `/${link}`}`;
+  return withCurrentVersionBase(link);
 }
 
 export function getLatestBlogIndexPath(lang: string) {
-  return lang === 'zh' ? '/next/zh/blog/' : '/next/blog/';
+  return withCurrentVersionBase(lang === 'zh' ? '/zh/blog/' : '/blog/');
 }

--- a/theme/index.tsx
+++ b/theme/index.tsx
@@ -4,6 +4,7 @@ import {
   useLang,
   useLocation,
   usePageData,
+  withBase,
 } from '@rspress/core/runtime';
 import {
   HomeLayout as BaseHomeLayout,
@@ -388,7 +389,7 @@ const Link = forwardRef<HTMLAnchorElement, BaseLinkProps>((props, ref) => {
   if (normalizedHref?.startsWith(`${getLangPrefix(lang)}/blog`)) {
     return (
       <BaseLink
-        href={`/next${removeBase(normalizedHref)}`}
+        href={withBase(removeBase(normalizedHref))}
         className={className ? `rp-link ${className}` : 'rp-link'}
         ref={ref}
         style={style as any}


### PR DESCRIPTION
## Summary

This is the main-branch counterpart of #1221. It derives the Rspress and canonical/OG base from the current entry's `docs_link` in `version.json`, so the `next` docs build keeps using `/next` while sharing the same base source of truth as release builds. It also aligns client-side blog/version links with `withBase()` and updates previous release docs links to their versioned paths.

Note: `netlify.toml` keeps main's existing `/next/* -> /:splat` rewrite; release-only redirect changes from #1221 are intentionally not applied on main.

## Related Links

- https://github.com/lynx-family/lynx-website/pull/1221
- https://github.com/lynx-family/lynx-website/pull/1221#pullrequestreview-4853170441
