### PR TITLE
fix(blog): read the blog from the developing version, not this build's copy

### DIFF
--- a/shared-route-config.ts
+++ b/shared-route-config.ts
@@ -1,6 +1,37 @@
 /**
  * Sub-sites and shared docs configuration
  */
+import versionJson from './docs/public/version.json';
+
+/** This build's Rspress base as a URL prefix — matches rspress.config.ts. */
+export const SITE_BASE_PREFIX = `/${versionJson.current_version}`;
+
+const developingDocsLink = versionJson.versions.find(
+  (version) => version.type === 'developing',
+)?.docs_link;
+
+if (!developingDocsLink) {
+  throw new Error('Missing docs_link for the developing version');
+}
+
+/**
+ * Base prefix for blog links, on every version of the site.
+ *
+ * The blog is not versioned content: this branch was cut before its own
+ * release post landed, and posts are never backported, so this build's copy
+ * of the blog is missing everything published since the cut. Blog links
+ * therefore point at the developing version, which is the single source of
+ * truth. Derived from `version.json` rather than hardcoded so it follows the
+ * developing entry if `next` is ever renamed.
+ */
+export const BLOG_BASE =
+  developingDocsLink === '/' ? '' : developingDocsLink.replace(/\/$/, '');
+
+/**
+ * Whether this build's blog links leave its own base. True on every release
+ * build; false on the developing build, where in-app routing just works.
+ */
+export const BLOG_IS_CROSS_VERSION = BLOG_BASE !== SITE_BASE_PREFIX;
 
 /**
  * Metadata for each subsites. This is used to

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,4 +4,5 @@ export {
   type LatestBlogConfig,
   type LatestBlogResult,
 } from './use-latest-blog';
+export { useCanonicalLatestBlog } from './use-canonical-latest-blog';
 export { useTiltEffect } from './use-tilt-effect';

--- a/src/hooks/use-canonical-latest-blog.ts
+++ b/src/hooks/use-canonical-latest-blog.ts
@@ -1,0 +1,115 @@
+import { useEffect, useState } from 'react';
+import { useLang } from '@rspress/core/runtime';
+import { BLOG_BASE, BLOG_IS_CROSS_VERSION } from '@site/shared-route-config';
+import { toLatestBlogPath } from '@site/src/lib/utils';
+import {
+  useLatestBlog,
+  type LatestBlogConfig,
+  type LatestBlogResult,
+} from './use-latest-blog';
+
+/**
+ * The developing build's blog feed, which lists every published post. Served
+ * from the same origin as every other version, so this is a plain fetch.
+ */
+const feedUrl = (lang: string) =>
+  `${BLOG_BASE}/rss/blog-rss${lang === 'zh' ? '-zh' : ''}.xml`;
+
+/**
+ * First entry of an RSS feed, as `{ text, link }`.
+ *
+ * The feed carries a post's `title`, not its `badge_text`, so a badge fed
+ * from here shows the full title. That is the deliberate trade: the
+ * alternative is a build announcing a months-old release because its own
+ * bundled content stops at the branch cut.
+ *
+ * `guid` is the site-relative route (`/blog/lynx-3-9`). `link` is absolute
+ * and, because the feed's `siteUrl` carries no version prefix, points at an
+ * unversioned path — so either form still has to be re-based.
+ */
+function parseFirstFeedEntry(
+  xml: string,
+): { text: string; link: string } | null {
+  const item = new DOMParser()
+    .parseFromString(xml, 'application/xml')
+    .querySelector('item');
+  const text = item?.querySelector('title')?.textContent?.trim();
+  if (!text) return null;
+
+  const guid = item?.querySelector('guid')?.textContent?.trim();
+  const path = guid?.startsWith('/')
+    ? guid
+    : pathnameOf(item?.querySelector('link')?.textContent?.trim());
+  if (!path) return null;
+
+  return { text, link: toLatestBlogPath(path) };
+}
+
+function pathnameOf(href?: string) {
+  if (!href) return undefined;
+  try {
+    return new URL(href).pathname;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The latest blog post, read from the canonical blog rather than from this
+ * build's own copy of it.
+ *
+ * Release builds are cut before a release post lands, and posts are never
+ * backported, so their bundled page data is missing everything published
+ * since the cut — {@link useLatestBlog} alone would announce a months-old
+ * post. On the developing build there is nothing to cross-check and this is
+ * exactly {@link useLatestBlog}.
+ *
+ * Falls back to the local result while the feed is in flight and if it can't
+ * be read, so the caller always has something to render.
+ */
+export const useCanonicalLatestBlog = (
+  config?: LatestBlogConfig,
+): LatestBlogResult => {
+  const local = useLatestBlog(config);
+  const lang = useLang();
+  const [canonical, setCanonical] = useState<LatestBlogResult | null>(null);
+
+  // A pinned post or an external link is an explicit choice — leave it alone.
+  const pinned = Boolean(config?.filename || config?.externalLink);
+  const skip = !BLOG_IS_CROSS_VERSION || pinned;
+
+  useEffect(() => {
+    if (skip) return;
+
+    const controller = new AbortController();
+
+    fetch(feedUrl(lang), { signal: controller.signal })
+      .then((res) => (res.ok ? res.text() : Promise.reject(res.status)))
+      .then((xml) => {
+        const entry = parseFirstFeedEntry(xml);
+        if (entry) {
+          setCanonical({
+            blog: null,
+            text: entry.text,
+            link: entry.link,
+            isExternal: false,
+          });
+        }
+      })
+      .catch(() => {
+        // Aborted, offline, feed missing, or unparseable — keep the local result.
+      });
+
+    return () => controller.abort();
+  }, [skip, lang]);
+
+  // `link` is returned in the form its consumer needs: a base-relative route
+  // for in-app navigation on the developing build, and a fully based path
+  // when it points at another version and only a page load can get there.
+  const fallback =
+    BLOG_IS_CROSS_VERSION && !local.isExternal && local.link
+      ? { ...local, link: toLatestBlogPath(local.link) }
+      : local;
+
+  return canonical ?? fallback;
+};

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,36 +1,35 @@
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
-import versionJson from '../../docs/public/version.json';
+import { BLOG_BASE } from '@site/shared-route-config';
 
-const CURRENT_VERSION_BASE = `/${versionJson.current_version}`;
 const VERSION_PREFIX_RE = /^\/(?:next|\d+\.\d+)(?=\/|$)/;
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-function withCurrentVersionBase(link: string) {
+function withBlogBase(link: string) {
   const normalizedLink = link.startsWith('/') ? link : `/${link}`;
 
   if (VERSION_PREFIX_RE.test(normalizedLink)) {
     return normalizedLink;
   }
 
-  return `${CURRENT_VERSION_BASE}${normalizedLink}`;
+  return `${BLOG_BASE}${normalizedLink}`;
 }
 
 export function toLatestBlogPath(link?: string) {
   if (!link) {
-    return withCurrentVersionBase('/blog/');
+    return withBlogBase('/blog/');
   }
 
   if (/^(https?:)?\/\//.test(link)) {
     return link;
   }
 
-  return withCurrentVersionBase(link);
+  return withBlogBase(link);
 }
 
 export function getLatestBlogIndexPath(lang: string) {
-  return withCurrentVersionBase(lang === 'zh' ? '/zh/blog/' : '/blog/');
+  return withBlogBase(lang === 'zh' ? '/zh/blog/' : '/blog/');
 }

--- a/theme/hooks/use-blog-btn-dom.ts
+++ b/theme/hooks/use-blog-btn-dom.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import { useLang, useNavigate, usePageData } from '@rspress/core/runtime';
-import { useLatestBlog, type LatestBlogConfig } from '@site/src/hooks';
+import { useCanonicalLatestBlog, type LatestBlogConfig } from '@site/src/hooks';
+import { BLOG_IS_CROSS_VERSION } from '@site/shared-route-config';
 
 type ConfigKey = '/' | '/react/' | '/rspeedy/';
 
@@ -70,13 +71,17 @@ const useBlogBtnDom = (src: string) => {
     text: blogText,
     link: blogLink,
     isExternal,
-  } = useLatestBlog(latestBlogConfig);
+  } = useCanonicalLatestBlog(latestBlogConfig);
 
   const handleInteraction = useCallback(() => {
     if (!blogLink) return;
 
     if (isExternal) {
       window.open(blogLink, '_blank');
+    } else if (BLOG_IS_CROSS_VERSION) {
+      // The blog lives under another version's base, outside this app's
+      // router — `navigate` would resolve it against the wrong base.
+      window.location.assign(blogLink);
     } else {
       navigate(blogLink);
     }

--- a/theme/index.tsx
+++ b/theme/index.tsx
@@ -27,8 +27,11 @@ import {
 import './index.scss';
 
 import { Footer } from '@/components/home-comps/footer';
-import { SUBSITES_CONFIG } from '@site/shared-route-config';
-import versionJson from '../docs/public/version.json';
+import {
+  BLOG_BASE,
+  BLOG_IS_CROSS_VERSION,
+  SUBSITES_CONFIG,
+} from '@site/shared-route-config';
 import AfterNavTitle from './AfterNavTitle';
 import BeforeSidebar from './BeforeSidebar';
 import { DeferredComponent } from './deferred-client';
@@ -36,8 +39,6 @@ import { HomeAfterHero } from './home-after-hero';
 import { HomeLayout as LynxUIHomeLayout } from './lynx-ui-home';
 import OgHead from './OgHead';
 import { useBlogBtnDom } from './hooks/use-blog-btn-dom';
-
-const CURRENT_VERSION_BASE = `/${versionJson.current_version}`;
 
 const loadMeteorsBackground = () =>
   import('@/components/home-comps/meteors-background').then(
@@ -398,10 +399,31 @@ const Link = forwardRef<HTMLAnchorElement, BaseLinkProps>((props, ref) => {
   }
 
   if (normalizedHref?.startsWith(`${getLangPrefix(lang)}/blog`)) {
+    const blogHref = `${BLOG_BASE}${removeBase(normalizedHref)}`;
+    const blogClassName = className ? `rp-link ${className}` : 'rp-link';
+
+    // The blog sits under the developing version's base, outside this app:
+    // `BaseLink` would re-apply this build's own base (`/4.0/next/blog/...`)
+    // and then intercept the click into a route that doesn't exist here. A
+    // plain anchor does the page load that actually gets there.
+    if (BLOG_IS_CROSS_VERSION) {
+      return (
+        <a
+          href={blogHref}
+          className={blogClassName}
+          ref={ref}
+          style={style}
+          {...(safeRestProps as React.AnchorHTMLAttributes<HTMLAnchorElement>)}
+        >
+          {children as React.ReactNode}
+        </a>
+      );
+    }
+
     return (
       <BaseLink
-        href={`${CURRENT_VERSION_BASE}${removeBase(normalizedHref)}`}
-        className={className ? `rp-link ${className}` : 'rp-link'}
+        href={blogHref}
+        className={blogClassName}
         ref={ref}
         style={style as any}
         {...safeRestProps}


### PR DESCRIPTION
## Problem

Two symptoms on the live 4.0 site, one cause:

- The homepage badge announces **Lynx × Rspack 2.0** (2026-06-30). It has never announced 3.9.
- `/4.0/blog/lynx-3-9` is a **404**, and every card on `/4.0/blog/` links to `/4.0/blog/...`.

This branch was cut before the 3.9 post landed, and blog posts are never backported — so this build's own copy of the blog stops at the cut. Anything that reads the blog out of this build reads a truncated list.

## Changes

**Blog links point at the developing version again.** They used to, for exactly this reason; that was replaced with a per-version base, which re-versions the blog and sends readers to pages this build doesn't have. The base is now derived from `version.json`'s `developing` entry rather than hardcoded `/next`, so it follows a rename.

**Cross-version blog hrefs no longer go through `BaseLink`.** With this build's base being `/4.0`, `BaseLink` re-applies it (`/4.0/next/blog/...`) and then intercepts the click into a route this app doesn't have. A plain anchor does the page load that actually gets there. Verified both failure modes in a browser before fixing.

**The hero badge reads the canonical blog.** It took the newest post from `usePages()` — the same truncated page data. It now reads the first entry of the developing build's RSS feed, which is same-origin from every version.

The feed carries `title` rather than `badge_text`, so the badge shows the full post title. Deliberate trade: naming the right release matters more than the shorter wording. The local result stays the fallback while the feed is in flight and if it can't be read, so the badge always renders. A pinned `filename` or an `externalLink` is left alone.

## Verification

The mechanism was verified end-to-end on `main` against a build configured to look like a release build (base `/3.9`, blog cross-version), driving a real browser with the **real** `/next/` feeds served through request interception:

| scenario | badge text | click target |
|---|---|---|
| en, feed ok | `Lynx 3.9: Autolink, Web-Aligned CSS, and ReactLynx Portal` | `/next/blog/lynx-3-9` |
| zh, feed ok | `Lynx 3.9：Autolink、更贴近 Web 的 CSS、ReactLynx Portal` | `/next/zh/blog/lynx-3-9` |
| feed returns 500 | local fallback | `/next/blog/lynx-3-9` |
| feed returns malformed XML | local fallback | `/next/blog/lynx-3-9` |

Blog index cards on that build resolve to `/next/blog/...` with no doubled base, and clicking the badge does a full page load rather than an SPA navigation.

On this branch: `tsc --noEmit` introduces no new errors over the unmodified branch. A full production build was run on the `main` counterpart, not here — CI covers this one.

Not touched: the `rel="alternate"` language link still points within the current version, which matches today's behaviour and is what hreflang wants.

## Related

- #1266 — the `main` counterpart.
- #1221 — overlaps here. That PR's base fix is right and needed; this only asks that the blog keep a base of its own rather than following `withBase()`. Happy to fold this into it instead if that's easier to land.

---
_Generated by [Claude Code](https://claude.ai/code/session_017UqU8yvoJn5uGFj9wF6KeC)_