### PR TITLE
fix(blog): read the blog from the developing version, not this build's copy

### DIFF
--- a/shared-route-config.ts
+++ b/shared-route-config.ts
@@ -1,6 +1,37 @@
 /**
  * Sub-sites and shared docs configuration
  */
+import versionJson from './docs/public/version.json';
+
+/** This build's Rspress base as a URL prefix — matches rspress.config.ts. */
+export const SITE_BASE_PREFIX = `/${versionJson.current_version}`;
+
+const developingDocsLink = versionJson.versions.find(
+  (version) => version.type === 'developing',
+)?.docs_link;
+
+if (!developingDocsLink) {
+  throw new Error('Missing docs_link for the developing version');
+}
+
+/**
+ * Base prefix for blog links, on every version of the site.
+ *
+ * The blog is not versioned content: this branch was cut before its own
+ * release post landed, and posts are never backported, so this build's copy
+ * of the blog is missing everything published since the cut. Blog links
+ * therefore point at the developing version, which is the single source of
+ * truth. Derived from `version.json` rather than hardcoded so it follows the
+ * developing entry if `next` is ever renamed.
+ */
+export const BLOG_BASE =
+  developingDocsLink === '/' ? '' : developingDocsLink.replace(/\/$/, '');
+
+/**
+ * Whether this build's blog links leave its own base. True on every release
+ * build; false on the developing build, where in-app routing just works.
+ */
+export const BLOG_IS_CROSS_VERSION = BLOG_BASE !== SITE_BASE_PREFIX;
 
 /**
  * Metadata for each subsites. This is used to

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,4 +4,5 @@ export {
   type LatestBlogConfig,
   type LatestBlogResult,
 } from './use-latest-blog';
+export { useCanonicalLatestBlog } from './use-canonical-latest-blog';
 export { useTiltEffect } from './use-tilt-effect';

--- a/src/hooks/use-canonical-latest-blog.ts
+++ b/src/hooks/use-canonical-latest-blog.ts
@@ -1,0 +1,115 @@
+import { useEffect, useState } from 'react';
+import { useLang } from '@rspress/core/runtime';
+import { BLOG_BASE, BLOG_IS_CROSS_VERSION } from '@site/shared-route-config';
+import { toLatestBlogPath } from '@site/src/lib/utils';
+import {
+  useLatestBlog,
+  type LatestBlogConfig,
+  type LatestBlogResult,
+} from './use-latest-blog';
+
+/**
+ * The developing build's blog feed, which lists every published post. Served
+ * from the same origin as every other version, so this is a plain fetch.
+ */
+const feedUrl = (lang: string) =>
+  `${BLOG_BASE}/rss/blog-rss${lang === 'zh' ? '-zh' : ''}.xml`;
+
+/**
+ * First entry of an RSS feed, as `{ text, link }`.
+ *
+ * The feed carries a post's `title`, not its `badge_text`, so a badge fed
+ * from here shows the full title. That is the deliberate trade: the
+ * alternative is a build announcing a months-old release because its own
+ * bundled content stops at the branch cut.
+ *
+ * `guid` is the site-relative route (`/blog/lynx-3-9`). `link` is absolute
+ * and, because the feed's `siteUrl` carries no version prefix, points at an
+ * unversioned path — so either form still has to be re-based.
+ */
+function parseFirstFeedEntry(
+  xml: string,
+): { text: string; link: string } | null {
+  const item = new DOMParser()
+    .parseFromString(xml, 'application/xml')
+    .querySelector('item');
+  const text = item?.querySelector('title')?.textContent?.trim();
+  if (!text) return null;
+
+  const guid = item?.querySelector('guid')?.textContent?.trim();
+  const path = guid?.startsWith('/')
+    ? guid
+    : pathnameOf(item?.querySelector('link')?.textContent?.trim());
+  if (!path) return null;
+
+  return { text, link: toLatestBlogPath(path) };
+}
+
+function pathnameOf(href?: string) {
+  if (!href) return undefined;
+  try {
+    return new URL(href).pathname;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The latest blog post, read from the canonical blog rather than from this
+ * build's own copy of it.
+ *
+ * Release builds are cut before a release post lands, and posts are never
+ * backported, so their bundled page data is missing everything published
+ * since the cut — {@link useLatestBlog} alone would announce a months-old
+ * post. On the developing build there is nothing to cross-check and this is
+ * exactly {@link useLatestBlog}.
+ *
+ * Falls back to the local result while the feed is in flight and if it can't
+ * be read, so the caller always has something to render.
+ */
+export const useCanonicalLatestBlog = (
+  config?: LatestBlogConfig,
+): LatestBlogResult => {
+  const local = useLatestBlog(config);
+  const lang = useLang();
+  const [canonical, setCanonical] = useState<LatestBlogResult | null>(null);
+
+  // A pinned post or an external link is an explicit choice — leave it alone.
+  const pinned = Boolean(config?.filename || config?.externalLink);
+  const skip = !BLOG_IS_CROSS_VERSION || pinned;
+
+  useEffect(() => {
+    if (skip) return;
+
+    const controller = new AbortController();
+
+    fetch(feedUrl(lang), { signal: controller.signal })
+      .then((res) => (res.ok ? res.text() : Promise.reject(res.status)))
+      .then((xml) => {
+        const entry = parseFirstFeedEntry(xml);
+        if (entry) {
+          setCanonical({
+            blog: null,
+            text: entry.text,
+            link: entry.link,
+            isExternal: false,
+          });
+        }
+      })
+      .catch(() => {
+        // Aborted, offline, feed missing, or unparseable — keep the local result.
+      });
+
+    return () => controller.abort();
+  }, [skip, lang]);
+
+  // `link` is returned in the form its consumer needs: a base-relative route
+  // for in-app navigation on the developing build, and a fully based path
+  // when it points at another version and only a page load can get there.
+  const fallback =
+    BLOG_IS_CROSS_VERSION && !local.isExternal && local.link
+      ? { ...local, link: toLatestBlogPath(local.link) }
+      : local;
+
+  return canonical ?? fallback;
+};

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,22 +1,41 @@
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
+import { BLOG_BASE } from '@site/shared-route-config';
+
+const VERSION_PREFIX_RE = /^\/(?:next|\d+\.\d+)(?=\/|$)/;
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export function toLatestBlogPath(link?: string) {
-  if (!link) {
-    return '/next/blog/';
+/**
+ * Point a blog path at the canonical blog rather than at this build's own
+ * copy of it. See {@link BLOG_BASE} for why the blog is not versioned
+ * alongside the docs.
+ */
+function withBlogBase(link: string) {
+  const normalizedLink = link.startsWith('/') ? link : `/${link}`;
+
+  // Already carries a version prefix — respect the caller's choice.
+  if (VERSION_PREFIX_RE.test(normalizedLink)) {
+    return normalizedLink;
   }
 
-  if (/^(https?:)?\/\//.test(link) || link.startsWith('/next/')) {
+  return `${BLOG_BASE}${normalizedLink}`;
+}
+
+export function toLatestBlogPath(link?: string) {
+  if (!link) {
+    return withBlogBase('/blog/');
+  }
+
+  if (/^(https?:)?\/\//.test(link)) {
     return link;
   }
 
-  return `/next${link.startsWith('/') ? link : `/${link}`}`;
+  return withBlogBase(link);
 }
 
 export function getLatestBlogIndexPath(lang: string) {
-  return lang === 'zh' ? '/next/zh/blog/' : '/next/blog/';
+  return withBlogBase(lang === 'zh' ? '/zh/blog/' : '/blog/');
 }

--- a/theme/blog-btn.scss
+++ b/theme/blog-btn.scss
@@ -2,8 +2,25 @@
   font-size: 14px;
   align-self: center;
   position: relative;
-  display: flex;
-  align-items: center;
+  // Keep the announcement to a single line. The badge shows the latest post's
+  // title, which is now read from the canonical blog and can be much longer
+  // than what this build's own content offered — long enough to wrap and
+  // spill out of the fixed-height pill. Block + line-height centering (the
+  // icon is absolutely positioned, so no flexbox is needed) lets
+  // text-overflow clip it with an ellipsis; `max-width` caps the pill at its
+  // container so the clip actually engages.
+  //
+  // line-height must match the border-box content height
+  // (height - 2*border - vertical padding). Write the padding as a shorthand:
+  // Rspress's own `.rp-home-hero__badge` rule sets `padding: .5rem 1rem`, and
+  // longhand `padding-left`/`padding-right` here would leave its 8px
+  // top/bottom in place, shrinking the content box so the centering misses.
+  display: block;
+  max-width: 100%;
+  box-sizing: border-box;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   height: 36px;
   flex-shrink: 0;
   border-radius: 37px;
@@ -13,9 +30,9 @@
   color: var(--home-blog-btn-color);
   font-style: normal;
   font-weight: 500;
-  line-height: 32px;
-  padding-left: 43px;
-  padding-right: 20px;
+  // content box = 36px - 2x1px border
+  line-height: 34px;
+  padding: 0 20px 0 43px;
   transition: all 0.3s ease;
   user-select: none;
   opacity: 0;
@@ -24,8 +41,9 @@
   @media (max-width: 768px) {
     font-size: 12px;
     height: 28px;
-    padding-left: 38px;
-    padding-right: 16px;
+    // content box = 28px - 2x1px border
+    line-height: 26px;
+    padding: 0 16px 0 38px;
   }
 
   &.active-hover {

--- a/theme/hooks/use-blog-btn-dom.ts
+++ b/theme/hooks/use-blog-btn-dom.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import { useLang, useNavigate, usePageData } from '@rspress/core/runtime';
-import { useLatestBlog, type LatestBlogConfig } from '@site/src/hooks';
+import { useCanonicalLatestBlog, type LatestBlogConfig } from '@site/src/hooks';
+import { BLOG_IS_CROSS_VERSION } from '@site/shared-route-config';
 
 type ConfigKey = '/' | '/react/' | '/rspeedy/';
 
@@ -70,13 +71,17 @@ const useBlogBtnDom = (src: string) => {
     text: blogText,
     link: blogLink,
     isExternal,
-  } = useLatestBlog(latestBlogConfig);
+  } = useCanonicalLatestBlog(latestBlogConfig);
 
   const handleInteraction = useCallback(() => {
     if (!blogLink) return;
 
     if (isExternal) {
       window.open(blogLink, '_blank');
+    } else if (BLOG_IS_CROSS_VERSION) {
+      // The blog lives under another version's base, outside this app's
+      // router — `navigate` would resolve it against the wrong base.
+      window.location.assign(blogLink);
     } else {
       navigate(blogLink);
     }

--- a/theme/index.tsx
+++ b/theme/index.tsx
@@ -34,7 +34,7 @@ import {
   MeteorsBackground,
   ShowCase,
 } from '@/components/home-comps';
-import { SUBSITES_CONFIG } from '@site/shared-route-config';
+import { BLOG_BASE, SUBSITES_CONFIG } from '@site/shared-route-config';
 import AfterNavTitle from './AfterNavTitle';
 import BeforeSidebar from './BeforeSidebar';
 import OgHead from './OgHead';
@@ -373,7 +373,7 @@ const Link = forwardRef<HTMLAnchorElement, BaseLinkProps>((props, ref) => {
   if (normalizedHref?.startsWith(`${getLangPrefix(lang)}/blog`)) {
     return (
       <a
-        href={`/next${removeBase(normalizedHref)}`}
+        href={`${BLOG_BASE}${removeBase(normalizedHref)}`}
         className={className ? `rp-link ${className}` : 'rp-link'}
         ref={ref}
         style={style as any}


### PR DESCRIPTION
## Problem

The 3.9 site's homepage badge announces **"Generative UI on Lynx with A2UI"** (2026-06-08). It has never announced 3.9.

This branch was cut before the 3.9 post landed, and blog posts are never backported, so this build's own copy of the blog stops at the cut — `/3.9/blog/` is missing both `lynx-3-9` and `lynx-rspack-2`. The badge picks the newest of what's left.

## Changes

**The badge reads the canonical blog.** It took the newest post from `usePages()` — this build's bundled page data. It now reads the first entry of the developing build's RSS feed, which is same-origin from every version.

The feed carries `title` rather than `badge_text`, so the badge shows the full post title. Deliberate trade: naming the right release matters more than the shorter wording. The local result stays the fallback while the feed is in flight and if it can't be read, so the badge always renders. A pinned `filename` or an `externalLink` is left alone.

**The badge is now single-line.** Those titles are much longer than the `badge_text` this build was showing (`Lynx 3.9: Autolink, Web-Aligned CSS, and ReactLynx Portal` vs `Lynx 3.5 is released!`), so this brings over the treatment from `main`: block + line-height centering with `text-overflow: ellipsis`, and the padding written as a shorthand so Rspress's own `padding: .5rem 1rem` leaves no vertical remainder to throw the centering off. Without this the long title wraps out of the fixed-height pill.

**One source of truth for the blog's base.** Blog links on this branch already point at the developing version by hand — `theme/index.tsx` and `src/lib/utils.ts` each hardcoded `/next`. They now read the same `BLOG_BASE` the badge does, derived from `version.json`'s `developing` entry.

Deliberately *not* changed: `theme/index.tsx` keeps rendering a plain anchor for blog links. That is correct here and must stay — this build's base is `/3.9` (its assets are served from `/3.9/static/...`), so routing a `/next/blog/...` href through `BaseLink` would emit `/3.9/next/blog/...` and intercept the click into a route that doesn't exist here.

## Verification

The mechanism was verified end-to-end on `main` against a build configured to look like this one (base `/3.9`, blog cross-version), driving a real browser with the **real** `/next/` feeds served through request interception:

| scenario | badge text | click target |
|---|---|---|
| en, feed ok | `Lynx 3.9: Autolink, Web-Aligned CSS, and ReactLynx Portal` | `/next/blog/lynx-3-9` |
| zh, feed ok | `Lynx 3.9：Autolink、更贴近 Web 的 CSS、ReactLynx Portal` | `/next/zh/blog/lynx-3-9` |
| feed returns 500 | local fallback | `/next/blog/lynx-3-9` |
| feed returns malformed XML | local fallback | `/next/blog/lynx-3-9` |

On this branch: `tsc --noEmit` introduces no new errors over the unmodified branch (2 pre-existing in `theme/index.tsx`, unchanged). A full production build was run on the `main` counterpart, not here — CI covers this one.

## Related

- #1266 — the `main` counterpart.
- #1270 — the same fix for `release/4.0`, which additionally has to undo a per-version blog base this branch never picked up.

---
_Generated by [Claude Code](https://claude.ai/code/session_017UqU8yvoJn5uGFj9wF6KeC)_