### PR TITLE
fix(home): drop the canonical blog result when its inputs change

### DIFF
--- a/src/hooks/use-canonical-latest-blog.ts
+++ b/src/hooks/use-canonical-latest-blog.ts
@@ -79,6 +79,12 @@ export const useCanonicalLatestBlog = (
   const skip = !BLOG_IS_CROSS_VERSION || pinned;
 
   useEffect(() => {
+    // Anything already fetched belongs to the previous language (or to a
+    // config that has since pinned a post), so drop it before deciding what
+    // to do — otherwise switching locale keeps announcing the old locale's
+    // title until the new feed lands, and a newly pinned post never wins.
+    setCanonical(null);
+
     if (skip) return;
 
     const controller = new AbortController();


### PR DESCRIPTION
Follow-up to #1270, which merged before this came back from review.

`canonical` outlived the language it was fetched for. The locale switcher is a client-side navigation, so `lang` changes without a remount and the badge kept announcing the previous locale's title until the new feed (~750KB) resolved. A config that pins a post — which skips the fetch entirely — also never displaced an already-fetched result.

Clearing the state as the effect re-runs means the local fallback covers that window instead.

Reported by CodeRabbit on #1266; the same change is in #1266 (main, `eb06130f`) and #1272 (`release/3.9`).

---
_Generated by [Claude Code](https://claude.ai/code/session_017UqU8yvoJn5uGFj9wF6KeC)_