### PR TITLE
docs(desktop): element backgrounds occlude native views; detaching is an alternative to cover-view

### DIFF
--- a/docs/en/api/elements/built-in/cover-view.mdx
+++ b/docs/en/api/elements/built-in/cover-view.mdx
@@ -13,6 +13,8 @@ import { APISummary, APITable, ClayMacOSOnly, ClayWindowsOnly } from '@lynx';
 
 For overlays that only need to cover other Clay-rendered content, prefer a regular `<view>` with `position: fixed`.
 
+This includes surfaces that *replace* a native view rather than float over it. Detach the platform control while the surface is up and there is nothing left to cover, so a regular `<view>` is enough and no platform overlay is needed.
+
 ## Usage
 
 Position and size `<cover-view>` with the same CSS layout properties used by `<view>`. Its children are rendered into the platform overlay surface within those bounds.

--- a/docs/en/guide/custom-native-component/custom-component-desktop.mdx
+++ b/docs/en/guide/custom-native-component/custom-component-desktop.mdx
@@ -132,6 +132,10 @@ The Native UI rendering backend attaches a platform control and updates its layo
 
 :::tip Covering native views or child windows
 Platform views or child windows attached by the Native UI backend are placed above Clay's main rendering surface, so regular Lynx `z-index` cannot reliably cover them. Keep the platform control inside the renderer host returned for its `lynx_view_t`, and place overlapping Lynx content inside a [`<cover-view>`](/api/elements/built-in/cover-view). If the UI requires arbitrary clipping, transforms, or interleaving with regular Lynx content, use the Texture backend instead.
+
+Ordinary element backgrounds also hide the control. Clay promotes a `background-color` to its own layer and the platform control composites below all of them, so a background on **any** element whose box overlaps the control covers it — including the application root, which is an ordinary element and not the render tree's root. Attachment, layout and content all stay correct while the region renders blank, which makes this read as a compositing failure rather than a paint order.
+
+Give the host window the background instead, and keep element backgrounds on nodes that do not overlap the control. The window is the only surface below both Lynx content and the platform control.
 :::
 
 <Tabs groupId="custom-component-desktop-native-ui-platform">

--- a/docs/zh/api/elements/built-in/cover-view.mdx
+++ b/docs/zh/api/elements/built-in/cover-view.mdx
@@ -13,6 +13,8 @@ import { APISummary, APITable, ClayMacOSOnly, ClayWindowsOnly } from '@lynx';
 
 如果浮层只需要覆盖其他由 Clay 渲染的内容，请优先使用设置了 `position: fixed` 的普通 `<view>`。
 
+这也包括那些**取代**原生视图（而非浮于其上）的界面：在它显示期间移除对应的平台控件，就没有需要覆盖的内容了，此时普通 `<view>` 已经足够，不需要平台覆盖层。
+
 ## 用法
 
 可以使用与 `<view>` 相同的 CSS 布局属性设置 `<cover-view>` 的位置和尺寸。它的子节点会在对应范围内渲染到平台覆盖层中。

--- a/docs/zh/guide/custom-native-component/custom-component-desktop.mdx
+++ b/docs/zh/guide/custom-native-component/custom-component-desktop.mdx
@@ -132,6 +132,10 @@ Native UI 渲染后端会挂载一个平台控件，并在 `OnLayoutChanged` 中
 
 :::tip 覆盖原生视图或子窗口
 Native UI 后端挂载的平台视图或子窗口位于 Clay 主渲染表面之上，因此普通 Lynx `z-index` 无法可靠地覆盖它们。应将平台控件保留在对应 `lynx_view_t` 返回的 renderer 宿主中，并将需要重叠显示的 Lynx 内容放入 [`<cover-view>`](/zh/api/elements/built-in/cover-view)。如果界面需要任意裁剪、变换，或与普通 Lynx 内容交错，请改用 Texture 后端。
+
+普通元素的背景同样会遮挡平台控件。Clay 会把 `background-color` 提升为独立图层，而平台控件合成于所有这些图层之下；因此**任何**盒子与该控件重叠的元素，只要设置了背景色，就会把它遮住 —— 包括应用的根元素，它只是一个普通元素，并非渲染树的根。此时挂载、布局和内容都是正确的，但该区域是空白的，很容易被误判为合成失败，而实际上只是绘制顺序。
+
+应改为由宿主窗口提供背景色，并只在不与该控件重叠的节点上设置元素背景。窗口是唯一同时位于 Lynx 内容与平台控件之下的表面。
 :::
 
 <Tabs groupId="custom-component-desktop-native-ui-platform">


### PR DESCRIPTION
Two gaps found while embedding a native editor (Scintilla) in a Lynxtron desktop app on Lynx 4.1 / Clay macOS. Each cost real debugging time, and neither is derivable from what the pages say today.

## 1. Element backgrounds hide the platform control

`custom-component-desktop` already says `z-index` cannot reliably interleave Lynx content with a Native UI control. That reads as *"you cannot put Lynx content above it"*. The sharper problem is the reverse — **a `background-color` on any element whose box overlaps the control hides the control entirely**, because Clay promotes the background to its own layer and the platform control composites below all of them.

That includes the **application root**, which is an ordinary element rather than the render tree's root — and which is exactly where an app is tempted to put its ground colour.

What makes this expensive is how it presents:

- attachment succeeds
- `OnLayoutChanged` reports the correct rect
- content is in the document and readable back
- the region is blank

Every signal says the control is healthy, so it reads as a compositor bug. In our case it survived a `git bisect` pointing at an unrelated commit, and I was about to file an engine issue against it.

Worse, putting the ground on the app root *looks* like a fix: it renders on some launches and not others, because it is a layer-order race. Only moving the background to the **host window** — the one surface below both Lynx content and the control — is stable.

The added note states the rule and where the background belongs.

## 2. Detaching is an alternative to `<cover-view>`

`cover-view` already recommends a plain `<view>` with `position: fixed` when the overlay only needs to cover Clay-rendered content. It stops one step short for a surface that **replaces** a native view rather than floating over it: detach the platform control while that surface is up, and there is nothing left to cover — so a regular `<view>` is enough and no platform overlay is needed.

This is not a micro-optimization. A full-page surface that takes over from an embedded editor is a common shape, and routing it through a platform overlay costs behaviour it does not need. The added sentence is what points a reader at the cheaper path.

## Notes

- Both changes are in `en` and `zh`.
- Documentation only; no code or compat-data changes.
- Related behaviours we also measured are *not* in this PR because they look like defects rather than contracts, and documenting them would risk freezing them — they are filed separately against `lynx-family/lynxtron`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Clarify how element and application-root backgrounds can occlude native controls, and recommend using the host window background.
- Explain when to detach native controls and use `<view>` instead of `<cover-view>`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->