### PR TITLE
docs: update Autolink compatibility versions

### DIFF
--- a/packages/lynx-compat-data/features/autolink.json
+++ b/packages/lynx-compat-data/features/autolink.json
@@ -6,10 +6,10 @@
         "lynx_path": "guide/autolink",
         "support": {
           "android": {
-            "version_added": "4.0.1"
+            "version_added": "4.0"
           },
           "ios": {
-            "version_added": "4.0.1"
+            "version_added": "4.0"
           },
           "harmony": {
             "version_added": false


### PR DESCRIPTION
## Summary

- Set the Android and iOS Autolink compatibility baseline to Lynx 4.0.
- Keep the installation examples on the published Autolink plugin version 4.0.1 while the compatibility table reports the Lynx release boundary.

## Validation

- Compatibility data schema and key validation
- Compatibility data tests (10 passed)
- Compatibility statistics generation and package build
- Documentation, spelling, Chinese prose, and formatting checks
- Full website build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Set Android and iOS Autolink compatibility to Lynx `4.0`.
- Keep installation examples on Autolink plugin version `4.0.1`.
- Align the compatibility table with the Lynx `4.0` release boundary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->