### PR TITLE
fix(compat-data): mark GetComputedStyleProperty and querySelector(All) as supported on web

### DIFF
--- a/packages/lynx-compat-data/api-stats.json
+++ b/packages/lynx-compat-data/api-stats.json
@@ -261,7 +261,7 @@
           "android": 45,
           "ios": 45,
           "harmony": 40,
-          "web_lynx": 10,
+          "web_lynx": 12,
           "clay_android": 1,
           "clay_ios": 1,
           "clay_macos": 45,
@@ -272,7 +272,7 @@
           "android": 100,
           "ios": 100,
           "harmony": 89,
-          "web_lynx": 22,
+          "web_lynx": 27,
           "clay_android": 2,
           "clay_ios": 2,
           "clay_macos": 100,
@@ -405,7 +405,7 @@
           "android": 18,
           "ios": 18,
           "harmony": 11,
-          "web_lynx": 13,
+          "web_lynx": 17,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 18,
@@ -416,7 +416,7 @@
           "android": 100,
           "ios": 100,
           "harmony": 61,
-          "web_lynx": 72,
+          "web_lynx": 94,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 100,
@@ -633,8 +633,8 @@
         "exclusive_count": 7
       },
       "web_lynx": {
-        "supported_count": 726,
-        "coverage_percent": 64,
+        "supported_count": 732,
+        "coverage_percent": 65,
         "exclusive_count": 30
       },
       "clay_android": {
@@ -48771,7 +48771,7 @@
           "android": 45,
           "ios": 45,
           "harmony": 40,
-          "web_lynx": 10,
+          "web_lynx": 12,
           "clay_android": 1,
           "clay_ios": 1,
           "clay_macos": 45,
@@ -48782,7 +48782,7 @@
           "android": 100,
           "ios": 100,
           "harmony": 89,
-          "web_lynx": 22,
+          "web_lynx": 27,
           "clay_android": 2,
           "clay_ios": 2,
           "clay_macos": 100,
@@ -49273,7 +49273,7 @@
             "android": "2.14",
             "ios": "2.14",
             "harmony": "3.4",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -49289,7 +49289,7 @@
             "android": "2.14",
             "ios": "2.14",
             "harmony": "3.4",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -50009,38 +50009,6 @@
             }
           },
           {
-            "path": "lynx-api/lynx/querySelector",
-            "name": "querySelector",
-            "doc_url": "api/lynx-api/main-thread/lynx-query-selector",
-            "support": {
-              "android": "2.14",
-              "ios": "2.14",
-              "harmony": "3.4",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
-            "path": "lynx-api/lynx/querySelectorAll",
-            "name": "querySelectorAll",
-            "doc_url": "api/lynx-api/main-thread/lynx-query-selector-all",
-            "support": {
-              "android": "2.14",
-              "ios": "2.14",
-              "harmony": "3.4",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
             "path": "lynx-api/lynx/registerModule",
             "name": "registerModule",
             "doc_url": "api/lynx-api/lynx/lynx-register-module",
@@ -50626,7 +50594,7 @@
               "android": "2.14",
               "ios": "2.14",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -50642,7 +50610,7 @@
               "android": "2.14",
               "ios": "2.14",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -51332,7 +51300,7 @@
               "android": "2.14",
               "ios": "2.14",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -51348,7 +51316,7 @@
               "android": "2.14",
               "ios": "2.14",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -53746,7 +53714,7 @@
           "android": 18,
           "ios": 18,
           "harmony": 11,
-          "web_lynx": 13,
+          "web_lynx": 17,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 18,
@@ -53757,7 +53725,7 @@
           "android": 100,
           "ios": 100,
           "harmony": 61,
-          "web_lynx": 72,
+          "web_lynx": 94,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 100,
@@ -53837,7 +53805,7 @@
             "android": "3.5",
             "ios": "3.5",
             "harmony": "3.5",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.7",
@@ -53997,7 +53965,7 @@
             "android": "3.5",
             "ios": "3.5",
             "harmony": "3.5",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.7",
@@ -54029,7 +53997,7 @@
             "android": "2.14",
             "ios": "2.14",
             "harmony": "3.4",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.7",
@@ -54045,7 +54013,7 @@
             "android": "2.14",
             "ios": "2.14",
             "harmony": "3.4",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.7",
@@ -54205,73 +54173,9 @@
         ],
         "web_lynx": [
           {
-            "path": "lynx-api/main-thread/Element.Element.getComputedStyleProperty",
-            "name": "getComputedStyleProperty",
-            "doc_url": "api/lynx-api/main-thread/element-get-computed-style",
-            "support": {
-              "android": "3.5",
-              "ios": "3.5",
-              "harmony": "3.5",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.7",
-              "clay_windows": "3.7",
-              "clay": "3.7"
-            }
-          },
-          {
-            "path": "lynx-api/main-thread/MainThread-APIs.Element.getComputedStyleProperty",
-            "name": "getComputedStyleProperty",
-            "doc_url": "api/lynx-api/main-thread/element-get-computed-style",
-            "support": {
-              "android": "3.5",
-              "ios": "3.5",
-              "harmony": "3.5",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.7",
-              "clay_windows": "3.7",
-              "clay": "3.7"
-            }
-          },
-          {
             "path": "lynx-api/main-thread/MainThread-APIs.lynx.getTextInfo",
             "name": "getTextInfo",
             "doc_url": "api/lynx-api/main-thread/lynx-get-text-info",
-            "support": {
-              "android": "2.14",
-              "ios": "2.14",
-              "harmony": "3.4",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.7",
-              "clay_windows": "3.7",
-              "clay": "3.7"
-            }
-          },
-          {
-            "path": "lynx-api/main-thread/MainThread-APIs.lynx.querySelector",
-            "name": "querySelector",
-            "doc_url": "api/lynx-api/main-thread/lynx-query-selector",
-            "support": {
-              "android": "2.14",
-              "ios": "2.14",
-              "harmony": "3.4",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.7",
-              "clay_windows": "3.7",
-              "clay": "3.7"
-            }
-          },
-          {
-            "path": "lynx-api/main-thread/MainThread-APIs.lynx.querySelectorAll",
-            "name": "querySelectorAll",
-            "doc_url": "api/lynx-api/main-thread/lynx-query-selector-all",
             "support": {
               "android": "2.14",
               "ios": "2.14",
@@ -54326,7 +54230,7 @@
               "android": "3.5",
               "ios": "3.5",
               "harmony": "3.5",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.7",
@@ -54486,7 +54390,7 @@
               "android": "3.5",
               "ios": "3.5",
               "harmony": "3.5",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.7",
@@ -54518,7 +54422,7 @@
               "android": "2.14",
               "ios": "2.14",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.7",
@@ -54534,7 +54438,7 @@
               "android": "2.14",
               "ios": "2.14",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.7",
@@ -54616,7 +54520,7 @@
               "android": "3.5",
               "ios": "3.5",
               "harmony": "3.5",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.7",
@@ -54776,7 +54680,7 @@
               "android": "3.5",
               "ios": "3.5",
               "harmony": "3.5",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.7",
@@ -54808,7 +54712,7 @@
               "android": "2.14",
               "ios": "2.14",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.7",
@@ -54824,7 +54728,7 @@
               "android": "2.14",
               "ios": "2.14",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.7",
@@ -110738,7 +110642,7 @@
           "version_added": "3.4"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -110774,7 +110678,7 @@
           "version_added": "3.4"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -112754,7 +112658,7 @@
           "version_added": "3.5"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -113114,7 +113018,7 @@
           "version_added": "3.5"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -113186,7 +113090,7 @@
           "version_added": "3.4"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -113222,7 +113126,7 @@
           "version_added": "3.4"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -121108,8 +121012,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 692,
-          "coverage": 61
+          "supported": 698,
+          "coverage": 62
         },
         "clay_android": {
           "supported": 222,
@@ -121150,8 +121054,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 692,
-          "coverage": 61
+          "supported": 698,
+          "coverage": 62
         },
         "clay_android": {
           "supported": 234,
@@ -121192,8 +121096,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 692,
-          "coverage": 61
+          "supported": 698,
+          "coverage": 62
         },
         "clay_android": {
           "supported": 385,
@@ -121234,8 +121138,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 692,
-          "coverage": 61
+          "supported": 698,
+          "coverage": 62
         },
         "clay_android": {
           "supported": 391,
@@ -121276,8 +121180,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 692,
-          "coverage": 61
+          "supported": 698,
+          "coverage": 62
         },
         "clay_android": {
           "supported": 403,
@@ -121318,8 +121222,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 692,
-          "coverage": 61
+          "supported": 698,
+          "coverage": 62
         },
         "clay_android": {
           "supported": 454,
@@ -121360,8 +121264,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 692,
-          "coverage": 61
+          "supported": 698,
+          "coverage": 62
         },
         "clay_android": {
           "supported": 466,
@@ -121402,8 +121306,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 692,
-          "coverage": 61
+          "supported": 698,
+          "coverage": 62
         },
         "clay_android": {
           "supported": 466,
@@ -121444,8 +121348,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 692,
-          "coverage": 61
+          "supported": 698,
+          "coverage": 62
         },
         "clay_android": {
           "supported": 466,
@@ -121486,8 +121390,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 692,
-          "coverage": 61
+          "supported": 698,
+          "coverage": 62
         },
         "clay_android": {
           "supported": 466,
@@ -121528,8 +121432,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 692,
-          "coverage": 61
+          "supported": 698,
+          "coverage": 62
         },
         "clay_android": {
           "supported": 467,
@@ -121570,8 +121474,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 692,
-          "coverage": 61
+          "supported": 698,
+          "coverage": 62
         },
         "clay_android": {
           "supported": 469,
@@ -121612,8 +121516,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 692,
-          "coverage": 61
+          "supported": 698,
+          "coverage": 62
         },
         "clay_android": {
           "supported": 469,
@@ -121654,8 +121558,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 692,
-          "coverage": 61
+          "supported": 698,
+          "coverage": 62
         },
         "clay_android": {
           "supported": 469,
@@ -121696,8 +121600,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 692,
-          "coverage": 61
+          "supported": 698,
+          "coverage": 62
         },
         "clay_android": {
           "supported": 469,
@@ -121738,8 +121642,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 692,
-          "coverage": 61
+          "supported": 698,
+          "coverage": 62
         },
         "clay_android": {
           "supported": 469,
@@ -121780,8 +121684,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 692,
-          "coverage": 61
+          "supported": 698,
+          "coverage": 62
         },
         "clay_android": {
           "supported": 470,
@@ -121822,8 +121726,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 692,
-          "coverage": 61
+          "supported": 698,
+          "coverage": 62
         },
         "clay_android": {
           "supported": 470,
@@ -121864,8 +121768,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 692,
-          "coverage": 61
+          "supported": 698,
+          "coverage": 62
         },
         "clay_android": {
           "supported": 490,
@@ -121906,8 +121810,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 692,
-          "coverage": 61
+          "supported": 698,
+          "coverage": 62
         },
         "clay_android": {
           "supported": 490,
@@ -121948,8 +121852,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 692,
-          "coverage": 61
+          "supported": 698,
+          "coverage": 62
         },
         "clay_android": {
           "supported": 496,
@@ -121990,8 +121894,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 692,
-          "coverage": 61
+          "supported": 698,
+          "coverage": 62
         },
         "clay_android": {
           "supported": 496,
@@ -122032,8 +121936,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 692,
-          "coverage": 61
+          "supported": 698,
+          "coverage": 62
         },
         "clay_android": {
           "supported": 507,
@@ -122074,8 +121978,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 692,
-          "coverage": 61
+          "supported": 698,
+          "coverage": 62
         },
         "clay_android": {
           "supported": 511,
@@ -122116,8 +122020,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 692,
-          "coverage": 61
+          "supported": 698,
+          "coverage": 62
         },
         "clay_android": {
           "supported": 511,
@@ -122158,8 +122062,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 692,
-          "coverage": 61
+          "supported": 698,
+          "coverage": 62
         },
         "clay_android": {
           "supported": 516,
@@ -122200,8 +122104,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 692,
-          "coverage": 61
+          "supported": 698,
+          "coverage": 62
         },
         "clay_android": {
           "supported": 516,
@@ -122242,8 +122146,8 @@
           "coverage": 59
         },
         "web_lynx": {
-          "supported": 692,
-          "coverage": 61
+          "supported": 698,
+          "coverage": 62
         },
         "clay_android": {
           "supported": 544,
@@ -122284,8 +122188,8 @@
           "coverage": 65
         },
         "web_lynx": {
-          "supported": 692,
-          "coverage": 61
+          "supported": 698,
+          "coverage": 62
         },
         "clay_android": {
           "supported": 561,
@@ -122326,8 +122230,8 @@
           "coverage": 67
         },
         "web_lynx": {
-          "supported": 692,
-          "coverage": 61
+          "supported": 698,
+          "coverage": 62
         },
         "clay_android": {
           "supported": 568,
@@ -122368,8 +122272,8 @@
           "coverage": 70
         },
         "web_lynx": {
-          "supported": 692,
-          "coverage": 61
+          "supported": 698,
+          "coverage": 62
         },
         "clay_android": {
           "supported": 576,
@@ -122410,7 +122314,7 @@
           "coverage": 72
         },
         "web_lynx": {
-          "supported": 700,
+          "supported": 706,
           "coverage": 62
         },
         "clay_android": {
@@ -122452,7 +122356,7 @@
           "coverage": 74
         },
         "web_lynx": {
-          "supported": 720,
+          "supported": 726,
           "coverage": 64
         },
         "clay_android": {
@@ -122494,7 +122398,7 @@
           "coverage": 75
         },
         "web_lynx": {
-          "supported": 720,
+          "supported": 726,
           "coverage": 64
         },
         "clay_android": {

--- a/packages/lynx-compat-data/api-stats.json
+++ b/packages/lynx-compat-data/api-stats.json
@@ -405,7 +405,7 @@
           "android": 18,
           "ios": 18,
           "harmony": 11,
-          "web_lynx": 12,
+          "web_lynx": 13,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 18,
@@ -416,7 +416,7 @@
           "android": 100,
           "ios": 100,
           "harmony": 61,
-          "web_lynx": 67,
+          "web_lynx": 72,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 100,
@@ -633,7 +633,7 @@
         "exclusive_count": 7
       },
       "web_lynx": {
-        "supported_count": 725,
+        "supported_count": 726,
         "coverage_percent": 64,
         "exclusive_count": 30
       },
@@ -53746,7 +53746,7 @@
           "android": 18,
           "ios": 18,
           "harmony": 11,
-          "web_lynx": 12,
+          "web_lynx": 13,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 18,
@@ -53757,7 +53757,7 @@
           "android": 100,
           "ios": 100,
           "harmony": 61,
-          "web_lynx": 67,
+          "web_lynx": 72,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 100,
@@ -53933,7 +53933,7 @@
             "android": "3.5",
             "ios": "3.5",
             "harmony": "3.5",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.7",
@@ -54221,22 +54221,6 @@
             }
           },
           {
-            "path": "lynx-api/main-thread/ElementGetComputedStyle",
-            "name": "Create An Animation in MTS",
-            "doc_url": "api/lynx-api/main-thread/ElementGetComputedStyle",
-            "support": {
-              "android": "3.5",
-              "ios": "3.5",
-              "harmony": "3.5",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.7",
-              "clay_windows": "3.7",
-              "clay": "3.7"
-            }
-          },
-          {
             "path": "lynx-api/main-thread/MainThread-APIs.Element.getComputedStyleProperty",
             "name": "getComputedStyleProperty",
             "doc_url": "api/lynx-api/main-thread/element-get-computed-style",
@@ -54438,7 +54422,7 @@
               "android": "3.5",
               "ios": "3.5",
               "harmony": "3.5",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.7",
@@ -54728,7 +54712,7 @@
               "android": "3.5",
               "ios": "3.5",
               "harmony": "3.5",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.7",
@@ -112986,7 +112970,7 @@
           "version_added": "3.5"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -121124,7 +121108,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 691,
+          "supported": 692,
           "coverage": 61
         },
         "clay_android": {
@@ -121166,7 +121150,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 691,
+          "supported": 692,
           "coverage": 61
         },
         "clay_android": {
@@ -121208,7 +121192,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 691,
+          "supported": 692,
           "coverage": 61
         },
         "clay_android": {
@@ -121250,7 +121234,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 691,
+          "supported": 692,
           "coverage": 61
         },
         "clay_android": {
@@ -121292,7 +121276,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 691,
+          "supported": 692,
           "coverage": 61
         },
         "clay_android": {
@@ -121334,7 +121318,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 691,
+          "supported": 692,
           "coverage": 61
         },
         "clay_android": {
@@ -121376,7 +121360,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 691,
+          "supported": 692,
           "coverage": 61
         },
         "clay_android": {
@@ -121418,7 +121402,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 691,
+          "supported": 692,
           "coverage": 61
         },
         "clay_android": {
@@ -121460,7 +121444,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 691,
+          "supported": 692,
           "coverage": 61
         },
         "clay_android": {
@@ -121502,7 +121486,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 691,
+          "supported": 692,
           "coverage": 61
         },
         "clay_android": {
@@ -121544,7 +121528,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 691,
+          "supported": 692,
           "coverage": 61
         },
         "clay_android": {
@@ -121586,7 +121570,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 691,
+          "supported": 692,
           "coverage": 61
         },
         "clay_android": {
@@ -121628,7 +121612,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 691,
+          "supported": 692,
           "coverage": 61
         },
         "clay_android": {
@@ -121670,7 +121654,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 691,
+          "supported": 692,
           "coverage": 61
         },
         "clay_android": {
@@ -121712,7 +121696,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 691,
+          "supported": 692,
           "coverage": 61
         },
         "clay_android": {
@@ -121754,7 +121738,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 691,
+          "supported": 692,
           "coverage": 61
         },
         "clay_android": {
@@ -121796,7 +121780,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 691,
+          "supported": 692,
           "coverage": 61
         },
         "clay_android": {
@@ -121838,7 +121822,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 691,
+          "supported": 692,
           "coverage": 61
         },
         "clay_android": {
@@ -121880,7 +121864,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 691,
+          "supported": 692,
           "coverage": 61
         },
         "clay_android": {
@@ -121922,7 +121906,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 691,
+          "supported": 692,
           "coverage": 61
         },
         "clay_android": {
@@ -121964,7 +121948,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 691,
+          "supported": 692,
           "coverage": 61
         },
         "clay_android": {
@@ -122006,7 +121990,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 691,
+          "supported": 692,
           "coverage": 61
         },
         "clay_android": {
@@ -122048,7 +122032,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 691,
+          "supported": 692,
           "coverage": 61
         },
         "clay_android": {
@@ -122090,7 +122074,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 691,
+          "supported": 692,
           "coverage": 61
         },
         "clay_android": {
@@ -122132,7 +122116,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 691,
+          "supported": 692,
           "coverage": 61
         },
         "clay_android": {
@@ -122174,7 +122158,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 691,
+          "supported": 692,
           "coverage": 61
         },
         "clay_android": {
@@ -122216,7 +122200,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 691,
+          "supported": 692,
           "coverage": 61
         },
         "clay_android": {
@@ -122258,7 +122242,7 @@
           "coverage": 59
         },
         "web_lynx": {
-          "supported": 691,
+          "supported": 692,
           "coverage": 61
         },
         "clay_android": {
@@ -122300,7 +122284,7 @@
           "coverage": 65
         },
         "web_lynx": {
-          "supported": 691,
+          "supported": 692,
           "coverage": 61
         },
         "clay_android": {
@@ -122342,7 +122326,7 @@
           "coverage": 67
         },
         "web_lynx": {
-          "supported": 691,
+          "supported": 692,
           "coverage": 61
         },
         "clay_android": {
@@ -122384,7 +122368,7 @@
           "coverage": 70
         },
         "web_lynx": {
-          "supported": 691,
+          "supported": 692,
           "coverage": 61
         },
         "clay_android": {
@@ -122426,7 +122410,7 @@
           "coverage": 72
         },
         "web_lynx": {
-          "supported": 699,
+          "supported": 700,
           "coverage": 62
         },
         "clay_android": {
@@ -122468,8 +122452,8 @@
           "coverage": 74
         },
         "web_lynx": {
-          "supported": 719,
-          "coverage": 63
+          "supported": 720,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 598,
@@ -122510,8 +122494,8 @@
           "coverage": 75
         },
         "web_lynx": {
-          "supported": 719,
-          "coverage": 63
+          "supported": 720,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 625,

--- a/packages/lynx-compat-data/lynx-api/lynx/querySelector.json
+++ b/packages/lynx-compat-data/lynx-api/lynx/querySelector.json
@@ -27,7 +27,8 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Implemented since `@lynx-js/web-core@0.19.6` (lynx-family/lynx-stack#2115)."
             }
           }
         }

--- a/packages/lynx-compat-data/lynx-api/lynx/querySelector.json
+++ b/packages/lynx-compat-data/lynx-api/lynx/querySelector.json
@@ -27,7 +27,7 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             }
           }
         }

--- a/packages/lynx-compat-data/lynx-api/lynx/querySelectorAll.json
+++ b/packages/lynx-compat-data/lynx-api/lynx/querySelectorAll.json
@@ -27,7 +27,8 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Implemented since `@lynx-js/web-core@0.20.0` (lynx-family/lynx-stack#2382)."
             }
           }
         }

--- a/packages/lynx-compat-data/lynx-api/lynx/querySelectorAll.json
+++ b/packages/lynx-compat-data/lynx-api/lynx/querySelectorAll.json
@@ -27,7 +27,7 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             }
           }
         }

--- a/packages/lynx-compat-data/lynx-api/main-thread/Element.json
+++ b/packages/lynx-compat-data/lynx-api/main-thread/Element.json
@@ -85,7 +85,7 @@
                 "version_added": "3.7"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": true
               }
             }
           }

--- a/packages/lynx-compat-data/lynx-api/main-thread/Element.json
+++ b/packages/lynx-compat-data/lynx-api/main-thread/Element.json
@@ -85,7 +85,8 @@
                 "version_added": "3.7"
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": true,
+                "notes": "Implemented since `@lynx-js/web-core@0.23.1` (lynx-family/lynx-stack#3262)."
               }
             }
           }

--- a/packages/lynx-compat-data/lynx-api/main-thread/ElementGetComputedStyle.json
+++ b/packages/lynx-compat-data/lynx-api/main-thread/ElementGetComputedStyle.json
@@ -26,7 +26,8 @@
               "version_added": "3.7"
             },
             "web_lynx": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Implemented since `@lynx-js/web-core@0.23.1` (lynx-family/lynx-stack#3262)."
             }
           }
         }

--- a/packages/lynx-compat-data/lynx-api/main-thread/ElementGetComputedStyle.json
+++ b/packages/lynx-compat-data/lynx-api/main-thread/ElementGetComputedStyle.json
@@ -26,7 +26,7 @@
               "version_added": "3.7"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             }
           }
         }

--- a/packages/lynx-compat-data/lynx-api/main-thread/MainThread-APIs.json
+++ b/packages/lynx-compat-data/lynx-api/main-thread/MainThread-APIs.json
@@ -116,7 +116,7 @@
                 "version_added": "3.7"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": true
               }
             }
           }
@@ -176,7 +176,7 @@
                 "version_added": "3.7"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": true
               }
             }
           }
@@ -206,7 +206,7 @@
                 "version_added": "3.7"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": true
               }
             }
           }

--- a/packages/lynx-compat-data/lynx-api/main-thread/MainThread-APIs.json
+++ b/packages/lynx-compat-data/lynx-api/main-thread/MainThread-APIs.json
@@ -116,7 +116,8 @@
                 "version_added": "3.7"
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": true,
+                "notes": "Implemented since `@lynx-js/web-core@0.23.1` (lynx-family/lynx-stack#3262)."
               }
             }
           }
@@ -176,7 +177,8 @@
                 "version_added": "3.7"
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": true,
+                "notes": "Implemented since `@lynx-js/web-core@0.19.6` (lynx-family/lynx-stack#2115)."
               }
             }
           }
@@ -206,7 +208,8 @@
                 "version_added": "3.7"
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": true,
+                "notes": "Implemented since `@lynx-js/web-core@0.20.0` (lynx-family/lynx-stack#2382)."
               }
             }
           }


### PR DESCRIPTION
## What

Two main-thread API surfaces are marked `web_lynx: { version_added: false }` in compat-data, but web-core (plus ReactLynx's worklet-runtime layer) implements and tests both. Verified against `lynx-family/lynx-stack@5fbabb8`.

### 1. `Element.getComputedStyleProperty()`

- Client (main thread): `__GetComputedStyleByKey` at `web-core/ts/client/mainthread/elementAPIs/pureElementPAPIs.ts:129`, via `Element.getComputedStyle(...).getPropertyValue(key)`. Tested at `web-core/tests/element-apis.spec.ts:415-441`.
- SSR intentionally stubs it (`server/elementAPIs/createElementAPI.ts:188`, `() => ''`), since SSR has neither layout nor cascade resolution — also covered by a test at `:2096`.

### 2. `lynx.querySelector()` / `lynx.querySelectorAll()`

- `__QuerySelector` / `__QuerySelectorAll` at `pureElementPAPIs.ts:232,240`, with `__GetPageElement` backing the page root.
- ReactLynx's worklet-runtime wires them onto the main-thread `lynx` global at `packages/react/runtime/src/worklet-runtime/api/lynxApi.ts:9,11` (via `lepusQuerySelector.ts`) — the same mechanism already backing the existing `web_lynx: true` entry for `Element.animate`.
- Covered by an existing e2e test at `web-core-e2e/tests/reactlynx.spec.ts:442` (`basic-main-query-selector`), which calls `lynx.querySelector('#scroll-view')` from a main-thread tap handler and asserts the resulting scroll behavior.

## Changes

`web_lynx.version_added` → `true` in:

- `lynx-api/main-thread/ElementGetComputedStyle.json`
- `lynx-api/main-thread/Element.json` (`Element.getComputedStyleProperty` duplicate)
- `lynx-api/main-thread/MainThread-APIs.json` (index mirrors for all three)
- `lynx-api/lynx/querySelector.json`, `lynx-api/lynx/querySelectorAll.json`
- `api-stats.json`: regenerated (web_lynx coverage 725 → 732)

## Introduction floors recorded as provenance

`version_added: true` means "supported, exact version unknown", but these introduction points are recoverable from lynx-stack history, so the entries were under-specified rather than genuinely unknown. Each floor is recorded in `notes`, with `version_added` left as `true` — `platforms/web_lynx.json` still declares `"releases": {}`, so no npm version is written into the Lynx-engine version axis.

| Entry | Floor | Introduced by |
| --- | --- | --- |
| `lynx.querySelector` | `@lynx-js/web-core@0.19.6` | lynx-stack#2115 |
| `lynx.querySelectorAll` | `0.20.0` | lynx-stack#2382 |
| `Element.getComputedStyleProperty` | `0.23.1` | lynx-stack#3262 |

Derived from `git log -S` on the introducing PAPI symbol plus the earliest `@lynx-js/web-core` tag containing that commit, cross-checked against `web-core/CHANGELOG.md`. Applied to the canonical entries and their main-thread mirrors so the duplicates don't drift.

## Known gap, tracked separately

`__QuerySelector` is a raw `element.querySelector(selector)` with no Lynx→web tag normalization, while `constants.ts:93` maps `view` → `x-view`, so `lynx.querySelector('view')` won't match. This is pre-existing and dataset-wide rather than specific to these entries: `SelectorQuery.select` runs through the same `__QuerySelector` (`crossThreadHandlers/queryNodes.ts:72`) and its "`selector` parameter supporting `tag` selector" entry is already `web_lynx: true`. Marking only these partial would make the dataset less consistent, so it's filed as follow-up rather than blocking here.

## Testing

- `generate-css-from-defines.ts` then `generate-stats.ts` — `api-stats.json` reproduces byte-identically
- `validate.ts`, `lint-key-names.ts` — pass
- `vitest run` in `packages/lynx-compat-data` — 10/10
- Full `ci.yml` Validate job run locally: case-collision and asset-URL checks, `format:check`, `pnpm install --frozen-lockfile`, and `pnpm run build` (3087 pages) all green

Found via the weekly Lynx Web Platform gap audit.