### PR TITLE
fix(compat-data): flip web_lynx to true for already-implemented APIs

### DIFF
--- a/packages/lynx-compat-data/api-stats.json
+++ b/packages/lynx-compat-data/api-stats.json
@@ -153,7 +153,7 @@
           "android": 24,
           "ios": 24,
           "harmony": 24,
-          "web_lynx": 22,
+          "web_lynx": 23,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 24,
@@ -164,7 +164,7 @@
           "android": 100,
           "ios": 100,
           "harmony": 100,
-          "web_lynx": 92,
+          "web_lynx": 96,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 100,
@@ -189,7 +189,7 @@
           "android": 39,
           "ios": 39,
           "harmony": 39,
-          "web_lynx": 62,
+          "web_lynx": 63,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 66,
@@ -200,7 +200,7 @@
           "android": 58,
           "ios": 58,
           "harmony": 58,
-          "web_lynx": 93,
+          "web_lynx": 94,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 99,
@@ -261,7 +261,7 @@
           "android": 45,
           "ios": 45,
           "harmony": 40,
-          "web_lynx": 12,
+          "web_lynx": 20,
           "clay_android": 1,
           "clay_ios": 1,
           "clay_macos": 45,
@@ -272,7 +272,7 @@
           "android": 100,
           "ios": 100,
           "harmony": 89,
-          "web_lynx": 27,
+          "web_lynx": 44,
           "clay_android": 2,
           "clay_ios": 2,
           "clay_macos": 100,
@@ -633,7 +633,7 @@
         "exclusive_count": 7
       },
       "web_lynx": {
-        "supported_count": 732,
+        "supported_count": 742,
         "coverage_percent": 65,
         "exclusive_count": 30
       },
@@ -39606,7 +39606,7 @@
           "android": 24,
           "ios": 24,
           "harmony": 24,
-          "web_lynx": 22,
+          "web_lynx": 23,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 24,
@@ -39617,7 +39617,7 @@
           "android": 100,
           "ios": 100,
           "harmony": 100,
-          "web_lynx": 92,
+          "web_lynx": 96,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 100,
@@ -39703,7 +39703,7 @@
             "android": "2.4",
             "ios": "2.4",
             "harmony": "3.4",
-            "web_lynx": false,
+            "web_lynx": "1.0",
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -40068,22 +40068,6 @@
               "clay_windows": "3.5",
               "clay": "3.5"
             }
-          },
-          {
-            "path": "lynx-api/global/SystemInfo.SystemInfo.lynxSdkVersion",
-            "name": "lynxSdkVersion",
-            "doc_url": "api/lynx-api/global/system-info",
-            "support": {
-              "android": "2.4",
-              "ios": "2.4",
-              "harmony": "3.4",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
           }
         ],
         "clay_android": [
@@ -40127,7 +40111,7 @@
               "android": "2.4",
               "ios": "2.4",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": "1.0",
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -40513,7 +40497,7 @@
               "android": "2.4",
               "ios": "2.4",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": "1.0",
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -40882,7 +40866,7 @@
           "android": 39,
           "ios": 39,
           "harmony": 39,
-          "web_lynx": 62,
+          "web_lynx": 63,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 66,
@@ -40893,7 +40877,7 @@
           "android": 58,
           "ios": 58,
           "harmony": 58,
-          "web_lynx": 93,
+          "web_lynx": 94,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 99,
@@ -41838,7 +41822,7 @@
             "android": "1.5",
             "ios": "1.5",
             "harmony": "3.4",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -43440,22 +43424,6 @@
             }
           },
           {
-            "path": "lynx-api/event/TouchEvent.detail",
-            "name": "detail",
-            "doc_url": "api/lynx-api/event/touch-event",
-            "support": {
-              "android": "1.5",
-              "ios": "1.5",
-              "harmony": "3.4",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
             "path": "lynx-api/event/TouchEvent.longpress",
             "name": "longpress",
             "doc_url": "api/lynx-api/event/touch-event",
@@ -44345,7 +44313,7 @@
               "android": "1.5",
               "ios": "1.5",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -45419,7 +45387,7 @@
               "android": "1.5",
               "ios": "1.5",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -48771,7 +48739,7 @@
           "android": 45,
           "ios": 45,
           "harmony": 40,
-          "web_lynx": 12,
+          "web_lynx": 20,
           "clay_android": 1,
           "clay_ios": 1,
           "clay_macos": 45,
@@ -48782,7 +48750,7 @@
           "android": 100,
           "ios": 100,
           "harmony": 89,
-          "web_lynx": 27,
+          "web_lynx": 44,
           "clay_android": 2,
           "clay_ios": 2,
           "clay_macos": 100,
@@ -49033,7 +49001,7 @@
             "android": "1.6",
             "ios": "1.6",
             "harmony": "3.4",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -49161,7 +49129,7 @@
             "android": "2.3",
             "ios": "2.3",
             "harmony": "3.4",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -49193,7 +49161,7 @@
             "android": "3.3",
             "ios": "3.3",
             "harmony": false,
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -49209,7 +49177,7 @@
             "android": "3.3",
             "ios": "3.3",
             "harmony": false,
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -49225,7 +49193,7 @@
             "android": "3.3",
             "ios": "3.3",
             "harmony": false,
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -49241,7 +49209,7 @@
             "android": "3.3",
             "ios": "3.3",
             "harmony": false,
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -49257,7 +49225,7 @@
             "android": "3.3",
             "ios": "3.3",
             "harmony": false,
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -49513,7 +49481,7 @@
             "android": "1.6",
             "ios": "1.6",
             "harmony": "3.4",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -49582,7 +49550,7 @@
               "android": "3.3",
               "ios": "3.3",
               "harmony": false,
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -49598,7 +49566,7 @@
               "android": "3.3",
               "ios": "3.3",
               "harmony": false,
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -49614,7 +49582,7 @@
               "android": "3.3",
               "ios": "3.3",
               "harmony": false,
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -49630,7 +49598,7 @@
               "android": "3.3",
               "ios": "3.3",
               "harmony": false,
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -49646,7 +49614,7 @@
               "android": "3.3",
               "ios": "3.3",
               "harmony": false,
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -49785,22 +49753,6 @@
             }
           },
           {
-            "path": "lynx-api/lynx/getSharedData",
-            "name": "Get the shared data set by `lynx.setSharedData()` used on pages belonging to the same LynxGroup.",
-            "doc_url": "api/lynx-api/lynx/lynx-get-shared-data",
-            "support": {
-              "android": "1.6",
-              "ios": "1.6",
-              "harmony": "3.4",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
             "path": "lynx-api/lynx/getTextInfo",
             "name": "Used to measure the width of text content.",
             "doc_url": "api/lynx-api/lynx/lynx-get-text-info",
@@ -49897,22 +49849,6 @@
             }
           },
           {
-            "path": "lynx-api/lynx/performance.lynx.performance",
-            "name": "performance",
-            "doc_url": "api/lynx-api/lynx/lynx-performance",
-            "support": {
-              "android": "2.3",
-              "ios": "2.3",
-              "harmony": "3.4",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
             "path": "lynx-api/lynx/performance.createObserver()",
             "name": "createObserver()",
             "doc_url": "api/lynx-api/lynx/lynx-performance",
@@ -49920,86 +49856,6 @@
               "android": "3.1",
               "ios": "3.1",
               "harmony": "3.4",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
-            "path": "lynx-api/lynx/performance.profileStart()",
-            "name": "profileStart()",
-            "doc_url": "api/lynx-api/lynx/lynx-performance",
-            "support": {
-              "android": "3.3",
-              "ios": "3.3",
-              "harmony": false,
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
-            "path": "lynx-api/lynx/performance.profileEnd()",
-            "name": "profileEnd()",
-            "doc_url": "api/lynx-api/lynx/lynx-performance",
-            "support": {
-              "android": "3.3",
-              "ios": "3.3",
-              "harmony": false,
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
-            "path": "lynx-api/lynx/performance.profileMark()",
-            "name": "profileMark()",
-            "doc_url": "api/lynx-api/lynx/lynx-performance",
-            "support": {
-              "android": "3.3",
-              "ios": "3.3",
-              "harmony": false,
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
-            "path": "lynx-api/lynx/performance.profileFlowId()",
-            "name": "profileFlowId()",
-            "doc_url": "api/lynx-api/lynx/lynx-performance",
-            "support": {
-              "android": "3.3",
-              "ios": "3.3",
-              "harmony": false,
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
-            "path": "lynx-api/lynx/performance.isProfileRecording()",
-            "name": "isProfileRecording()",
-            "doc_url": "api/lynx-api/lynx/lynx-performance",
-            "support": {
-              "android": "3.3",
-              "ios": "3.3",
-              "harmony": false,
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -50128,22 +49984,6 @@
               "android": "2.9",
               "ios": "2.9",
               "harmony": "3.8",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
-            "path": "lynx-api/lynx/setSharedData",
-            "name": "设置同 LynxGroup 的页面间的共享数据。",
-            "doc_url": "api/lynx-api/lynx/lynx-set-shared-data",
-            "support": {
-              "android": "1.6",
-              "ios": "1.6",
-              "harmony": "3.4",
               "web_lynx": false,
               "clay_android": false,
               "clay_ios": false,
@@ -50354,7 +50194,7 @@
               "android": "1.6",
               "ios": "1.6",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -50482,7 +50322,7 @@
               "android": "2.3",
               "ios": "2.3",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -50514,7 +50354,7 @@
               "android": "3.3",
               "ios": "3.3",
               "harmony": false,
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -50530,7 +50370,7 @@
               "android": "3.3",
               "ios": "3.3",
               "harmony": false,
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -50546,7 +50386,7 @@
               "android": "3.3",
               "ios": "3.3",
               "harmony": false,
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -50562,7 +50402,7 @@
               "android": "3.3",
               "ios": "3.3",
               "harmony": false,
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -50578,7 +50418,7 @@
               "android": "3.3",
               "ios": "3.3",
               "harmony": false,
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -50834,7 +50674,7 @@
               "android": "1.6",
               "ios": "1.6",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -51060,7 +50900,7 @@
               "android": "1.6",
               "ios": "1.6",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -51188,7 +51028,7 @@
               "android": "2.3",
               "ios": "2.3",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -51220,7 +51060,7 @@
               "android": "3.3",
               "ios": "3.3",
               "harmony": false,
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -51236,7 +51076,7 @@
               "android": "3.3",
               "ios": "3.3",
               "harmony": false,
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -51252,7 +51092,7 @@
               "android": "3.3",
               "ios": "3.3",
               "harmony": false,
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -51268,7 +51108,7 @@
               "android": "3.3",
               "ios": "3.3",
               "harmony": false,
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -51284,7 +51124,7 @@
               "android": "3.3",
               "ios": "3.3",
               "harmony": false,
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -51540,7 +51380,7 @@
               "android": "1.6",
               "ios": "1.6",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -103802,7 +103642,7 @@
           "version_added": "3.4"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": "1.0"
         },
         "clay_android": {
           "version_added": false
@@ -106502,7 +106342,7 @@
           "version_added": "3.4"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -110102,7 +109942,7 @@
           "version_added": "3.4"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -110390,7 +110230,7 @@
           "version_added": "3.4"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -110462,7 +110302,7 @@
           "version_added": false
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -110498,7 +110338,7 @@
           "version_added": false
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -110534,7 +110374,7 @@
           "version_added": false
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -110570,7 +110410,7 @@
           "version_added": false
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -110606,7 +110446,7 @@
           "version_added": false
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -111182,7 +111022,7 @@
           "version_added": "3.4"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -121012,7 +120852,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 698,
+          "supported": 708,
           "coverage": 62
         },
         "clay_android": {
@@ -121054,7 +120894,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 698,
+          "supported": 708,
           "coverage": 62
         },
         "clay_android": {
@@ -121096,7 +120936,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 698,
+          "supported": 708,
           "coverage": 62
         },
         "clay_android": {
@@ -121138,7 +120978,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 698,
+          "supported": 708,
           "coverage": 62
         },
         "clay_android": {
@@ -121180,7 +121020,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 698,
+          "supported": 708,
           "coverage": 62
         },
         "clay_android": {
@@ -121222,7 +121062,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 698,
+          "supported": 708,
           "coverage": 62
         },
         "clay_android": {
@@ -121264,7 +121104,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 698,
+          "supported": 708,
           "coverage": 62
         },
         "clay_android": {
@@ -121306,7 +121146,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 698,
+          "supported": 708,
           "coverage": 62
         },
         "clay_android": {
@@ -121348,7 +121188,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 698,
+          "supported": 708,
           "coverage": 62
         },
         "clay_android": {
@@ -121390,7 +121230,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 698,
+          "supported": 708,
           "coverage": 62
         },
         "clay_android": {
@@ -121432,7 +121272,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 698,
+          "supported": 708,
           "coverage": 62
         },
         "clay_android": {
@@ -121474,7 +121314,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 698,
+          "supported": 708,
           "coverage": 62
         },
         "clay_android": {
@@ -121516,7 +121356,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 698,
+          "supported": 708,
           "coverage": 62
         },
         "clay_android": {
@@ -121558,7 +121398,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 698,
+          "supported": 708,
           "coverage": 62
         },
         "clay_android": {
@@ -121600,7 +121440,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 698,
+          "supported": 708,
           "coverage": 62
         },
         "clay_android": {
@@ -121642,7 +121482,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 698,
+          "supported": 708,
           "coverage": 62
         },
         "clay_android": {
@@ -121684,7 +121524,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 698,
+          "supported": 708,
           "coverage": 62
         },
         "clay_android": {
@@ -121726,7 +121566,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 698,
+          "supported": 708,
           "coverage": 62
         },
         "clay_android": {
@@ -121768,7 +121608,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 698,
+          "supported": 708,
           "coverage": 62
         },
         "clay_android": {
@@ -121810,7 +121650,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 698,
+          "supported": 708,
           "coverage": 62
         },
         "clay_android": {
@@ -121852,7 +121692,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 698,
+          "supported": 708,
           "coverage": 62
         },
         "clay_android": {
@@ -121894,7 +121734,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 698,
+          "supported": 708,
           "coverage": 62
         },
         "clay_android": {
@@ -121936,7 +121776,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 698,
+          "supported": 708,
           "coverage": 62
         },
         "clay_android": {
@@ -121978,7 +121818,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 698,
+          "supported": 708,
           "coverage": 62
         },
         "clay_android": {
@@ -122020,7 +121860,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 698,
+          "supported": 708,
           "coverage": 62
         },
         "clay_android": {
@@ -122062,7 +121902,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 698,
+          "supported": 708,
           "coverage": 62
         },
         "clay_android": {
@@ -122104,7 +121944,7 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 698,
+          "supported": 708,
           "coverage": 62
         },
         "clay_android": {
@@ -122146,7 +121986,7 @@
           "coverage": 59
         },
         "web_lynx": {
-          "supported": 698,
+          "supported": 708,
           "coverage": 62
         },
         "clay_android": {
@@ -122188,7 +122028,7 @@
           "coverage": 65
         },
         "web_lynx": {
-          "supported": 698,
+          "supported": 708,
           "coverage": 62
         },
         "clay_android": {
@@ -122230,7 +122070,7 @@
           "coverage": 67
         },
         "web_lynx": {
-          "supported": 698,
+          "supported": 708,
           "coverage": 62
         },
         "clay_android": {
@@ -122272,7 +122112,7 @@
           "coverage": 70
         },
         "web_lynx": {
-          "supported": 698,
+          "supported": 708,
           "coverage": 62
         },
         "clay_android": {
@@ -122314,8 +122154,8 @@
           "coverage": 72
         },
         "web_lynx": {
-          "supported": 706,
-          "coverage": 62
+          "supported": 716,
+          "coverage": 63
         },
         "clay_android": {
           "supported": 576,
@@ -122356,8 +122196,8 @@
           "coverage": 74
         },
         "web_lynx": {
-          "supported": 726,
-          "coverage": 64
+          "supported": 736,
+          "coverage": 65
         },
         "clay_android": {
           "supported": 598,
@@ -122398,8 +122238,8 @@
           "coverage": 75
         },
         "web_lynx": {
-          "supported": 726,
-          "coverage": 64
+          "supported": 736,
+          "coverage": 65
         },
         "clay_android": {
           "supported": 625,

--- a/packages/lynx-compat-data/lynx-api/event/TouchEvent.json
+++ b/packages/lynx-compat-data/lynx-api/event/TouchEvent.json
@@ -47,7 +47,7 @@
               "web_lynx": {
                 "version_added": true,
                 "partial_implementation": true,
-                "notes": "`detail.{x,y}` is read from `touches[0]` while a finger is down (`touchstart`, `touchmove`). On `touchend` and `touchcancel` the touch list is empty, so `detail` falls back to the raw DOM `UIEvent.detail` (a number) instead of the native release position."
+                "notes": "`detail.{x,y}` is read from `touches[0]` while a finger is down (`touchstart`, `touchmove`). On `touchend` and `touchcancel` the touch list is empty, so `detail` falls back to the raw DOM `UIEvent.detail` (a number) instead of the native release position. Implemented since `@lynx-js/web-core@0.20.2` (lynx-family/lynx-stack#2458); lynx-view-relative since `0.21.0` (#2583)."
               }
             }
           }

--- a/packages/lynx-compat-data/lynx-api/event/TouchEvent.json
+++ b/packages/lynx-compat-data/lynx-api/event/TouchEvent.json
@@ -45,7 +45,9 @@
                 "version_added": "3.5"
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": true,
+                "partial_implementation": true,
+                "notes": "`detail.{x,y}` is read from `touches[0]`, so it is only populated while a finger is down (`touchstart`, `touchmove`). On `touchend` and `touchcancel` the touch list is empty and no position is reported."
               }
             }
           }

--- a/packages/lynx-compat-data/lynx-api/event/TouchEvent.json
+++ b/packages/lynx-compat-data/lynx-api/event/TouchEvent.json
@@ -45,7 +45,7 @@
                 "version_added": "3.5"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": true
               }
             }
           }

--- a/packages/lynx-compat-data/lynx-api/event/TouchEvent.json
+++ b/packages/lynx-compat-data/lynx-api/event/TouchEvent.json
@@ -47,7 +47,7 @@
               "web_lynx": {
                 "version_added": true,
                 "partial_implementation": true,
-                "notes": "`detail.{x,y}` is read from `touches[0]`, so it is only populated while a finger is down (`touchstart`, `touchmove`). On `touchend` and `touchcancel` the touch list is empty and no position is reported."
+                "notes": "`detail.{x,y}` is read from `touches[0]` while a finger is down (`touchstart`, `touchmove`). On `touchend` and `touchcancel` the touch list is empty, so `detail` falls back to the raw DOM `UIEvent.detail` (a number) instead of the native release position."
               }
             }
           }

--- a/packages/lynx-compat-data/lynx-api/global/SystemInfo.json
+++ b/packages/lynx-compat-data/lynx-api/global/SystemInfo.json
@@ -29,7 +29,7 @@
             "web_lynx": {
               "version_added": "1.0",
               "partial_implementation": true,
-              "notes": "only support SystemInfo.platform"
+              "notes": "SystemInfo.platform and SystemInfo.lynxSdkVersion are supported; SystemInfo.engineVersion is not."
             }
           }
         },
@@ -90,7 +90,7 @@
                 "version_added": "3.5"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": "1.0"
               }
             }
           }

--- a/packages/lynx-compat-data/lynx-api/global/SystemInfo.json
+++ b/packages/lynx-compat-data/lynx-api/global/SystemInfo.json
@@ -90,7 +90,8 @@
                 "version_added": "3.5"
               },
               "web_lynx": {
-                "version_added": "1.0"
+                "version_added": "1.0",
+                "notes": "Implemented since `@lynx-js/web-core@0.13.0` (lynx-family/lynx-stack#628)."
               }
             }
           }

--- a/packages/lynx-compat-data/lynx-api/lynx/getSharedData.json
+++ b/packages/lynx-compat-data/lynx-api/lynx/getSharedData.json
@@ -27,7 +27,9 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": true
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "The shared store is scoped to one background Web Worker. Cards only share it when the host opts them into the same group via the `lynx-group-id` attribute (`lynxGroupId`) on `<lynx-view>`; without it every card gets its own worker and therefore its own store."
             }
           }
         }

--- a/packages/lynx-compat-data/lynx-api/lynx/getSharedData.json
+++ b/packages/lynx-compat-data/lynx-api/lynx/getSharedData.json
@@ -29,7 +29,7 @@
             "web_lynx": {
               "version_added": true,
               "partial_implementation": true,
-              "notes": "The shared store is scoped to one background Web Worker. Cards only share it when the host opts them into the same group via the `lynx-group-id` attribute (`lynxGroupId`) on `<lynx-view>`; without it every card gets its own worker and therefore its own store."
+              "notes": "The shared store is scoped to one background Web Worker. Cards only share it when the host opts them into the same group via the `lynx-group-id` attribute (`lynxGroupId`) on `<lynx-view>`; without it every card gets its own worker and therefore its own store. Implemented since `@lynx-js/web-core@0.11.0`."
             }
           }
         }

--- a/packages/lynx-compat-data/lynx-api/lynx/getSharedData.json
+++ b/packages/lynx-compat-data/lynx-api/lynx/getSharedData.json
@@ -27,7 +27,7 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             }
           }
         }

--- a/packages/lynx-compat-data/lynx-api/lynx/performance.json
+++ b/packages/lynx-compat-data/lynx-api/lynx/performance.json
@@ -23,7 +23,8 @@
                 "version_added": "3.5"
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": true,
+                "notes": "Implemented since `@lynx-js/web-core@0.22.0` (lynx-family/lynx-stack#2874)."
               }
             }
           }
@@ -72,7 +73,8 @@
                 "version_added": "3.5"
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": true,
+                "notes": "Implemented since `@lynx-js/web-core@0.22.0` (lynx-family/lynx-stack#2874)."
               }
             }
           }
@@ -95,7 +97,8 @@
                 "version_added": "3.5"
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": true,
+                "notes": "Implemented since `@lynx-js/web-core@0.22.0` (lynx-family/lynx-stack#2874)."
               }
             }
           }
@@ -118,7 +121,8 @@
                 "version_added": "3.5"
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": true,
+                "notes": "Implemented since `@lynx-js/web-core@0.22.0` (lynx-family/lynx-stack#2874)."
               }
             }
           }
@@ -141,7 +145,8 @@
                 "version_added": "3.5"
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": true,
+                "notes": "Implemented since `@lynx-js/web-core@0.22.0` (lynx-family/lynx-stack#2874)."
               }
             }
           }
@@ -166,7 +171,7 @@
               "web_lynx": {
                 "version_added": true,
                 "partial_implementation": true,
-                "notes": "Reports whether the browser User Timing API (`performance.mark`/`performance.measure`) is available, not whether trace recording is currently active. In practice this is always `true` in a browser, so it cannot be used to gate profiling work the way it can on other platforms."
+                "notes": "Reports whether the browser User Timing API (`performance.mark`/`performance.measure`) is available, not whether trace recording is currently active. In practice this is always `true` in a browser, so it cannot be used to gate profiling work the way it can on other platforms. Implemented since `@lynx-js/web-core@0.22.0` (lynx-family/lynx-stack#2874)."
               }
             }
           }

--- a/packages/lynx-compat-data/lynx-api/lynx/performance.json
+++ b/packages/lynx-compat-data/lynx-api/lynx/performance.json
@@ -164,7 +164,9 @@
                 "version_added": "3.5"
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": true,
+                "partial_implementation": true,
+                "notes": "Reports whether the browser User Timing API (`performance.mark`/`performance.measure`) is available, not whether trace recording is currently active. In practice this is always `true` in a browser, so it cannot be used to gate profiling work the way it can on other platforms."
               }
             }
           }

--- a/packages/lynx-compat-data/lynx-api/lynx/performance.json
+++ b/packages/lynx-compat-data/lynx-api/lynx/performance.json
@@ -23,7 +23,7 @@
                 "version_added": "3.5"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": true
               }
             }
           }
@@ -72,7 +72,7 @@
                 "version_added": "3.5"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": true
               }
             }
           }
@@ -95,7 +95,7 @@
                 "version_added": "3.5"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": true
               }
             }
           }
@@ -118,7 +118,7 @@
                 "version_added": "3.5"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": true
               }
             }
           }
@@ -141,7 +141,7 @@
                 "version_added": "3.5"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": true
               }
             }
           }
@@ -164,7 +164,7 @@
                 "version_added": "3.5"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": true
               }
             }
           }

--- a/packages/lynx-compat-data/lynx-api/lynx/setSharedData.json
+++ b/packages/lynx-compat-data/lynx-api/lynx/setSharedData.json
@@ -27,7 +27,9 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": true
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "The shared store is scoped to one background Web Worker. Cards only share it when the host opts them into the same group via the `lynx-group-id` attribute (`lynxGroupId`) on `<lynx-view>`; without it every card gets its own worker and therefore its own store."
             }
           }
         }

--- a/packages/lynx-compat-data/lynx-api/lynx/setSharedData.json
+++ b/packages/lynx-compat-data/lynx-api/lynx/setSharedData.json
@@ -29,7 +29,7 @@
             "web_lynx": {
               "version_added": true,
               "partial_implementation": true,
-              "notes": "The shared store is scoped to one background Web Worker. Cards only share it when the host opts them into the same group via the `lynx-group-id` attribute (`lynxGroupId`) on `<lynx-view>`; without it every card gets its own worker and therefore its own store."
+              "notes": "The shared store is scoped to one background Web Worker. Cards only share it when the host opts them into the same group via the `lynx-group-id` attribute (`lynxGroupId`) on `<lynx-view>`; without it every card gets its own worker and therefore its own store. Implemented since `@lynx-js/web-core@0.11.0`."
             }
           }
         }

--- a/packages/lynx-compat-data/lynx-api/lynx/setSharedData.json
+++ b/packages/lynx-compat-data/lynx-api/lynx/setSharedData.json
@@ -27,7 +27,7 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             }
           }
         }


### PR DESCRIPTION
## Summary

Reverse-drift fixes for Web (`web_lynx`) compat data. These APIs are implemented in lynx-stack's web-core, but `lynx-compat-data` still marked `web_lynx` as unsupported. Every claim below was verified against `lynx-family/lynx-stack@5fbabb8`.

Rebased onto `main` after #1278 merged; the two conflicted on `api-stats.json`, resolved by regenerating rather than hand-merging.

## Changes

| API | Before | After | Evidence |
| --- | --- | --- | --- |
| `SystemInfo.lynxSdkVersion` | `false` | `"1.0"` | `constants.ts:45` puts it in `systemInfoBase`; composed on the main thread at `LynxViewInstance.ts:56` and handed to the worker realm at `client/background/index.ts:13` |
| `TouchEvent.detail` | `false` | `true` + partial | `createCrossThreadEvent.ts:78-88` fills `detail.{x,y}` from `touches[0]` |
| `lynx.performance` (base) | `false` | `true` | `createMainThreadLynxPerformance.ts` / `createPerformanceApis.ts` |
| `profileStart` / `profileEnd` / `profileMark` / `profileFlowId` | `false` | `true` | Browser User Timing API |
| `isProfileRecording()` | `false` | `true` + partial | `createMainThreadLynxPerformance.ts:161` |
| `lynx.getSharedData` / `setSharedData` | `false` | `true` + partial | `createNativeApp.ts:36` module-scoped store |

`lynx.performance.createObserver()` is **not** implemented on web and is deliberately left `false`.

## Three entries are partial, not fully supported

Review surfaced three places where a bare `version_added: true` would have overstated Web parity:

- **`TouchEvent.detail`** — `detail` is initialized as `domEvent.detail ?? {}` and only reassigned inside `if (touch[0])`. On `touchend`/`touchcancel` the touch list is empty, so it keeps the raw DOM `UIEvent.detail` (a number), not a position. Pinned by `element-apis.spec.ts:169`.
- **`isProfileRecording()`** — returns `getUserTimingPerformance() !== undefined`, a feature probe for `performance.mark`/`measure`, so effectively a constant `true` in a browser. The reference defines it as whether trace recording is *currently active*, so the documented gating idiom doesn't gate on Web.
- **`getSharedData` / `setSharedData`** — the store is scoped to one background worker. `Background.ts:147-161` only reuses a worker across cards when `lynxGroupId` is set; otherwise each card calls `createWebWorker()` and gets an isolated store. The "shared within a LynxGroup" semantics need the host to set `lynx-group-id`.

`SystemInfo`'s note was also updated from `"only support SystemInfo.platform"` to name both supported fields and call out that `engineVersion` is missing.

## Introduction floors recorded as provenance

`version_added: true` means "supported, exact version unknown", but these introduction points are recoverable, so the entries were under-specified rather than genuinely unknown. Each floor is recorded in `notes`, with `version_added` left as `true` — `platforms/web_lynx.json` still declares `"releases": {}`, so no npm version is put into the Lynx-engine version axis.

| Entry | Floor | Introduced by |
| --- | --- | --- |
| `getSharedData` / `setSharedData` | `@lynx-js/web-core@0.11.0` | — |
| `SystemInfo.lynxSdkVersion` | `0.13.0` | lynx-stack#628 |
| `TouchEvent.detail` | `0.20.2` | lynx-stack#2458; lynx-view-relative since `0.21.0` (#2583) |
| `lynx.performance` + `profile*` | `0.22.0` | lynx-stack#2874 |

Derived from `git log -S` on the introducing symbol plus the earliest `@lynx-js/web-core` tag containing that commit, cross-checked against `web-core/CHANGELOG.md`.

## Coverage

`api-stats.json` is regenerated, not hand-edited. Against the post-#1278 baseline on `main` (732), Web coverage moves **732 → 742** of 1133 platform APIs. `partial_implementation` still counts as supported, so the caveats above don't change the count.

## Verification

- `generate-css-from-defines.ts` then `generate-stats.ts` — `api-stats.json` reproduces **byte-identically** after the rebase, so the whole stats diff is attributable to the data edits
- `validate.ts`, `lint-key-names.ts` — pass
- `vitest run` in `packages/lynx-compat-data` — 10/10
- Full `ci.yml` Validate job run locally: case-collision and asset-URL checks, `format:check`, `pnpm install --frozen-lockfile`, and `pnpm run build` (3087 pages) all green