### PR TITLE
docs(gallery): let the tutorial's list fill its wrapper

### DIFF
--- a/docs/en/learn/gallery.mdx
+++ b/docs/en/learn/gallery.mdx
@@ -100,7 +100,7 @@ Since the focus of this tutorial is not on how to style your UI, you may just sa
   padding-bottom: 20px;
   padding-left: 20px;
   padding-right: 20px;
-  height: calc(100% - 48px);
+  height: 100%;
   list-main-axis-gap: 10px;
   list-cross-axis-gap: 10px;
 }
@@ -340,7 +340,8 @@ Similar to the `bindtap` event used to add the like functionality, we add the [`
 const onScroll = (event: ScrollEvent) => {
   scrollbarRef.current?.adjustScrollbar(
     event.detail.scrollTop,
-    event.detail.scrollHeight
+    event.detail.scrollHeight,
+    event.detail.listHeight || SystemInfo.pixelHeight / SystemInfo.pixelRatio
   );
 };
 ...
@@ -365,8 +366,11 @@ We use many React techniques in this component, such as `forwardRef` and `useImp
 
 ```tsx title="NiceScrollbar.tsx" {14-19}
 ...
-const adjustScrollbar = (scrollTop: number, scrollHeight: number) => {
-  const listHeight = lynx.__globalProps.screenHeight - 48;
+const adjustScrollbar = (
+  scrollTop: number,
+  scrollHeight: number,
+  listHeight: number
+) => {
   const scrollbarHeight = listHeight * (listHeight / scrollHeight);
   const scrollbarTop = listHeight * (scrollTop / scrollHeight);
   setScrollbarHeight(scrollbarHeight);
@@ -375,8 +379,8 @@ const adjustScrollbar = (scrollTop: number, scrollHeight: number) => {
 ...
 ```
 
-:::details \_\_globalProps
-We use [globalProps](/api/lynx-api/lynx/lynx-global-props) in this method, where you can use `screenHeight` and `screenWidth` to get the screen height and width.
+:::details listHeight
+The [`scroll`](/api/elements/built-in/list.html#scroll) event reports `listHeight`, the height of the `<list>` itself. Using it keeps the scrollbar correct whatever box the list ends up with — a full-screen page, a page under Lynx Explorer's title bar, or an embedded preview on the web. Lynx for Web reports `0` there, so the page height stands in; once the list fills the page, it is the same number.
 :::
 
 :::details list-item's estimated-main-axis-size-px

--- a/docs/zh/learn/gallery.mdx
+++ b/docs/zh/learn/gallery.mdx
@@ -96,7 +96,7 @@ import { Go, CodeFold, LearnTutorialTabs } from '@lynx';
   padding-bottom: 20px;
   padding-left: 20px;
   padding-right: 20px;
-  height: calc(100% - 48px);
+  height: 100%;
   list-main-axis-gap: 10px;
   list-cross-axis-gap: 10px;
 }
@@ -336,7 +336,8 @@ useEffect(() => {
 const onScroll = (event: ScrollEvent) => {
   scrollbarRef.current?.adjustScrollbar(
     event.detail.scrollTop,
-    event.detail.scrollHeight
+    event.detail.scrollHeight,
+    event.detail.listHeight || SystemInfo.pixelHeight / SystemInfo.pixelRatio
   );
 };
 ...
@@ -361,8 +362,11 @@ const onScroll = (event: ScrollEvent) => {
 
 ```tsx title="NiceScrollbar.tsx" {14-19}
 ...
-const adjustScrollbar = (scrollTop: number, scrollHeight: number) => {
-  const listHeight = lynx.__globalProps.screenHeight - 48;
+const adjustScrollbar = (
+  scrollTop: number,
+  scrollHeight: number,
+  listHeight: number
+) => {
   const scrollbarHeight = listHeight * (listHeight / scrollHeight);
   const scrollbarTop = listHeight * (scrollTop / scrollHeight);
   setScrollbarHeight(scrollbarHeight);
@@ -371,8 +375,8 @@ const adjustScrollbar = (scrollTop: number, scrollHeight: number) => {
 ...
 ```
 
-:::details \_\_globalProps
-我们在这个方法里使用了 [globalProps](/api/lynx-api/lynx/lynx-global-props)，你可以使用 `screenHeight` 和 `screenWidth` 来获取屏幕高度和宽度。
+:::details listHeight
+[`scroll`](/api/elements/built-in/list.html#scroll) 事件会给出 `listHeight`，也就是 `<list>` 自身的高度。用它来计算，无论 `<list>` 实际拿到多大的区域——整屏的页面、Lynx Explorer 标题栏下的页面，还是网页里嵌入的预览——滚动条都是对的。Lynx for Web 上这个值是 `0`，此时用页面高度代替即可——`<list>` 铺满页面之后，两者是同一个数。
 :::
 
 :::details list-item 的 estimated-main-axis-size-px


### PR DESCRIPTION
## What

The gallery tutorial's CSS leaves a 48px black band under the grid — visible in
the `<Go>` previews on this very page.

## Why

`.list` is `height: calc(100% - 48px)` inside a `.gallery-wrapper` that is
`height: 100%` with a black background, and the scrollbar derives its viewport
from `lynx.__globalProps.screenHeight - 48`.

That 48 is **Lynx Explorer's title bar** — which this tutorial's own QR schema
turns on with `?bar_color=000000&back_button_style=dark&title=Popular Furniture`.
But `100%` is already the page area *below* that bar, so the code subtracts it a
second time. And a shorter list would not move content out from under a *top* bar
anyway, so the 48px only ever appears as dead space at the bottom:

- on **Lynx for Web**, including the previews on this page;
- in **Explorer's fullscreen** mode;
- and **under the title bar** itself.

## How

- `.list` fills its wrapper (`height: 100%`).
- The scrollbar takes its viewport from `event.detail.listHeight` — the list's own
  box — so it is correct whatever area the list ends up with. Lynx for Web reports
  `0` there, so the page height stands in; once the list fills the page it is the
  same number.
- The `:::details __globalProps` aside is replaced with one about `listHeight`,
  since the snippet no longer uses `globalProps`.
- Both `en` and `zh` are updated together.

## Verification

Measured through `@lynx-js/web-core` in headless Chromium against the example
these snippets are quoted from, `GalleryComplete`:

| | before | after |
| --- | --- | --- |
| `.gallery-wrapper` height | 700 | 700 |
| `.list` height | 652 | **700** |
| band at bottom | **48px** | **0** |
| scrollbar inline style | `height: 60.1px; top: 51.5px` | `height: 69.3px; top: 53.4px` |

## Related

Depends on lynx-family/lynx-examples#396, which fixes the example this page's
previews load. Merging this alone would leave the prose ahead of the code.

The same defect is inherited by the Vue Lynx and Octane ports:

- Huxpro/vue-lynx#360
- octanejs/octane#616


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Set the gallery `.list` height to `100%` in the English and Chinese tutorials.
- Pass `event.detail.listHeight` to scrollbar sizing, with a Lynx for Web page-height fallback.
- Replace `__globalProps` documentation with `listHeight` behavior details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->