### PR TITLE
docs(css): document the :hover pseudo-class

### DIFF
--- a/docs/en/api/css/selectors.mdx
+++ b/docs/en/api/css/selectors.mdx
@@ -1,3 +1,9 @@
+---
+api: css/selectors.hover
+---
+
+import { APISummary, APITable } from '@lynx';
+
 # Selectors
 
 CSS selectors specify which elements a CSS rule applies to. Pedantically speaking, CSS selectors is an umbrella term that includes Selectors, Combinators, Pseudo-elements, and Pseudo-classes.
@@ -234,6 +240,7 @@ A `:` pseudo-class is a type of selector used to select elements in a specific s
 Supports
 
 - `:active`
+- `:hover`
 - `:not()`
 - `:root`
 
@@ -248,6 +255,20 @@ Similar to the `page` selector used to match the root node. Usage aligns with [W
 #### `:active`
 
 When a node is pressed, it gets activated and selected. Releasing the finger deactivates it. Usage aligns with [W3C :active](https://developer.mozilla.org/zh-CN/docs/Web/CSS/:active)
+
+#### `:hover`
+
+<APISummary />
+
+When a pointing device hovers over a node, the node matches `:hover`. Usage aligns with [W3C `:hover`](https://developer.mozilla.org/en-US/docs/Web/CSS/:hover).
+
+On native platforms, `:hover` is supported by Clay on macOS and Windows since Lynx 3.7. Clay on Android supports it since Lynx 3.7 in full Clay builds when the host injects pointer hover events; Clay Lite does not support it. The classic Android, iOS, and HarmonyOS renderers and Clay on iOS do not support it. Web Lynx uses the browser's `:hover` implementation.
+
+Focus navigation with a keyboard or game controller does not generate pointer hover events and therefore does not activate `:hover`.
+
+##### Compatibility
+
+<APITable />
 
 #### Example Usage
 

--- a/docs/zh/api/css/selectors.mdx
+++ b/docs/zh/api/css/selectors.mdx
@@ -1,3 +1,9 @@
+---
+api: css/selectors.hover
+---
+
+import { APISummary, APITable } from '@lynx';
+
 # 选择器
 
 CSS 选择器规定了 CSS 规则会被应用到哪些元件上。严格来说，CSS 选择器是一个涵盖选择器、组合器、伪元素和伪类的总称。
@@ -231,6 +237,7 @@ selector2 {
 - `:not()`
 - `:root`
 - `:active`
+- `:hover`
 
 #### `:not()`
 
@@ -243,6 +250,20 @@ selector2 {
 #### `:active`
 
 节点被用户按压后，会被激活选中，松开手指则不被激活，用法对齐 [W3C `:active`](https://developer.mozilla.org/zh-CN/docs/Web/CSS/:active)
+
+#### `:hover`
+
+<APISummary />
+
+当指针设备悬停在节点上时，该节点会匹配 `:hover`，用法对齐 [W3C `:hover`](https://developer.mozilla.org/zh-CN/docs/Web/CSS/:hover)。
+
+在原生平台上，Clay macOS 和 Clay Windows 自 Lynx 3.7 起支持 `:hover`。Clay Android 自 Lynx 3.7 起在完整 Clay 构建中支持，但宿主必须向 Clay 注入指针悬停事件；Clay Lite 不支持。经典 Android、iOS、HarmonyOS 渲染器以及 Clay iOS 不支持。Web Lynx 使用浏览器的 `:hover` 实现。
+
+键盘和手柄的焦点导航不会生成指针悬停事件，因此不会激活 `:hover`。
+
+##### 兼容性
+
+<APITable />
 
 #### 使用示例
 

--- a/packages/lynx-compat-data/css/selectors.json
+++ b/packages/lynx-compat-data/css/selectors.json
@@ -1,0 +1,45 @@
+{
+  "css": {
+    "selectors": {
+      "hover": {
+        "__compat": {
+          "description": "The :hover pseudo-class matches a node while a pointing device is hovering over it.",
+          "lynx_path": "api/css/selectors#hover",
+          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/CSS/:hover",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "3.7",
+              "partial_implementation": true,
+              "notes": "Requires a full Clay build and a host that sends pointer hover events to Clay. Clay Lite is not supported."
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "3.7"
+            },
+            "clay_windows": {
+              "version_added": "3.7"
+            },
+            "web_lynx": {
+              "version_added": true
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `:hover` to the supported pseudo-class list in the English and Chinese CSS selector references.
- Clarify that `:hover` depends on host pointer hover input and is not activated by focus navigation.

## Checks

- `prettier --check` on both changed files
- `cspell lint` on both changed files
- `node scripts/ci/check-api-summary.mjs` on both changed files
- `node scripts/ci/check-asset-urls.mjs` on both changed files
- `zhlint docs/zh/api/css/selectors.mdx`
- `python3 -m scripts.check_api_doc.index`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Document `:hover` behavior in the English and Chinese CSS selector references.
- List `:hover` among supported pseudo-classes.
- Define `:hover` compatibility metadata and pointer-hover requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->