### PR TITLE
fix: detect ui subsite under 4.0 base

### DIFF
--- a/theme/index.tsx
+++ b/theme/index.tsx
@@ -50,7 +50,7 @@ const TYPING_START_DELAY_MS = 1600;
 
 // Match subsite by checking if any path segment exactly equals the subsite value
 const findSubsite = (pathname: string) => {
-  const segments = pathname.split('/');
+  const segments = removeBase(pathname).split('/');
   return SUBSITES_CONFIG.find((s) => {
     if (s.value === 'ui') {
       return segments.some((seg) => {


### PR DESCRIPTION
## Summary
- normalize the pathname with removeBase before matching subsites
- fix SSR subsite detection for version-prefixed routes such as /4.0/zh/ui/

## Validation
- pnpm run build
- verified doc_build/zh/ui/index.html renders with data-subsite="ui"