### PR TITLE
chore: update go-web to 0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@dugyu/luna-demo-bundles": "0.2.0",
     "@dugyu/luna-stage": "0.2.2",
     "@dugyu/luna-studio": "0.2.0",
-    "@lynx-js/go-web": "^0.9.0",
+    "@lynx-js/go-web": "^0.10.0",
     "@lynx-js/lynx-core": "^0.1.3",
     "@lynx-js/web-core": "^0.20.3",
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 0.2.0
         version: 0.2.0(@lynx-js/web-core-canary@0.23.1-canary-20260730-6cbcb870(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(motion@12.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@lynx-js/go-web':
-        specifier: ^0.9.0
-        version: 0.9.0(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core-canary@0.23.1-canary-20260730-6cbcb870(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.19(@rspack/core@2.1.7(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)
+        specifier: ^0.10.0
+        version: 0.10.0(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core-canary@0.23.1-canary-20260730-6cbcb870(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.19(@rspack/core@2.1.7(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)
       '@lynx-js/lynx-core':
         specifier: ^0.1.3
         version: 0.1.3
@@ -1689,8 +1689,8 @@ packages:
       '@lynx-js/react': '*'
       '@lynx-js/types': '*'
 
-  '@lynx-js/go-web@0.9.0':
-    resolution: {integrity: sha512-JLRkS3zd9rRmL3Eqk8FoB98rcf3TqvxEjeM7nwvTFmRU+kw2Wsv1B88Oozifq9TwiDSRd9oyOewR95uUzDo8Tg==}
+  '@lynx-js/go-web@0.10.0':
+    resolution: {integrity: sha512-xZVpMLHIPrOWsX1tjCX0WrK4sZB+DMb3Gh70fiXYeZllKXgeKXDw2ovmVyKDNUx4rVOapAcCUIwDLmiI3aNCrQ==}
     engines: {node: ^22 || ^24}
     peerDependencies:
       '@douyinfe/semi-icons': '>=2.74.0'
@@ -8365,7 +8365,7 @@ snapshots:
       '@lynx-js/react': 0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
       '@lynx-js/types': 3.9.0
 
-  '@lynx-js/go-web@0.9.0(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core-canary@0.23.1-canary-20260730-6cbcb870(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.19(@rspack/core@2.1.7(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)':
+  '@lynx-js/go-web@0.10.0(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core-canary@0.23.1-canary-20260730-6cbcb870(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.19(@rspack/core@2.1.7(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)':
     dependencies:
       '@douyinfe/semi-icons': 2.74.0(react@18.3.1)
       '@douyinfe/semi-ui': 2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)


### PR DESCRIPTION
## Summary

- update `@lynx-js/go-web` from `^0.9.0` to `^0.10.0`
- refresh the pnpm lockfile to the published `0.10.0` package
- enable complete Web host previews, including stable site-root iframe entries used by Lynxtron examples

## Validation

- `pnpm install --frozen-lockfile`
- `node scripts/ci/check-case-collisions.mjs`
- `node scripts/ci/check-asset-urls.mjs`
- `pnpm run format:check`
- `pnpm run build` (3,179 pages rendered)

Upstream release: https://github.com/lynx-community/go-web/releases/tag/v0.10.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Update `@lynx-js/go-web` to `^0.10.0`.
- Refresh the pnpm lockfile.
- Enable complete Web host previews with stable site-root iframe entries for Lynxtron examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->