### PR TITLE
fix(spec): flush HTML viewer to edges, add open-externally button

### DIFF
--- a/src/components/html-viewer/index.module.less
+++ b/src/components/html-viewer/index.module.less
@@ -36,7 +36,9 @@
     box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
     backdrop-filter: blur(4px);
     opacity: 0;
-    transition: opacity 0.2s ease, background 0.15s ease;
+    transition:
+      opacity 0.2s ease,
+      background 0.15s ease;
     text-decoration: none;
   }
 

--- a/src/components/html-viewer/index.module.less
+++ b/src/components/html-viewer/index.module.less
@@ -1,7 +1,9 @@
 .html-viewer-frame {
   position: relative;
-  width: 100%;
-  height: calc(100vh - 72px);
+  margin: calc(-1 * var(--rp-content-padding-y))
+    calc(-1 * var(--rp-content-padding-x));
+  width: calc(100% + 2 * var(--rp-content-padding-x));
+  height: calc(100vh - var(--rp-nav-height, 64px));
 
   .iframe-frame {
     width: 100%;

--- a/src/components/html-viewer/index.module.less
+++ b/src/components/html-viewer/index.module.less
@@ -1,12 +1,60 @@
 .html-viewer-frame {
+  position: relative;
   width: 100%;
   height: calc(100vh - 72px);
+
   .iframe-frame {
     width: 100%;
-    margin: auto;
     height: 100%;
-    background: rgba(220, 220, 220, 0.71);
-    border: 0px;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    display: block;
+    background: transparent;
     resize: none;
+  }
+
+  .open-external {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 6px;
+    background: rgba(255, 255, 255, 0.9);
+    color: #333;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
+    backdrop-filter: blur(4px);
+    opacity: 0;
+    transition: opacity 0.2s ease, background 0.15s ease;
+    text-decoration: none;
+  }
+
+  &:hover .open-external {
+    opacity: 1;
+  }
+
+  .open-external:hover {
+    background: #fff;
+    color: #111;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.16);
+  }
+}
+
+:root[class~='dark'] {
+  .html-viewer-frame .open-external {
+    background: rgba(50, 50, 50, 0.9);
+    color: #ccc;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+  }
+
+  .html-viewer-frame .open-external:hover {
+    background: rgba(70, 70, 70, 0.95);
+    color: #fff;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
   }
 }

--- a/src/components/html-viewer/index.module.less
+++ b/src/components/html-viewer/index.module.less
@@ -1,9 +1,13 @@
 .html-viewer-frame {
   position: relative;
   margin: calc(-1 * var(--rp-content-padding-y))
-    calc(-1 * var(--rp-content-padding-x));
+    calc(-1 * var(--rp-content-padding-x)) 0;
   width: calc(100% + 2 * var(--rp-content-padding-x));
   height: calc(100vh - var(--rp-nav-height, 64px));
+  margin-bottom: 48px;
+  border-radius: 0 0 8px 8px;
+  overflow: hidden;
+  box-shadow: 0 8px 24px -4px rgba(0, 0, 0, 0.15);
 
   .iframe-frame {
     width: 100%;

--- a/src/components/html-viewer/index.tsx
+++ b/src/components/html-viewer/index.tsx
@@ -25,6 +25,7 @@ function formatUrlWithBase(url: string): string {
 const HtmlViewer = ({ path }: { path: string }) => {
   const location = useLocation();
   const formattedPath = formatUrlWithBase(path);
+  const iframeSrc = `${formattedPath}?ts=${Date.now()}${location.hash}`;
 
   useEffect(() => {
     const rootContainer = document.querySelector('#root');
@@ -46,10 +47,29 @@ const HtmlViewer = ({ path }: { path: string }) => {
 
   return (
     <div className={styles['html-viewer-frame']}>
-      <iframe
-        src={`${formattedPath}?ts=${Date.now()}${location.hash}`}
-        className={styles['iframe-frame']}
-      />
+      <a
+        href={formattedPath}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={styles['open-external']}
+        title="Open in new tab"
+      >
+        <svg
+          viewBox="0 0 16 16"
+          width="14"
+          height="14"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M14 8.5v5a1.5 1.5 0 0 1-1.5 1.5h-9A1.5 1.5 0 0 1 2 13.5v-9A1.5 1.5 0 0 1 3.5 3H8" />
+          <path d="M10 1h5v5" />
+          <path d="M7 9 14.5 1.5" />
+        </svg>
+      </a>
+      <iframe src={iframeSrc} className={styles['iframe-frame']} />
     </div>
   );
 };

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -164,6 +164,7 @@
   .rspress-doc {
     padding: 0 !important;
     margin: 0 !important;
+    max-width: 100% !important;
   }
   .rspress-doc-footer {
     display: none !important;
@@ -171,52 +172,15 @@
   div[class^='aside-container_'] {
     display: none !important;
   }
-}
-
-@media (max-width: 960px) {
-  .html-viewer-root {
-    div[class^='content_'] {
-      padding: 0 !important;
-      /* padding-top: 48px !important; */
-    }
+  div[class^='content_'] {
+    padding: 0 !important;
   }
 }
 
 @media (min-width: 960px) {
   .html-viewer-root {
     .rspress-doc {
-      max-width: 100% !important;
       width: calc(100vw - var(--rp-sidebar-width));
-    }
-    div[class^='content_'] {
-      padding: 0 !important;
-      /* padding-top: 48px !important; */
-    }
-  }
-}
-
-@media (min-width: 1280px) {
-  .html-viewer-root {
-    .rspress-doc {
-      max-width: 100% !important;
-      width: calc(100vw - var(--rp-sidebar-width));
-    }
-    div[class^='content_'] {
-      padding: 0 !important;
-      /* padding-top: 48px !important; */
-    }
-  }
-}
-
-@media (min-width: 1440px) {
-  .html-viewer-root {
-    .rspress-doc {
-      max-width: 100% !important;
-      width: calc(100vw - var(--rp-sidebar-width));
-    }
-    div[class^='content_'] {
-      padding: 0 !important;
-      /* padding-top: 48px !important; */
     }
   }
 }


### PR DESCRIPTION
## Summary
- Remove gray iframe background gutters so the living spec content sits flush against the content area edges
- Consolidate redundant per-breakpoint media queries into a single rule
- Add a hover-reveal "open in new tab" button (top-right corner) so users can view the spec standalone

## Test plan
- [ ] Verify spec page at `/guide/spec.html` has no visible gray borders around iframe
- [ ] Hover over the content area and confirm the external-link button appears top-right
- [ ] Click the button to confirm it opens the living spec in a new tab
- [ ] Test in dark mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Remove iframe gutters and preserve full-width spec content.
- Consolidate responsive `rspress-doc` styles.
- Provide a hover-revealed control to open the living spec in a new tab.
- Support light and dark mode control styling.
- Add rounded corners, bottom spacing, and a shadow to the spec viewer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->