### PR TITLE
docs(start): add Lynx specs repo to iOS integration guides

### DIFF
--- a/docs/en/guide/autolink.mdx
+++ b/docs/en/guide/autolink.mdx
@@ -78,7 +78,7 @@ lynx-app/
 
 - `package.json` is required so the app can declare Autolink library packages as dependencies.
 - For Android, the project needs a Gradle settings file, such as `settings.gradle` or `settings.gradle.kts`, and an Android application build file, such as `app/build.gradle` or `app/build.gradle.kts`.
-- For iOS, the project needs a CocoaPods entry point, usually `Podfile`. If your team manages Ruby dependencies with Bundler, keep the `cocoapods-lynx-library` gem in `Gemfile`.
+- For iOS, the project needs a CocoaPods entry point, usually `Podfile`. The Podfile must configure the Lynx specs repo `https://github.com/lynx-family/Specs.git`. If your team manages Ruby dependencies with Bundler, keep the `cocoapods-lynx-library` gem in `Gemfile`.
 - For HarmonyOS, the project needs a root `hvigorconfig.ts` and an entry or feature HAP module that depends on `@lynx/lynx`.
 - `shared/` is used when the host app owns cross-platform native source code and CMake build entry points; build these sources yourself.
 - For Lynxtron, the app needs a host-side Rspack build that can install npm packages and load native libraries through `pluginLynxtron()`; it generally consumes the compiled `dist/` artifacts.
@@ -115,9 +115,12 @@ After Gradle sync/build, Autolink generates a fixed Android registry entry and a
 
 <PlatformTabs.Tab platform="ios">
 
-Install the `cocoapods-lynx-library` gem in your iOS build environment. Then add the CocoaPods plugin to the app's Podfile and call `use_lynx_library!` so podspecs from installed libraries and the generated registry pod are added during `pod install`:
+Install the `cocoapods-lynx-library` gem in your iOS build environment. Then add the Lynx specs repo, the CocoaPods plugin, and call `use_lynx_library!` in the app's Podfile so podspecs from installed libraries and the generated registry pod are added during `pod install`:
 
 ```ruby
+source 'https://github.com/lynx-family/Specs.git'
+source 'https://cdn.cocoapods.org/'
+
 plugin 'cocoapods-lynx-library'
 
 target 'LynxApp' do

--- a/docs/en/guide/start/fragments/ios/integrating-lynx-with-existing-app-ios.mdx
+++ b/docs/en/guide/start/fragments/ios/integrating-lynx-with-existing-app-ios.mdx
@@ -15,7 +15,7 @@ import versionJson from '@site/docs/public/version.json';
 
 ## 1. Dependency configuration
 
-Using [Cocoapods](https://cocoapods.org/) can easily integrate Lynx into your application
+Using [Cocoapods](https://cocoapods.org/) can easily integrate Lynx into your application. Lynx iOS Pods are published through the Lynx CocoaPods specs repo, so configure both the Lynx specs repo and the CocoaPods CDN in your Podfile.
 
 <Info title="Recommended Versions">
 
@@ -32,11 +32,12 @@ Using [Cocoapods](https://cocoapods.org/) can easily integrate Lynx into your ap
 
 The core capabilities of [Lynx Engine](/guide/spec.html#engine) include basic capabilities such as parsing [Bundle](/guide/spec.html#lynx-bundle-or-bundle), style parsing, layout, and rendering views
 
-Get the latest version of Lynx from Cocoapods. Then add Lynx to your Podfile:
+Get the latest version of Lynx from the Lynx specs repo. Then add Lynx to your Podfile:
 
 <CodeFold height={360} toggle>
 
 ```ruby title="Podfile" {1,6-8,10}
+source 'https://github.com/lynx-family/Specs.git'
 source 'https://cdn.cocoapods.org/'
 
 platform :ios, '10.0'
@@ -57,11 +58,12 @@ end
 Lynx Service includes `LynxImageService`, `LynxLogService`, etc. It aims to provide the ability to strongly correlate some host App features, allowing the App to inject custom Services at runtime, or use the default implementation provided by the official. For example, `LynxImageService` is implemented using the [SDWebImage](https://github.com/SDWebImage/SDWebImage) image library by default. Apps that do not integrate SDWebImage components can rely on other image libraries to implement Image Service.
 Lynx provides standard native Image, Log, and Http service capabilities, which can be quickly accessed and used by the access party;
 
-Get the latest version of Lynx Service from Cocoapods. Then add Lynx Service to your Podfile:
+Get the latest version of Lynx Service from the Lynx specs repo. Then add Lynx Service to your Podfile:
 
 <CodeFold height={360} toggle>
 
 ```ruby title="Podfile" {13-17,20-21}
+source 'https://github.com/lynx-family/Specs.git'
 source 'https://cdn.cocoapods.org/'
 
 platform :ios, '10.0'
@@ -94,6 +96,7 @@ end
 
 <CodeFold height={360} toggle>
 ```ruby title="Podfile" {23}
+source 'https://github.com/lynx-family/Specs.git'
 source 'https://cdn.cocoapods.org/'
 
 platform :ios, '10.0'

--- a/docs/en/guide/start/integrate-lynx-dev-version.mdx
+++ b/docs/en/guide/start/integrate-lynx-dev-version.mdx
@@ -35,6 +35,7 @@ Refer to the [Lynx DevTool integration guide](/guide/start/integrate-lynx-devtoo
 ### Switch to the dev version of Lynx
 
 Update your `Podfile` to use the dev version of the Lynx component.
+Make sure the Podfile has configured the Lynx specs repo as shown in [the iOS integration guide](/guide/start/integrate-with-existing-apps.html?platform=ios).
 
 ```ruby title="Podfile"
 pod 'Lynx', '{versionJson.LYNX_VERSION}' # [!code --]

--- a/docs/en/guide/start/integrate-lynx-devtool.mdx
+++ b/docs/en/guide/start/integrate-lynx-devtool.mdx
@@ -29,6 +29,7 @@ All code examples in this documentation can be found in the [integrating-lynx-de
 ### Adding Dependencies
 
 You need to add these components: the `Devtool` subcomponent of `LynxService`, `LynxDevTool`, and `DebugRouter`.
+Make sure the Podfile has configured the Lynx specs repo as shown in [the iOS integration guide](/guide/start/integrate-with-existing-apps.html?platform=ios).
 
 ```ruby title="Podfile" {2-8}
 # Ensure Lynx DevTool version matches the Lynx version when integrating

--- a/docs/zh/guide/autolink.mdx
+++ b/docs/zh/guide/autolink.mdx
@@ -78,7 +78,7 @@ lynx-app/
 
 - `package.json` 是必需的，用来声明 Autolink 库依赖。
 - Android 接入需要 Gradle settings 文件，例如 `settings.gradle` 或 `settings.gradle.kts`，以及 Android application 的构建文件，例如 `app/build.gradle` 或 `app/build.gradle.kts`。
-- iOS 接入需要 CocoaPods 入口，通常是 `Podfile`。如果团队通过 Bundler 管理 Ruby 依赖，可以在 `Gemfile` 中维护 `cocoapods-lynx-library` gem。
+- iOS 接入需要 CocoaPods 入口，通常是 `Podfile`。Podfile 需要配置 Lynx specs 源 `https://github.com/lynx-family/Specs.git`。如果团队通过 Bundler 管理 Ruby 依赖，可以在 `Gemfile` 中维护 `cocoapods-lynx-library` gem。
 - HarmonyOS 接入需要根目录的 `hvigorconfig.ts`，以及一个依赖 `@lynx/lynx` 的 entry 或 feature HAP 模块。
 - `shared/` 用于宿主应用自有的跨端原生源码和 CMake 构建入口，需要自行编译。
 - Lynxtron 接入需要应用具备宿主侧 Rspack 构建，并通过 `pluginLynxtron()` 安装和加载原生库；一般消费编译后的 `dist/` 产物。
@@ -115,9 +115,12 @@ Gradle sync/build 后，Autolink 会生成固定的 Android registry 入口并�
 
 <PlatformTabs.Tab platform="ios">
 
-在 iOS 构建环境中安装 `cocoapods-lynx-library` gem。然后在应用的 Podfile 中加入 CocoaPods plugin，并调用 `use_lynx_library!`。执行 `pod install` 时，插件会加入库的 podspec 和生成的 registry pod：
+在 iOS 构建环境中安装 `cocoapods-lynx-library` gem。然后在应用的 Podfile 中加入 Lynx specs 源、CocoaPods plugin，并调用 `use_lynx_library!`。执行 `pod install` 时，插件会加入库的 podspec 和生成的 registry pod：
 
 ```ruby
+source 'https://github.com/lynx-family/Specs.git'
+source 'https://cdn.cocoapods.org/'
+
 plugin 'cocoapods-lynx-library'
 
 target 'LynxApp' do

--- a/docs/zh/guide/start/fragments/ios/integrating-lynx-with-existing-app-ios.mdx
+++ b/docs/zh/guide/start/fragments/ios/integrating-lynx-with-existing-app-ios.mdx
@@ -13,7 +13,7 @@ import versionJson from '@site/docs/public/version.json';
 
 ## 1. 依赖配置
 
-使用 [Cocoapods](https://cocoapods.org/) 可以方便的将 Lynx 集成到你的应用中
+使用 [Cocoapods](https://cocoapods.org/) 可以方便的将 Lynx 集成到你的应用中。Lynx 的 iOS Pod 产物发布在 Lynx CocoaPods specs 源中，请在 Podfile 中同时配置 Lynx specs 源和 CocoaPods 官方源。
 
 <Info title="推荐版本">
 
@@ -30,10 +30,11 @@ import versionJson from '@site/docs/public/version.json';
 
 [Lynx Engine](/guide/spec.html#engine) 核心能力，包含了解析 [Bundle](/guide/spec.html#lynx-bundle-or-bundle)、样式解析、排版以及渲染视图等基础能力。
 
-从 Cocoapods 中获取 Lynx 的最新版本。然后将 Lynx 添加到你的 Podfile 中：
+从 Lynx specs 源中获取 Lynx 的最新版本。然后将 Lynx 添加到你的 Podfile 中：
 
 <CodeFold height={360} toggle>
 ```ruby title="Podfile" {1,6-8,10}
+source 'https://github.com/lynx-family/Specs.git'
 source 'https://cdn.cocoapods.org/'
 
 platform :ios, '10.0'
@@ -53,10 +54,11 @@ end
 Lynx Service 包括 `LynxImageService`、`LynxLogService` 等，旨在提供一些宿主应用特性强相关的能力，允许宿主应用在运行时注入自定义实现 Image Service 默认是使用 [SDWebImage](https://github.com/SDWebImage/SDWebImage) 图片库实现，在没有集成 SDWebImage 组件的宿主应用上则可以依赖其他图片库。
 Lynx 提供了标准的原生 Image、Log、Http 服务的能力，接入方可以快速接入并使用;
 
-从 Cocoapods 中获取 Lynx Service 的最新版本。然后将 Lynx Service 添加到你的 Podfile 中：
+从 Lynx specs 源中获取 Lynx Service 的最新版本。然后将 Lynx Service 添加到你的 Podfile 中：
 
 <CodeFold height={360} toggle>
 ```ruby title="Podfile" {13-17,20-21}
+source 'https://github.com/lynx-family/Specs.git'
 source 'https://cdn.cocoapods.org/'
 
 platform :ios, '10.0'
@@ -86,10 +88,11 @@ end
 
 XElement 是 Lynx 团队维护的客户端扩展元件集合，提供更丰富的元件能力，能够让 Lynx 能够更快速的被用到生产环境中，提升 Lynx 生态的活力。
 
-从 Cocoapods 中获取 XElement 的最新版本。然后将 XElement 添加到你的 Podfile 中：
+从 Lynx specs 源中获取 XElement 的最新版本。然后将 XElement 添加到你的 Podfile 中：
 
 <CodeFold height={360} toggle>
 ```ruby title="Podfile" {23}
+source 'https://github.com/lynx-family/Specs.git'
 source 'https://cdn.cocoapods.org/'
 
 platform :ios, '10.0'

--- a/docs/zh/guide/start/integrate-lynx-dev-version.mdx
+++ b/docs/zh/guide/start/integrate-lynx-dev-version.mdx
@@ -34,7 +34,8 @@ import versionJson from '@site/docs/public/version.json';
 
 ### 切换为 Lynx 开发版本
 
-在 `Podfile` 里，将 Lynx 组件版本号改为开发版本：
+在 `Podfile` 里，将 Lynx 组件版本号改为开发版本。
+请确保 Podfile 已按 [iOS 集成指南](/guide/start/integrate-with-existing-apps.html?platform=ios) 配置 Lynx specs 源。
 
 ```ruby title="Podfile"
 pod 'Lynx', '{versionJson.LYNX_VERSION}' # [!code --]

--- a/docs/zh/guide/start/integrate-lynx-devtool.mdx
+++ b/docs/zh/guide/start/integrate-lynx-devtool.mdx
@@ -29,6 +29,7 @@ import versionJson from '@site/docs/public/version.json';
 ### 引入依赖
 
 你需要新增以下组件：`LynxService` 的 `Devtool` 子组件、 `LynxDevTool` 和 `DebugRouter`。
+请确保 Podfile 已按 [iOS 集成指南](/guide/start/integrate-with-existing-apps.html?platform=ios) 配置 Lynx specs 源。
 
 ```ruby title="Podfile" {2-8}
 target 'YourTarget' do


### PR DESCRIPTION
- add the Lynx specs repo to iOS Podfile examples
- clarify that Lynx iOS pods are resolved from the Lynx specs repo
- add follow-up notes in DevTool and dev version integration docs

Change-Id: I8032821c9d3d4df5ba9d6c9e94490e7490279bbd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Configure the Lynx CocoaPods specs repository in iOS Podfile examples.
- Clarify Lynx pod resolution in iOS integration guides.
- Link DevTool and development-version guides to the Lynx specs repository setup instructions.
- Apply the documentation updates to English and Chinese guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->