### PR TITLE
chore(codeowners): fix ownership rule precedence

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,9 @@
 # =============================================
 # CODEOWNERS for lynx-family/lynx-website
 # Based on commit authorship + PR merge/review patterns
+#
+# IMPORTANT: Order matters — last matching pattern wins!
+# General/broader rules go FIRST; specific/override rules go LAST.
 # =============================================
 
 # ── Global fallback ──────────────────────────
@@ -14,14 +17,6 @@ tsconfig.json                           @Huxpro
 /scripts/                               @icecreamx10 @Huxpro
 /functions/                             @icecreamx10
 
-# ── Theme & Site UI ──────────────────────────
-/src/                                   @Huxpro @SoonIter
-/theme/                                 @Huxpro @SoonIter
-
-# ── LUNA ─────────────────────────────────────
-**/*luna*                               @Dugyu
-/src/luna/                              @Dugyu
-
 # ── Plugins ──────────────────────────────────
 /plugins/                               @colinaaa @hzy
 
@@ -30,18 +25,32 @@ tsconfig.json                           @Huxpro
 /packages/lynx-example-packages/        @toretto-wt @loongliu @MoonfaceX
 /packages/lynx-living-spec/             @Huxpro
 
+# ── Theme & Site UI ──────────────────────────
+/src/                                   @Huxpro @SoonIter
+/theme/                                 @Huxpro @SoonIter
+
 # ═════════════════════════════════════════════
-# DOCS: API Reference
+# DOCS: Broad section catch-alls (go FIRST so sub-sections can override below)
+# ═════════════════════════════════════════════
+/docs/**/help/                          @Huxpro
+/docs/**/ai/                            @hzy @Huxpro @colinaaa
+/docs/**/blog/                          @Huxpro
+/docs/**/rspeedy/                       @colinaaa
+/docs/**/react/                         @colinaaa @Yradex @gaoachao @upupming
+/docs/**/ui/                            @MoonfaceX @f0rdream @toretto-wt @fzx2666-fz
+
+# ═════════════════════════════════════════════
+# DOCS: API Reference — parent fallbacks first, sub-directories override after
 # ═════════════════════════════════════════════
 
 # ── api/css ──────────────────────────────────
+/docs/**/api/css/                       @Huxpro
 /docs/**/api/css/data-type/             @zhongyr @Huxpro
 /docs/**/api/css/properties/            @Huxpro
-/docs/**/api/css/                       @Huxpro
 
 # ── api/elements ─────────────────────────────
-/docs/**/api/elements/built-in/         @toretto-wt @MoonfaceX
 /docs/**/api/elements/                  @toretto-wt
+/docs/**/api/elements/built-in/         @toretto-wt @MoonfaceX
 
 # ── api/engine ───────────────────────────────
 /docs/**/api/engine/                    @Huxpro @loongliu
@@ -50,16 +59,16 @@ tsconfig.json                           @Huxpro
 /docs/**/api/errors/                    @mitchilling @Huxpro
 
 # ── api/lynx-api ─────────────────────────────
+/docs/**/api/lynx-api/                  @loongliu @Huxpro
 /docs/**/api/lynx-api/event/            @loongliu @toretto-wt @hexionghui
 /docs/**/api/lynx-api/global/           @toretto-wt @Huxpro
 /docs/**/api/lynx-api/lynx/            @loongliu @colinaaa
 /docs/**/api/lynx-api/main-thread/      @Huxpro @colinaaa @f0rdream
 /docs/**/api/lynx-api/performance-api/  @loongliu
-/docs/**/api/lynx-api/                  @loongliu @Huxpro
 
 # ── api/lynx-native-api ─────────────────────
-/docs/**/api/lynx-native-api/lynx-background-runtime*/  @lybvinci @toretto-wt
 /docs/**/api/lynx-native-api/           @toretto-wt @loongliu @pilipala195 @PupilTong
+/docs/**/api/lynx-native-api/lynx-background-runtime*/  @lybvinci @toretto-wt
 
 # ── api/lynx-devtool-native-api ─────────────
 /docs/**/api/lynx-devtool-native-api/   @mitchilling @Dango-2021
@@ -73,8 +82,9 @@ tsconfig.json                           @Huxpro
 /docs/**/api/rspeedy/                   @colinaaa @upupming
 
 # ═════════════════════════════════════════════
-# DOCS: Guide
+# DOCS: Guide — guide fallback first, sub-sections override after
 # ═════════════════════════════════════════════
+/docs/**/guide/                         @Huxpro @loongliu
 
 # ── guide/start ──────────────────────────────
 /docs/**/guide/start/                   @Huxpro @loongliu @toretto-wt @PupilTong
@@ -107,15 +117,6 @@ tsconfig.json                           @Huxpro
 # ── guide/inclusion ──────────────────────────
 /docs/**/guide/inclusion/               @SoonIter @loongliu @colinaaa
 
-# ── guide fallback ───────────────────────────
-/docs/**/guide/                         @Huxpro @loongliu
-
-# ═════════════════════════════════════════════
-# DOCS: Other Sections
-# ═════════════════════════════════════════════
-/docs/**/ui/                            @MoonfaceX @f0rdream @toretto-wt @fzx2666-fz
-/docs/**/blog/                          @Huxpro
-/docs/**/react/                         @colinaaa @Yradex @gaoachao @upupming
-/docs/**/rspeedy/                       @colinaaa
-/docs/**/ai/                            @hzy @Huxpro @colinaaa
-/docs/**/help/                          @Huxpro
+# ── LUNA ─────────────────────────────────────
+**/*luna*                               @Dugyu
+/src/luna/                              @Dugyu


### PR DESCRIPTION
## Motivation

The current CODEOWNERS order does not align with GitHub's last-match-wins behavior.
Several broad docs rules were placed after more specific sub-path rules, which caused
nested ownership mappings to be shadowed unexpectedly.

## Changes by component

### CODEOWNERS
- move broad docs section catch-all rules before API and Guide overrides
- reorder API ownership rules from parent fallback to more specific sub-path overrides
- reorder Guide ownership rules from guide fallback to more specific sub-sections
- keep luna ownership rules at the end so luna-related files override section-level docs owners
- add clarifying comments about precedence to reduce future maintenance mistakes

## Validation
- reviewed the final rule order against GitHub CODEOWNERS precedence semantics
- verified that broad docs rules no longer override API and Guide sub-path ownership
- verified that luna-related docs are resolved by the luna ownership rules

## Additional notes
- this change only updates review routing metadata
- no runtime or build behavior is affected

Change-Id: I7fbd7fbb5beed8b565aba2f76cf1998302dfef56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Align `.github/CODEOWNERS` ordering with GitHub last-match-wins behavior.
- Preserve nested documentation ownership with broad Docs UI fallbacks.
- Reorder API and Guide rules from broad fallbacks to specific sub-paths.
- Keep Luna rules last so they take precedence.
- Add comments that clarify rule ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->