### PR TITLE
fix(docs): restore broken lynx-ui CDN asset paths in styling-theming

### DIFF
--- a/docs/en/ui/styling-theming.mdx
+++ b/docs/en/ui/styling-theming.mdx
@@ -171,7 +171,7 @@ selectors or utilities, treat overlapping states as a design decision rather
 than something to leave to specificity.
 
 <Go
-  img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/ui/ui-cover-switch.webm"
+  img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/lynx-ui/lynx-ui-cover-switch.webm"
   example="lynx-ui-switch"
   defaultEntryName="SwitchBasicTailwind"
   entry="BasicTailwind"
@@ -353,7 +353,7 @@ The example below applies the pattern in a real UI: a controlled switch drives c
 and nested surfaces can override theme independently. The same demo is embedded on the [`<Switch>`](./components/switch.mdx) page.
 
 <Go
-  img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/ui/ui-cover-switch_themed.webm"
+  img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/lynx-ui/lynx-ui-cover-switch_themed.webm"
   example="lynx-ui-switch"
   defaultEntryName="SwitchThemed"
   entry="Themed"

--- a/docs/zh/ui/styling-theming.mdx
+++ b/docs/zh/ui/styling-theming.mdx
@@ -168,7 +168,7 @@ transform 写法。
 关系，应当作为明确的设计决策来处理。
 
 <Go
-  img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/ui/ui-cover-switch.webm"
+  img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/lynx-ui/lynx-ui-cover-switch.webm"
   example="lynx-ui-switch"
   defaultEntryName="SwitchBasicTailwind"
   entry="BasicTailwind"
@@ -324,7 +324,7 @@ export function ThemedSwitch(props: SwitchProps) {
 下面的示例展示了这一模式在实际 UI 中的用法：通过受控 Switch 切换容器主题，并演示嵌套 surface 如何独立覆盖主题。这个 demo 也会出现在 [`<Switch>`](./components/switch.mdx) 组件页。
 
 <Go
-  img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/ui/ui-cover-switch_themed.webm"
+  img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/lynx-ui/lynx-ui-cover-switch_themed.webm"
   example="lynx-ui-switch"
   defaultEntryName="SwitchThemed"
   entry="Themed"


### PR DESCRIPTION
Commit 784424f incorrectly rewrote external CDN asset URLs during the lynx-ui → ui subsite migration, affecting both the directory segment (assets/ui → assets/lynx-ui) and the filename prefix (ui-cover-* → lynx-ui-cover-*).

Affected assets:
- lynx-ui-cover-switch.webm (basic switch demo)
- lynx-ui-cover-switch_themed.webm (themed switch demo)

Files fixed:
- docs/en/ui/styling-theming.mdx (2 images)
- docs/zh/ui/styling-theming.mdx (2 images)

Change-Id: I42337556d86b9f92c74c7ad13ced98baafc98f56