### PR TITLE
fix(lynx-ui): align theme and docs with the /ui route migration

### DIFF
--- a/docs/en/api/_meta.json
+++ b/docs/en/api/_meta.json
@@ -1327,7 +1327,7 @@
   },
   {
     "type": "custom-link",
-    "link": "/lynx-ui/components/button",
+    "link": "/ui/components/button",
     "label": "lynx-ui Components ↗"
   },
   {

--- a/docs/en/ui/styling-theming.mdx
+++ b/docs/en/ui/styling-theming.mdx
@@ -67,7 +67,7 @@ hidden built-in visual to override.
 Using `Switch`:
 
 ```tsx
-import { Switch, SwitchThumb, SwitchTrack } from '@lynx-js/ui';
+import { Switch, SwitchThumb, SwitchTrack } from '@lynx-js/lynx-ui';
 
 export function ExampleSwitch() {
   return (
@@ -279,12 +279,12 @@ import {
   Switch as SwitchPrimitive,
   SwitchThumb as SwitchThumbPrimitive,
   SwitchTrack as SwitchTrackPrimitive,
-} from '@lynx-js/ui';
+} from '@lynx-js/lynx-ui';
 import type {
   SwitchProps,
   SwitchThumbProps,
   SwitchTrackProps,
-} from '@lynx-js/ui';
+} from '@lynx-js/lynx-ui';
 import { clsx } from 'clsx';
 
 export function ThemedSwitch(props: SwitchProps) {

--- a/docs/zh/api/_meta.json
+++ b/docs/zh/api/_meta.json
@@ -1327,7 +1327,7 @@
   },
   {
     "type": "custom-link",
-    "link": "/lynx-ui/components/button",
+    "link": "/ui/components/button",
     "label": "lynx-ui Components ↗"
   },
   {

--- a/docs/zh/ui/styling-theming.mdx
+++ b/docs/zh/ui/styling-theming.mdx
@@ -65,7 +65,7 @@ className。底层不会存在需要你覆盖的隐藏默认样式。
 以 `Switch` 为例：
 
 ```tsx
-import { Switch, SwitchThumb, SwitchTrack } from '@lynx-js/ui';
+import { Switch, SwitchThumb, SwitchTrack } from '@lynx-js/lynx-ui';
 
 export function ExampleSwitch() {
   return (
@@ -252,12 +252,12 @@ import {
   Switch as SwitchPrimitive,
   SwitchThumb as SwitchThumbPrimitive,
   SwitchTrack as SwitchTrackPrimitive,
-} from '@lynx-js/ui';
+} from '@lynx-js/lynx-ui';
 import type {
   SwitchProps,
   SwitchThumbProps,
   SwitchTrackProps,
-} from '@lynx-js/ui';
+} from '@lynx-js/lynx-ui';
 import { clsx } from 'clsx';
 
 export function ThemedSwitchRoot({ className, ...props }: SwitchProps) {

--- a/scripts/sync-lynx-ui-docs-to-shared.js
+++ b/scripts/sync-lynx-ui-docs-to-shared.js
@@ -114,15 +114,22 @@ const hoistMdxImports = (filePath) => {
   }
 };
 
-const rewriteLynxUiRouteLinks = (filePath) => {
-  if (!filePath.endsWith('.mdx')) {
+const normalizeSyncedDoc = (filePath) => {
+  if (!/\.mdx?$/.test(filePath)) {
     return;
   }
 
   const original = fs.readFileSync(filePath, 'utf8');
-  const next = original
-    .replace(/\((\/zh)?\/lynx-ui(?=[/#).?])/g, '($1/ui')
-    .replace(/(href=["'])(\/zh)?\/lynx-ui(?=[/#?])/g, '$1$2/ui');
+  const hasLegacyEnglishUrl = original.includes('https://lynxjs.org/en/');
+  let next = original
+    // Rewrite route links without touching package, repository, or asset names.
+    .replace(/(^|[("'\s=:])(\/(?:en\/|zh\/)?)lynx-ui\//gm, '$1$2ui/')
+    // English is the default locale and is not served under an /en prefix.
+    .replaceAll('https://lynxjs.org/en/', 'https://lynxjs.org/');
+
+  if (hasLegacyEnglishUrl) {
+    next = next.replace(/(?:\r?\n[ \t]*)+$/, '\n');
+  }
 
   if (next !== original) {
     fs.writeFileSync(filePath, next, 'utf8');
@@ -145,13 +152,11 @@ packages.forEach((pkgName) => {
     }
 
     copyRecursiveSync(pkgDocsDir, targetDir);
-    if (ENABLE_MDX_HOIST) {
-      for (const filePath of collectFilesRecursively(targetDir)) {
+    for (const filePath of collectFilesRecursively(targetDir)) {
+      normalizeSyncedDoc(filePath);
+      if (ENABLE_MDX_HOIST) {
         hoistMdxImports(filePath);
       }
-    }
-    for (const filePath of collectFilesRecursively(targetDir)) {
-      rewriteLynxUiRouteLinks(filePath);
     }
     copiedCount++;
   }

--- a/shared-og-config.ts
+++ b/shared-og-config.ts
@@ -168,7 +168,7 @@ export type OgSelection =
  * A leading `zh` segment is stripped before classifying. Precedence:
  *   1. blog   — a `blog` segment followed by a slug (the blog index is not a post)
  *   2. api    — first effective segment is `api`
- *   3. subsite — first segment matching a cover (react/rspeedy/lynx-ui/ai)
+ *   3. subsite — first effective segment matching a cover (react/rspeedy/ui/ai)
  *   4. guide  — fallback
  *
  * Examples (imagePath via ogBlogPath/ogCoverPath):
@@ -200,8 +200,10 @@ export function selectOg(pathnameNoBase: string, lang: string): OgSelection {
     return { kind: 'cover', value: 'api', imagePath: ogCoverPath(lang, 'api') };
   }
 
-  // 3. Subsite docs (react/rspeedy/lynx-ui/ai) — match a segment to a cover.
-  const value = SUBSITE_COVER_VALUES.find((v) => afterLang.includes(v));
+  // 3. Subsite docs (react/rspeedy/ui/ai) — match the first effective segment
+  // to a cover. Deeper segments must not count: /guide/ui/* is a guide page,
+  // not a lynx-ui one.
+  const value = SUBSITE_COVER_VALUES.find((v) => afterLang[0] === v);
   if (value)
     return { kind: 'cover', value, imagePath: ogCoverPath(lang, value) };
 

--- a/theme/index.scss
+++ b/theme/index.scss
@@ -98,7 +98,7 @@ $link-color-dark: rgba(84, 169, 255, 1);
   @include subsite-theme(#ff8b00);
 }
 
-:root[data-subsite='lynx-ui'] {
+:root[data-subsite='ui'] {
   @include subsite-theme(#ff1a6e);
   --rp-c-bg: #ffffff;
   --rp-c-bg-alt: #f5f5f5;
@@ -120,7 +120,7 @@ $link-color-dark: rgba(84, 169, 255, 1);
   }
 }
 
-.dark[data-subsite='lynx-ui'] {
+.dark[data-subsite='ui'] {
   @include subsite-theme(#ff8ab5);
   --rp-c-bg: #0a0a0a;
   --rp-c-bg-alt: #000000;

--- a/theme/lynx-ui-home/StartBuildingBottom.tsx
+++ b/theme/lynx-ui-home/StartBuildingBottom.tsx
@@ -21,7 +21,7 @@ export const StartBuilding = () => {
       <button
         type="button"
         className="relative z-10 mt-[20px] flex h-[48px] w-[142px] cursor-pointer flex-col items-center justify-center rounded-[24px] bg-[linear-gradient(275deg,var(--rp-c-brand-darker)_3%,var(--rp-c-brand)_97%)]"
-        onClick={() => linkNavigate('guides/introduction')}
+        onClick={() => linkNavigate('introduction')}
       >
         <span className="text-[var(--home-button-font-color)]">
           {lang === 'zh' ? '快速开始' : 'Get Started'}

--- a/theme/lynx-ui-home/hero-text.scss
+++ b/theme/lynx-ui-home/hero-text.scss
@@ -1,4 +1,4 @@
-:root[data-subsite='lynx-ui'] {
+:root[data-subsite='ui'] {
   .hero-title {
     animation: fade-in 0.8s ease-out;
     word-wrap: break-word;

--- a/theme/lynx-ui-home/home-layout-var.scss
+++ b/theme/lynx-ui-home/home-layout-var.scss
@@ -1,4 +1,4 @@
-:root[data-subsite='lynx-ui'] {
+:root[data-subsite='ui'] {
   --major-brand-color: #ff3d63;
   --gradient-brand-color: #ff5d99;
   --second-brand-color: #3dd5e9;
@@ -28,7 +28,7 @@
   --responsive-font-size: 1rem;
 }
 
-:root.dark[data-subsite='lynx-ui'] {
+:root.dark[data-subsite='ui'] {
   --major-brand-color: #ff7385;
   --gradient-brand-color: #fe69a1;
   --second-brand-color: #00d0f1;
@@ -69,7 +69,7 @@
   );
 }
 
-:root[data-subsite='lynx-ui'] .rspress-home-hero-tagline {
+:root[data-subsite='ui'] .rspress-home-hero-tagline {
   color: var(--home-features-item-desc-color);
 }
 

--- a/theme/lynx-ui-home/hooks/use-link-navigate.ts
+++ b/theme/lynx-ui-home/hooks/use-link-navigate.ts
@@ -3,24 +3,16 @@
 // LICENSE file in the root directory of this source tree.
 
 import { useCallback } from 'react';
-import { useLang, useNavigate, usePage } from '@rspress/core/runtime';
+import { useLang, useNavigate } from '@rspress/core/runtime';
 
 export const useLinkNavigate = () => {
   const navigate = useNavigate();
   const lang = useLang() as 'en' | 'zh';
-  const { page } = usePage();
   const handleInteraction = useCallback(
     (path: string) => {
-      if (
-        page.pagePath.startsWith('en/lynx-ui') ||
-        page.pagePath.startsWith('zh/lynx-ui')
-      ) {
-        navigate(lang === 'en' ? `/en/lynx-ui/${path}` : `/zh/lynx-ui/${path}`);
-      } else {
-        navigate(lang === 'en' ? `/en/${path}` : `/zh/${path}`);
-      }
+      navigate(lang === 'en' ? `/ui/${path}` : `/zh/ui/${path}`);
     },
-    [navigate, lang, page.pagePath],
+    [navigate, lang],
   );
 
   return {

--- a/theme/lynx-ui-home/index.scss
+++ b/theme/lynx-ui-home/index.scss
@@ -4,7 +4,7 @@
 @use '../semi.scss';
 @use './sidebar-badge';
 
-:root[data-subsite='lynx-ui'] {
+:root[data-subsite='ui'] {
   .rp-home-hero__badge {
     opacity: 1;
   }

--- a/theme/lynx-ui-home/shiki.scss
+++ b/theme/lynx-ui-home/shiki.scss
@@ -1,4 +1,4 @@
-:root[data-subsite='lynx-ui'] {
+:root[data-subsite='ui'] {
   --shiki-foreground: #24292f;
   --shiki-background: transparent;
   --shiki-token-constant: #0550ae;
@@ -14,7 +14,7 @@
   --shiki-token-inserted: #116329;
 }
 
-:root:where(.dark, .rp-dark)[data-subsite='lynx-ui'] {
+:root:where(.dark, .rp-dark)[data-subsite='ui'] {
   --shiki-foreground: #c9d1d9;
   --shiki-background: transparent;
   --shiki-token-constant: #79c0ff;

--- a/theme/lynx-ui-home/sidebar-badge.scss
+++ b/theme/lynx-ui-home/sidebar-badge.scss
@@ -14,7 +14,7 @@ $lynx-ui-badge-names: (
 );
 
 // Scope to lynx-ui subsite to avoid leaking into main site sidebar
-[data-subsite='lynx-ui'] {
+[data-subsite='ui'] {
   @each $context, $label in $lynx-ui-badge-names {
     .rspress-sidebar-collapse[data-context='#{$context}'],
     .rspress-sidebar-item[data-context='#{$context}']:not(


### PR DESCRIPTION
Motivation:
The release/3.9 backport moved lynx-ui docs from /lynx-ui to /ui, but theme scopes, navigation, generated links, and synced docs still used parts of the old route model. Some authored examples also replaced the canonical package name with an incorrect import path.

Changes:
- align lynx-ui theme scopes with data-subsite="ui"
- update the homepage CTA to navigate to canonical /ui docs paths
- restore @lynx-js/lynx-ui imports in styling and theming docs
- update API sidebar links to /ui/components/button
- normalize synced route links without rewriting package or asset names
- prevent the swiper API document from drifting after pnpm install
- classify OG covers by the first effective route segment

Validation:
- ran pnpm prepare:sync-lynx-ui twice with no packageDocs diff
- passed formatting, spelling, API summary, and git diff --check
- completed a production Rspress build

Related:
- #1289 
- #1154 
- #1160 

Change-Id: I1e059a87f3a40ca3115689e1eb4b4adc959f814d