### PR TITLE
fix(ui): fix Lynx UI homepage routes

### DIFF
--- a/docs/zh/ui/index.md
+++ b/docs/zh/ui/index.md
@@ -15,5 +15,5 @@ hero:
       link: /zh/ui/introduction.html#快速开始
     - theme: alt
       text: 组件
-      link: /ui/components/button
+      link: /zh/ui/components/button
 ---

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -201,10 +201,6 @@ export default defineConfig({
           from: '^/zh/lynx-ui(/.*)?$',
           to: '/zh/ui$1',
         },
-        {
-          from: '^/en/lynx-ui(/.*)?$',
-          to: '/en/ui$1',
-        },
       ],
     }),
     pluginSitemap({

--- a/theme/lynx-ui-home/StartBuildingBottom.tsx
+++ b/theme/lynx-ui-home/StartBuildingBottom.tsx
@@ -21,7 +21,7 @@ export const StartBuilding = () => {
       <button
         type="button"
         className="relative z-10 mt-[20px] flex h-[48px] w-[142px] cursor-pointer flex-col items-center justify-center rounded-[24px] bg-[linear-gradient(275deg,var(--rp-c-brand-darker)_3%,var(--rp-c-brand)_97%)]"
-        onClick={() => linkNavigate('guides/introduction')}
+        onClick={() => linkNavigate('introduction')}
       >
         <span className="text-[var(--home-button-font-color)]">
           {lang === 'zh' ? '快速开始' : 'Get Started'}

--- a/theme/lynx-ui-home/hooks/use-link-navigate.ts
+++ b/theme/lynx-ui-home/hooks/use-link-navigate.ts
@@ -3,24 +3,16 @@
 // LICENSE file in the root directory of this source tree.
 
 import { useCallback } from 'react';
-import { useLang, useNavigate, usePage } from '@rspress/core/runtime';
+import { useLang, useNavigate } from '@rspress/core/runtime';
 
 export const useLinkNavigate = () => {
   const navigate = useNavigate();
   const lang = useLang() as 'en' | 'zh';
-  const { page } = usePage();
   const handleInteraction = useCallback(
     (path: string) => {
-      if (
-        page.pagePath.startsWith('en/ui/') ||
-        page.pagePath.startsWith('zh/ui/')
-      ) {
-        navigate(lang === 'en' ? `/en/ui/${path}` : `/zh/ui/${path}`);
-      } else {
-        navigate(lang === 'en' ? `/en/${path}` : `/zh/${path}`);
-      }
+      navigate(lang === 'en' ? `/ui/${path}` : `/zh/ui/${path}`);
     },
-    [navigate, lang, page.pagePath],
+    [navigate, lang],
   );
 
   return {


### PR DESCRIPTION
## Motivation

The Lynx UI route migration to `/ui/*` left a few homepage navigation paths inconsistent with the site's canonical locale model.

This PR keeps the fix focused on route behavior and homepage navigation only:
- English should resolve to `/ui/*`
- Chinese should resolve to `/zh/ui/*`
- the client redirect set should match the site's default-English routing model

## Changes by component

### Lynx UI homepage navigation
- simplify the homepage navigation helper to route directly to canonical `/ui/*` and `/zh/ui/*` destinations
- update the Start Building CTA to point to the canonical introduction page
- remove stale page-path branching and old `/en/...` assumptions

### Lynx UI homepage content
- fix the Chinese homepage Components action to use `/zh/ui/components/button`

### Client redirects
- remove the unnecessary `/en/lynx-ui/*` client redirect
- keep the redirect set aligned with the site's default-English and `/zh/*` route shape

## Additional notes

- This PR intentionally stays within the route-behavior / homepage-navigation scope.
- It does not include synced docs updates or OG asset work.
- The scope should stay easy to cherry-pick onto release branches.

## Validation

- Not run in CI.
- Verified by inspection that:
  - the homepage CTA resolves to `/ui/introduction` for English
  - the homepage CTA resolves to `/zh/ui/introduction` for Chinese
  - the Chinese homepage Components action points to `/zh/ui/components/button`
  - the remaining client redirects match the supported canonical locale shape
  
 ## Related
 - #1310 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Route English users to `/ui/*` and Chinese users to `/zh/ui/*`.
- Navigate the Start Building CTA to the localized `introduction` pages.
- Point the Chinese Components action to `/zh/ui/components/button`.
- Remove the obsolete `/en/lynx-ui/*` client redirect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->