### PR TITLE
chore(cherry-pick): add newer release targets

### DIFF
--- a/.github/ISSUE_TEMPLATE/cherry_pick_request.yml
+++ b/.github/ISSUE_TEMPLATE/cherry_pick_request.yml
@@ -19,6 +19,9 @@ body:
       label: Target release branches
       description: Select one or more release branches.
       options:
+        - label: release/4.0
+        - label: release/3.9
+        - label: release/3.8
         - label: release/3.7
         - label: release/3.6
         - label: release/3.5

--- a/.github/cherry-pick-config.json
+++ b/.github/cherry-pick-config.json
@@ -1,5 +1,8 @@
 {
   "targetBranches": [
+    "release/4.0",
+    "release/3.9",
+    "release/3.8",
     "release/3.7",
     "release/3.6",
     "release/3.5",


### PR DESCRIPTION
Why
- Keep the cherry-pick automation aligned with the currently supported release branches.

What changed
- Added release/4.0, release/3.9, and release/3.8 to the cherry-pick target branch config.
- Updated the cherry-pick request issue template to expose the same branch options.

Validation
- Ran `node .github/scripts/cherry-pick-request.mjs check-config`.

Change-Id: Icf6726eeb43baef435eb492eaee18eb9aabeec0e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Support `release/4.0`, `release/3.9`, and `release/3.8` in cherry-pick automation.
- Expose the supported release branches in the cherry-pick request issue template.
- Validate the configuration with `node .github/scripts/cherry-pick-request.mjs check-config`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->