### PR TITLE
fix(compat-data): mark getComputedStyleProperty's specific properties as supported on web

### DIFF
--- a/packages/lynx-compat-data/api-stats.json
+++ b/packages/lynx-compat-data/api-stats.json
@@ -9,7 +9,7 @@
           "android": 279,
           "ios": 281,
           "harmony": 240,
-          "web_lynx": 182,
+          "web_lynx": 202,
           "clay_android": 232,
           "clay_ios": 228,
           "clay_macos": 243,
@@ -20,7 +20,7 @@
           "android": 83,
           "ios": 83,
           "harmony": 71,
-          "web_lynx": 54,
+          "web_lynx": 60,
           "clay_android": 69,
           "clay_ios": 68,
           "clay_macos": 72,
@@ -31,7 +31,7 @@
           "android": 6,
           "ios": 12,
           "harmony": 0,
-          "web_lynx": 4,
+          "web_lynx": 5,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 0,
@@ -633,9 +633,9 @@
         "exclusive_count": 7
       },
       "web_lynx": {
-        "supported_count": 742,
-        "coverage_percent": 65,
-        "exclusive_count": 30
+        "supported_count": 762,
+        "coverage_percent": 67,
+        "exclusive_count": 31
       },
       "clay_android": {
         "supported_count": 629,
@@ -692,7 +692,7 @@
           "android": 279,
           "ios": 281,
           "harmony": 240,
-          "web_lynx": 182,
+          "web_lynx": 202,
           "clay_android": 232,
           "clay_ios": 228,
           "clay_macos": 243,
@@ -703,7 +703,7 @@
           "android": 83,
           "ios": 83,
           "harmony": 71,
-          "web_lynx": 54,
+          "web_lynx": 60,
           "clay_android": 69,
           "clay_ios": 68,
           "clay_macos": 72,
@@ -714,7 +714,7 @@
           "android": 6,
           "ios": 12,
           "harmony": 0,
-          "web_lynx": 4,
+          "web_lynx": 5,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 0,
@@ -1551,7 +1551,7 @@
             "android": "3.5",
             "ios": "3.5",
             "harmony": "3.5",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -1567,7 +1567,7 @@
             "android": "3.5",
             "ios": "3.5",
             "harmony": "3.5",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -1583,7 +1583,7 @@
             "android": "3.5",
             "ios": "3.5",
             "harmony": "3.5",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -1599,7 +1599,7 @@
             "android": "3.5",
             "ios": "3.5",
             "harmony": "3.5",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -1615,7 +1615,7 @@
             "android": "3.5",
             "ios": "3.5",
             "harmony": "3.5",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -1631,7 +1631,7 @@
             "android": "3.5",
             "ios": "3.5",
             "harmony": "3.5",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -1647,7 +1647,7 @@
             "android": "3.5",
             "ios": "3.5",
             "harmony": "3.5",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -1663,7 +1663,7 @@
             "android": "3.5",
             "ios": "3.5",
             "harmony": "3.5",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -1679,7 +1679,7 @@
             "android": "3.5",
             "ios": "3.5",
             "harmony": "3.5",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -1695,7 +1695,7 @@
             "android": "3.5",
             "ios": "3.5",
             "harmony": "3.5",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -1711,7 +1711,7 @@
             "android": "3.5",
             "ios": "3.5",
             "harmony": "3.5",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -1727,7 +1727,7 @@
             "android": "3.6",
             "ios": "3.6",
             "harmony": "3.6",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.6",
@@ -1743,7 +1743,7 @@
             "android": "3.6",
             "ios": "3.6",
             "harmony": "3.6",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.6",
@@ -1759,7 +1759,7 @@
             "android": "3.6",
             "ios": "3.6",
             "harmony": "3.6",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.6",
@@ -1775,7 +1775,7 @@
             "android": "3.6",
             "ios": "3.6",
             "harmony": "3.6",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.6",
@@ -1791,7 +1791,7 @@
             "android": "3.6",
             "ios": "3.6",
             "harmony": "3.6",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.6",
@@ -1807,7 +1807,7 @@
             "android": "3.6",
             "ios": "3.6",
             "harmony": "3.6",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.6",
@@ -1823,7 +1823,7 @@
             "android": "3.6",
             "ios": "3.6",
             "harmony": "3.6",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.6",
@@ -1839,7 +1839,7 @@
             "android": "3.6",
             "ios": "3.6",
             "harmony": "3.6",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.6",
@@ -1855,7 +1855,7 @@
             "android": "3.6",
             "ios": "3.6",
             "harmony": "3.6",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.6",
@@ -1871,7 +1871,7 @@
             "android": false,
             "ios": false,
             "harmony": false,
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": false,
@@ -10801,326 +10801,6 @@
             }
           },
           {
-            "path": "elements/get-computed-style-supported-properties.top",
-            "name": "top",
-            "doc_url": "/api/elements/built-in/get-computed-style-supported-properties",
-            "support": {
-              "android": "3.5",
-              "ios": "3.5",
-              "harmony": "3.5",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
-            "path": "elements/get-computed-style-supported-properties.left",
-            "name": "left",
-            "doc_url": "/api/elements/built-in/get-computed-style-supported-properties",
-            "support": {
-              "android": "3.5",
-              "ios": "3.5",
-              "harmony": "3.5",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
-            "path": "elements/get-computed-style-supported-properties.width",
-            "name": "width",
-            "doc_url": "/api/elements/built-in/get-computed-style-supported-properties",
-            "support": {
-              "android": "3.5",
-              "ios": "3.5",
-              "harmony": "3.5",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
-            "path": "elements/get-computed-style-supported-properties.height",
-            "name": "height",
-            "doc_url": "/api/elements/built-in/get-computed-style-supported-properties",
-            "support": {
-              "android": "3.5",
-              "ios": "3.5",
-              "harmony": "3.5",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
-            "path": "elements/get-computed-style-supported-properties.right",
-            "name": "right",
-            "doc_url": "/api/elements/built-in/get-computed-style-supported-properties",
-            "support": {
-              "android": "3.5",
-              "ios": "3.5",
-              "harmony": "3.5",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
-            "path": "elements/get-computed-style-supported-properties.bottom",
-            "name": "bottom",
-            "doc_url": "/api/elements/built-in/get-computed-style-supported-properties",
-            "support": {
-              "android": "3.5",
-              "ios": "3.5",
-              "harmony": "3.5",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
-            "path": "elements/get-computed-style-supported-properties.transform",
-            "name": "transform",
-            "doc_url": "/api/elements/built-in/get-computed-style-supported-properties",
-            "support": {
-              "android": "3.5",
-              "ios": "3.5",
-              "harmony": "3.5",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
-            "path": "elements/get-computed-style-supported-properties.transform-origin",
-            "name": "transform-origin",
-            "doc_url": "/api/elements/built-in/get-computed-style-supported-properties",
-            "support": {
-              "android": "3.5",
-              "ios": "3.5",
-              "harmony": "3.5",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
-            "path": "elements/get-computed-style-supported-properties.opacity",
-            "name": "opacity",
-            "doc_url": "/api/elements/built-in/get-computed-style-supported-properties",
-            "support": {
-              "android": "3.5",
-              "ios": "3.5",
-              "harmony": "3.5",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
-            "path": "elements/get-computed-style-supported-properties.color",
-            "name": "color",
-            "doc_url": "/api/elements/built-in/get-computed-style-supported-properties",
-            "support": {
-              "android": "3.5",
-              "ios": "3.5",
-              "harmony": "3.5",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
-            "path": "elements/get-computed-style-supported-properties.background-color",
-            "name": "background-color",
-            "doc_url": "/api/elements/built-in/get-computed-style-supported-properties",
-            "support": {
-              "android": "3.5",
-              "ios": "3.5",
-              "harmony": "3.5",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
-            "path": "elements/get-computed-style-supported-properties.direction",
-            "name": "direction",
-            "doc_url": "/api/elements/built-in/get-computed-style-supported-properties",
-            "support": {
-              "android": "3.6",
-              "ios": "3.6",
-              "harmony": "3.6",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.6",
-              "clay_windows": "3.6",
-              "clay": "3.6"
-            }
-          },
-          {
-            "path": "elements/get-computed-style-supported-properties.z-index",
-            "name": "z-index",
-            "doc_url": "/api/elements/built-in/get-computed-style-supported-properties",
-            "support": {
-              "android": "3.6",
-              "ios": "3.6",
-              "harmony": "3.6",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.6",
-              "clay_windows": "3.6",
-              "clay": "3.6"
-            }
-          },
-          {
-            "path": "elements/get-computed-style-supported-properties.background-position",
-            "name": "background-position",
-            "doc_url": "/api/elements/built-in/get-computed-style-supported-properties",
-            "support": {
-              "android": "3.6",
-              "ios": "3.6",
-              "harmony": "3.6",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.6",
-              "clay_windows": "3.6",
-              "clay": "3.6"
-            }
-          },
-          {
-            "path": "elements/get-computed-style-supported-properties.filter",
-            "name": "filter",
-            "doc_url": "/api/elements/built-in/get-computed-style-supported-properties",
-            "support": {
-              "android": "3.6",
-              "ios": "3.6",
-              "harmony": "3.6",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.6",
-              "clay_windows": "3.6",
-              "clay": "3.6"
-            }
-          },
-          {
-            "path": "elements/get-computed-style-supported-properties.margin & margin-left & margin-right & margin-top & margin-bottom",
-            "name": "margin & margin-left & margin-right & margin-top & margin-bottom",
-            "doc_url": "/api/elements/built-in/get-computed-style-supported-properties",
-            "support": {
-              "android": "3.6",
-              "ios": "3.6",
-              "harmony": "3.6",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.6",
-              "clay_windows": "3.6",
-              "clay": "3.6"
-            }
-          },
-          {
-            "path": "elements/get-computed-style-supported-properties.padding & padding-left & padding-right & padding-top & padding-bottom",
-            "name": "padding & padding-left & padding-right & padding-top & padding-bottom",
-            "doc_url": "/api/elements/built-in/get-computed-style-supported-properties",
-            "support": {
-              "android": "3.6",
-              "ios": "3.6",
-              "harmony": "3.6",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.6",
-              "clay_windows": "3.6",
-              "clay": "3.6"
-            }
-          },
-          {
-            "path": "elements/get-computed-style-supported-properties.border-width & border-top-width & border-bottom-width & border-left-width & border-right-width",
-            "name": "border-width & border-top-width & border-bottom-width & border-left-width & border-right-width",
-            "doc_url": "/api/elements/built-in/get-computed-style-supported-properties",
-            "support": {
-              "android": "3.6",
-              "ios": "3.6",
-              "harmony": "3.6",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.6",
-              "clay_windows": "3.6",
-              "clay": "3.6"
-            }
-          },
-          {
-            "path": "elements/get-computed-style-supported-properties.border-radius & border-top-left-radius & border-top-right-radius & border-bottom-right-radius & border-bottom-left-radius",
-            "name": "border-radius & border-top-left-radius & border-top-right-radius & border-bottom-right-radius & border-bottom-left-radius",
-            "doc_url": "/api/elements/built-in/get-computed-style-supported-properties",
-            "support": {
-              "android": "3.6",
-              "ios": "3.6",
-              "harmony": "3.6",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.6",
-              "clay_windows": "3.6",
-              "clay": "3.6"
-            }
-          },
-          {
-            "path": "elements/get-computed-style-supported-properties.border-color & border-top-color & border-right-color & border-bottom-color & border-left-color",
-            "name": "border-color & border-top-color & border-right-color & border-bottom-color & border-left-color",
-            "doc_url": "/api/elements/built-in/get-computed-style-supported-properties",
-            "support": {
-              "android": "3.6",
-              "ios": "3.6",
-              "harmony": "3.6",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.6",
-              "clay_windows": "3.6",
-              "clay": "3.6"
-            }
-          },
-          {
             "path": "elements/image.prefetch-width",
             "name": "prefetch-width",
             "doc_url": "/api/elements/built-in/image",
@@ -13162,7 +12842,7 @@
               "android": "3.5",
               "ios": "3.5",
               "harmony": "3.5",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -13178,7 +12858,7 @@
               "android": "3.5",
               "ios": "3.5",
               "harmony": "3.5",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -13194,7 +12874,7 @@
               "android": "3.5",
               "ios": "3.5",
               "harmony": "3.5",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -13210,7 +12890,7 @@
               "android": "3.5",
               "ios": "3.5",
               "harmony": "3.5",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -13226,7 +12906,7 @@
               "android": "3.5",
               "ios": "3.5",
               "harmony": "3.5",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -13242,7 +12922,7 @@
               "android": "3.5",
               "ios": "3.5",
               "harmony": "3.5",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -13258,7 +12938,7 @@
               "android": "3.5",
               "ios": "3.5",
               "harmony": "3.5",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -13274,7 +12954,7 @@
               "android": "3.5",
               "ios": "3.5",
               "harmony": "3.5",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -13290,7 +12970,7 @@
               "android": "3.5",
               "ios": "3.5",
               "harmony": "3.5",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -13306,7 +12986,7 @@
               "android": "3.5",
               "ios": "3.5",
               "harmony": "3.5",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -13322,7 +13002,7 @@
               "android": "3.5",
               "ios": "3.5",
               "harmony": "3.5",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -13338,7 +13018,7 @@
               "android": "3.6",
               "ios": "3.6",
               "harmony": "3.6",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.6",
@@ -13354,7 +13034,7 @@
               "android": "3.6",
               "ios": "3.6",
               "harmony": "3.6",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.6",
@@ -13370,7 +13050,7 @@
               "android": "3.6",
               "ios": "3.6",
               "harmony": "3.6",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.6",
@@ -13386,7 +13066,7 @@
               "android": "3.6",
               "ios": "3.6",
               "harmony": "3.6",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.6",
@@ -13402,7 +13082,7 @@
               "android": "3.6",
               "ios": "3.6",
               "harmony": "3.6",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.6",
@@ -13418,7 +13098,7 @@
               "android": "3.6",
               "ios": "3.6",
               "harmony": "3.6",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.6",
@@ -13434,7 +13114,7 @@
               "android": "3.6",
               "ios": "3.6",
               "harmony": "3.6",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.6",
@@ -13450,7 +13130,7 @@
               "android": "3.6",
               "ios": "3.6",
               "harmony": "3.6",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.6",
@@ -13466,7 +13146,7 @@
               "android": "3.6",
               "ios": "3.6",
               "harmony": "3.6",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.6",
@@ -14828,7 +14508,7 @@
               "android": "3.5",
               "ios": "3.5",
               "harmony": "3.5",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -14844,7 +14524,7 @@
               "android": "3.5",
               "ios": "3.5",
               "harmony": "3.5",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -14860,7 +14540,7 @@
               "android": "3.5",
               "ios": "3.5",
               "harmony": "3.5",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -14876,7 +14556,7 @@
               "android": "3.5",
               "ios": "3.5",
               "harmony": "3.5",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -14892,7 +14572,7 @@
               "android": "3.5",
               "ios": "3.5",
               "harmony": "3.5",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -14908,7 +14588,7 @@
               "android": "3.5",
               "ios": "3.5",
               "harmony": "3.5",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -14924,7 +14604,7 @@
               "android": "3.5",
               "ios": "3.5",
               "harmony": "3.5",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -14940,7 +14620,7 @@
               "android": "3.5",
               "ios": "3.5",
               "harmony": "3.5",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -14956,7 +14636,7 @@
               "android": "3.5",
               "ios": "3.5",
               "harmony": "3.5",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -14972,7 +14652,7 @@
               "android": "3.5",
               "ios": "3.5",
               "harmony": "3.5",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -14988,7 +14668,7 @@
               "android": "3.5",
               "ios": "3.5",
               "harmony": "3.5",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -15004,7 +14684,7 @@
               "android": "3.6",
               "ios": "3.6",
               "harmony": "3.6",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.6",
@@ -15020,7 +14700,7 @@
               "android": "3.6",
               "ios": "3.6",
               "harmony": "3.6",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.6",
@@ -15036,7 +14716,7 @@
               "android": "3.6",
               "ios": "3.6",
               "harmony": "3.6",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.6",
@@ -15052,7 +14732,7 @@
               "android": "3.6",
               "ios": "3.6",
               "harmony": "3.6",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.6",
@@ -15068,7 +14748,7 @@
               "android": "3.6",
               "ios": "3.6",
               "harmony": "3.6",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.6",
@@ -15084,7 +14764,7 @@
               "android": "3.6",
               "ios": "3.6",
               "harmony": "3.6",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.6",
@@ -15100,7 +14780,7 @@
               "android": "3.6",
               "ios": "3.6",
               "harmony": "3.6",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.6",
@@ -15116,7 +14796,7 @@
               "android": "3.6",
               "ios": "3.6",
               "harmony": "3.6",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.6",
@@ -15132,7 +14812,7 @@
               "android": "3.6",
               "ios": "3.6",
               "harmony": "3.6",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.6",
@@ -20851,6 +20531,22 @@
         ],
         "harmony": [],
         "web_lynx": [
+          {
+            "path": "elements/get-computed-style-supported-properties.Other CSS Properties",
+            "name": "Other CSS Properties",
+            "doc_url": "/api/elements/built-in/get-computed-style-supported-properties",
+            "support": {
+              "android": false,
+              "ios": false,
+              "harmony": false,
+              "web_lynx": true,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          },
           {
             "path": "elements/list.CSS.nested_value_2",
             "name": "<code>border-radius</code> related",
@@ -72970,7 +72666,7 @@
           "version_added": "3.5"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -73006,7 +72702,7 @@
           "version_added": "3.5"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -73042,7 +72738,7 @@
           "version_added": "3.5"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -73078,7 +72774,7 @@
           "version_added": "3.5"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -73114,7 +72810,7 @@
           "version_added": "3.5"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -73150,7 +72846,7 @@
           "version_added": "3.5"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -73186,7 +72882,7 @@
           "version_added": "3.5"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -73222,7 +72918,7 @@
           "version_added": "3.5"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -73258,7 +72954,7 @@
           "version_added": "3.5"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -73294,7 +72990,7 @@
           "version_added": "3.5"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -73330,7 +73026,7 @@
           "version_added": "3.5"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -73366,7 +73062,7 @@
           "version_added": "3.6"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -73402,7 +73098,7 @@
           "version_added": "3.6"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -73438,7 +73134,7 @@
           "version_added": "3.6"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -73474,7 +73170,7 @@
           "version_added": "3.6"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -73510,7 +73206,7 @@
           "version_added": "3.6"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -73546,7 +73242,7 @@
           "version_added": "3.6"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -73582,7 +73278,7 @@
           "version_added": "3.6"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -73618,7 +73314,7 @@
           "version_added": "3.6"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -73654,7 +73350,7 @@
           "version_added": "3.6"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -73690,7 +73386,7 @@
           "version_added": false
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -120852,8 +120548,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 728,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 222,
@@ -120894,8 +120590,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 728,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 234,
@@ -120936,8 +120632,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 728,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 385,
@@ -120978,8 +120674,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 728,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 391,
@@ -121020,8 +120716,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 728,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 403,
@@ -121062,8 +120758,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 728,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 454,
@@ -121104,8 +120800,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 728,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 466,
@@ -121146,8 +120842,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 728,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 466,
@@ -121188,8 +120884,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 728,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 466,
@@ -121230,8 +120926,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 728,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 466,
@@ -121272,8 +120968,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 728,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 467,
@@ -121314,8 +121010,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 728,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 469,
@@ -121356,8 +121052,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 728,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 469,
@@ -121398,8 +121094,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 728,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 469,
@@ -121440,8 +121136,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 728,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 469,
@@ -121482,8 +121178,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 728,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 469,
@@ -121524,8 +121220,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 728,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 470,
@@ -121566,8 +121262,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 728,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 470,
@@ -121608,8 +121304,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 728,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 490,
@@ -121650,8 +121346,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 728,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 490,
@@ -121692,8 +121388,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 728,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 496,
@@ -121734,8 +121430,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 728,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 496,
@@ -121776,8 +121472,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 728,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 507,
@@ -121818,8 +121514,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 728,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 511,
@@ -121860,8 +121556,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 728,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 511,
@@ -121902,8 +121598,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 728,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 516,
@@ -121944,8 +121640,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 728,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 516,
@@ -121986,8 +121682,8 @@
           "coverage": 59
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 728,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 544,
@@ -122028,8 +121724,8 @@
           "coverage": 65
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 728,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 561,
@@ -122070,8 +121766,8 @@
           "coverage": 67
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 728,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 568,
@@ -122112,8 +121808,8 @@
           "coverage": 70
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 728,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 576,
@@ -122154,8 +121850,8 @@
           "coverage": 72
         },
         "web_lynx": {
-          "supported": 716,
-          "coverage": 63
+          "supported": 736,
+          "coverage": 65
         },
         "clay_android": {
           "supported": 576,
@@ -122196,8 +121892,8 @@
           "coverage": 74
         },
         "web_lynx": {
-          "supported": 736,
-          "coverage": 65
+          "supported": 756,
+          "coverage": 67
         },
         "clay_android": {
           "supported": 598,
@@ -122238,8 +121934,8 @@
           "coverage": 75
         },
         "web_lynx": {
-          "supported": 736,
-          "coverage": 65
+          "supported": 756,
+          "coverage": 67
         },
         "clay_android": {
           "supported": 625,

--- a/packages/lynx-compat-data/elements/get-computed-style-supported-properties.json
+++ b/packages/lynx-compat-data/elements/get-computed-style-supported-properties.json
@@ -24,7 +24,8 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented via the generic `__GetComputedStyleByKey` PAPI (`web-core/ts/client/mainthread/elementAPIs/pureElementPAPIs.ts`), which forwards any key to the browser's native `getComputedStyle(element).getPropertyValue(key)` rather than a curated per-property allowlist. Since `@lynx-js/web-core@0.23.1` (lynx-family/lynx-stack#3262), same as `lynx-api/main-thread/ElementGetComputedStyle`."
             }
           }
         }
@@ -52,7 +53,8 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented via the generic `__GetComputedStyleByKey` PAPI (`web-core/ts/client/mainthread/elementAPIs/pureElementPAPIs.ts`), which forwards any key to the browser's native `getComputedStyle(element).getPropertyValue(key)` rather than a curated per-property allowlist. Since `@lynx-js/web-core@0.23.1` (lynx-family/lynx-stack#3262), same as `lynx-api/main-thread/ElementGetComputedStyle`."
             }
           }
         }
@@ -80,7 +82,8 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented via the generic `__GetComputedStyleByKey` PAPI (`web-core/ts/client/mainthread/elementAPIs/pureElementPAPIs.ts`), which forwards any key to the browser's native `getComputedStyle(element).getPropertyValue(key)` rather than a curated per-property allowlist. Since `@lynx-js/web-core@0.23.1` (lynx-family/lynx-stack#3262), same as `lynx-api/main-thread/ElementGetComputedStyle`."
             }
           }
         }
@@ -108,7 +111,8 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented via the generic `__GetComputedStyleByKey` PAPI (`web-core/ts/client/mainthread/elementAPIs/pureElementPAPIs.ts`), which forwards any key to the browser's native `getComputedStyle(element).getPropertyValue(key)` rather than a curated per-property allowlist. Since `@lynx-js/web-core@0.23.1` (lynx-family/lynx-stack#3262), same as `lynx-api/main-thread/ElementGetComputedStyle`."
             }
           }
         }
@@ -136,7 +140,8 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented via the generic `__GetComputedStyleByKey` PAPI (`web-core/ts/client/mainthread/elementAPIs/pureElementPAPIs.ts`), which forwards any key to the browser's native `getComputedStyle(element).getPropertyValue(key)` rather than a curated per-property allowlist. Since `@lynx-js/web-core@0.23.1` (lynx-family/lynx-stack#3262), same as `lynx-api/main-thread/ElementGetComputedStyle`."
             }
           }
         }
@@ -164,7 +169,8 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented via the generic `__GetComputedStyleByKey` PAPI (`web-core/ts/client/mainthread/elementAPIs/pureElementPAPIs.ts`), which forwards any key to the browser's native `getComputedStyle(element).getPropertyValue(key)` rather than a curated per-property allowlist. Since `@lynx-js/web-core@0.23.1` (lynx-family/lynx-stack#3262), same as `lynx-api/main-thread/ElementGetComputedStyle`."
             }
           }
         }
@@ -192,7 +198,8 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented via the generic `__GetComputedStyleByKey` PAPI (`web-core/ts/client/mainthread/elementAPIs/pureElementPAPIs.ts`), which forwards any key to the browser's native `getComputedStyle(element).getPropertyValue(key)` rather than a curated per-property allowlist. Since `@lynx-js/web-core@0.23.1` (lynx-family/lynx-stack#3262), same as `lynx-api/main-thread/ElementGetComputedStyle`."
             }
           }
         }
@@ -220,7 +227,8 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented via the generic `__GetComputedStyleByKey` PAPI (`web-core/ts/client/mainthread/elementAPIs/pureElementPAPIs.ts`), which forwards any key to the browser's native `getComputedStyle(element).getPropertyValue(key)` rather than a curated per-property allowlist. Since `@lynx-js/web-core@0.23.1` (lynx-family/lynx-stack#3262), same as `lynx-api/main-thread/ElementGetComputedStyle`."
             }
           }
         }
@@ -248,7 +256,8 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented via the generic `__GetComputedStyleByKey` PAPI (`web-core/ts/client/mainthread/elementAPIs/pureElementPAPIs.ts`), which forwards any key to the browser's native `getComputedStyle(element).getPropertyValue(key)` rather than a curated per-property allowlist. Since `@lynx-js/web-core@0.23.1` (lynx-family/lynx-stack#3262), same as `lynx-api/main-thread/ElementGetComputedStyle`."
             }
           }
         }
@@ -276,7 +285,8 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented via the generic `__GetComputedStyleByKey` PAPI (`web-core/ts/client/mainthread/elementAPIs/pureElementPAPIs.ts`), which forwards any key to the browser's native `getComputedStyle(element).getPropertyValue(key)` rather than a curated per-property allowlist. Since `@lynx-js/web-core@0.23.1` (lynx-family/lynx-stack#3262), same as `lynx-api/main-thread/ElementGetComputedStyle`."
             }
           }
         }
@@ -304,7 +314,8 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented via the generic `__GetComputedStyleByKey` PAPI (`web-core/ts/client/mainthread/elementAPIs/pureElementPAPIs.ts`), which forwards any key to the browser's native `getComputedStyle(element).getPropertyValue(key)` rather than a curated per-property allowlist. Since `@lynx-js/web-core@0.23.1` (lynx-family/lynx-stack#3262), same as `lynx-api/main-thread/ElementGetComputedStyle`."
             }
           }
         }
@@ -332,7 +343,8 @@
               "version_added": "3.6"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented via the generic `__GetComputedStyleByKey` PAPI (`web-core/ts/client/mainthread/elementAPIs/pureElementPAPIs.ts`), which forwards any key to the browser's native `getComputedStyle(element).getPropertyValue(key)` rather than a curated per-property allowlist. Since `@lynx-js/web-core@0.23.1` (lynx-family/lynx-stack#3262), same as `lynx-api/main-thread/ElementGetComputedStyle`."
             }
           }
         }
@@ -360,7 +372,8 @@
               "version_added": "3.6"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented via the generic `__GetComputedStyleByKey` PAPI (`web-core/ts/client/mainthread/elementAPIs/pureElementPAPIs.ts`), which forwards any key to the browser's native `getComputedStyle(element).getPropertyValue(key)` rather than a curated per-property allowlist. Since `@lynx-js/web-core@0.23.1` (lynx-family/lynx-stack#3262), same as `lynx-api/main-thread/ElementGetComputedStyle`."
             }
           }
         }
@@ -388,7 +401,8 @@
               "version_added": "3.6"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented via the generic `__GetComputedStyleByKey` PAPI (`web-core/ts/client/mainthread/elementAPIs/pureElementPAPIs.ts`), which forwards any key to the browser's native `getComputedStyle(element).getPropertyValue(key)` rather than a curated per-property allowlist. Since `@lynx-js/web-core@0.23.1` (lynx-family/lynx-stack#3262), same as `lynx-api/main-thread/ElementGetComputedStyle`."
             }
           }
         }
@@ -416,7 +430,8 @@
               "version_added": "3.6"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented via the generic `__GetComputedStyleByKey` PAPI (`web-core/ts/client/mainthread/elementAPIs/pureElementPAPIs.ts`), which forwards any key to the browser's native `getComputedStyle(element).getPropertyValue(key)` rather than a curated per-property allowlist. Since `@lynx-js/web-core@0.23.1` (lynx-family/lynx-stack#3262), same as `lynx-api/main-thread/ElementGetComputedStyle`."
             }
           }
         }
@@ -444,7 +459,8 @@
               "version_added": "3.6"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented via the generic `__GetComputedStyleByKey` PAPI (`web-core/ts/client/mainthread/elementAPIs/pureElementPAPIs.ts`), which forwards any key to the browser's native `getComputedStyle(element).getPropertyValue(key)` rather than a curated per-property allowlist. Since `@lynx-js/web-core@0.23.1` (lynx-family/lynx-stack#3262), same as `lynx-api/main-thread/ElementGetComputedStyle`."
             }
           }
         }
@@ -472,7 +488,8 @@
               "version_added": "3.6"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented via the generic `__GetComputedStyleByKey` PAPI (`web-core/ts/client/mainthread/elementAPIs/pureElementPAPIs.ts`), which forwards any key to the browser's native `getComputedStyle(element).getPropertyValue(key)` rather than a curated per-property allowlist. Since `@lynx-js/web-core@0.23.1` (lynx-family/lynx-stack#3262), same as `lynx-api/main-thread/ElementGetComputedStyle`."
             }
           }
         }
@@ -500,7 +517,8 @@
               "version_added": "3.6"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented via the generic `__GetComputedStyleByKey` PAPI (`web-core/ts/client/mainthread/elementAPIs/pureElementPAPIs.ts`), which forwards any key to the browser's native `getComputedStyle(element).getPropertyValue(key)` rather than a curated per-property allowlist. Since `@lynx-js/web-core@0.23.1` (lynx-family/lynx-stack#3262), same as `lynx-api/main-thread/ElementGetComputedStyle`."
             }
           }
         }
@@ -528,7 +546,8 @@
               "version_added": "3.6"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented via the generic `__GetComputedStyleByKey` PAPI (`web-core/ts/client/mainthread/elementAPIs/pureElementPAPIs.ts`), which forwards any key to the browser's native `getComputedStyle(element).getPropertyValue(key)` rather than a curated per-property allowlist. Since `@lynx-js/web-core@0.23.1` (lynx-family/lynx-stack#3262), same as `lynx-api/main-thread/ElementGetComputedStyle`."
             }
           }
         }
@@ -556,7 +575,8 @@
               "version_added": "3.6"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented via the generic `__GetComputedStyleByKey` PAPI (`web-core/ts/client/mainthread/elementAPIs/pureElementPAPIs.ts`), which forwards any key to the browser's native `getComputedStyle(element).getPropertyValue(key)` rather than a curated per-property allowlist. Since `@lynx-js/web-core@0.23.1` (lynx-family/lynx-stack#3262), same as `lynx-api/main-thread/ElementGetComputedStyle`."
             }
           }
         }
@@ -575,7 +595,8 @@
               "version_added": false
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Unlike native, which resolves computed style through a fixed per-property allowlist, web's `__GetComputedStyleByKey` forwards any key to the browser's native `getComputedStyle(element).getPropertyValue(key)` (`web-core/ts/client/mainthread/elementAPIs/pureElementPAPIs.ts`), so properties outside the named list above resolve too, as long as they are valid CSS and the browser can compute a value for them. Since `@lynx-js/web-core@0.23.1` (lynx-family/lynx-stack#3262)."
             }
           }
         }


### PR DESCRIPTION
## What

`elements/get-computed-style-supported-properties.json` lists the 20 named CSS properties (plus a catch-all `"Other CSS Properties"` entry) that `Element.getComputedStyleProperty()` / `__GetComputedStyleByKey` supports. Every one of them is `web_lynx: { version_added: false }`, but web-core's implementation supports all of them — and more.

This is a companion follow-up to #1278, which flipped the parent `lynx-api/main-thread/ElementGetComputedStyle` entry to `true` but didn't touch this per-property breakdown file.

## Why this is drift, not a gap

`__GetComputedStyleByKey` in `lynx-family/lynx-stack` (`web-core/ts/client/mainthread/elementAPIs/pureElementPAPIs.ts:134`) is:

```ts
export const __GetComputedStyleByKey: GetComputedStyleByKeyPAPI =
  (element, key) =>
    element.ownerDocument.defaultView?.getComputedStyle(element)
      .getPropertyValue(key) ?? '';
```

Unlike native, which resolves computed style through a fixed per-property allowlist (hence the curated list in this compat-data file), web forwards *any* key straight to the browser's native `getComputedStyle().getPropertyValue()`. There's no allowlist in the web implementation, so:

- All 20 named properties (`top`, `left`, `width`, `height`, `right`, `bottom`, `transform`, `transform-origin`, `opacity`, `color`, `background-color`, `direction`, `z-index`, `background-position`, `filter`, and the `margin`/`padding`/`border-width`/`border-radius`/`border-color` longhand groups) resolve on web.
- `"Other CSS Properties"` also resolves on web — this makes web *exclusive* here relative to native, which is why that entry's `web_lynx` also flips (unlike android/ios/harmony, which stay `false`).

Existing test coverage already exercises this generically, not per-property: `web-core/tests/element-apis.spec.ts:415-441` calls `__GetComputedStyleByKey` with both a property from this list (`color`) and one that isn't (`margin-top`, a longhand of the grouped `margin & ...` entry), through the same code path — confirming there's no per-property gating to trip on.

## Changes

- `web_lynx.version_added` → `true` for all 21 entries in `elements/get-computed-style-supported-properties.json`, each with a `notes` field explaining the generic pass-through and pointing at the `0.23.1` / lynx-stack#3262 introduction floor already recorded on the parent `ElementGetComputedStyle` entry.
- `api-stats.json` regenerated (`web_lynx` `elements` coverage 54% → 60%, exclusive count 4 → 5).

## Testing

- `node --loader=ts-node/esm scripts/generate-stats.ts` — reproduces the stats update
- `node --loader=ts-node/esm scripts/validate.ts` — passes
- `vitest run` in `packages/lynx-compat-data` — 10/10

Found via the weekly Lynx Web Platform gap audit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8tEjGUdvZveXyDoqQ82ks)_