### PR TITLE
docs: add Grid Lanes references and guidance (#8621)

### DIFF
--- a/docs/en/api/css/properties/display.mdx
+++ b/docs/en/api/css/properties/display.mdx
@@ -36,6 +36,7 @@ display: none;
 display: linear;
 display: relative;
 display: grid;
+display: grid-lanes;
 ```
 
 ### Values
@@ -64,6 +65,13 @@ display: grid;
 
   Element will layout according to the grid layout layout model.
 
+- `grid-lanes`
+
+  The element becomes a [Grid Lanes container](/guide/ui/layout/grid-lanes-layout.mdx).
+  Tracks on one axis define the lanes, while items stack along the
+  perpendicular axis. This value is experimental from Lynx 4.3 and requires
+  `enableGridLanes`.
+
 - `relative`
 
   Relative layout is a Layout model developed by Lynx.
@@ -87,7 +95,7 @@ import { PropertyDefinition } from '@/components/PropertyDefinition';
 ## Formal syntax
 
 ```
-display = none | linear | flex | grid | relative
+display = none | linear | flex | grid | grid-lanes | relative
 ```
 
 ## Difference with the web

--- a/docs/en/api/css/properties/flow-tolerance.mdx
+++ b/docs/en/api/css/properties/flow-tolerance.mdx
@@ -1,0 +1,75 @@
+---
+title: flow-tolerance
+api: css/properties/flow-tolerance
+---
+
+import { APISummary, APITable } from '@lynx';
+
+<APISummary />
+
+## Introduction
+
+The `flow-tolerance` property controls how Grid Lanes chooses among lanes whose
+running positions are close to the shortest lane. It only applies to a
+container with
+[`display: grid-lanes`](/guide/ui/layout/grid-lanes-layout.mdx).
+
+Grid Lanes is experimental from Lynx 4.3 and requires `enableGridLanes`.
+
+## Syntax
+
+```css
+flow-tolerance: normal;
+flow-tolerance: 0px;
+flow-tolerance: 12px;
+flow-tolerance: 5%;
+flow-tolerance: infinite;
+```
+
+### Values
+
+- `normal`
+
+  Resolves to `1em`. The used value is recomputed when the container's font
+  size changes.
+
+- `<length-percentage>`
+
+  A non-negative tolerance. Percentages resolve against the content size of
+  the lane axis.
+
+- `infinite`
+
+  Treats every eligible lane as being within the tolerance, so lane selection
+  preserves document-order progression strictly.
+
+For each item, Grid Lanes first finds the shortest eligible running position.
+Lanes no longer than `shortest + flow-tolerance` form the candidate set. The
+auto-placement cursor then chooses from that set.
+
+## Formal Definition
+
+import { PropertyDefinition } from '@/components/PropertyDefinition';
+
+<PropertyDefinition
+  initialValue={<>normal</>}
+  appliesTo={<>Grid Lanes containers</>}
+  inherited="no"
+  percentages={<>refer to the Grid Lanes grid-axis content size</>}
+/>
+
+## Formal Syntax
+
+```
+flow-tolerance = normal | <length-percentage [0,∞]> | infinite
+```
+
+## Compatibility
+
+<APITable />
+
+## See Also
+
+- [Grid Lanes Layout](/guide/ui/layout/grid-lanes-layout.mdx)
+- [`display`](/api/css/properties/display.mdx)
+- [`grid-auto-flow`](/api/css/properties/grid-auto-flow.mdx)

--- a/docs/en/guide/ui/layout/_meta.json
+++ b/docs/en/guide/ui/layout/_meta.json
@@ -16,6 +16,11 @@
   },
   {
     "type": "file",
+    "name": "grid-lanes-layout",
+    "label": "Learn Grid Lanes Layout"
+  },
+  {
+    "type": "file",
     "name": "relative-layout",
     "label": "Learn Relative Layout"
   }

--- a/docs/en/guide/ui/layout/grid-lanes-layout.mdx
+++ b/docs/en/guide/ui/layout/grid-lanes-layout.mdx
@@ -1,0 +1,112 @@
+---
+description: 'Build bounded masonry layouts with CSS Grid Lanes and choose when to use a virtualized waterfall list instead.'
+---
+
+# Grid Lanes Layout
+
+Grid Lanes is the CSS Grid Level 3 masonry layout for bounded, composable
+content. Set [`display: grid-lanes`](/api/css/properties/display.mdx) on a
+container, define its lanes with `grid-template-columns` or
+`grid-template-rows`, and let items stack along the perpendicular axis.
+
+:::warning Experimental
+Grid Lanes is available from Lynx 4.3 and is guarded by
+`enableGridLanes`. The flag remains disabled by default during the
+observation period. Current `@lynx-js/template-webpack-plugin` versions that
+support Grid Lanes write the compile and page configuration automatically.
+Custom encoders must set both configurations explicitly.
+:::
+
+For a custom encoder integration, pass the flag in both fields of the encode
+input:
+
+```ts
+encodeData.compilerOptions.enableGridLanes = true;
+encodeData.sourceContent.config.enableGridLanes = true;
+```
+
+Setting only one field is not sufficient: `compilerOptions` controls encoding,
+while `sourceContent.config` carries the runtime Page Config.
+
+## Create a Vertical Grid Lanes Layout
+
+The following container creates responsive columns. Each item is placed from
+the tolerance-defined candidate lanes by the auto-placement cursor.
+
+```css
+.container {
+  display: grid;
+  display: grid-lanes;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 12px;
+  flow-tolerance: normal;
+}
+```
+
+The first `display: grid` declaration is a controlled fallback for older Lynx
+encoders, which strip the unsupported `grid-lanes` declaration. Do not add
+`display: masonry` to Lynx source: it is not a supported Lynx display value.
+Lynx for Web passes `display: grid-lanes` directly to the browser. If the
+browser does not support it, normal CSS invalid-value handling ignores that
+declaration and the preceding authored `display: grid` declaration applies.
+Without an authored fallback, the unsupported declaration remains unsupported.
+
+To stack horizontally instead, define lanes with `grid-template-rows`. Grid
+placement properties apply along the lane axis. Items can span lanes with
+`grid-column` or `grid-row`, depending on the selected axis.
+
+## Control Placement Order
+
+[`flow-tolerance`](/api/css/properties/flow-tolerance.mdx) controls how much
+longer an eligible lane may be than the shortest lane:
+
+- `0px` always chooses a shortest eligible lane.
+- `normal` treats eligible lanes within `1em` of the shortest lane as tied,
+  then selects among the tied lanes in document order.
+- `infinite` preserves document-order lane selection strictly.
+
+Use `grid-auto-flow: dense` when later items may backfill compatible gaps.
+Dense placement can change visual order, so avoid it when visual order must
+match reading order.
+
+## Choose Grid Lanes or a Waterfall List
+
+| Requirement                          | `display: grid-lanes` | `<list list-type="waterfall">` |
+| ------------------------------------ | --------------------- | ------------------------------ |
+| Arbitrary composable children        | Yes                   | List items only                |
+| Grid-axis spans and intrinsic tracks | Yes                   | No                             |
+| CSS Grid Level 3 placement           | Yes                   | No                             |
+| Recycling for an unbounded feed      | No                    | Yes                            |
+| Recommended content size             | Bounded               | Large or unbounded             |
+
+Use Grid Lanes for product shelves, media groups, dashboards, and other
+bounded sections where CSS composition and spans matter. Use
+[`<list list-type="waterfall">`](/api/elements/built-in/list.mdx#required-list-type)
+for long or infinite feeds that require recycling. Do not replace an
+unbounded virtualized list with a non-virtualized Grid Lanes container.
+
+## Compatibility and Fallback
+
+- **Lynx 4.3 and later:** opt in with `enableGridLanes` while the feature is
+  experimental.
+- **Older Lynx encoders:** unsupported Grid Lanes declarations are stripped
+  with a warning. Provide a `grid`, flex, or waterfall fallback according to
+  the product's content model.
+- **Safari 26.4 and later:** Lynx for Web uses native `display: grid-lanes`.
+- **Chromium experimental implementation:** enable
+  `CSSGridLanesLayout` until the browser enables it by default.
+- **Other Web browsers:** Lynx for Web still passes through
+  `display: grid-lanes`. Unsupported browsers ignore the declaration; they do
+  not receive an automatic `masonry` or `grid` fallback.
+
+Grid Lanes does not virtualize its children. The compatibility fallback does
+not change that boundary.
+
+## Related APIs
+
+- [`display`](/api/css/properties/display.mdx)
+- [`flow-tolerance`](/api/css/properties/flow-tolerance.mdx)
+- [`grid-template-columns`](/api/css/properties/grid-template-columns.mdx)
+- [`grid-template-rows`](/api/css/properties/grid-template-rows.mdx)
+- [`grid-auto-flow`](/api/css/properties/grid-auto-flow.mdx)
+- [`gap`](/api/css/properties/gap.mdx)

--- a/docs/en/guide/ui/layout/index.mdx
+++ b/docs/en/guide/ui/layout/index.mdx
@@ -6,7 +6,7 @@ import { Columns } from '@/components/Columns.jsx';
 Lynx provides:
 
 - Properties such as [`width`], [`height`], [`margin`], and [`padding`] are used to describe the size of elements.
-- The [`display`] property, along with [linear layout], [flexible box layout], [grid layout], and [relative layout], are used for laying out elements.
+- The [`display`] property, along with [linear layout], [flexible box layout], [grid layout], [Grid Lanes layout], and [relative layout], are used for laying out elements.
 - The aligning properties, including [`align-items`], [`justify-content`] and etc., are used for aligning elements.
 - The [`position`] property, along with [`left`], [`right`], [`top`], [`bottom`] properties, are used to position elements.
 - [`direction`] and [logical properties] are used to support the internationalization of layouts.
@@ -37,7 +37,7 @@ Lynx does not exhibit the behavior of [margin collapsing](https://developer.mozi
 
 ## Layout the Elements
 
-The [`<view>`] element can be used for laying out child elements, and by setting the [`display`] property on the `<view>` element, you can control the way it lays out its child elements. The display property supports five values: `linear`, `flex`, `grid`, `relative` and `none`.
+The [`<view>`] element can be used for laying out child elements, and by setting the [`display`] property on the `<view>` element, you can control the way it lays out its child elements. The display property supports `linear`, `flex`, `grid`, experimental `grid-lanes`, `relative`, and `none`.
 
 ### Linear Layout
 
@@ -74,6 +74,13 @@ If you want to arrange multiple elements alternately in both vertical and horizo
   defaultFile="src/grid/index.tsx"
   entry="src/grid"
 />
+
+### Grid Lanes Layout
+
+For a bounded masonry section with composable children, intrinsic lanes, or
+lane spans, set [`display`] to `grid-lanes` and use the
+[Grid Lanes layout]. For long or infinite feeds that require recycling, keep
+using a virtualized `<list list-type="waterfall">`.
 
 ### Relative Layout
 
@@ -171,5 +178,6 @@ You can use the [`direction`] property and [logical properties] to make your pag
 [relative layout]: /guide/ui/layout/relative-layout.mdx
 [flexible box layout]: /guide/ui/layout/flexible-box-layout.mdx
 [grid layout]: /guide/ui/layout/grid-layout.mdx
+[Grid Lanes layout]: /guide/ui/layout/grid-lanes-layout.mdx
 [logical properties]: https://developer.mozilla.org/en/docs/Web/CSS/CSS_logical_properties_and_values
 [`enableCSSInheritance`]: /api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enablecssinheritance#pluginreactlynxoptionsenablecssinheritance-property

--- a/docs/zh/api/css/properties/display.mdx
+++ b/docs/zh/api/css/properties/display.mdx
@@ -55,6 +55,12 @@ Lynx 没有[流式布局（Flow）](https://developer.mozilla.org/zh-CN/docs/Web
 
 指定容器采用[网格布局](/guide/ui/layout/grid-layout.mdx)。
 
+### `grid-lanes`
+
+指定容器采用 [Grid Lanes 布局](/guide/ui/layout/grid-lanes-layout.mdx)。一个轴上的
+轨道定义巷道，子元件沿垂直轴堆叠。此值从 Lynx 4.3 开始以实验性功能提供，需要
+启用 `enableGridLanes`。
+
 ### `relative`
 
 Lynx 自研的布局模型。指定容器采用[相对布局](/guide/ui/layout/relative-layout.mdx)。相对布局是一个以相对位置显示子视图的布局方式，每个视图的位置可以指定为相对于同级元件的位置（例如，在另一个视图的左侧或下方）或相对于父级区域的位置（例如在底部、左侧或中心对齐）。
@@ -67,6 +73,7 @@ display: none;
 display: linear;
 display: relative;
 display: grid;
+display: grid-lanes;
 ```
 
 ## 形式定义
@@ -86,7 +93,7 @@ import { PropertyDefinition } from '@/components/PropertyDefinition';
 ## 形式语法
 
 ```
-display = none | linear | flex | grid | relative
+display = none | linear | flex | grid | grid-lanes | relative
 ```
 
 ## 与 Web 的区别

--- a/docs/zh/api/css/properties/flow-tolerance.mdx
+++ b/docs/zh/api/css/properties/flow-tolerance.mdx
@@ -1,0 +1,72 @@
+---
+api: css/properties/flow-tolerance
+---
+
+import { APISummary, APITable } from '@lynx';
+
+# flow-tolerance
+
+<APISummary />
+
+## 介绍
+
+`flow-tolerance` 控制 Grid Lanes 如何从当前位置接近最短位置的巷道中选择放置位置。
+该属性仅作用于设置了
+[`display: grid-lanes`](/guide/ui/layout/grid-lanes-layout.mdx) 的容器。
+
+Grid Lanes 从 Lynx 4.3 开始以实验性功能提供，需要启用 `enableGridLanes`。
+
+## 语法
+
+```css
+flow-tolerance: normal;
+flow-tolerance: 0px;
+flow-tolerance: 12px;
+flow-tolerance: 5%;
+flow-tolerance: infinite;
+```
+
+### 取值
+
+- `normal`
+
+  解析为 `1em`。容器字号变化时会重新计算使用值。
+
+- `<length-percentage>`
+
+  非负的容差。百分比相对于巷道轴的内容尺寸解析。
+
+- `infinite`
+
+  所有候选巷道都视为处于容差范围内，因此会严格保持按文档顺序推进巷道选择。
+
+布局每个子元件时，Grid Lanes 会先找到最短的候选位置。当前位置不超过
+`最短位置 + flow-tolerance` 的巷道组成候选集合，随后由自动放置游标从集合中
+选择巷道。
+
+## 形式定义
+
+import { PropertyDefinition } from '@/components/PropertyDefinition';
+
+<PropertyDefinition
+  initialValue={<>normal</>}
+  appliesTo={<>Grid Lanes 容器</>}
+  inherited="否"
+  percentages={<>相对于 Grid Lanes 巷道轴的内容尺寸</>}
+/>
+
+## 形式语法
+
+```
+flow-tolerance = normal | <length-percentage [0,∞]> | infinite
+```
+
+## 兼容性
+
+<APITable />
+
+## 另请参阅
+
+- [Grid Lanes 布局](/guide/ui/layout/grid-lanes-layout.mdx)
+- [`display`](/api/css/properties/display.mdx)
+- [`grid-auto-flow`](/api/css/properties/grid-auto-flow.mdx)

--- a/docs/zh/guide/ui/layout/_meta.json
+++ b/docs/zh/guide/ui/layout/_meta.json
@@ -16,6 +16,11 @@
   },
   {
     "type": "file",
+    "name": "grid-lanes-layout",
+    "label": "Grid Lanes 布局"
+  },
+  {
+    "type": "file",
     "name": "relative-layout",
     "label": "相对布局"
   }

--- a/docs/zh/guide/ui/layout/grid-lanes-layout.mdx
+++ b/docs/zh/guide/ui/layout/grid-lanes-layout.mdx
@@ -1,0 +1,104 @@
+---
+description: '使用 CSS Grid Lanes 构建有界瀑布流布局，并根据内容规模选择虚拟化 waterfall list。'
+---
+
+# Grid Lanes 布局
+
+Grid Lanes 是 CSS Grid Level 3 定义的瀑布流布局，适用于内容数量有界、需要
+CSS 组合能力的区域。在容器上设置
+[`display: grid-lanes`](/api/css/properties/display.mdx)，再通过
+`grid-template-columns` 或 `grid-template-rows` 定义巷道，子元件会沿垂直于巷道轴的
+方向堆叠。
+
+:::warning 实验性功能
+Grid Lanes 从 Lynx 4.3 开始提供，并受 `enableGridLanes` 控制。在观察期内，
+该开关默认关闭。支持 Grid Lanes 的新版
+`@lynx-js/template-webpack-plugin` 会自动写入编译配置和 Page Config；自定义
+编码流程则必须显式写入两处配置。
+:::
+
+自定义编码流程需要在编码输入的两个字段中同时写入开关：
+
+```ts
+encodeData.compilerOptions.enableGridLanes = true;
+encodeData.sourceContent.config.enableGridLanes = true;
+```
+
+只写入其中一处并不足够：`compilerOptions` 控制编码行为，`sourceContent.config`
+负责把运行时 Page Config 写入 bundle。
+
+## 创建纵向 Grid Lanes 布局
+
+以下容器会创建自适应列。自动放置游标会从 `flow-tolerance` 定义的候选巷道中
+为每个子元件选择位置。
+
+```css
+.container {
+  display: grid;
+  display: grid-lanes;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 12px;
+  flow-tolerance: normal;
+}
+```
+
+第一条 `display: grid` 是为旧版 Lynx 编码器提供的受控回退；旧编码器会移除
+不支持的 `grid-lanes` 声明。不要在 Lynx 源码中添加 `display: masonry`，它不是
+Lynx 支持的 `display` 值。Lynx for Web 会把 `display: grid-lanes` 原样交给
+浏览器。不支持该值的浏览器会按标准 CSS 无效值规则忽略这条声明，并应用作者在
+前面显式写入的 `display: grid`。如果作者没有提供回退，该声明会保持不受支持。
+
+如需横向堆叠，可以改用 `grid-template-rows` 定义巷道。网格定位属性只作用于
+巷道轴；根据巷道方向，可以用 `grid-column` 或 `grid-row` 让子元件跨越多个巷道。
+
+## 控制放置顺序
+
+[`flow-tolerance`](/api/css/properties/flow-tolerance.mdx) 控制候选巷道相对最短
+巷道允许多出的长度：
+
+- `0px` 始终选择最短的候选巷道。
+- `normal` 将与最短巷道相差不超过 `1em` 的候选巷道视为并列，再按文档顺序
+  从这些并列巷道中选择。
+- `infinite` 严格保持按文档顺序选择巷道。
+
+使用 `grid-auto-flow: dense` 可以让后续子元件回填满足条件的空隙。稠密放置可能
+改变视觉顺序；如果视觉顺序必须与阅读顺序一致，请不要使用它。
+
+## 选择 Grid Lanes 还是瀑布流列表
+
+| 需求                      | `display: grid-lanes` | `<list list-type="waterfall">` |
+| ------------------------- | --------------------- | ------------------------------ |
+| 任意可组合子元件          | 支持                  | 仅支持列表项                   |
+| 巷道轴跨度和内在尺寸轨道  | 支持                  | 不支持                         |
+| CSS Grid Level 3 放置语义 | 支持                  | 不支持                         |
+| 为无限数据回收元件        | 不支持                | 支持                           |
+| 建议内容规模              | 有界                  | 大量或无界                     |
+
+商品陈列、媒体分组、仪表盘等内容有界且需要 CSS 组合或跨巷道能力的区域，适合使用
+Grid Lanes。需要元件回收的长列表或无限信息流，应继续使用
+[`<list list-type="waterfall">`](/api/elements/built-in/list.mdx#required-list-type)。
+不要使用非虚拟化的 Grid Lanes 容器替换无界虚拟化列表。
+
+## 兼容与回退
+
+- **Lynx 4.3 及以上版本：**在实验期内通过 `enableGridLanes` 显式启用。
+- **旧版 Lynx 编码器：**不支持的 Grid Lanes 声明会被移除并产生警告。请根据
+  内容模型提供普通网格、弹性布局或瀑布流列表回退。
+- **Safari 26.4 及以上版本：**Lynx for Web 使用原生
+  `display: grid-lanes`。
+- **Chromium 实验实现：**在浏览器默认启用前，需要打开
+  `CSSGridLanesLayout`。
+- **其他 Web 浏览器：**Lynx for Web 仍会原样传递
+  `display: grid-lanes`。不支持该值的浏览器会忽略声明，不会自动获得
+  `masonry` 或 `grid` 回退。
+
+Grid Lanes 不会虚拟化子元件，兼容性回退也不会改变这个边界。
+
+## 相关 API
+
+- [`display`](/api/css/properties/display.mdx)
+- [`flow-tolerance`](/api/css/properties/flow-tolerance.mdx)
+- [`grid-template-columns`](/api/css/properties/grid-template-columns.mdx)
+- [`grid-template-rows`](/api/css/properties/grid-template-rows.mdx)
+- [`grid-auto-flow`](/api/css/properties/grid-auto-flow.mdx)
+- [`gap`](/api/css/properties/gap.mdx)

--- a/docs/zh/guide/ui/layout/index.mdx
+++ b/docs/zh/guide/ui/layout/index.mdx
@@ -6,7 +6,7 @@ import { Columns } from '@/components/Columns.jsx';
 Lynx 提供了：
 
 - [`width`]、[`height`]、[`margin`]、[`padding`] 等属性，用于描述元件的大小。
-- [`display`] 属性及[线性布局]、[弹性布局]、[网格布局]、[相对布局]，用于对元件进行布局。
+- [`display`] 属性及[线性布局]、[弹性布局]、[网格布局]、[Grid Lanes 布局]、[相对布局]，用于对元件进行布局。
 - 包含 [`align-items`]、[`justify-content`] 等的对齐属性，用于对齐元件。
 - [`position`] 及 [`left`]、[`right`]、[`top`]、[`bottom`] 属性，用于定位元件。
 - [`direction`] 及[逻辑属性]，用于支持布局的国际化。
@@ -44,7 +44,7 @@ Lynx 支持的布局属性与 Web 中同名的属性在行为上表现一致。�
 
 ## 布局元件
 
-[`<view>`] 元件可以用于布局子元件，且可以通过在 `<view>` 元件上设置 [`display`] 属性，来控制其对子元件的布局方式。`display` 支持 `linear`、`flex`、`grid`、`relative`、`none` 五种取值。
+[`<view>`] 元件可以用于布局子元件，且可以通过在 `<view>` 元件上设置 [`display`] 属性，来控制其对子元件的布局方式。`display` 支持 `linear`、`flex`、`grid`、实验性的 `grid-lanes`、`relative` 和 `none`。
 
 ### 线性布局（linear）
 
@@ -81,6 +81,13 @@ Lynx 支持的布局属性与 Web 中同名的属性在行为上表现一致。�
   defaultFile="src/grid/index.tsx"
   entry="src/grid"
 />
+
+### Grid Lanes 布局（grid-lanes）
+
+对于内容数量有界、需要任意子元件组合、内在尺寸巷道或跨巷道能力的瀑布流区域，
+可以将 [`display`] 设置为 `grid-lanes`，使用 [Grid Lanes 布局]。需要元件回收
+的长列表或无限信息流，应继续使用虚拟化的
+`<list list-type="waterfall">`。
 
 ### 相对布局（relative）
 
@@ -177,5 +184,6 @@ Lynx 支持的布局属性与 Web 中同名的属性在行为上表现一致。�
 [相对布局]: /guide/ui/layout/relative-layout.mdx
 [弹性布局]: /guide/ui/layout/flexible-box-layout.mdx
 [网格布局]: /guide/ui/layout/grid-layout.mdx
+[Grid Lanes 布局]: /guide/ui/layout/grid-lanes-layout.mdx
 [逻辑属性]: https://developer.mozilla.org/zh/docs/Web/CSS/CSS_logical_properties_and_values
 [`enableCSSInheritance`]: /api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.enablecssinheritance#pluginreactlynxoptionsenablecssinheritance-property


### PR DESCRIPTION
## Summary

- document the experimental `display: grid-lanes` value and add bilingual `flow-tolerance` references
- add bilingual Grid Lanes guidance covering placement, direct browser pass-through, authored CSS fallback, and the `grid-lanes` versus virtualized waterfall-list boundary
- expose the guide in the layout sidebar and layout overview

This is the required `lynx-family/lynx-website` portion of lynx-family/lynx#8621. The implementation PR is lynx-family/lynx-stack#3547.

## Web behavior

Lynx for Web passes `display: grid-lanes` directly to the browser. Unsupported browsers apply normal CSS invalid-value handling; Lynx for Web does not translate the value to `masonry` or `grid`. Authors who need a fallback can place an explicit `display: grid` declaration before `display: grid-lanes`.

## Dependency

The compatibility table is sourced from `@lynx-js/css-defines@0.0.18`, which is defined by engine M1 in lynx-family/lynx#8644 but is not published yet. The docs were validated against that exact M1 metadata and should land together with the automated css-defines dependency update after M1 publishes.

## Validation

- Prettier passed for the updated English and Chinese guides
- CSpell passed for the updated English guide
- focused zhlint passed for the updated Chinese guide
- commit hooks passed formatting, CSpell, asset URL, and API summary checks
- prior full API documentation checker passed all 1,727 pages
- prior full `pnpm build` passed and generated 3,191 pages
- prior final-state build with M1 `@lynx-js/css-defines@0.0.18` metadata passed; the rendered `flow-tolerance` compatibility table reports Lynx 4.3 on native and Clay platforms

Closes the documentation deliverable of lynx-family/lynx#8621.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Document experimental `grid-lanes` and `flow-tolerance` in English and Chinese.
- Explain placement, feature gating, fallbacks, browser behavior, and waterfall list selection.
- Register Grid Lanes guides in layout navigation and overview pages.
- Document Lynx 4.3 compatibility and `@lynx-js/css-defines@0.0.18` data.
- Validate formatting, spelling, Chinese linting, API checks, and builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->