### PR TITLE
fix(ui): cover remaining Lynx UI route follow-ups on release/3.9

### DIFF
--- a/docs/zh/ui/index.md
+++ b/docs/zh/ui/index.md
@@ -15,5 +15,5 @@ hero:
       link: /zh/ui/introduction.html#快速开始
     - theme: alt
       text: 组件
-      link: /ui/components/button
+      link: /zh/ui/components/button
 ---

--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -191,10 +191,6 @@ export default defineConfig({
           from: '^/zh/lynx-ui(/.*)?$',
           to: '/zh/ui$1',
         },
-        {
-          from: '^/en/lynx-ui(/.*)?$',
-          to: '/en/ui$1',
-        },
       ],
     }),
     ...(!IS_LIGHTWEIGHT_BUILD


### PR DESCRIPTION
## Motivation

The earlier `lynx-ui -> ui` backport on `release/3.9` already covered the homepage navigation helper and the Start Building CTA, but two route-alignment follow-ups from the main-branch cleanup were still missing.

This PR closes those remaining gaps by:
- fixing the Chinese Lynx UI homepage Components action to use the localized `/zh/ui/...` route
- removing the stale `/en/lynx-ui/* -> /en/ui/*` client redirect so the redirect set matches the site's canonical root-based English route model

## Notice

This PR is not expected to introduce a user-visible regression.

`/en/lynx-ui/*` was not a first-class supported public route family before this change. The previous client redirect only forwarded it to `/en/ui/*`, which is itself non-canonical and still relies on the site's default-English normalization behavior to reach the published `/ui/*` route.

After this change, the effective reachability still resolves to the same canonical destination through the existing default-language normalization and legacy `/lynx-ui/* -> /ui/*` redirect path. In practice, this keeps release behavior aligned with the site's broader English routing model rather than introducing a Lynx UI-only exception.

## Changes by component

### `docs/zh/ui/index.md`
- update the homepage Components action from `/ui/components/button` to `/zh/ui/components/button`

### `rspress.config.ts`
- remove the legacy `/en/lynx-ui/* -> /en/ui/*` client redirect
- keep the supported legacy redirect coverage focused on `/lynx-ui/*` and `/zh/lynx-ui/*`

## Additional notes

- this PR intentionally stays scoped to the two remaining route-behavior gaps on `release/3.9`
- the already-covered homepage helper and Start Building CTA changes remain unchanged
- this follow-up is tracked under #1310

## Validation

- verified the Chinese Lynx UI homepage Components action now points to `/zh/ui/components/button`
- verified `rspress.config.ts` no longer includes the `/en/lynx-ui/*` client redirect
- ran `prettier --check docs/zh/ui/index.md rspress.config.ts`
- ran `git diff --check`

Refs #1310

Change-Id: Iaa8a6b6ad4118a4f8f0850678cdab2f96ea7a5ad