### PR TITLE
fix(lynx-ui): normalize invalid English URLs in synced docs

### DIFF
--- a/scripts/sync-lynx-ui-docs-to-shared.js
+++ b/scripts/sync-lynx-ui-docs-to-shared.js
@@ -60,15 +60,30 @@ const collectFilesRecursively = (dir) => {
 // are touched: the leading-boundary class excludes `assets/lynx-ui/` CDN paths
 // and `@lynx-js/lynx-ui` / `family/lynx-ui` package references (no such
 // boundary + trailing slash).
-const rewriteSubsiteLinks = (filePath) => {
-  if (!/\.(mdx?|md)$/.test(filePath)) {
+// Absolute English links are also normalized because the default locale is
+// served from the root rather than under /en.
+const normalizeSyncedDoc = (filePath) => {
+  if (!/\.mdx?$/.test(filePath)) {
     return;
   }
+
   const original = fs.readFileSync(filePath, 'utf8');
-  const next = original.replace(
-    /(^|[("'\s=:])(\/(?:en\/|zh\/)?)lynx-ui\//gm,
-    '$1$2ui/',
-  );
+  let hasInvalidEnglishUrl = false;
+  let next = original
+    .replace(/(^|[("'\s=:])(\/(?:en\/|zh\/)?)lynx-ui\//gm, '$1$2ui/')
+    // English is the default locale and is not served under an /en prefix.
+    .replace(
+      /https:\/\/lynxjs\.org\/((?:next|\d+(?:\.\d+)*)\/)?en\//g,
+      (_match, versionPrefix = '') => {
+        hasInvalidEnglishUrl = true;
+        return `https://lynxjs.org/${versionPrefix}`;
+      },
+    );
+
+  if (hasInvalidEnglishUrl) {
+    next = next.replace(/[ \t]*(?:\r?\n[ \t]*)*$/, '\n');
+  }
+
   if (next !== original) {
     fs.writeFileSync(filePath, next, 'utf8');
   }
@@ -152,7 +167,7 @@ packages.forEach((pkgName) => {
 
     copyRecursiveSync(pkgDocsDir, targetDir);
     for (const filePath of collectFilesRecursively(targetDir)) {
-      rewriteSubsiteLinks(filePath);
+      normalizeSyncedDoc(filePath);
       if (ENABLE_MDX_HOIST) {
         hoistMdxImports(filePath);
       }

--- a/sharedDocs/packageDocs/lynx-ui-swiper/APIReference.mdx
+++ b/sharedDocs/packageDocs/lynx-ui-swiper/APIReference.mdx
@@ -122,7 +122,7 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     "summary": [
       {
         "kind": "text",
-        "text": "Determines how swiper respond to touch in different angle.\nBy default, swiper will only respond to horizontal touches.\nRefer to https://lynxjs.org/en/api/elements/built-in/view.html#consume-slide-event for more"
+        "text": "Determines how swiper respond to touch in different angle.\nBy default, swiper will only respond to horizontal touches.\nRefer to https://lynxjs.org/api/elements/built-in/view.html#consume-slide-event for more"
       }
     ],
     "summary_zh": [
@@ -1054,5 +1054,3 @@ import { UIApiTable, ClassRenderPropTable } from "@lynx-ui/index";
     "docTypeFallback": null
   }
 ]}/>
-  
-  


### PR DESCRIPTION
## Motivation

Rspress publishes English documentation from the root path rather than
under `/en/`. However, the pinned upstream Lynx UI source can still contain
URLs such as:

- `https://lynxjs.org/en/...`
- `https://lynxjs.org/next/en/...`
- `https://lynxjs.org/4.0/en/...`

This is especially relevant to release backports where updating the Lynx UI
source pointer is not practical. Without sync-time normalization, every
re-sync can reintroduce invalid links.

## Changes by component

### Sync normalization

- rename the sync transform to reflect its broader normalization role
- retain the existing `/lynx-ui/*` to `/ui/*` normalization
- remove invalid `/en/` segments from root English URLs
- preserve optional `next` and numeric version prefixes
- avoid rewriting unrelated nested paths

### Generated documentation

- re-sync the Swiper API reference with the canonical root-based English URL
- remove trailing whitespace inherited from the upstream generated file

## Impact

Older pinned Lynx UI sources can be safely re-synced without restoring
invalid English links. Version-specific links remain scoped to their
original release or `next` path.

## Validation

- verified root, `next`, `4.0`, and multi-part version URL cases
- verified unrelated nested `/en/` paths remain unchanged
- ran the sync twice and confirmed identical output hashes
- passed Prettier, Node syntax, and `git diff --check`

## Related issue

Related to #1310

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Normalize invalid English `lynx-ui` URLs while preserving `next` and version prefixes.
- Preserve `/lynx-ui/*` to `/ui/*` route normalization without altering unrelated paths.
- Re-sync the Swiper API reference with the canonical English URL.
- Remove inherited trailing whitespace from the Swiper documentation.
- Validate repeated sync consistency, formatting, syntax, and diff cleanliness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->