### PR TITLE
fix(docs): preserve versioned lynx-ui routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Asset URL Check
         run: node scripts/ci/check-asset-urls.mjs
 
+      - name: lynx-ui Route Contract Check
+        run: node scripts/ci/check-lynx-ui-routes.mjs
+
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -140,6 +140,57 @@
   status = 301
   force = true
 
+# Preserve the route name used by each historical release. lynx-ui shipped at
+# /lynx-ui in 3.8 and at /ui in 3.9; these aliases keep links version-local
+# instead of falling through to the current unversioned documentation.
+[[redirects]]
+  from = "/3.8/ui"
+  to = "/3.8/lynx-ui/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/3.8/ui/*"
+  to = "/3.8/lynx-ui/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/3.8/zh/ui"
+  to = "/3.8/zh/lynx-ui/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/3.8/zh/ui/*"
+  to = "/3.8/zh/lynx-ui/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/3.9/lynx-ui"
+  to = "/3.9/ui/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/3.9/lynx-ui/*"
+  to = "/3.9/ui/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/3.9/zh/lynx-ui"
+  to = "/3.9/zh/ui/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/3.9/zh/lynx-ui/*"
+  to = "/3.9/zh/ui/:splat"
+  status = 301
+  force = true
+
 # Serve everything under /next/ from the site root.
 [[redirects]]
   from = "/next/*"

--- a/scripts/ci/check-lynx-ui-routes.mjs
+++ b/scripts/ci/check-lynx-ui-routes.mjs
@@ -1,0 +1,59 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const netlifyConfig = await readFile(
+  new URL('../../netlify.toml', import.meta.url),
+  'utf8',
+);
+const rspressConfig = await readFile(
+  new URL('../../rspress.config.ts', import.meta.url),
+  'utf8',
+);
+const routeConfig = await readFile(
+  new URL('../../shared-route-config.ts', import.meta.url),
+  'utf8',
+);
+
+function assertNetlifyRedirect(from, to) {
+  const block = [
+    '[[redirects]]',
+    `  from = "${from}"`,
+    `  to = "${to}"`,
+    '  status = 301',
+    '  force = true',
+  ].join('\n');
+
+  assert.ok(
+    netlifyConfig.includes(block),
+    `Missing permanent redirect: ${from} -> ${to}`,
+  );
+}
+
+assert.match(routeConfig, /home: '\/ui\/'/);
+assert.match(routeConfig, /url: '\/ui\/introduction'/);
+
+for (const [from, to] of [
+  ['/lynx-ui/*', '/ui/:splat'],
+  ['/zh/lynx-ui/*', '/zh/ui/:splat'],
+  ['/next/lynx-ui/*', '/next/ui/:splat'],
+  ['/next/zh/lynx-ui/*', '/next/zh/ui/:splat'],
+  ['/3.8/ui', '/3.8/lynx-ui/'],
+  ['/3.8/ui/*', '/3.8/lynx-ui/:splat'],
+  ['/3.8/zh/ui', '/3.8/zh/lynx-ui/'],
+  ['/3.8/zh/ui/*', '/3.8/zh/lynx-ui/:splat'],
+  ['/3.9/lynx-ui', '/3.9/ui/'],
+  ['/3.9/lynx-ui/*', '/3.9/ui/:splat'],
+  ['/3.9/zh/lynx-ui', '/3.9/zh/ui/'],
+  ['/3.9/zh/lynx-ui/*', '/3.9/zh/ui/:splat'],
+]) {
+  assertNetlifyRedirect(from, to);
+}
+
+assert.match(rspressConfig, /from: '\^\/lynx-ui\(\/\.\*\)\?\$'/);
+assert.match(rspressConfig, /from: '\^\/zh\/lynx-ui\(\/\.\*\)\?\$'/);
+
+console.log('lynx-ui route contract check passed.');


### PR DESCRIPTION
- Preserve version-local aliases for the 3.8 and 3.9 lynx-ui documentation.
- Add route-contract coverage for current, next, and historical aliases.

Closes #1320

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Preserve version-local `lynx-ui` aliases for 3.8 and 3.9 routes.
- Add permanent redirects that preserve locale, path, query strings, and fragments.
- Validate current, `next`, historical, English, and Chinese route contracts in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->