### PR TITLE
fix(ui): align Luna showcase import with shared `@luna` alias

### DIFF
--- a/theme/lynx-ui-home/index.tsx
+++ b/theme/lynx-ui-home/index.tsx
@@ -12,7 +12,7 @@ import { useRef } from 'react';
 import { ClearAPI } from './ClearApi';
 import { ConsistencyAndPerformance } from './CombinedConsistencyAndPerformance';
 import { StartBuilding } from './StartBuildingBottom';
-import { LunaStudioShowcase } from '@site/src/luna';
+import { LunaStudioShowcase } from '@luna';
 
 export const HomeLayout = () => {
   const { pre: PreWithCodeButtonGroup, code: Code } =


### PR DESCRIPTION
## Motivation

`@site` should stay scoped to site-local implementations. Luna is part of the OSS-synced shared component flow, so consuming it through `@site/src/luna` leaks a site-specific path into a shared integration point.

This change moves the remaining Luna consumer onto the dedicated `@luna` alias so OSS and inhouse can map the component independently while keeping the import contract stable.

## Changes by component

### `theme/lynx-ui-home`
- Switched `LunaStudioShowcase` from `@site/src/luna` to `@luna`.

### Alias usage
- Kept Luna consumption aligned with the existing alias definitions in `rspress.config.ts` and `tsconfig.json`.
- Removed the last remaining direct `@site/src/luna` usage in the repo.

## Additional notes

This PR is intentionally narrow. It updates the remaining Luna consumer without changing the alias definitions themselves.

It also follows the current sync rule:
- use `@site` for site-owned implementations
- use a dedicated alias for OSS-synced shared components

## Validation

- Searched the repository to confirm there are no remaining `@site/src/luna` references.
- Ran `pnpm exec tsc --noEmit`.

Change-Id: Icd1c4d0e92be3d8b337c6fb45ab9aabb1afe3315

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Use the shared `@luna` alias for the `lynx-ui` Luna showcase import.
- Remove the final direct `@site/src/luna` reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->