### PR TITLE
fix(ui): align Luna showcase import with shared `@luna` alias

### DIFF
--- a/theme/lynx-ui-home/below-hero.tsx
+++ b/theme/lynx-ui-home/below-hero.tsx
@@ -2,7 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { LunaStudioShowcase } from '@site/src/luna';
+import { LunaStudioShowcase } from '@luna';
 import { ClearAPI } from './ClearApi';
 import { ConsistencyAndPerformance } from './CombinedConsistencyAndPerformance';
 import { StartBuilding } from './StartBuildingBottom';


### PR DESCRIPTION
Why
- `@site` resolves against the current site and should remain scoped to site-owned implementations.
- Luna is shared through the OSS-to-inhouse synchronization flow and needs a stable, site-independent import contract.

What changed
- Replaced the Lynx UI below-hero showcase import from `@site/src/luna` with `@luna`.
- Kept the consumer aligned with the existing Rspress and TypeScript alias definitions.

Impact
- The release/4.0 UI homepage now resolves Luna through the dedicated shared-component alias.
- No runtime behavior or rendered output is intended to change.

Validation
- Confirmed no `@site/src/luna` references remain in the repository.
- Ran Prettier against `theme/lynx-ui-home/below-hero.tsx`.
- Ran `git diff --cached --check`.

Change-Id: Ibe0f76b7e2380433043603037f620a0955ed1587