### PR TITLE
fix(theme): decouple shared OG config from `@site`

### DIFF
--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -68,6 +68,7 @@ export default defineConfig({
           'node_modules/react-render-to-markdown/dist/index.js',
         ),
         '@site': path.join(__dirname),
+        '@og-config$': path.join(__dirname, 'shared-og-config.ts'),
         '@': path.join(__dirname, 'src'),
         '@docs': path.join(__dirname, 'sharedDocs', 'packageDocs'),
         '@assets': path.join(__dirname, 'docs', 'public', 'assets'),

--- a/theme/OgHead.tsx
+++ b/theme/OgHead.tsx
@@ -16,12 +16,7 @@ import {
   useLocation,
   usePageData,
 } from '@rspress/core/runtime';
-import {
-  OG_BASE,
-  getCover,
-  ogAbsolute,
-  selectOg,
-} from '@site/shared-og-config';
+import { OG_BASE, getCover, ogAbsolute, selectOg } from '@og-config';
 
 const TWITTER_SITE = '@LynxJS_org';
 /** Keep og:description bounded — blog descriptions can be long. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "allowImportingTsExtensions": true,
     "paths": {
       "@site/*": ["./*"],
+      "@og-config": ["./shared-og-config.ts"],
       "@/*": ["./src/*"],
       "@lynx": ["./src/components/index.tsx"],
       "@lynx/*": ["./src/components/*"],


### PR DESCRIPTION
## Motivation

`theme/OgHead.tsx` currently reads shared OG config through `@site`, which behaves as a host-dependent directory alias in cross-repository consumption. That makes it unsuitable as a stable dependency boundary for shared configuration modules.

This PR introduces a dedicated alias for shared OG config so the dependency is explicit, semantic, and independently configurable by different hosts.

## Changes by component

### `rspress.config.ts`
- Add a dedicated `@og-config` alias for `shared-og-config.ts`

### `theme/OgHead.tsx`
- Replace `@site/shared-og-config` with `@og-config`

### `tsconfig.json`
- Add the matching TypeScript path mapping for `@og-config`

## Additional notes

- This change only updates import resolution and dependency boundaries.
- It does not change OG image selection logic, canonical URL logic, or generated meta tag behavior.
- `@site` remains unchanged in this PR, but shared config modules no longer depend on it as a general directory alias.

## Validation

- Run `pnpm build`
- Confirm `theme/OgHead.tsx` no longer imports `@site/shared-og-config`
- Verify generated canonical URLs and Open Graph tags remain unchanged

## Related

- #1328 

Change-Id: I088d1b6642343e8fe95f58ad2b3ab50d35f06803

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Add the `@og-config` alias to `rspress.config.ts` and `tsconfig.json`.
- Use `@og-config` to import shared Open Graph configuration in `theme/OgHead.tsx`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->