### PR TITLE
fix(og): align lynx-ui vendored logo asset naming

### DIFF
--- a/scripts/og/README.md
+++ b/scripts/og/README.md
@@ -8,9 +8,9 @@ shared with the theme.
 ## Outputs (`docs/public/og/`, git-ignored, regenerated each build)
 
 - `covers/<lang>/<subsite>.png` — one shared cover per subsite (`guide`, `react`,
-  `rspeedy`, `lynx-ui`, `ai`, `api`) per language (`en`/`zh`), reused across
-  every URL in that subsite+language. Label is language-neutral; the description,
-  footer URL, and "Documentation/文档" label localize.
+  `rspeedy`, `ui`, `ai`, `lynxtron`, `api`) per language (`en`/`zh`), reused
+  across every URL in that subsite+language. Label is language-neutral; the
+  description, footer URL, and "Documentation/文档" label localize.
 - `blog/<lang>/<slug>.png` — a unique image per blog post (en + zh).
 
 Each image has a `<name>.png.meta.json` sidecar holding a hash of its inputs;
@@ -39,11 +39,13 @@ pnpm gen:og:assets       # re-fetch + rasterize the vendored logos (rarely)
   static TTF), JetBrains Mono (URLs), Noto Sans (Latin fallback) and Noto Sans SC
   (CJK, from notofonts/noto-cjk SubsetOTF — required for Chinese blog titles).
   satori needs raw `ttf`/`otf` (not `woff2`).
-- `assets/<subsite>.png` — each subsite's logo, pre-rasterized to a uniform
-  white silhouette so it reads on the gradient. Exceptions keep their native
-  colors (`native: true`): the two-tone lynx-ui hex and the detailed Rspeedy
-  crab mascot, which a flat silhouette would reduce to a featureless blob.
-  Produced by `prepare-assets.mjs` from the `logo.dark` artwork in
+- `assets/<filename>` — each subsite's logo, pre-rasterized to a uniform white
+  silhouette so it reads on the gradient. Most filenames match the cover id;
+  the UI cover intentionally keeps `lynx-ui.png` for brand continuity even
+  though the docs route is `/ui`. Exceptions keep their native colors
+  (`native: true`): the two-tone lynx-ui hex and the detailed Rspeedy crab
+  mascot, which a flat silhouette would reduce to a featureless blob. Produced
+  by `prepare-assets.mjs` from the `logo.dark` artwork in
   `shared-route-config.ts`; committed so the build stays offline.
 
 ## OG meta tags

--- a/scripts/og/prepare-assets.mjs
+++ b/scripts/og/prepare-assets.mjs
@@ -5,8 +5,10 @@
  * Subsite logos in `shared-route-config.ts` are a mix of remote CDN SVGs/PNGs
  * and local SVGs. Fetching them during `gen:og` would make the build
  * network-dependent (the spec forbids this), so we rasterize them **once** into
- * committed PNGs under `scripts/og/assets/<value>.png`. The OG generator then
- * reads only these local files.
+ * committed PNGs under `scripts/og/assets/`. The OG generator then reads only
+ * these local files. Most covers keep the route/cover id as the filename; the
+ * UI cover intentionally keeps the brand-aligned `lynx-ui.png` filename even
+ * though the public docs route moved to `/ui`.
  *
  * We use each subsite's dark-mode logo variant (`logo.dark`), i.e. the
  * light/white artwork meant for dark surfaces — it reads best on the saturated
@@ -35,7 +37,7 @@ const CDN =
  * `native: true` keeps the source artwork's own colors (used for the two-tone
  * lynx-ui mark, whose inner cut-out reads on the gradient); otherwise the mark
  * is flattened to white.
- * @type {Record<string, { remoteSvg?: string; localSvg?: string; remotePng?: string; native?: boolean }>}
+ * @type {Record<string, { file?: string; remoteSvg?: string; localSvg?: string; remotePng?: string; native?: boolean }>}
  */
 const SOURCES = {
   guide: { remoteSvg: `${CDN}/lynx-light-logo.svg` },
@@ -44,6 +46,7 @@ const SOURCES = {
   // silhouette loses all its internal detail, so keep its native colors.
   rspeedy: { remotePng: `${CDN}/rspeedy.PNG`, native: true },
   ui: {
+    file: 'lynx-ui.png',
     localSvg: join(PUBLIC_ASSETS, 'lynx-ui-icon-light.svg'),
     native: true,
   },
@@ -116,7 +119,8 @@ async function main() {
   mkdirSync(ASSETS_DIR, { recursive: true });
 
   for (const [value, src] of Object.entries(SOURCES)) {
-    const out = join(ASSETS_DIR, `${value}.png`);
+    const file = src.file ?? `${value}.png`;
+    const out = join(ASSETS_DIR, file);
     try {
       const provided = [src.remotePng, src.localSvg, src.remoteSvg].filter(
         Boolean,
@@ -136,7 +140,7 @@ async function main() {
         if (!src.native) svg = recolorSvg(svg, '#ffffff');
         writeFileSync(out, rasterizeSvg(svg));
       }
-      console.log(`✓ ${value}.png`);
+      console.log(`✓ ${value} -> ${file}`);
     } catch (err) {
       console.error(`✗ ${value}: ${err instanceof Error ? err.message : err}`);
       process.exitCode = 1;

--- a/shared-og-config.ts
+++ b/shared-og-config.ts
@@ -79,6 +79,8 @@ const COVER_EXTRAS: Record<string, Pick<OgCover, 'gradient' | 'logo'>> = {
   },
   ui: {
     gradient: ['#ff1a6e', OG_GRADIENT_BRIDGE, OG_MAJOR_BRAND],
+    // Keep the vendored logo brand-aligned with the package/repo name even
+    // though the public docs route moved from `/lynx-ui/*` to `/ui/*`.
     logo: 'lynx-ui.png',
   },
   ai: {


### PR DESCRIPTION
## Motivation

The UI OG pipeline used two different naming conventions for the same brand asset.

`shared-og-config.ts` already declares the UI cover logo as `lynx-ui.png`, but
`scripts/og/prepare-assets.mjs` previously derived output filenames from the
cover key, which meant the `ui` entry defaulted to `ui.png`.

That made the pipeline inconsistent:
- `pnpm gen:og:assets` refreshed `ui.png`
- `pnpm gen:og` consumed `lynx-ui.png`

The current repository already carried a committed `lynx-ui.png`, so this did
not always break visibly, but it left the regeneration path brittle and could
produce stale UI OG assets.

## Changes by component

### `scripts/og/prepare-assets.mjs`
- add an explicit `file: 'lynx-ui.png'` override for the `ui` source
- resolve output filenames from `src.file ?? \`${value}.png\``
- log the final resolved filename for each generated asset
- document why UI intentionally keeps the brand-aligned filename

### `shared-og-config.ts`
- document that the UI cover continues to use `lynx-ui.png` even though the
  public docs route moved from `/lynx-ui/*` to `/ui/*`

### `scripts/og/README.md`
- clarify that cover outputs are keyed by cover id (`ui`)
- clarify that vendored logo assets are mostly keyed the same way, with the UI
  logo intentionally remaining `lynx-ui.png`

## Additional notes

This PR does not change public route behavior.

- UI docs routes remain under `/ui`
- generated cover outputs remain `/og/covers/<lang>/ui.png`
- only the vendored logo asset consumed inside that cover is aligned to the
  existing brand filename `lynx-ui.png`

In other words, this PR fixes a pipeline mismatch, not a route contract.

## Validation

- `pnpm gen:og:assets`
- `pnpm gen:og -- --force`
- `node scripts/ci/check-lynx-ui-routes.mjs`

## Related

- #1310 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Support explicit OG asset filenames in `prepare-assets.mjs`.
- Map the UI logo to `lynx-ui.png` while keep the UI cover output as `ui.png`.
- Document the distinction between cover IDs, asset filenames, and public routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->