### PR TITLE
chore(deps): upgrade @lynx-js/go-web to 0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@dugyu/luna-demo-bundles": "0.2.0",
     "@dugyu/luna-stage": "0.2.2",
     "@dugyu/luna-studio": "0.2.0",
-    "@lynx-js/go-web": "^0.10.0",
+    "@lynx-js/go-web": "^0.11.0",
     "@lynx-js/lynx-core": "^0.1.3",
     "@lynx-js/web-core": "^0.20.3",
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 0.2.0
         version: 0.2.0(@lynx-js/web-core-canary@0.23.1-canary-20260730-6cbcb870(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(motion@12.40.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@lynx-js/go-web':
-        specifier: ^0.10.0
-        version: 0.10.0(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core-canary@0.23.1-canary-20260730-6cbcb870(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.19(@rspack/core@2.1.7(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)
+        specifier: ^0.11.0
+        version: 0.11.0(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core-canary@0.23.1-canary-20260730-6cbcb870(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.19(@rspack/core@2.1.7(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)
       '@lynx-js/lynx-core':
         specifier: ^0.1.3
         version: 0.1.3
@@ -1689,8 +1689,8 @@ packages:
       '@lynx-js/react': '*'
       '@lynx-js/types': '*'
 
-  '@lynx-js/go-web@0.10.0':
-    resolution: {integrity: sha512-xZVpMLHIPrOWsX1tjCX0WrK4sZB+DMb3Gh70fiXYeZllKXgeKXDw2ovmVyKDNUx4rVOapAcCUIwDLmiI3aNCrQ==}
+  '@lynx-js/go-web@0.11.0':
+    resolution: {integrity: sha512-llruqMiSdbGzHfMwzbcM1Kren30+9qWhp0R3c8mFW4VZnNkzphjizHanKWYov+sBgFX6yFxXk044Pgd52LTlCA==}
     engines: {node: ^22 || ^24}
     peerDependencies:
       '@douyinfe/semi-icons': '>=2.74.0'
@@ -8365,7 +8365,7 @@ snapshots:
       '@lynx-js/react': 0.121.2(@lynx-js/types@3.9.0)(@types/react@18.3.31)
       '@lynx-js/types': 3.9.0
 
-  '@lynx-js/go-web@0.10.0(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core-canary@0.23.1-canary-20260730-6cbcb870(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.19(@rspack/core@2.1.7(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)':
+  '@lynx-js/go-web@0.11.0(@douyinfe/semi-icons@2.74.0(react@18.3.1))(@douyinfe/semi-ui@2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/web-core-canary@0.23.1-canary-20260730-6cbcb870(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.19(@rspack/core@2.1.7(@swc/helpers@0.5.23))(micromark-util-types@2.0.2)(micromark@4.0.1))(@shikijs/transformers@4.0.2)(qrcode.react@4.2.0(react@18.3.1))(react-copy-to-clipboard@5.1.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(swr@2.4.1(react@18.3.1))(vscode-icons-js@11.6.1)':
     dependencies:
       '@douyinfe/semi-icons': 2.74.0(react@18.3.1)
       '@douyinfe/semi-ui': 2.75.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)


### PR DESCRIPTION
Bumps `@lynx-js/go-web` from `^0.10.0` to `^0.11.0`.

## What changes

0.11.0 is a minor release containing exactly one change, from [lynx-community/go-web#85](https://github.com/lynx-community/go-web/pull/85): a small `<Go/>` mark now sits in every embed's footer, between the file-tree button and the `example › file` breadcrumb.

At rest it is printed in the same tertiary ink as the lettering around it — no badge, no button. On hover it lights up in link blue with a soft glow and links to https://github.com/lynx-community/go-web, with a tooltip reading "Powered by `<Go/>` / Want one on your own site? Open the repo".

The point is discoverability: nothing in an embed previously said what the surrounding widget *was*. The footer's GitHub button goes to the example's source, so a reader who wanted the same code-plus-live-preview pane on their own site had no name to search for and nowhere to click.

**No breaking API changes.** The release adds one optional config field, `GoConfig.poweredBy` (`false` hides the mark, a string points it at another URL). This PR deliberately leaves it unset, so the mark is visible on this site — that is the intended behaviour here. `src/components/go/Go.tsx` is unchanged.

## Diff

Two files, both mechanical:

- `package.json` — `"@lynx-js/go-web": "^0.10.0"` → `"^0.11.0"` (existing caret range style preserved)
- `pnpm-lock.yaml` — refreshed via a normal `pnpm install`; the diff is 3 hunks touching only the `@lynx-js/go-web` specifier, resolution integrity hash, and snapshot key. No other dependency moved.

## Verification

Ran everything `.github/workflows/ci.yml` runs, in order, on this branch:

| Command | Result |
| --- | --- |
| `node scripts/ci/check-case-collisions.mjs` | pass (no output) |
| `node scripts/ci/check-asset-urls.mjs` | pass (no output) |
| `node scripts/ci/check-lynx-ui-routes.mjs` | `lynx-ui route contract check passed.` |
| `pnpm install --frozen-lockfile` | `Already up to date` — lockfile is in sync with `package.json` |
| `pnpm run format:check` | `All matched files use Prettier code style!` |
| `pnpm run build` | success — 42 OG images generated, markdown rendered, SSG pages rendered, sitemap for 3187 pages |

The build emitted one warning, about `require` in `vscode-languageserver-types`' UMD wrapper. It is pre-existing and unrelated to this upgrade.

Nothing broke, so nothing needed fixing.

Additional checks:

- `npm view @lynx-js/go-web version` → `0.11.0`, confirming the release is published.
- Grepped the repo for other places the version is written down (docs, README, version tables, example snippets). There are none — `package.json` is the only file naming a `go-web` version; the other references are bare imports in `src/components/go/` and a `node_modules` path pattern in `rspress.config.ts`, none of which are version-pinned.
- Confirmed the mark actually ships: the built bundle (`doc_build/static/js/async/11167.*.js`) contains the powered-by component with its default `https://github.com/lynx-community/go-web` href, reached because `poweredBy` is unset.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KjtzV9kMjycgtj8g4LKpAi)_