### PR TITLE
fix(docs): pin PRIMJS_VERSION to a published version and repair code snippets

### DIFF
--- a/docs/en/blog/lynx-3-2.mdx
+++ b/docs/en/blog/lynx-3-2.mdx
@@ -258,7 +258,7 @@ dependencies {
     implementation("org.lynxsdk.lynx:primjs:2.12.0")
 
     // integrating image-service
-    implementation("org.lynxsdk.lynx:lynx-service-image:3.2.0-")
+    implementation("org.lynxsdk.lynx:lynx-service-image:3.2.0")
 
     // image-service dependencies, if not added, images cannot be loaded; if the host APP needs to use other image libraries, you can customize the image-service and remove this dependency
     implementation("com.facebook.fresco:fresco:2.3.0")

--- a/docs/en/guide/custom-native-component/custom-component-iOS.mdx
+++ b/docs/en/guide/custom-native-component/custom-component-iOS.mdx
@@ -275,7 +275,7 @@ LYNX_LAZY_REGISTER_UI("explorer-input")
   self.view.padding = self.padding;
   }
 
-LYNX_PROP_SETTER("value", setValue, NSString \*) {
+LYNX_PROP_SETTER("value", setValue, NSString *) {
 self.view.text = value;
 }
 
@@ -295,7 +295,7 @@ self.view.text = value;
   }
 
 - (void)setPadding:(UIEdgeInsets)padding {
-  \_padding = padding;
+  _padding = padding;
   [self setNeedsLayout];
   }
 

--- a/docs/en/guide/start/fragments/macos/integrating-lynx-with-existing-app-macos.mdx
+++ b/docs/en/guide/start/fragments/macos/integrating-lynx-with-existing-app-macos.mdx
@@ -94,6 +94,7 @@ target_link_options(${PROJECT_NAME} PRIVATE
 - Lynx Service needs to be actively injected
 
 <CodeFold height={360} toggle>
+
 ```objective-c title=AppDelegate.mm {17,20-30}
 #import "AppDelegate.h"
 #import "ViewController.h"
@@ -118,13 +119,15 @@ void Request(std::shared_ptr<lynx::pub::LynxHttpRequest> request, std::shared_pt
 @implementation AppDelegate {
 }
 
-- (void)applicationDidFinishLaunching:(NSNotification \*)aNotification {
+- (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
   // Register http service for lynx.fetch.
   lynx::pub::LynxServiceCenter::GetInstance().RegisterService(std::make_shared<LynxHttpServiceImpl>());
 
   }
 
-````
+@end
+```
+
 </CodeFold>
 
 <div style={{ marginBottom: 30 }} />
@@ -134,13 +137,24 @@ void Request(std::shared_ptr<lynx::pub::LynxHttpRequest> request, std::shared_pt
 LynxEnv provides the global initialization interface for the Lynx Engine. Please ensure that the initialization of LynxEnv occurs before any interface calls to the Lynx Engine. It is recommended to complete the initialization of LynxEnv before LynxView creation.
 
 <CodeFold height={360} toggle>
-```objective-c title=AppDelegate.mm {9,12-19}
+
+```objective-c title=AppDelegate.mm {19,22-29}
 #import "AppDelegate.h"
 #import "ViewController.h"
 
 #import "lynx_env.h"
 #import "lynx_http_service.h"
 #import "lynx_view.h"
+
+// Implements the http service if needed.
+class LynxHttpServiceImpl : public lynx::pub::LynxHttpService {
+public:
+LynxHttpServiceImpl() = default;
+~LynxHttpServiceImpl() = default;
+void Request(std::shared_ptr<lynx::pub::LynxHttpRequest> request, std::shared_ptr<lynx::pub::LynxHttpResponse> response) override {
+// TODO
+}
+};
 
 @interface AppDelegate ()
 @end
@@ -162,7 +176,8 @@ LynxEnv provides the global initialization interface for the Lynx Engine. Please
   // lynx_env.RegisterNativeModule("ExplorerModule", ExplorerModuleCreator, nullptr);
 }
 
-````
+@end
+```
 
 </CodeFold>
 
@@ -184,24 +199,27 @@ Bundle Example:
 Impl Resource Fetcher
 
 <CodeFold toggle>
+
 ```objective-c title=ExampleGenericResourceFetcher.h {9,12-19}
 #import <Foundation/Foundation.h>
 #import "lynx_generic_resource_fetcher.h"
 
 class ExampleGenericResourceFetcher : public lynx::pub::LynxGenericResourceFetcher {
 public:
-void FetchResource(std::shared_ptr<lynx::pub::LynxResourceRequest> request, std::shared_ptr<lynx::pub::LynxResourceResponse> response) override;
+void FetchResource(std::shared_ptr<lynx::pub::resource::LynxResourceRequest> request, std::shared_ptr<lynx::pub::resource::LynxResourceResponse> response) override;
 };
 
-````
+```
+
 </CodeFold>
 
 <CodeFold height={360} toggle>
+
 ```objective-c title=ExampleGenericResourceFetcher.mm {9,12-19}
 #import <Foundation/Foundation.h>
 #import "ExampleGenericResourceFetcher.h"
 
-void ExampleGenericResourceFetcher::FetchResource(std::shared_ptr<lynx::pub::LynxResourceRequest> request, std::shared_ptr<lynx::pub::LynxResourceResponse> response) {
+void ExampleGenericResourceFetcher::FetchResource(std::shared_ptr<lynx::pub::resource::LynxResourceRequest> request, std::shared_ptr<lynx::pub::resource::LynxResourceResponse> response) {
   const char *url_str = request->GetUrl();
   NSString *ns_string = [NSString stringWithUTF8String:url_str];
 
@@ -228,7 +246,7 @@ void ExampleGenericResourceFetcher::FetchResource(std::shared_ptr<lynx::pub::Lyn
   [dataTask resume];
 }
 
-````
+```
 
 </CodeFold>
 
@@ -237,6 +255,7 @@ void ExampleGenericResourceFetcher::FetchResource(std::shared_ptr<lynx::pub::Lyn
 `LynxView` is the basic rendering view provided by `Lynx Engine`. You can quickly construct a LynxView and provide a NSView as it's parent.
 
 <CodeFold height={360} toggle>
+
 ```objective-c title=ViewController.mm {9,12-19}
 #import "ViewController.h"
 #import "ExampleGenericResourceFetcher.h"
@@ -258,7 +277,7 @@ void ExampleGenericResourceFetcher::FetchResource(std::shared_ptr<lynx::pub::Lyn
   lynx::pub::LynxView::Builder builder;
   builder.SetScreenSize(self.view.frame.size.width, self.view.frame.size.height, 1.0)
   .SetFrame(0, 0, self.view.frame.size.width, self.view.frame.size.height)
-  .SetParent((\_\_bridge NativeWindow)self.view)
+  .SetParent((__bridge NativeWindow)self.view)
   .SetGenericResourceFetcher(std::make_shared<ExampleGenericResourceFetcher>());
   self.lynxView = builder.Build();
   }
@@ -271,7 +290,8 @@ void ExampleGenericResourceFetcher::FetchResource(std::shared_ptr<lynx::pub::Lyn
   self.lynxView->SetFrame(0, 0, self.view.frame.size.width, self.view.frame.size.height);
   }
 
-````
+@end
+```
 
 </CodeFold>
 
@@ -282,6 +302,7 @@ void ExampleGenericResourceFetcher::FetchResource(std::shared_ptr<lynx::pub::Lyn
 After completing the above steps, all the work of initializing LynxView have been completed. Call the `lynxView->LoadTemplate` method to render the corresponding Bundle onto the LynxView.
 
 <CodeFold height={360} toggle>
+
 ```objective-c title=ViewController.mm {9,12-19}
 #import "ViewController.h"
 #import "ExampleGenericResourceFetcher.h"
@@ -317,13 +338,18 @@ After completing the above steps, all the work of initializing LynxView have bee
   self.lynxView->LoadTemplate(meta_data);
   }
 
+@end
 ```
+
 </CodeFold>
 
 Then you will see the following interface on the screen:
 
 <center>
-  <img src="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/plugin/static/hello-world-showcase-macos.png" width="800" />
+  <img
+    src="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/plugin/static/hello-world-showcase-macos.png"
+    width="800"
+  />
 </center>
 
 </Steps>
@@ -333,4 +359,3 @@ Congratulations, you have now completed all the work of rendering the LynxView!
 ## 4. Now what?
 
 At this stage, you have successfully integrated Lynx into your App. Refer to our [developing](/guide/start/quick-start) and [debugging](/guide/devtool/panels) docs for in-depth insights on working with Lynx.
-````

--- a/docs/public/AGENTS.md
+++ b/docs/public/AGENTS.md
@@ -150,7 +150,7 @@ Common APIs:
 - **Main Thread Script**: Keep animations/gestures responsive while respecting thread isolation and data synchronization. (See [Main Thread Script](/react/main-thread-script.md))
 - **NodesRef.invoke**: Batch native operations (for example `autoScroll`) to avoid cross-thread overhead. (See [Direct Manipulation](/guide/interaction/event-handling/manipulating-element.react.md))
 - **Lynx DevTool & Trace**: The desktop DevTool offers Elements/Console/Sources/Trace panels to record render pipelines and analyze the ReactLynx render process. (See [Lynx DevTool](/guide/devtool.md), [Trace](/guide/devtool/trace.md))
-- **Performance metrics**: Use `lynx.performance` and `PerformanceObserver` to capture metrics such as FCP and InitContainer. (See [Performance API](/guide/performance/metrics/performance-api.md))
+- **Performance metrics**: Use `lynx.performance` and `PerformanceObserver` to capture metrics such as FCP and InitContainer. (See [Performance API](/guide/performance/monitor-performance/performance-api.md))
 
 ## 15. Engineering Practices and Tooling
 
@@ -228,10 +228,8 @@ The following official Lynx tutorials cover scenarios from beginner to advancedâ
 - [`<textarea>` element](/api/elements/built-in/textarea.md)
 - [`<overlay>` element](/api/elements/built-in/overlay.md)
 - [`<refresh>` element](/api/elements/built-in/refresh.md)
-- [`<scroll-coordinator>` element](/api/elements/built-in/scroll-coordinator.md)
 - [`<svg>` element](/api/elements/built-in/svg.md)
 - [`<title-bar-view>` element](/api/elements/built-in/title-bar-view.md)
-- [`<viewpager>` element](/api/elements/built-in/viewpager.md)
 
 ---
 

--- a/docs/public/version.json
+++ b/docs/public/version.json
@@ -1,7 +1,7 @@
 {
   "current_version": "3.9",
   "LYNX_VERSION": "3.9.0",
-  "PRIMJS_VERSION": "3.9.0",
+  "PRIMJS_VERSION": "3.8.0-alpha.6",
   "versions": [
     {
       "type": "developing",

--- a/docs/public/zh/AGENTS.md
+++ b/docs/public/zh/AGENTS.md
@@ -150,7 +150,7 @@
 - **Main Thread Script**：确保动画/手势无延迟，注意线程隔离与数据同步。（参考：[Main Thread Script](/zh/react/main-thread-script.md)）
 - **NodesRef.invoke**：批量调用原生特性（如 `autoScroll`）避免跨线程瓶颈。（参考：[Direct Manipulation](/zh/guide/interaction/event-handling/manipulating-element.react.md)）
 - **Lynx DevTool & Trace**：桌面 DevTool 提供 Elements/Console/Sources/Trace 面板，可记录渲染流水、分析 ReactLynx Render Pipeline。（参考：[Lynx DevTool](/zh/guide/devtool.md), [Trace](/zh/guide/devtool/trace.md)）
-- **Performance Metrics**：通过 `lynx.performance`、`PerformanceObserver` 采集 FCP、InitContainer 等指标。（参考：[Performance API](/zh/guide/performance/metrics/performance-api.md)）
+- **Performance Metrics**：通过 `lynx.performance`、`PerformanceObserver` 采集 FCP、InitContainer 等指标。（参考：[Performance API](/zh/guide/performance/monitor-performance/performance-api.md)）
 
 ## 15. 工程实践与工具链
 

--- a/docs/zh/blog/lynx-3-2.mdx
+++ b/docs/zh/blog/lynx-3-2.mdx
@@ -258,7 +258,7 @@ dependencies {
     implementation("org.lynxsdk.lynx:primjs:2.12.0")
 
     // integrating image-service
-    implementation("org.lynxsdk.lynx:lynx-service-image:3.2.0-")
+    implementation("org.lynxsdk.lynx:lynx-service-image:3.2.0")
 
     // image-service dependencies, if not added, images cannot be loaded; if the host APP needs to use other image libraries, you can customize the image-service and remove this dependency
     implementation("com.facebook.fresco:fresco:2.3.0")

--- a/docs/zh/guide/custom-native-component/custom-component-iOS.mdx
+++ b/docs/zh/guide/custom-native-component/custom-component-iOS.mdx
@@ -297,7 +297,7 @@ LYNX_LAZY_REGISTER_UI("explorer-input")
   self.view.padding = self.padding;
   }
 
-LYNX_PROP_SETTER("value", setValue, NSString \*) {
+LYNX_PROP_SETTER("value", setValue, NSString *) {
 self.view.text = value;
 }
 
@@ -317,7 +317,7 @@ self.view.text = value;
   }
 
 - (void)setPadding:(UIEdgeInsets)padding {
-  \_padding = padding;
+  _padding = padding;
   [self setNeedsLayout];
   }
 

--- a/docs/zh/guide/start/fragments/macos/integrating-lynx-with-existing-app-macos.mdx
+++ b/docs/zh/guide/start/fragments/macos/integrating-lynx-with-existing-app-macos.mdx
@@ -93,6 +93,7 @@ target_link_options(${PROJECT_NAME} PRIVATE
 - Lynx Service 需主动注入。
 
 <CodeFold height={360} toggle>
+
 ```objective-c title=AppDelegate.mm {17,20-30}
 #import "AppDelegate.h"
 #import "ViewController.h"
@@ -117,12 +118,14 @@ void Request(std::shared_ptr<lynx::pub::LynxHttpRequest> request, std::shared_pt
 @implementation AppDelegate {
 }
 
-- (void)applicationDidFinishLaunching:(NSNotification \*)aNotification {
+- (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
   // Register http service for lynx.fetch.
   lynx::pub::LynxServiceCenter::GetInstance().RegisterService(std::make_shared<LynxHttpServiceImpl>());
   }
 
-````
+@end
+```
+
 </CodeFold>
 
 <div style={{ marginBottom: 30 }} />
@@ -132,13 +135,24 @@ void Request(std::shared_ptr<lynx::pub::LynxHttpRequest> request, std::shared_pt
 LynxEnv 提供了 Lynx Engine 的全局初始化接口, 请保证 LynxEnv 的初始化发生在 Lynx Engine 的任何接口调用之前。
 
 <CodeFold height={360} toggle>
-```objective-c title=AppDelegate.mm {9,12-19}
+
+```objective-c title=AppDelegate.mm {19,22-29}
 #import "AppDelegate.h"
 #import "ViewController.h"
 
 #import "lynx_env.h"
 #import "lynx_http_service.h"
 #import "lynx_view.h"
+
+// Implements the http service if needed.
+class LynxHttpServiceImpl : public lynx::pub::LynxHttpService {
+public:
+LynxHttpServiceImpl() = default;
+~LynxHttpServiceImpl() = default;
+void Request(std::shared_ptr<lynx::pub::LynxHttpRequest> request, std::shared_ptr<lynx::pub::LynxHttpResponse> response) override {
+// TODO
+}
+};
 
 @interface AppDelegate ()
 @end
@@ -160,7 +174,8 @@ LynxEnv 提供了 Lynx Engine 的全局初始化接口, 请保证 LynxEnv 的初
   // lynx_env.RegisterNativeModule("ExplorerModule", ExplorerModuleCreator, nullptr);
 }
 
-````
+@end
+```
 
 </CodeFold>
 
@@ -183,24 +198,27 @@ Bundle 示例:
 实现 Resource Fetcher
 
 <CodeFold toggle>
+
 ```objective-c title=ExampleGenericResourceFetcher.h {9,12-19}
 #import <Foundation/Foundation.h>
 #import "lynx_generic_resource_fetcher.h"
 
 class ExampleGenericResourceFetcher : public lynx::pub::LynxGenericResourceFetcher {
 public:
-void FetchResource(std::shared_ptr<lynx::pub::LynxResourceRequest> request, std::shared_ptr<lynx::pub::LynxResourceResponse> response) override;
+void FetchResource(std::shared_ptr<lynx::pub::resource::LynxResourceRequest> request, std::shared_ptr<lynx::pub::resource::LynxResourceResponse> response) override;
 };
 
-````
+```
+
 </CodeFold>
 
 <CodeFold height={360} toggle>
+
 ```objective-c title=ExampleGenericResourceFetcher.mm {9,12-19}
 #import <Foundation/Foundation.h>
 #import "ExampleGenericResourceFetcher.h"
 
-void ExampleGenericResourceFetcher::FetchResource(std::shared_ptr<lynx::pub::LynxResourceRequest> request, std::shared_ptr<lynx::pub::LynxResourceResponse> response) {
+void ExampleGenericResourceFetcher::FetchResource(std::shared_ptr<lynx::pub::resource::LynxResourceRequest> request, std::shared_ptr<lynx::pub::resource::LynxResourceResponse> response) {
   const char *url_str = request->GetUrl();
   NSString *ns_string = [NSString stringWithUTF8String:url_str];
 
@@ -227,7 +245,7 @@ void ExampleGenericResourceFetcher::FetchResource(std::shared_ptr<lynx::pub::Lyn
   [dataTask resume];
 }
 
-````
+```
 
 </CodeFold>
 
@@ -236,6 +254,7 @@ void ExampleGenericResourceFetcher::FetchResource(std::shared_ptr<lynx::pub::Lyn
 LynxView 是 Lynx Engine 提供的渲染基本单元，你可以快速的构造一个 LynxView，并通过设置一个NSView作为父容器将其任意添加到原生macOS的视图树上。
 
 <CodeFold height={360} toggle>
+
 ```objective-c title=ViewController.mm {9,12-19}
 #import "ViewController.h"
 #import "ExampleGenericResourceFetcher.h"
@@ -257,7 +276,7 @@ LynxView 是 Lynx Engine 提供的渲染基本单元，你可以快速的构造�
   lynx::pub::LynxView::Builder builder;
   builder.SetScreenSize(self.view.frame.size.width, self.view.frame.size.height, 1.0)
   .SetFrame(0, 0, self.view.frame.size.width, self.view.frame.size.height)
-  .SetParent((\_\_bridge NativeWindow)self.view)
+  .SetParent((__bridge NativeWindow)self.view)
   .SetGenericResourceFetcher(std::make_shared<ExampleGenericResourceFetcher>());
   self.lynxView = builder.Build();
   }
@@ -270,7 +289,8 @@ LynxView 是 Lynx Engine 提供的渲染基本单元，你可以快速的构造�
   self.lynxView->SetFrame(0, 0, self.view.frame.size.width, self.view.frame.size.height);
   }
 
-````
+@end
+```
 
 </CodeFold>
 
@@ -281,6 +301,7 @@ LynxView 是 Lynx Engine 提供的渲染基本单元，你可以快速的构造�
 当你完成以上步骤之后，已经完成了 LynxView 创建与资源读取的全部工作，调用 `lynxView->LoadTemplate` 方法，即可将对应的 Bundle 内容渲染到 LynxView 视图上。
 
 <CodeFold height={360} toggle>
+
 ```objective-c title=ViewController.mm {9,12-19}
 #import "ViewController.h"
 #import "ExampleGenericResourceFetcher.h"
@@ -316,13 +337,18 @@ LynxView 是 Lynx Engine 提供的渲染基本单元，你可以快速的构造�
   self.lynxView->LoadTemplate(meta_data);
   }
 
+@end
 ```
+
 </CodeFold>
 
 然后你将在屏幕上看到如下内容：
 
 <center>
-  <img src="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/plugin/static/hello-world-showcase-macos.png" width="800" />
+  <img
+    src="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/plugin/static/hello-world-showcase-macos.png"
+    width="800"
+  />
 </center>
 
 </Steps>
@@ -332,4 +358,3 @@ LynxView 是 Lynx Engine 提供的渲染基本单元，你可以快速的构造�
 ## 4. 进入 Lynx 世界
 
 现在你已经将 Lynx 集成到你的应用中了。请参考[开发](/guide/start/quick-start)和[调试](/guide/devtool/panels)文档进一步在 Lynx 的世界里遨游吧！
-````


### PR DESCRIPTION
Fixes documentation defects on `release/3.9`, including one that makes the
integration guide unbuildable on both mobile platforms.

- **`PRIMJS_VERSION` points at a version that was never published.**
  `docs/public/version.json` pins `3.9.0`, but no PrimJS 3.9.0 exists. Every
  Android and iOS dependency snippet on the branch renders from this value, so
  the guide fails at dependency resolution on both platforms before any code
  runs. Lynx 3.9.0 depends on `primjs 3.8.0-alpha.6` on Android, and the
  `Lynx/Framework` 3.9.0 podspec pins `PrimJS/quickjs` to exactly that version —
  it is the only value that satisfies both Gradle and CocoaPods.
- **macOS guide does not compile** — unterminated `@implementation` blocks, an
  escaped pointer star in `applicationDidFinishLaunching`, the
  `lynx::pub::resource` namespace, and an unmatched trailing fence.
- **Objective-C escapes** in the custom component guide.
- **Dead links in `AGENTS.md`**.
- **Truncated version** in the 3.2 blog post.

With the version fix, the Android app builds and runs against 3.9.0 and the iOS
pods resolve and build; both were checked end to end.

## Verification

- **macOS** — every Objective-C++ block is extracted from the `.mdx` and compiled
  with `clang -fsyntax-only -fobjc-arc` against the released macOS SDK headers.
  As published **none of the five compile**; at this head **all five do**, in both
  locales.
- **Android** — the guide's dependency block is handed to Gradle against
  `google()` + `mavenCentral()` to confirm every documented coordinate resolves.
- **Links** — checked against the real route table, modelling `route.exclude`,
  `.html`/`.mdx` equivalence, client redirects and Netlify 301s, so only genuinely
  dead links are reported.
- **CI locally** — `check-case-collisions`, `check-asset-urls`,
  `check-lynx-ui-routes`, `pnpm install --frozen-lockfile`, `pnpm run format:check`
  and `pnpm run build` all pass on this branch.

## Series

`main` #1332 · `release/4.0` #1333 · `release/3.9` #1334 · `release/3.8` #1346 ·
`release/3.7` #1335 · `release/3.6` #1341 · `release/3.5` #1340 ·
`release/3.4` #1339.

The 3.2 blog line (`lynx-service-image:3.2.0-`) is now corrected on **every**
published branch, including `release/3.8` via #1346, so no site version disagrees
with another.

## Follow-up split out

The element-API `invoke()` example convention — type declarations written where
runnable code is shown — is tracked in #1347 with a measured inventory across all
five branches, the two candidate representations, and a coordinated landing plan.
It is not fixed here because doing so would pull in `text.mdx`, `list.mdx`,
`image.mdx` and `webview-API.mdx` — files untouched by the defects these PRs
exist for — and land a convention change on five release branches without
coordination.
