### PR TITLE
docs(compat-data): add WebAssembly compat data

### DIFF
--- a/docs/en/guide/scripting-runtime/webassembly.mdx
+++ b/docs/en/guide/scripting-runtime/webassembly.mdx
@@ -2,7 +2,7 @@
 description: 'WebAssembly support in Lynx via the PrimJS runtime on Android.'
 ---
 
-import { Go, VersionBadge } from '@lynx';
+import { APITable, Go, VersionBadge } from '@lynx';
 
 # WebAssembly
 
@@ -54,3 +54,7 @@ Try the complete Lynx example below to see the same flow in a page:
 />
 
 For more details about the underlying runtime support, see the [PrimJS WebAssembly document](https://github.com/lynx-family/primjs/blob/develop/docs/wasm.md).
+
+## Compatibility
+
+<APITable query="lynx-api/global/WebAssembly" />

--- a/docs/zh/guide/scripting-runtime/webassembly.mdx
+++ b/docs/zh/guide/scripting-runtime/webassembly.mdx
@@ -2,7 +2,7 @@
 description: 'Lynx 3.8 起通过 PrimJS 支持 WebAssembly。'
 ---
 
-import { Go, VersionBadge } from '@lynx';
+import { APITable, Go, VersionBadge } from '@lynx';
 
 # WebAssembly
 
@@ -54,3 +54,7 @@ const result = instance.exports.add(1, 2);
 />
 
 更多底层运行时支持的说明，可参考 [PrimJS 的 WebAssembly 文档](https://github.com/lynx-family/primjs/blob/develop/docs/wasm.md)。
+
+## 兼容性
+
+<APITable query="lynx-api/global/WebAssembly" />

--- a/packages/lynx-compat-data/api-stats.json
+++ b/packages/lynx-compat-data/api-stats.json
@@ -172,7 +172,7 @@
           "clay": 100
         },
         "exclusive": {
-          "android": 0,
+          "android": 1,
           "ios": 0,
           "harmony": 0,
           "web_lynx": 0,
@@ -620,7 +620,7 @@
       "android": {
         "supported_count": 1010,
         "coverage_percent": 89,
-        "exclusive_count": 18
+        "exclusive_count": 19
       },
       "ios": {
         "supported_count": 1011,
@@ -39625,7 +39625,7 @@
           "clay": 100
         },
         "exclusive": {
-          "android": 0,
+          "android": 1,
           "ios": 0,
           "harmony": 0,
           "web_lynx": 0,
@@ -39640,6 +39640,7 @@
         "lynx-api/global/SystemInfo",
         "lynx-api/global/SystemInfo.SystemInfo.engineVersion",
         "lynx-api/global/SystemInfo.SystemInfo.lynxSdkVersion",
+        "lynx-api/global/WebAssembly",
         "lynx-api/global/clearInterval",
         "lynx-api/global/clearTimeout",
         "lynx-api/global/console/assert",
@@ -39709,6 +39710,22 @@
             "clay_macos": "3.5",
             "clay_windows": "3.5",
             "clay": "3.5"
+          }
+        },
+        {
+          "path": "lynx-api/global/WebAssembly",
+          "name": "<code>WebAssembly</code>",
+          "doc_url": "guide/scripting-runtime/webassembly",
+          "support": {
+            "android": "3.8",
+            "ios": false,
+            "harmony": false,
+            "web_lynx": false,
+            "clay_android": false,
+            "clay_ios": false,
+            "clay_macos": false,
+            "clay_windows": false,
+            "clay": false
           }
         },
         {
@@ -40847,7 +40864,24 @@
         "clay": []
       },
       "exclusive": {
-        "android": [],
+        "android": [
+          {
+            "path": "lynx-api/global/WebAssembly",
+            "name": "<code>WebAssembly</code>",
+            "doc_url": "guide/scripting-runtime/webassembly",
+            "support": {
+              "android": "3.8",
+              "ios": false,
+              "harmony": false,
+              "web_lynx": false,
+              "clay_android": false,
+              "clay_ios": false,
+              "clay_macos": false,
+              "clay_windows": false,
+              "clay": false
+            }
+          }
+        ],
         "ios": [],
         "harmony": [],
         "web_lynx": [],
@@ -103663,6 +103697,42 @@
     },
     {
       "id": "feature-881",
+      "query": "lynx-api/global/WebAssembly",
+      "name": "<code>WebAssembly</code>",
+      "category": "lynx-api/global",
+      "source_file": "lynx-api/global/WebAssembly.json",
+      "support": {
+        "android": {
+          "version_added": "3.8"
+        },
+        "ios": {
+          "version_added": false
+        },
+        "harmony": {
+          "version_added": false
+        },
+        "web_lynx": {
+          "version_added": false
+        },
+        "clay_android": {
+          "version_added": false
+        },
+        "clay_ios": {
+          "version_added": false
+        },
+        "clay_macos": {
+          "version_added": false
+        },
+        "clay_windows": {
+          "version_added": false
+        },
+        "clay": {
+          "version_added": false
+        }
+      }
+    },
+    {
+      "id": "feature-882",
       "query": "lynx-api/global/clearInterval",
       "name": "Cancels the timer set by `setInterval`.",
       "category": "lynx-api/global",
@@ -103698,7 +103768,7 @@
       }
     },
     {
-      "id": "feature-882",
+      "id": "feature-883",
       "query": "lynx-api/global/clearTimeout",
       "name": "Cancel the timer set by `setTimeout`.",
       "category": "lynx-api/global",
@@ -103734,7 +103804,7 @@
       }
     },
     {
-      "id": "feature-883",
+      "id": "feature-884",
       "query": "lynx-api/global/console/assert",
       "name": "assert failed and output error level message",
       "category": "lynx-api/global",
@@ -103770,7 +103840,7 @@
       }
     },
     {
-      "id": "feature-884",
+      "id": "feature-885",
       "query": "lynx-api/global/console/count",
       "name": "start count",
       "category": "lynx-api/global",
@@ -103806,7 +103876,7 @@
       }
     },
     {
-      "id": "feature-885",
+      "id": "feature-886",
       "query": "lynx-api/global/console/countReset",
       "name": "reset count",
       "category": "lynx-api/global",
@@ -103842,7 +103912,7 @@
       }
     },
     {
-      "id": "feature-886",
+      "id": "feature-887",
       "query": "lynx-api/global/console/debug",
       "name": "output a debug level message",
       "category": "lynx-api/global",
@@ -103878,7 +103948,7 @@
       }
     },
     {
-      "id": "feature-887",
+      "id": "feature-888",
       "query": "lynx-api/global/console/error",
       "name": "output a error level message",
       "category": "lynx-api/global",
@@ -103914,7 +103984,7 @@
       }
     },
     {
-      "id": "feature-888",
+      "id": "feature-889",
       "query": "lynx-api/global/console/group",
       "name": "start a console group",
       "category": "lynx-api/global",
@@ -103950,7 +104020,7 @@
       }
     },
     {
-      "id": "feature-889",
+      "id": "feature-890",
       "query": "lynx-api/global/console/groupCollapsed",
       "name": "start a collapsed console group",
       "category": "lynx-api/global",
@@ -103986,7 +104056,7 @@
       }
     },
     {
-      "id": "feature-890",
+      "id": "feature-891",
       "query": "lynx-api/global/console/groupEnd",
       "name": "end a console group",
       "category": "lynx-api/global",
@@ -104022,7 +104092,7 @@
       }
     },
     {
-      "id": "feature-891",
+      "id": "feature-892",
       "query": "lynx-api/global/console/info",
       "name": "output a info level message",
       "category": "lynx-api/global",
@@ -104058,7 +104128,7 @@
       }
     },
     {
-      "id": "feature-892",
+      "id": "feature-893",
       "query": "lynx-api/global/console/log",
       "name": "output a log level message",
       "category": "lynx-api/global",
@@ -104094,7 +104164,7 @@
       }
     },
     {
-      "id": "feature-893",
+      "id": "feature-894",
       "query": "lynx-api/global/console/profile",
       "name": "output a message",
       "category": "lynx-api/global",
@@ -104130,7 +104200,7 @@
       }
     },
     {
-      "id": "feature-894",
+      "id": "feature-895",
       "query": "lynx-api/global/console/profileEnd",
       "name": "end profile",
       "category": "lynx-api/global",
@@ -104166,7 +104236,7 @@
       }
     },
     {
-      "id": "feature-895",
+      "id": "feature-896",
       "query": "lynx-api/global/console/table",
       "name": "print message by table",
       "category": "lynx-api/global",
@@ -104202,7 +104272,7 @@
       }
     },
     {
-      "id": "feature-896",
+      "id": "feature-897",
       "query": "lynx-api/global/console/time",
       "name": "start a timer",
       "category": "lynx-api/global",
@@ -104238,7 +104308,7 @@
       }
     },
     {
-      "id": "feature-897",
+      "id": "feature-898",
       "query": "lynx-api/global/console/timeEnd",
       "name": "end a timer",
       "category": "lynx-api/global",
@@ -104274,7 +104344,7 @@
       }
     },
     {
-      "id": "feature-898",
+      "id": "feature-899",
       "query": "lynx-api/global/console/timeLog",
       "name": "print timer",
       "category": "lynx-api/global",
@@ -104310,7 +104380,7 @@
       }
     },
     {
-      "id": "feature-899",
+      "id": "feature-900",
       "query": "lynx-api/global/console/warn",
       "name": "output a warn level message",
       "category": "lynx-api/global",
@@ -104346,7 +104416,7 @@
       }
     },
     {
-      "id": "feature-900",
+      "id": "feature-901",
       "query": "lynx-api/global/setInterval",
       "name": "Repeatedly calls a function or executes a code fragment with a fixed time interval between each call.",
       "category": "lynx-api/global",
@@ -104382,7 +104452,7 @@
       }
     },
     {
-      "id": "feature-901",
+      "id": "feature-902",
       "query": "lynx-api/global/setTimeout",
       "name": "setTimeout",
       "category": "lynx-api/global",
@@ -104418,7 +104488,7 @@
       }
     },
     {
-      "id": "feature-902",
+      "id": "feature-903",
       "query": "lynx-api/event/AnimationEvent",
       "name": "AnimationEvent",
       "category": "lynx-api/event",
@@ -104454,7 +104524,7 @@
       }
     },
     {
-      "id": "feature-903",
+      "id": "feature-904",
       "query": "lynx-api/event/AnimationEvent.detail",
       "name": "detail",
       "category": "lynx-api/event",
@@ -104490,7 +104560,7 @@
       }
     },
     {
-      "id": "feature-904",
+      "id": "feature-905",
       "query": "lynx-api/event/AnimationEvent.animationstart",
       "name": "animationstart",
       "category": "lynx-api/event",
@@ -104526,7 +104596,7 @@
       }
     },
     {
-      "id": "feature-905",
+      "id": "feature-906",
       "query": "lynx-api/event/AnimationEvent.animationend",
       "name": "animationend",
       "category": "lynx-api/event",
@@ -104562,7 +104632,7 @@
       }
     },
     {
-      "id": "feature-906",
+      "id": "feature-907",
       "query": "lynx-api/event/AnimationEvent.animationiteration",
       "name": "animationiteration",
       "category": "lynx-api/event",
@@ -104598,7 +104668,7 @@
       }
     },
     {
-      "id": "feature-907",
+      "id": "feature-908",
       "query": "lynx-api/event/AnimationEvent.animationcancel",
       "name": "animationcancel",
       "category": "lynx-api/event",
@@ -104634,7 +104704,7 @@
       }
     },
     {
-      "id": "feature-908",
+      "id": "feature-909",
       "query": "lynx-api/event/AnimationEvent.transitionstart",
       "name": "transitionstart",
       "category": "lynx-api/event",
@@ -104670,7 +104740,7 @@
       }
     },
     {
-      "id": "feature-909",
+      "id": "feature-910",
       "query": "lynx-api/event/AnimationEvent.transitionend",
       "name": "transitionend",
       "category": "lynx-api/event",
@@ -104706,7 +104776,7 @@
       }
     },
     {
-      "id": "feature-910",
+      "id": "feature-911",
       "query": "lynx-api/event/AnimationEvent.transitioncancel",
       "name": "transitioncancel",
       "category": "lynx-api/event",
@@ -104742,7 +104812,7 @@
       }
     },
     {
-      "id": "feature-911",
+      "id": "feature-912",
       "query": "lynx-api/event/CustomEvent",
       "name": "CustomEvent",
       "category": "lynx-api/event",
@@ -104778,7 +104848,7 @@
       }
     },
     {
-      "id": "feature-912",
+      "id": "feature-913",
       "query": "lynx-api/event/CustomEvent.params",
       "name": "params",
       "category": "lynx-api/event",
@@ -104814,7 +104884,7 @@
       }
     },
     {
-      "id": "feature-913",
+      "id": "feature-914",
       "query": "lynx-api/event/CustomEvent.detail",
       "name": "detail",
       "category": "lynx-api/event",
@@ -104850,7 +104920,7 @@
       }
     },
     {
-      "id": "feature-914",
+      "id": "feature-915",
       "query": "lynx-api/event/Event",
       "name": "Event",
       "category": "lynx-api/event",
@@ -104886,7 +104956,7 @@
       }
     },
     {
-      "id": "feature-915",
+      "id": "feature-916",
       "query": "lynx-api/event/Event.TouchEvent",
       "name": "TouchEvent",
       "category": "lynx-api/event",
@@ -104922,7 +104992,7 @@
       }
     },
     {
-      "id": "feature-916",
+      "id": "feature-917",
       "query": "lynx-api/event/Event.CustomEvent",
       "name": "CustomEvent",
       "category": "lynx-api/event",
@@ -104958,7 +105028,7 @@
       }
     },
     {
-      "id": "feature-917",
+      "id": "feature-918",
       "query": "lynx-api/event/Event.AnimationEvent",
       "name": "AnimationEvent",
       "category": "lynx-api/event",
@@ -104994,7 +105064,7 @@
       }
     },
     {
-      "id": "feature-918",
+      "id": "feature-919",
       "query": "lynx-api/event/Event.type",
       "name": "type",
       "category": "lynx-api/event",
@@ -105030,7 +105100,7 @@
       }
     },
     {
-      "id": "feature-919",
+      "id": "feature-920",
       "query": "lynx-api/event/Event.timestamp",
       "name": "timestamp",
       "category": "lynx-api/event",
@@ -105066,7 +105136,7 @@
       }
     },
     {
-      "id": "feature-920",
+      "id": "feature-921",
       "query": "lynx-api/event/Event.target",
       "name": "target",
       "category": "lynx-api/event",
@@ -105102,7 +105172,7 @@
       }
     },
     {
-      "id": "feature-921",
+      "id": "feature-922",
       "query": "lynx-api/event/Event.currentTarget",
       "name": "currentTarget",
       "category": "lynx-api/event",
@@ -105138,7 +105208,7 @@
       }
     },
     {
-      "id": "feature-922",
+      "id": "feature-923",
       "query": "lynx-api/event/Event.stopPropagation",
       "name": "stopPropagation",
       "category": "lynx-api/event",
@@ -105174,7 +105244,7 @@
       }
     },
     {
-      "id": "feature-923",
+      "id": "feature-924",
       "query": "lynx-api/event/Event.stopImmediatePropagation",
       "name": "stopImmediatePropagation",
       "category": "lynx-api/event",
@@ -105210,7 +105280,7 @@
       }
     },
     {
-      "id": "feature-924",
+      "id": "feature-925",
       "query": "lynx-api/event/GlobalEvent",
       "name": "GlobalEvent",
       "category": "lynx-api/event",
@@ -105246,7 +105316,7 @@
       }
     },
     {
-      "id": "feature-925",
+      "id": "feature-926",
       "query": "lynx-api/event/GlobalEvent.keyboardstatuschanged",
       "name": "keyboardstatuschanged",
       "category": "lynx-api/event",
@@ -105282,7 +105352,7 @@
       }
     },
     {
-      "id": "feature-926",
+      "id": "feature-927",
       "query": "lynx-api/event/GlobalEvent.onWindowResize",
       "name": "onWindowResize",
       "category": "lynx-api/event",
@@ -105318,7 +105388,7 @@
       }
     },
     {
-      "id": "feature-927",
+      "id": "feature-928",
       "query": "lynx-api/event/GlobalEvent.exposure",
       "name": "exposure",
       "category": "lynx-api/event",
@@ -105354,7 +105424,7 @@
       }
     },
     {
-      "id": "feature-928",
+      "id": "feature-929",
       "query": "lynx-api/event/GlobalEvent.disexposure",
       "name": "disexposure",
       "category": "lynx-api/event",
@@ -105390,7 +105460,7 @@
       }
     },
     {
-      "id": "feature-929",
+      "id": "feature-930",
       "query": "lynx-api/event/KeyEvent",
       "name": "KeyEvent",
       "category": "lynx-api/event",
@@ -105426,7 +105496,7 @@
       }
     },
     {
-      "id": "feature-930",
+      "id": "feature-931",
       "query": "lynx-api/event/KeyEvent.key",
       "name": "key",
       "category": "lynx-api/event",
@@ -105462,7 +105532,7 @@
       }
     },
     {
-      "id": "feature-931",
+      "id": "feature-932",
       "query": "lynx-api/event/KeyEvent.repeat",
       "name": "repeat",
       "category": "lynx-api/event",
@@ -105498,7 +105568,7 @@
       }
     },
     {
-      "id": "feature-932",
+      "id": "feature-933",
       "query": "lynx-api/event/KeyEvent.altKey",
       "name": "altKey",
       "category": "lynx-api/event",
@@ -105534,7 +105604,7 @@
       }
     },
     {
-      "id": "feature-933",
+      "id": "feature-934",
       "query": "lynx-api/event/KeyEvent.ctrlKey",
       "name": "ctrlKey",
       "category": "lynx-api/event",
@@ -105570,7 +105640,7 @@
       }
     },
     {
-      "id": "feature-934",
+      "id": "feature-935",
       "query": "lynx-api/event/KeyEvent.metaKey",
       "name": "metaKey",
       "category": "lynx-api/event",
@@ -105606,7 +105676,7 @@
       }
     },
     {
-      "id": "feature-935",
+      "id": "feature-936",
       "query": "lynx-api/event/KeyEvent.shiftKey",
       "name": "shiftKey",
       "category": "lynx-api/event",
@@ -105642,7 +105712,7 @@
       }
     },
     {
-      "id": "feature-936",
+      "id": "feature-937",
       "query": "lynx-api/event/KeyEvent.keydown",
       "name": "keydown",
       "category": "lynx-api/event",
@@ -105678,7 +105748,7 @@
       }
     },
     {
-      "id": "feature-937",
+      "id": "feature-938",
       "query": "lynx-api/event/KeyEvent.keyup",
       "name": "keyup",
       "category": "lynx-api/event",
@@ -105714,7 +105784,7 @@
       }
     },
     {
-      "id": "feature-938",
+      "id": "feature-939",
       "query": "lynx-api/event/MemoryEvent",
       "name": "MemoryEvent",
       "category": "lynx-api/event",
@@ -105750,7 +105820,7 @@
       }
     },
     {
-      "id": "feature-939",
+      "id": "feature-940",
       "query": "lynx-api/event/MouseEvent",
       "name": "MouseEvent",
       "category": "lynx-api/event",
@@ -105786,7 +105856,7 @@
       }
     },
     {
-      "id": "feature-940",
+      "id": "feature-941",
       "query": "lynx-api/event/MouseEvent.button",
       "name": "button",
       "category": "lynx-api/event",
@@ -105822,7 +105892,7 @@
       }
     },
     {
-      "id": "feature-941",
+      "id": "feature-942",
       "query": "lynx-api/event/MouseEvent.buttons",
       "name": "buttons",
       "category": "lynx-api/event",
@@ -105858,7 +105928,7 @@
       }
     },
     {
-      "id": "feature-942",
+      "id": "feature-943",
       "query": "lynx-api/event/MouseEvent.x",
       "name": "x",
       "category": "lynx-api/event",
@@ -105894,7 +105964,7 @@
       }
     },
     {
-      "id": "feature-943",
+      "id": "feature-944",
       "query": "lynx-api/event/MouseEvent.y",
       "name": "y",
       "category": "lynx-api/event",
@@ -105930,7 +106000,7 @@
       }
     },
     {
-      "id": "feature-944",
+      "id": "feature-945",
       "query": "lynx-api/event/MouseEvent.pageX",
       "name": "pageX",
       "category": "lynx-api/event",
@@ -105966,7 +106036,7 @@
       }
     },
     {
-      "id": "feature-945",
+      "id": "feature-946",
       "query": "lynx-api/event/MouseEvent.pageY",
       "name": "pageY",
       "category": "lynx-api/event",
@@ -106002,7 +106072,7 @@
       }
     },
     {
-      "id": "feature-946",
+      "id": "feature-947",
       "query": "lynx-api/event/MouseEvent.clientX",
       "name": "clientX",
       "category": "lynx-api/event",
@@ -106038,7 +106108,7 @@
       }
     },
     {
-      "id": "feature-947",
+      "id": "feature-948",
       "query": "lynx-api/event/MouseEvent.clientY",
       "name": "clientY",
       "category": "lynx-api/event",
@@ -106074,7 +106144,7 @@
       }
     },
     {
-      "id": "feature-948",
+      "id": "feature-949",
       "query": "lynx-api/event/MouseEvent.mousedown",
       "name": "mousedown",
       "category": "lynx-api/event",
@@ -106110,7 +106180,7 @@
       }
     },
     {
-      "id": "feature-949",
+      "id": "feature-950",
       "query": "lynx-api/event/MouseEvent.mousemove",
       "name": "mousemove",
       "category": "lynx-api/event",
@@ -106146,7 +106216,7 @@
       }
     },
     {
-      "id": "feature-950",
+      "id": "feature-951",
       "query": "lynx-api/event/MouseEvent.mouseup",
       "name": "mouseup",
       "category": "lynx-api/event",
@@ -106182,7 +106252,7 @@
       }
     },
     {
-      "id": "feature-951",
+      "id": "feature-952",
       "query": "lynx-api/event/MouseEvent.mouseenter",
       "name": "mouseenter",
       "category": "lynx-api/event",
@@ -106218,7 +106288,7 @@
       }
     },
     {
-      "id": "feature-952",
+      "id": "feature-953",
       "query": "lynx-api/event/MouseEvent.mouseover",
       "name": "mouseover",
       "category": "lynx-api/event",
@@ -106254,7 +106324,7 @@
       }
     },
     {
-      "id": "feature-953",
+      "id": "feature-954",
       "query": "lynx-api/event/MouseEvent.mouseleave",
       "name": "mouseleave",
       "category": "lynx-api/event",
@@ -106290,7 +106360,7 @@
       }
     },
     {
-      "id": "feature-954",
+      "id": "feature-955",
       "query": "lynx-api/event/TouchEvent",
       "name": "TouchEvent",
       "category": "lynx-api/event",
@@ -106326,7 +106396,7 @@
       }
     },
     {
-      "id": "feature-955",
+      "id": "feature-956",
       "query": "lynx-api/event/TouchEvent.detail",
       "name": "detail",
       "category": "lynx-api/event",
@@ -106362,7 +106432,7 @@
       }
     },
     {
-      "id": "feature-956",
+      "id": "feature-957",
       "query": "lynx-api/event/TouchEvent.touches",
       "name": "touches",
       "category": "lynx-api/event",
@@ -106398,7 +106468,7 @@
       }
     },
     {
-      "id": "feature-957",
+      "id": "feature-958",
       "query": "lynx-api/event/TouchEvent.changedTouches",
       "name": "changedTouches",
       "category": "lynx-api/event",
@@ -106434,7 +106504,7 @@
       }
     },
     {
-      "id": "feature-958",
+      "id": "feature-959",
       "query": "lynx-api/event/TouchEvent.touchstart",
       "name": "touchstart",
       "category": "lynx-api/event",
@@ -106470,7 +106540,7 @@
       }
     },
     {
-      "id": "feature-959",
+      "id": "feature-960",
       "query": "lynx-api/event/TouchEvent.touchmove",
       "name": "touchmove",
       "category": "lynx-api/event",
@@ -106506,7 +106576,7 @@
       }
     },
     {
-      "id": "feature-960",
+      "id": "feature-961",
       "query": "lynx-api/event/TouchEvent.touchend",
       "name": "touchend",
       "category": "lynx-api/event",
@@ -106542,7 +106612,7 @@
       }
     },
     {
-      "id": "feature-961",
+      "id": "feature-962",
       "query": "lynx-api/event/TouchEvent.touchcancel",
       "name": "touchcancel",
       "category": "lynx-api/event",
@@ -106578,7 +106648,7 @@
       }
     },
     {
-      "id": "feature-962",
+      "id": "feature-963",
       "query": "lynx-api/event/TouchEvent.tap",
       "name": "tap",
       "category": "lynx-api/event",
@@ -106614,7 +106684,7 @@
       }
     },
     {
-      "id": "feature-963",
+      "id": "feature-964",
       "query": "lynx-api/event/TouchEvent.longpress",
       "name": "longpress",
       "category": "lynx-api/event",
@@ -106650,7 +106720,7 @@
       }
     },
     {
-      "id": "feature-964",
+      "id": "feature-965",
       "query": "lynx-api/event/TouchEvent.click",
       "name": "click",
       "category": "lynx-api/event",
@@ -106686,7 +106756,7 @@
       }
     },
     {
-      "id": "feature-965",
+      "id": "feature-966",
       "query": "lynx-api/event/WheelEvent",
       "name": "WheelEvent",
       "category": "lynx-api/event",
@@ -106722,7 +106792,7 @@
       }
     },
     {
-      "id": "feature-966",
+      "id": "feature-967",
       "query": "lynx-api/event/WheelEvent.deltaX",
       "name": "deltaX",
       "category": "lynx-api/event",
@@ -106758,7 +106828,7 @@
       }
     },
     {
-      "id": "feature-967",
+      "id": "feature-968",
       "query": "lynx-api/event/WheelEvent.deltaY",
       "name": "deltaY",
       "category": "lynx-api/event",
@@ -106794,7 +106864,7 @@
       }
     },
     {
-      "id": "feature-968",
+      "id": "feature-969",
       "query": "lynx-api/event/WheelEvent.wheel",
       "name": "wheel",
       "category": "lynx-api/event",
@@ -106830,7 +106900,7 @@
       }
     },
     {
-      "id": "feature-969",
+      "id": "feature-970",
       "query": "lynx-api/fetch/Headers",
       "name": "Headers",
       "category": "lynx-api/fetch",
@@ -106866,7 +106936,7 @@
       }
     },
     {
-      "id": "feature-970",
+      "id": "feature-971",
       "query": "lynx-api/fetch/Headers",
       "name": "<code>Headers()</code> constructor",
       "category": "lynx-api/fetch",
@@ -106902,7 +106972,7 @@
       }
     },
     {
-      "id": "feature-971",
+      "id": "feature-972",
       "query": "lynx-api/fetch/Headers.append",
       "name": "append",
       "category": "lynx-api/fetch",
@@ -106938,7 +107008,7 @@
       }
     },
     {
-      "id": "feature-972",
+      "id": "feature-973",
       "query": "lynx-api/fetch/Headers.delete",
       "name": "delete",
       "category": "lynx-api/fetch",
@@ -106974,7 +107044,7 @@
       }
     },
     {
-      "id": "feature-973",
+      "id": "feature-974",
       "query": "lynx-api/fetch/Headers.entries",
       "name": "entries",
       "category": "lynx-api/fetch",
@@ -107010,7 +107080,7 @@
       }
     },
     {
-      "id": "feature-974",
+      "id": "feature-975",
       "query": "lynx-api/fetch/Headers.forEach",
       "name": "forEach",
       "category": "lynx-api/fetch",
@@ -107046,7 +107116,7 @@
       }
     },
     {
-      "id": "feature-975",
+      "id": "feature-976",
       "query": "lynx-api/fetch/Headers.get",
       "name": "get",
       "category": "lynx-api/fetch",
@@ -107082,7 +107152,7 @@
       }
     },
     {
-      "id": "feature-976",
+      "id": "feature-977",
       "query": "lynx-api/fetch/Headers.getSetCookie",
       "name": "getSetCookie",
       "category": "lynx-api/fetch",
@@ -107118,7 +107188,7 @@
       }
     },
     {
-      "id": "feature-977",
+      "id": "feature-978",
       "query": "lynx-api/fetch/Headers.has",
       "name": "has",
       "category": "lynx-api/fetch",
@@ -107154,7 +107224,7 @@
       }
     },
     {
-      "id": "feature-978",
+      "id": "feature-979",
       "query": "lynx-api/fetch/Headers.keys",
       "name": "keys",
       "category": "lynx-api/fetch",
@@ -107190,7 +107260,7 @@
       }
     },
     {
-      "id": "feature-979",
+      "id": "feature-980",
       "query": "lynx-api/fetch/Headers.set",
       "name": "set",
       "category": "lynx-api/fetch",
@@ -107226,7 +107296,7 @@
       }
     },
     {
-      "id": "feature-980",
+      "id": "feature-981",
       "query": "lynx-api/fetch/Headers.values",
       "name": "values",
       "category": "lynx-api/fetch",
@@ -107262,7 +107332,7 @@
       }
     },
     {
-      "id": "feature-981",
+      "id": "feature-982",
       "query": "lynx-api/fetch/Headers.@@iterator",
       "name": "<code>[Symbol.iterator]</code>",
       "category": "lynx-api/fetch",
@@ -107298,7 +107368,7 @@
       }
     },
     {
-      "id": "feature-982",
+      "id": "feature-983",
       "query": "lynx-api/fetch/Request",
       "name": "Request",
       "category": "lynx-api/fetch",
@@ -107334,7 +107404,7 @@
       }
     },
     {
-      "id": "feature-983",
+      "id": "feature-984",
       "query": "lynx-api/fetch/Request",
       "name": "`Request()` constructor",
       "category": "lynx-api/fetch",
@@ -107370,7 +107440,7 @@
       }
     },
     {
-      "id": "feature-984",
+      "id": "feature-985",
       "query": "lynx-api/fetch/Request.cors",
       "name": "cors",
       "category": "lynx-api/fetch",
@@ -107406,7 +107476,7 @@
       }
     },
     {
-      "id": "feature-985",
+      "id": "feature-986",
       "query": "lynx-api/fetch/Request.init_attributionReporting_parameter",
       "name": "`init.attributionReporting` parameter",
       "category": "lynx-api/fetch",
@@ -107442,7 +107512,7 @@
       }
     },
     {
-      "id": "feature-986",
+      "id": "feature-987",
       "query": "lynx-api/fetch/Request.init_browsingTopics_parameter",
       "name": "`init.browsingTopics` parameter",
       "category": "lynx-api/fetch",
@@ -107478,7 +107548,7 @@
       }
     },
     {
-      "id": "feature-987",
+      "id": "feature-988",
       "query": "lynx-api/fetch/Request.init_keepalive_parameter",
       "name": "`init.keepalive` parameter",
       "category": "lynx-api/fetch",
@@ -107514,7 +107584,7 @@
       }
     },
     {
-      "id": "feature-988",
+      "id": "feature-989",
       "query": "lynx-api/fetch/Request.init_priority_parameter",
       "name": "`init.priority` parameter",
       "category": "lynx-api/fetch",
@@ -107550,7 +107620,7 @@
       }
     },
     {
-      "id": "feature-989",
+      "id": "feature-990",
       "query": "lynx-api/fetch/Request.init_referrer_parameter",
       "name": "`init.referrer` parameter",
       "category": "lynx-api/fetch",
@@ -107586,7 +107656,7 @@
       }
     },
     {
-      "id": "feature-990",
+      "id": "feature-991",
       "query": "lynx-api/fetch/Request.request_body_readablestream",
       "name": "Send `ReadableStream` in request body",
       "category": "lynx-api/fetch",
@@ -107622,7 +107692,7 @@
       }
     },
     {
-      "id": "feature-991",
+      "id": "feature-992",
       "query": "lynx-api/fetch/Request.response_body_readablestream",
       "name": "Consume `ReadableStream` as a response body",
       "category": "lynx-api/fetch",
@@ -107658,7 +107728,7 @@
       }
     },
     {
-      "id": "feature-992",
+      "id": "feature-993",
       "query": "lynx-api/fetch/Request.arrayBuffer",
       "name": "arrayBuffer",
       "category": "lynx-api/fetch",
@@ -107694,7 +107764,7 @@
       }
     },
     {
-      "id": "feature-993",
+      "id": "feature-994",
       "query": "lynx-api/fetch/Request.blob",
       "name": "blob",
       "category": "lynx-api/fetch",
@@ -107730,7 +107800,7 @@
       }
     },
     {
-      "id": "feature-994",
+      "id": "feature-995",
       "query": "lynx-api/fetch/Request.body",
       "name": "body",
       "category": "lynx-api/fetch",
@@ -107766,7 +107836,7 @@
       }
     },
     {
-      "id": "feature-995",
+      "id": "feature-996",
       "query": "lynx-api/fetch/Request.bodyUsed",
       "name": "bodyUsed",
       "category": "lynx-api/fetch",
@@ -107802,7 +107872,7 @@
       }
     },
     {
-      "id": "feature-996",
+      "id": "feature-997",
       "query": "lynx-api/fetch/Request.bytes",
       "name": "bytes",
       "category": "lynx-api/fetch",
@@ -107838,7 +107908,7 @@
       }
     },
     {
-      "id": "feature-997",
+      "id": "feature-998",
       "query": "lynx-api/fetch/Request.cache",
       "name": "cache",
       "category": "lynx-api/fetch",
@@ -107874,7 +107944,7 @@
       }
     },
     {
-      "id": "feature-998",
+      "id": "feature-999",
       "query": "lynx-api/fetch/Request.cache.only-if-cached",
       "name": "only-if-cached",
       "category": "lynx-api/fetch",
@@ -107910,7 +107980,7 @@
       }
     },
     {
-      "id": "feature-999",
+      "id": "feature-1000",
       "query": "lynx-api/fetch/Request.clone",
       "name": "clone",
       "category": "lynx-api/fetch",
@@ -107946,7 +108016,7 @@
       }
     },
     {
-      "id": "feature-1000",
+      "id": "feature-1001",
       "query": "lynx-api/fetch/Request.credentials",
       "name": "credentials",
       "category": "lynx-api/fetch",
@@ -107982,7 +108052,7 @@
       }
     },
     {
-      "id": "feature-1001",
+      "id": "feature-1002",
       "query": "lynx-api/fetch/Request.destination",
       "name": "destination",
       "category": "lynx-api/fetch",
@@ -108018,7 +108088,7 @@
       }
     },
     {
-      "id": "feature-1002",
+      "id": "feature-1003",
       "query": "lynx-api/fetch/Request.duplex",
       "name": "duplex",
       "category": "lynx-api/fetch",
@@ -108054,7 +108124,7 @@
       }
     },
     {
-      "id": "feature-1003",
+      "id": "feature-1004",
       "query": "lynx-api/fetch/Request.formData",
       "name": "formData",
       "category": "lynx-api/fetch",
@@ -108090,7 +108160,7 @@
       }
     },
     {
-      "id": "feature-1004",
+      "id": "feature-1005",
       "query": "lynx-api/fetch/Request.headers",
       "name": "headers",
       "category": "lynx-api/fetch",
@@ -108126,7 +108196,7 @@
       }
     },
     {
-      "id": "feature-1005",
+      "id": "feature-1006",
       "query": "lynx-api/fetch/Request.integrity",
       "name": "integrity",
       "category": "lynx-api/fetch",
@@ -108162,7 +108232,7 @@
       }
     },
     {
-      "id": "feature-1006",
+      "id": "feature-1007",
       "query": "lynx-api/fetch/Request.isHistoryNavigation",
       "name": "isHistoryNavigation",
       "category": "lynx-api/fetch",
@@ -108198,7 +108268,7 @@
       }
     },
     {
-      "id": "feature-1007",
+      "id": "feature-1008",
       "query": "lynx-api/fetch/Request.json",
       "name": "json",
       "category": "lynx-api/fetch",
@@ -108234,7 +108304,7 @@
       }
     },
     {
-      "id": "feature-1008",
+      "id": "feature-1009",
       "query": "lynx-api/fetch/Request.keepalive",
       "name": "keepalive",
       "category": "lynx-api/fetch",
@@ -108270,7 +108340,7 @@
       }
     },
     {
-      "id": "feature-1009",
+      "id": "feature-1010",
       "query": "lynx-api/fetch/Request.method",
       "name": "method",
       "category": "lynx-api/fetch",
@@ -108306,7 +108376,7 @@
       }
     },
     {
-      "id": "feature-1010",
+      "id": "feature-1011",
       "query": "lynx-api/fetch/Request.mode",
       "name": "mode",
       "category": "lynx-api/fetch",
@@ -108342,7 +108412,7 @@
       }
     },
     {
-      "id": "feature-1011",
+      "id": "feature-1012",
       "query": "lynx-api/fetch/Request.mode.navigate_mode",
       "name": "`navigate` mode",
       "category": "lynx-api/fetch",
@@ -108378,7 +108448,7 @@
       }
     },
     {
-      "id": "feature-1012",
+      "id": "feature-1013",
       "query": "lynx-api/fetch/Request.redirect",
       "name": "redirect",
       "category": "lynx-api/fetch",
@@ -108414,7 +108484,7 @@
       }
     },
     {
-      "id": "feature-1013",
+      "id": "feature-1014",
       "query": "lynx-api/fetch/Request.referrer",
       "name": "referrer",
       "category": "lynx-api/fetch",
@@ -108450,7 +108520,7 @@
       }
     },
     {
-      "id": "feature-1014",
+      "id": "feature-1015",
       "query": "lynx-api/fetch/Request.referrerPolicy",
       "name": "referrerPolicy",
       "category": "lynx-api/fetch",
@@ -108486,7 +108556,7 @@
       }
     },
     {
-      "id": "feature-1015",
+      "id": "feature-1016",
       "query": "lynx-api/fetch/Request.signal",
       "name": "signal",
       "category": "lynx-api/fetch",
@@ -108522,7 +108592,7 @@
       }
     },
     {
-      "id": "feature-1016",
+      "id": "feature-1017",
       "query": "lynx-api/fetch/Request.targetAddressSpace",
       "name": "targetAddressSpace",
       "category": "lynx-api/fetch",
@@ -108558,7 +108628,7 @@
       }
     },
     {
-      "id": "feature-1017",
+      "id": "feature-1018",
       "query": "lynx-api/fetch/Request.text",
       "name": "text",
       "category": "lynx-api/fetch",
@@ -108594,7 +108664,7 @@
       }
     },
     {
-      "id": "feature-1018",
+      "id": "feature-1019",
       "query": "lynx-api/fetch/Request.url",
       "name": "url",
       "category": "lynx-api/fetch",
@@ -108630,7 +108700,7 @@
       }
     },
     {
-      "id": "feature-1019",
+      "id": "feature-1020",
       "query": "lynx-api/fetch/Response",
       "name": "Response",
       "category": "lynx-api/fetch",
@@ -108666,7 +108736,7 @@
       }
     },
     {
-      "id": "feature-1020",
+      "id": "feature-1021",
       "query": "lynx-api/fetch/Response",
       "name": "`Response()` constructor",
       "category": "lynx-api/fetch",
@@ -108702,7 +108772,7 @@
       }
     },
     {
-      "id": "feature-1021",
+      "id": "feature-1022",
       "query": "lynx-api/fetch/Response.accept_readablestream",
       "name": "body parameter accepts ReadableByteStream",
       "category": "lynx-api/fetch",
@@ -108738,7 +108808,7 @@
       }
     },
     {
-      "id": "feature-1022",
+      "id": "feature-1023",
       "query": "lynx-api/fetch/Response.body_parameter_optional",
       "name": "`body` parameter is optional",
       "category": "lynx-api/fetch",
@@ -108774,7 +108844,7 @@
       }
     },
     {
-      "id": "feature-1023",
+      "id": "feature-1024",
       "query": "lynx-api/fetch/Response.arrayBuffer",
       "name": "arrayBuffer",
       "category": "lynx-api/fetch",
@@ -108810,7 +108880,7 @@
       }
     },
     {
-      "id": "feature-1024",
+      "id": "feature-1025",
       "query": "lynx-api/fetch/Response.blob",
       "name": "blob",
       "category": "lynx-api/fetch",
@@ -108846,7 +108916,7 @@
       }
     },
     {
-      "id": "feature-1025",
+      "id": "feature-1026",
       "query": "lynx-api/fetch/Response.body",
       "name": "body",
       "category": "lynx-api/fetch",
@@ -108882,7 +108952,7 @@
       }
     },
     {
-      "id": "feature-1026",
+      "id": "feature-1027",
       "query": "lynx-api/fetch/Response.body.readable_byte_stream",
       "name": "`body` is a readable byte stream",
       "category": "lynx-api/fetch",
@@ -108918,7 +108988,7 @@
       }
     },
     {
-      "id": "feature-1027",
+      "id": "feature-1028",
       "query": "lynx-api/fetch/Response.bodyUsed",
       "name": "bodyUsed",
       "category": "lynx-api/fetch",
@@ -108954,7 +109024,7 @@
       }
     },
     {
-      "id": "feature-1028",
+      "id": "feature-1029",
       "query": "lynx-api/fetch/Response.bytes",
       "name": "bytes",
       "category": "lynx-api/fetch",
@@ -108990,7 +109060,7 @@
       }
     },
     {
-      "id": "feature-1029",
+      "id": "feature-1030",
       "query": "lynx-api/fetch/Response.clone",
       "name": "clone",
       "category": "lynx-api/fetch",
@@ -109026,7 +109096,7 @@
       }
     },
     {
-      "id": "feature-1030",
+      "id": "feature-1031",
       "query": "lynx-api/fetch/Response.error_static",
       "name": "`error()` static method",
       "category": "lynx-api/fetch",
@@ -109062,7 +109132,7 @@
       }
     },
     {
-      "id": "feature-1031",
+      "id": "feature-1032",
       "query": "lynx-api/fetch/Response.formData",
       "name": "formData",
       "category": "lynx-api/fetch",
@@ -109098,7 +109168,7 @@
       }
     },
     {
-      "id": "feature-1032",
+      "id": "feature-1033",
       "query": "lynx-api/fetch/Response.headers",
       "name": "headers",
       "category": "lynx-api/fetch",
@@ -109134,7 +109204,7 @@
       }
     },
     {
-      "id": "feature-1033",
+      "id": "feature-1034",
       "query": "lynx-api/fetch/Response.json",
       "name": "json",
       "category": "lynx-api/fetch",
@@ -109170,7 +109240,7 @@
       }
     },
     {
-      "id": "feature-1034",
+      "id": "feature-1035",
       "query": "lynx-api/fetch/Response.json_static",
       "name": "json_static",
       "category": "lynx-api/fetch",
@@ -109206,7 +109276,7 @@
       }
     },
     {
-      "id": "feature-1035",
+      "id": "feature-1036",
       "query": "lynx-api/fetch/Response.ok",
       "name": "ok",
       "category": "lynx-api/fetch",
@@ -109242,7 +109312,7 @@
       }
     },
     {
-      "id": "feature-1036",
+      "id": "feature-1037",
       "query": "lynx-api/fetch/Response.redirect_static",
       "name": "`redirect()` static method",
       "category": "lynx-api/fetch",
@@ -109278,7 +109348,7 @@
       }
     },
     {
-      "id": "feature-1037",
+      "id": "feature-1038",
       "query": "lynx-api/fetch/Response.redirected",
       "name": "redirected",
       "category": "lynx-api/fetch",
@@ -109314,7 +109384,7 @@
       }
     },
     {
-      "id": "feature-1038",
+      "id": "feature-1039",
       "query": "lynx-api/fetch/Response.status",
       "name": "status",
       "category": "lynx-api/fetch",
@@ -109350,7 +109420,7 @@
       }
     },
     {
-      "id": "feature-1039",
+      "id": "feature-1040",
       "query": "lynx-api/fetch/Response.statusText",
       "name": "statusText",
       "category": "lynx-api/fetch",
@@ -109386,7 +109456,7 @@
       }
     },
     {
-      "id": "feature-1040",
+      "id": "feature-1041",
       "query": "lynx-api/fetch/Response.text",
       "name": "text",
       "category": "lynx-api/fetch",
@@ -109422,7 +109492,7 @@
       }
     },
     {
-      "id": "feature-1041",
+      "id": "feature-1042",
       "query": "lynx-api/fetch/Response.type",
       "name": "type",
       "category": "lynx-api/fetch",
@@ -109458,7 +109528,7 @@
       }
     },
     {
-      "id": "feature-1042",
+      "id": "feature-1043",
       "query": "lynx-api/fetch/Response.url",
       "name": "url",
       "category": "lynx-api/fetch",
@@ -109494,7 +109564,7 @@
       }
     },
     {
-      "id": "feature-1043",
+      "id": "feature-1044",
       "query": "lynx-api/fetch/fetch",
       "name": "<code>fetch</code>",
       "category": "lynx-api/fetch",
@@ -109530,7 +109600,7 @@
       }
     },
     {
-      "id": "feature-1044",
+      "id": "feature-1045",
       "query": "lynx-api/lynx/accessibilityAnnounce",
       "name": "Used to have the specified text content read by the screen reader.",
       "category": "lynx-api/lynx",
@@ -109566,7 +109636,7 @@
       }
     },
     {
-      "id": "feature-1045",
+      "id": "feature-1046",
       "query": "lynx-api/lynx/addFont",
       "name": "Used for dynamically adding fonts.",
       "category": "lynx-api/lynx",
@@ -109602,7 +109672,7 @@
       }
     },
     {
-      "id": "feature-1046",
+      "id": "feature-1047",
       "query": "lynx-api/lynx/animateAPI.compat",
       "name": "Used to import modules.",
       "category": "lynx-api/lynx",
@@ -109638,7 +109708,7 @@
       }
     },
     {
-      "id": "feature-1047",
+      "id": "feature-1048",
       "query": "lynx-api/lynx/animateAPI.multiple animation implementation",
       "name": "Multiple animate",
       "category": "lynx-api/lynx",
@@ -109674,7 +109744,7 @@
       }
     },
     {
-      "id": "feature-1048",
+      "id": "feature-1049",
       "query": "lynx-api/lynx/cancelAnimationFrame",
       "name": "Cancel a `requestAnimationFrame` callback.",
       "category": "lynx-api/lynx",
@@ -109710,7 +109780,7 @@
       }
     },
     {
-      "id": "feature-1049",
+      "id": "feature-1050",
       "query": "lynx-api/lynx/cancelResourcePrefetch",
       "name": "Used to cancel the prefetch of resource.",
       "category": "lynx-api/lynx",
@@ -109746,7 +109816,7 @@
       }
     },
     {
-      "id": "feature-1050",
+      "id": "feature-1051",
       "query": "lynx-api/lynx/createIntersectionObserver",
       "name": "Create an IntersectionObserver object.",
       "category": "lynx-api/lynx",
@@ -109782,7 +109852,7 @@
       }
     },
     {
-      "id": "feature-1051",
+      "id": "feature-1052",
       "query": "lynx-api/lynx/createSelectorQuery",
       "name": " Create a `SelectorQuery` with the root node of the page as the root.",
       "category": "lynx-api/lynx",
@@ -109818,7 +109888,7 @@
       }
     },
     {
-      "id": "feature-1052",
+      "id": "feature-1053",
       "query": "lynx-api/lynx/getElementById",
       "name": "Used to import modules.",
       "category": "lynx-api/lynx",
@@ -109854,7 +109924,7 @@
       }
     },
     {
-      "id": "feature-1053",
+      "id": "feature-1054",
       "query": "lynx-api/lynx/getJSModule",
       "name": "getJSModule",
       "category": "lynx-api/lynx",
@@ -109890,7 +109960,7 @@
       }
     },
     {
-      "id": "feature-1054",
+      "id": "feature-1055",
       "query": "lynx-api/lynx/getSessionStorageItem",
       "name": "The `lynx.getSessionStorageItem` method is used to retrieve data shared across multiple LynxViews. This enables data sharing between multiple pages via `SessionStorage`. You can call [lynx.setSessionStorageItem](./lynx-set-session-storage.mdx) to set the cached data.",
       "category": "lynx-api/lynx",
@@ -109926,7 +109996,7 @@
       }
     },
     {
-      "id": "feature-1055",
+      "id": "feature-1056",
       "query": "lynx-api/lynx/getSharedData",
       "name": "Get the shared data set by `lynx.setSharedData()` used on pages belonging to the same LynxGroup.",
       "category": "lynx-api/lynx",
@@ -109962,7 +110032,7 @@
       }
     },
     {
-      "id": "feature-1056",
+      "id": "feature-1057",
       "query": "lynx-api/lynx/getTextInfo",
       "name": "Used to measure the width of text content.",
       "category": "lynx-api/lynx",
@@ -109998,7 +110068,7 @@
       }
     },
     {
-      "id": "feature-1057",
+      "id": "feature-1058",
       "query": "lynx-api/lynx/globalProps",
       "name": "global data set by client.",
       "category": "lynx-api/lynx",
@@ -110034,7 +110104,7 @@
       }
     },
     {
-      "id": "feature-1058",
+      "id": "feature-1059",
       "query": "lynx-api/lynx/lynx-before-publish-event/BeforePublishEvent",
       "name": "Used to register/remove monitoring of an element event",
       "category": "lynx-api/lynx",
@@ -110070,7 +110140,7 @@
       }
     },
     {
-      "id": "feature-1059",
+      "id": "feature-1060",
       "query": "lynx-api/lynx/lynx-before-publish-event/BeforePublishEvent.add",
       "name": "Register to listen for an element event.",
       "category": "lynx-api/lynx",
@@ -110106,7 +110176,7 @@
       }
     },
     {
-      "id": "feature-1060",
+      "id": "feature-1061",
       "query": "lynx-api/lynx/lynx-before-publish-event/BeforePublishEvent.remove",
       "name": "Remove monitoring of an element event.",
       "category": "lynx-api/lynx",
@@ -110142,7 +110212,7 @@
       }
     },
     {
-      "id": "feature-1061",
+      "id": "feature-1062",
       "query": "lynx-api/lynx/lynx-before-publish-event/add",
       "name": "Register to listen for an element event.",
       "category": "lynx-api/lynx",
@@ -110178,7 +110248,7 @@
       }
     },
     {
-      "id": "feature-1062",
+      "id": "feature-1063",
       "query": "lynx-api/lynx/lynx-before-publish-event/remove",
       "name": "Remove monitoring of an element event.",
       "category": "lynx-api/lynx",
@@ -110214,7 +110284,7 @@
       }
     },
     {
-      "id": "feature-1063",
+      "id": "feature-1064",
       "query": "lynx-api/lynx/performance.lynx.performance",
       "name": "performance",
       "category": "lynx-api/lynx",
@@ -110250,7 +110320,7 @@
       }
     },
     {
-      "id": "feature-1064",
+      "id": "feature-1065",
       "query": "lynx-api/lynx/performance.createObserver()",
       "name": "createObserver()",
       "category": "lynx-api/lynx",
@@ -110286,7 +110356,7 @@
       }
     },
     {
-      "id": "feature-1065",
+      "id": "feature-1066",
       "query": "lynx-api/lynx/performance.profileStart()",
       "name": "profileStart()",
       "category": "lynx-api/lynx",
@@ -110322,7 +110392,7 @@
       }
     },
     {
-      "id": "feature-1066",
+      "id": "feature-1067",
       "query": "lynx-api/lynx/performance.profileEnd()",
       "name": "profileEnd()",
       "category": "lynx-api/lynx",
@@ -110358,7 +110428,7 @@
       }
     },
     {
-      "id": "feature-1067",
+      "id": "feature-1068",
       "query": "lynx-api/lynx/performance.profileMark()",
       "name": "profileMark()",
       "category": "lynx-api/lynx",
@@ -110394,7 +110464,7 @@
       }
     },
     {
-      "id": "feature-1068",
+      "id": "feature-1069",
       "query": "lynx-api/lynx/performance.profileFlowId()",
       "name": "profileFlowId()",
       "category": "lynx-api/lynx",
@@ -110430,7 +110500,7 @@
       }
     },
     {
-      "id": "feature-1069",
+      "id": "feature-1070",
       "query": "lynx-api/lynx/performance.isProfileRecording()",
       "name": "isProfileRecording()",
       "category": "lynx-api/lynx",
@@ -110466,7 +110536,7 @@
       }
     },
     {
-      "id": "feature-1070",
+      "id": "feature-1071",
       "query": "lynx-api/lynx/querySelector",
       "name": "querySelector",
       "category": "lynx-api/lynx",
@@ -110502,7 +110572,7 @@
       }
     },
     {
-      "id": "feature-1071",
+      "id": "feature-1072",
       "query": "lynx-api/lynx/querySelectorAll",
       "name": "querySelectorAll",
       "category": "lynx-api/lynx",
@@ -110538,7 +110608,7 @@
       }
     },
     {
-      "id": "feature-1072",
+      "id": "feature-1073",
       "query": "lynx-api/lynx/queueMicrotask",
       "name": "insert a task into microtask queue",
       "category": "lynx-api/lynx",
@@ -110574,7 +110644,7 @@
       }
     },
     {
-      "id": "feature-1073",
+      "id": "feature-1074",
       "query": "lynx-api/lynx/registerModule",
       "name": "registerModule",
       "category": "lynx-api/lynx",
@@ -110610,7 +110680,7 @@
       }
     },
     {
-      "id": "feature-1074",
+      "id": "feature-1075",
       "query": "lynx-api/lynx/registerSharedDataObserver",
       "name": "Listen for shared data updates initiated by `lynx.setSharedData()` within pages in the same LynxGroup.",
       "category": "lynx-api/lynx",
@@ -110646,7 +110716,7 @@
       }
     },
     {
-      "id": "feature-1075",
+      "id": "feature-1076",
       "query": "lynx-api/lynx/reload",
       "name": "Reloads the current page, like the Refresh button.",
       "category": "lynx-api/lynx",
@@ -110682,7 +110752,7 @@
       }
     },
     {
-      "id": "feature-1076",
+      "id": "feature-1077",
       "query": "lynx-api/lynx/removeSharedDataObserver",
       "name": "取消使用 `lynx.registerSharedDataObserver()` 进行的监听。",
       "category": "lynx-api/lynx",
@@ -110718,7 +110788,7 @@
       }
     },
     {
-      "id": "feature-1077",
+      "id": "feature-1078",
       "query": "lynx-api/lynx/reportError",
       "name": "Used to report a JavaScript Error.",
       "category": "lynx-api/lynx",
@@ -110754,7 +110824,7 @@
       }
     },
     {
-      "id": "feature-1078",
+      "id": "feature-1079",
       "query": "lynx-api/lynx/requestAnimationFrame",
       "name": "Invoke the specified callback function at the next VSYNC.",
       "category": "lynx-api/lynx",
@@ -110790,7 +110860,7 @@
       }
     },
     {
-      "id": "feature-1079",
+      "id": "feature-1080",
       "query": "lynx-api/lynx/requestResourcePrefetch",
       "name": "Used to request the prefetch of resource.",
       "category": "lynx-api/lynx",
@@ -110826,7 +110896,7 @@
       }
     },
     {
-      "id": "feature-1080",
+      "id": "feature-1081",
       "query": "lynx-api/lynx/requireModule",
       "name": "Used to import modules and JSON.",
       "category": "lynx-api/lynx",
@@ -110862,7 +110932,7 @@
       }
     },
     {
-      "id": "feature-1081",
+      "id": "feature-1082",
       "query": "lynx-api/lynx/requireModuleAsync",
       "name": "Used to import modules.",
       "category": "lynx-api/lynx",
@@ -110898,7 +110968,7 @@
       }
     },
     {
-      "id": "feature-1082",
+      "id": "feature-1083",
       "query": "lynx-api/lynx/resumeExposure",
       "name": "Turn on exposure detection, that is, to restart the detection of the visibility of the target node, and subsequently trigger the exposure/anti-exposure event normally.",
       "category": "lynx-api/lynx",
@@ -110934,7 +111004,7 @@
       }
     },
     {
-      "id": "feature-1083",
+      "id": "feature-1084",
       "query": "lynx-api/lynx/setObserverFrameRate",
       "name": "Set the frequency of exposure detection.",
       "category": "lynx-api/lynx",
@@ -110970,7 +111040,7 @@
       }
     },
     {
-      "id": "feature-1084",
+      "id": "feature-1085",
       "query": "lynx-api/lynx/setSessionStorageItem",
       "name": "The `lynx.setSessionStorageItem` method is used to set data shared across multiple LynxViews.",
       "category": "lynx-api/lynx",
@@ -111006,7 +111076,7 @@
       }
     },
     {
-      "id": "feature-1085",
+      "id": "feature-1086",
       "query": "lynx-api/lynx/setSharedData",
       "name": "设置同 LynxGroup 的页面间的共享数据。",
       "category": "lynx-api/lynx",
@@ -111042,7 +111112,7 @@
       }
     },
     {
-      "id": "feature-1086",
+      "id": "feature-1087",
       "query": "lynx-api/lynx/stopExposure",
       "name": "Stop exposure detection, that is, the visibility of the target node will no longer be detected, and exposure/anti-exposure events will no longer be triggered in the future.",
       "category": "lynx-api/lynx",
@@ -111078,7 +111148,7 @@
       }
     },
     {
-      "id": "feature-1087",
+      "id": "feature-1088",
       "query": "lynx-api/lynx/subscribeSessionStorage",
       "name": "The `lynx.subscribeSessionStorage` method is used to listen for changes in data shared across multiple LynxViews. This enables data sharing between multiple pages via `SessionStorage`. You can call [lynx.setSessionStorageItem](./lynx-set-session-storage.mdx) to set the cached data.",
       "category": "lynx-api/lynx",
@@ -111114,7 +111184,7 @@
       }
     },
     {
-      "id": "feature-1088",
+      "id": "feature-1089",
       "query": "lynx-api/lynx/unsubscribeSessionStorage",
       "name": "The `lynx.unsubscribeSessionStorage` method is used to cancel the listener for changes in data shared across multiple LynxViews. This enables data sharing between multiple pages via `SessionStorage`. You can call [lynx.setSessionStorageItem](./lynx-set-session-storage.mdx) to set the cached data. After cancellation, the cached data corresponding to this key will no longer be listened to.",
       "category": "lynx-api/lynx",
@@ -111150,7 +111220,7 @@
       }
     },
     {
-      "id": "feature-1089",
+      "id": "feature-1090",
       "query": "lynx-api/selector-query/SelectorQuery",
       "name": "Gets a reference to the specified node in order to call its methods or get its properties.",
       "category": "lynx-api/selector-query",
@@ -111186,7 +111256,7 @@
       }
     },
     {
-      "id": "feature-1090",
+      "id": "feature-1091",
       "query": "lynx-api/selector-query/SelectorQuery.`exec`",
       "name": "Execute all submitted operations.",
       "category": "lynx-api/selector-query",
@@ -111222,7 +111292,7 @@
       }
     },
     {
-      "id": "feature-1091",
+      "id": "feature-1092",
       "query": "lynx-api/selector-query/SelectorQuery.`select`",
       "name": "Select the first node that matches the specified selector in the descendants of the root node specified in `SelectorQuery`.",
       "category": "lynx-api/selector-query",
@@ -111258,7 +111328,7 @@
       }
     },
     {
-      "id": "feature-1092",
+      "id": "feature-1093",
       "query": "lynx-api/selector-query/SelectorQuery.`selectAll`",
       "name": "Select all nodes that match the specified CSS selector under the root node specified by `SelectorQuery`.",
       "category": "lynx-api/selector-query",
@@ -111294,7 +111364,7 @@
       }
     },
     {
-      "id": "feature-1093",
+      "id": "feature-1094",
       "query": "lynx-api/selector-query/SelectorQuery.`selectRoot`",
       "name": "Select the root node specified by `SelectorQuery`.",
       "category": "lynx-api/selector-query",
@@ -111330,7 +111400,7 @@
       }
     },
     {
-      "id": "feature-1094",
+      "id": "feature-1095",
       "query": "lynx-api/selector-query/SelectorQuery.`selectUniqueID`",
       "name": "Select nodes by specifying `uid`.",
       "category": "lynx-api/selector-query",
@@ -111366,7 +111436,7 @@
       }
     },
     {
-      "id": "feature-1095",
+      "id": "feature-1096",
       "query": "lynx-api/selector-query/exec",
       "name": "Execute all submitted operations.",
       "category": "lynx-api/selector-query",
@@ -111402,7 +111472,7 @@
       }
     },
     {
-      "id": "feature-1096",
+      "id": "feature-1097",
       "query": "lynx-api/selector-query/select",
       "name": "Select the first node that matches the specified selector in the descendants of the root node specified in `SelectorQuery`.",
       "category": "lynx-api/selector-query",
@@ -111438,7 +111508,7 @@
       }
     },
     {
-      "id": "feature-1097",
+      "id": "feature-1098",
       "query": "lynx-api/selector-query/select.`selector` parameter supporting `tag` selector",
       "name": "`selector` parameter supporting `tag` selector.",
       "category": "lynx-api/selector-query",
@@ -111474,7 +111544,7 @@
       }
     },
     {
-      "id": "feature-1098",
+      "id": "feature-1099",
       "query": "lynx-api/selector-query/select.`selector` parameter supporting `attribute` selector `[attr]`, `[attr=value]",
       "name": "`selector` parameter supporting `attribute` selector `[attr]`, `[attr=value].",
       "category": "lynx-api/selector-query",
@@ -111510,7 +111580,7 @@
       }
     },
     {
-      "id": "feature-1099",
+      "id": "feature-1100",
       "query": "lynx-api/selector-query/select.`selector` parameter supporting `attribute` selector `[attr*=value]`, `[attr^=value]`, `[attr$=value]`",
       "name": "`selector` parameter supporting `attribute` selector `[attr*=value]`, `[attr^=value]`, `[attr$=value]`.",
       "category": "lynx-api/selector-query",
@@ -111546,7 +111616,7 @@
       }
     },
     {
-      "id": "feature-1100",
+      "id": "feature-1101",
       "query": "lynx-api/selector-query/selectAll",
       "name": "Select all nodes that match the specified CSS selector under the root node specified by `SelectorQuery`.",
       "category": "lynx-api/selector-query",
@@ -111582,7 +111652,7 @@
       }
     },
     {
-      "id": "feature-1101",
+      "id": "feature-1102",
       "query": "lynx-api/selector-query/selectRoot",
       "name": "Select the root node specified by `SelectorQuery`.",
       "category": "lynx-api/selector-query",
@@ -111618,7 +111688,7 @@
       }
     },
     {
-      "id": "feature-1102",
+      "id": "feature-1103",
       "query": "lynx-api/selector-query/selectUniqueID",
       "name": "Select nodes by specifying `uid`.",
       "category": "lynx-api/selector-query",
@@ -111654,7 +111724,7 @@
       }
     },
     {
-      "id": "feature-1103",
+      "id": "feature-1104",
       "query": "lynx-api/nodes-ref/NodesRef",
       "name": "Represents a reference to one or more UI nodes. It can be used to call methods, get and set properties on UI nodes.",
       "category": "lynx-api/nodes-ref",
@@ -111690,7 +111760,7 @@
       }
     },
     {
-      "id": "feature-1104",
+      "id": "feature-1105",
       "query": "lynx-api/nodes-ref/NodesRef.`fields`",
       "name": "Query the attributes of the selected node.",
       "category": "lynx-api/nodes-ref",
@@ -111726,7 +111796,7 @@
       }
     },
     {
-      "id": "feature-1105",
+      "id": "feature-1106",
       "query": "lynx-api/nodes-ref/NodesRef.`invoke`",
       "name": "Execute the UI method of the selected node.",
       "category": "lynx-api/nodes-ref",
@@ -111762,7 +111832,7 @@
       }
     },
     {
-      "id": "feature-1106",
+      "id": "feature-1107",
       "query": "lynx-api/nodes-ref/NodesRef.`path`",
       "name": "Query the path information from the node to the root node of the page.",
       "category": "lynx-api/nodes-ref",
@@ -111798,7 +111868,7 @@
       }
     },
     {
-      "id": "feature-1107",
+      "id": "feature-1108",
       "query": "lynx-api/nodes-ref/NodesRef.`setNativeProps`",
       "name": "Directly set the attributes of the selected node.",
       "category": "lynx-api/nodes-ref",
@@ -111834,7 +111904,7 @@
       }
     },
     {
-      "id": "feature-1108",
+      "id": "feature-1109",
       "query": "lynx-api/nodes-ref/fields",
       "name": "Query the attributes of the selected node.",
       "category": "lynx-api/nodes-ref",
@@ -111870,7 +111940,7 @@
       }
     },
     {
-      "id": "feature-1109",
+      "id": "feature-1110",
       "query": "lynx-api/nodes-ref/fields.`fields` parameter supporting the `attribute` property",
       "name": "`fields` parameter supporting the `attribute` property.",
       "category": "lynx-api/nodes-ref",
@@ -111906,7 +111976,7 @@
       }
     },
     {
-      "id": "feature-1110",
+      "id": "feature-1111",
       "query": "lynx-api/nodes-ref/invoke",
       "name": "Execute the UI method of the selected node.",
       "category": "lynx-api/nodes-ref",
@@ -111942,7 +112012,7 @@
       }
     },
     {
-      "id": "feature-1111",
+      "id": "feature-1112",
       "query": "lynx-api/nodes-ref/path",
       "name": "Query the path information from the node to the root node of the page.",
       "category": "lynx-api/nodes-ref",
@@ -111978,7 +112048,7 @@
       }
     },
     {
-      "id": "feature-1112",
+      "id": "feature-1113",
       "query": "lynx-api/nodes-ref/setNativeProps",
       "name": "Directly set the attributes of the selected node.",
       "category": "lynx-api/nodes-ref",
@@ -112014,7 +112084,7 @@
       }
     },
     {
-      "id": "feature-1113",
+      "id": "feature-1114",
       "query": "lynx-api/intersection-observer/IntersectionObserver",
       "name": "Observe the intersection status between the target node and the reference node and the target node and the ancestor node. When the intersection status changes, the corresponding callback is triggered. Based on this, you can monitor whether the target node is exposed/de-exposed.",
       "category": "lynx-api/intersection-observer",
@@ -112050,7 +112120,7 @@
       }
     },
     {
-      "id": "feature-1114",
+      "id": "feature-1115",
       "query": "lynx-api/intersection-observer/IntersectionObserver.relativeTo",
       "name": "Specify a reference node. The reference node is specified by id.",
       "category": "lynx-api/intersection-observer",
@@ -112086,7 +112156,7 @@
       }
     },
     {
-      "id": "feature-1115",
+      "id": "feature-1116",
       "query": "lynx-api/intersection-observer/IntersectionObserver.relativeToViewport",
       "name": "Specify a LynxView as a reference node.",
       "category": "lynx-api/intersection-observer",
@@ -112122,7 +112192,7 @@
       }
     },
     {
-      "id": "feature-1116",
+      "id": "feature-1117",
       "query": "lynx-api/intersection-observer/IntersectionObserver.relativeToScreen",
       "name": "Specify the screen as the reference node.",
       "category": "lynx-api/intersection-observer",
@@ -112158,7 +112228,7 @@
       }
     },
     {
-      "id": "feature-1117",
+      "id": "feature-1118",
       "query": "lynx-api/intersection-observer/IntersectionObserver.observe",
       "name": "Specify the target node and callback, and the target node is specified according to id.",
       "category": "lynx-api/intersection-observer",
@@ -112194,7 +112264,7 @@
       }
     },
     {
-      "id": "feature-1118",
+      "id": "feature-1119",
       "query": "lynx-api/intersection-observer/IntersectionObserver.disconnect",
       "name": "Clear the target node and callback. The target node will no longer be observed and the corresponding callback will not be triggered.",
       "category": "lynx-api/intersection-observer",
@@ -112230,7 +112300,7 @@
       }
     },
     {
-      "id": "feature-1119",
+      "id": "feature-1120",
       "query": "lynx-api/intersection-observer/disconnect",
       "name": "Clear the target node and callback. The target node will no longer be observed and the corresponding callback will not be triggered.",
       "category": "lynx-api/intersection-observer",
@@ -112266,7 +112336,7 @@
       }
     },
     {
-      "id": "feature-1120",
+      "id": "feature-1121",
       "query": "lynx-api/intersection-observer/observe",
       "name": "Specify the target node and callback, and the target node is specified according to id.",
       "category": "lynx-api/intersection-observer",
@@ -112302,7 +112372,7 @@
       }
     },
     {
-      "id": "feature-1121",
+      "id": "feature-1122",
       "query": "lynx-api/intersection-observer/relativeTo",
       "name": "Specify a reference node. The reference node is specified by id.",
       "category": "lynx-api/intersection-observer",
@@ -112338,7 +112408,7 @@
       }
     },
     {
-      "id": "feature-1122",
+      "id": "feature-1123",
       "query": "lynx-api/intersection-observer/relativeToScreen",
       "name": "Specify the screen as the reference node.",
       "category": "lynx-api/intersection-observer",
@@ -112374,7 +112444,7 @@
       }
     },
     {
-      "id": "feature-1123",
+      "id": "feature-1124",
       "query": "lynx-api/intersection-observer/relativeToViewport",
       "name": "Specify a LynxView as a reference node.",
       "category": "lynx-api/intersection-observer",
@@ -112410,7 +112480,7 @@
       }
     },
     {
-      "id": "feature-1124",
+      "id": "feature-1125",
       "query": "lynx-api/main-thread/Element",
       "name": "Represents an element in the main thread.",
       "category": "lynx-api/main-thread",
@@ -112446,7 +112516,7 @@
       }
     },
     {
-      "id": "feature-1125",
+      "id": "feature-1126",
       "query": "lynx-api/main-thread/Element.Element.animate",
       "name": "animate",
       "category": "lynx-api/main-thread",
@@ -112482,7 +112552,7 @@
       }
     },
     {
-      "id": "feature-1126",
+      "id": "feature-1127",
       "query": "lynx-api/main-thread/Element.Element.getComputedStyleProperty",
       "name": "getComputedStyleProperty",
       "category": "lynx-api/main-thread",
@@ -112518,7 +112588,7 @@
       }
     },
     {
-      "id": "feature-1127",
+      "id": "feature-1128",
       "query": "lynx-api/main-thread/ElementAnimate",
       "name": "Create An Animation in MTS",
       "category": "lynx-api/main-thread",
@@ -112554,7 +112624,7 @@
       }
     },
     {
-      "id": "feature-1128",
+      "id": "feature-1129",
       "query": "lynx-api/main-thread/ElementAnimate.Animation.play()",
       "name": "play()",
       "category": "lynx-api/main-thread",
@@ -112590,7 +112660,7 @@
       }
     },
     {
-      "id": "feature-1129",
+      "id": "feature-1130",
       "query": "lynx-api/main-thread/ElementAnimate.Animation.pause()",
       "name": "pause()",
       "category": "lynx-api/main-thread",
@@ -112626,7 +112696,7 @@
       }
     },
     {
-      "id": "feature-1130",
+      "id": "feature-1131",
       "query": "lynx-api/main-thread/ElementAnimate.Animation.cancel()",
       "name": "cancel()",
       "category": "lynx-api/main-thread",
@@ -112662,7 +112732,7 @@
       }
     },
     {
-      "id": "feature-1131",
+      "id": "feature-1132",
       "query": "lynx-api/main-thread/ElementAnimate.Animation.finish()",
       "name": "finish()",
       "category": "lynx-api/main-thread",
@@ -112698,7 +112768,7 @@
       }
     },
     {
-      "id": "feature-1132",
+      "id": "feature-1133",
       "query": "lynx-api/main-thread/ElementGetComputedStyle",
       "name": "Create An Animation in MTS",
       "category": "lynx-api/main-thread",
@@ -112734,7 +112804,7 @@
       }
     },
     {
-      "id": "feature-1133",
+      "id": "feature-1134",
       "query": "lynx-api/main-thread/MainThread-APIs",
       "name": "APIs available on the main thread.",
       "category": "lynx-api/main-thread",
@@ -112770,7 +112840,7 @@
       }
     },
     {
-      "id": "feature-1134",
+      "id": "feature-1135",
       "query": "lynx-api/main-thread/MainThread-APIs.Element",
       "name": "Element",
       "category": "lynx-api/main-thread",
@@ -112806,7 +112876,7 @@
       }
     },
     {
-      "id": "feature-1135",
+      "id": "feature-1136",
       "query": "lynx-api/main-thread/MainThread-APIs.Element.animate",
       "name": "animate",
       "category": "lynx-api/main-thread",
@@ -112842,7 +112912,7 @@
       }
     },
     {
-      "id": "feature-1136",
+      "id": "feature-1137",
       "query": "lynx-api/main-thread/MainThread-APIs.Element.getComputedStyleProperty",
       "name": "getComputedStyleProperty",
       "category": "lynx-api/main-thread",
@@ -112878,7 +112948,7 @@
       }
     },
     {
-      "id": "feature-1137",
+      "id": "feature-1138",
       "query": "lynx-api/main-thread/MainThread-APIs.lynx.getTextInfo",
       "name": "getTextInfo",
       "category": "lynx-api/main-thread",
@@ -112914,7 +112984,7 @@
       }
     },
     {
-      "id": "feature-1138",
+      "id": "feature-1139",
       "query": "lynx-api/main-thread/MainThread-APIs.lynx.querySelector",
       "name": "querySelector",
       "category": "lynx-api/main-thread",
@@ -112950,7 +113020,7 @@
       }
     },
     {
-      "id": "feature-1139",
+      "id": "feature-1140",
       "query": "lynx-api/main-thread/MainThread-APIs.lynx.querySelectorAll",
       "name": "querySelectorAll",
       "category": "lynx-api/main-thread",
@@ -112986,7 +113056,7 @@
       }
     },
     {
-      "id": "feature-1140",
+      "id": "feature-1141",
       "query": "lynx-api/main-thread/MainThread-APIs.lynx.requestAnimationFrame",
       "name": "requestAnimationFrame",
       "category": "lynx-api/main-thread",
@@ -113022,7 +113092,7 @@
       }
     },
     {
-      "id": "feature-1141",
+      "id": "feature-1142",
       "query": "lynx-api/main-thread/MainThread-APIs.lynx.__globalProps",
       "name": "__globalProps",
       "category": "lynx-api/main-thread",
@@ -113058,7 +113128,7 @@
       }
     },
     {
-      "id": "feature-1142",
+      "id": "feature-1143",
       "query": "lynx-api/performance-api/framework-pipeline-timing",
       "name": "framework-pipeline-timing",
       "category": "lynx-api/performance-api",
@@ -113094,7 +113164,7 @@
       }
     },
     {
-      "id": "feature-1143",
+      "id": "feature-1144",
       "query": "lynx-api/performance-api/host-platform-timing/android-host-platform-timing",
       "name": "android-host-platform-timing",
       "category": "lynx-api/performance-api",
@@ -113130,7 +113200,7 @@
       }
     },
     {
-      "id": "feature-1144",
+      "id": "feature-1145",
       "query": "lynx-api/performance-api/host-platform-timing/harmony-host-platform-timing",
       "name": "harmony-host-platform-timing",
       "category": "lynx-api/performance-api",
@@ -113166,7 +113236,7 @@
       }
     },
     {
-      "id": "feature-1145",
+      "id": "feature-1146",
       "query": "lynx-api/performance-api/host-platform-timing/ios-host-platform-timing",
       "name": "ios-host-platform-timing",
       "category": "lynx-api/performance-api",
@@ -113202,7 +113272,7 @@
       }
     },
     {
-      "id": "feature-1146",
+      "id": "feature-1147",
       "query": "lynx-api/performance-api/performance-entry/entry-type",
       "name": "entry-type",
       "category": "lynx-api/performance-api",
@@ -113238,7 +113308,7 @@
       }
     },
     {
-      "id": "feature-1147",
+      "id": "feature-1148",
       "query": "lynx-api/performance-api/performance-entry/init-background-runtime-entry",
       "name": "Entry for background runtime initialization performance data.",
       "category": "lynx-api/performance-api",
@@ -113274,7 +113344,7 @@
       }
     },
     {
-      "id": "feature-1148",
+      "id": "feature-1149",
       "query": "lynx-api/performance-api/performance-entry/init-container-entry",
       "name": "init-container-entry",
       "category": "lynx-api/performance-api",
@@ -113310,7 +113380,7 @@
       }
     },
     {
-      "id": "feature-1149",
+      "id": "feature-1150",
       "query": "lynx-api/performance-api/performance-entry/init-lynxview-entry",
       "name": "init-lynxview-entry",
       "category": "lynx-api/performance-api",
@@ -113346,7 +113416,7 @@
       }
     },
     {
-      "id": "feature-1150",
+      "id": "feature-1151",
       "query": "lynx-api/performance-api/performance-entry/lazy-bundle-entry",
       "name": "lazy-bundle-entry",
       "category": "lynx-api/performance-api",
@@ -113382,7 +113452,7 @@
       }
     },
     {
-      "id": "feature-1151",
+      "id": "feature-1152",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry",
       "name": "load-bundle-entry",
       "category": "lynx-api/performance-api",
@@ -113418,7 +113488,7 @@
       }
     },
     {
-      "id": "feature-1152",
+      "id": "feature-1153",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.entryType",
       "name": "entryType",
       "category": "lynx-api/performance-api",
@@ -113454,7 +113524,7 @@
       }
     },
     {
-      "id": "feature-1153",
+      "id": "feature-1154",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.name",
       "name": "name",
       "category": "lynx-api/performance-api",
@@ -113490,7 +113560,7 @@
       }
     },
     {
-      "id": "feature-1154",
+      "id": "feature-1155",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.identifier",
       "name": "identifier",
       "category": "lynx-api/performance-api",
@@ -113526,7 +113596,7 @@
       }
     },
     {
-      "id": "feature-1155",
+      "id": "feature-1156",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.loadBundleStart",
       "name": "loadBundleStart",
       "category": "lynx-api/performance-api",
@@ -113562,7 +113632,7 @@
       }
     },
     {
-      "id": "feature-1156",
+      "id": "feature-1157",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.loadBundleEnd",
       "name": "loadBundleEnd",
       "category": "lynx-api/performance-api",
@@ -113598,7 +113668,7 @@
       }
     },
     {
-      "id": "feature-1157",
+      "id": "feature-1158",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.parseStart",
       "name": "parseStart",
       "category": "lynx-api/performance-api",
@@ -113634,7 +113704,7 @@
       }
     },
     {
-      "id": "feature-1158",
+      "id": "feature-1159",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.parseEnd",
       "name": "parseEnd",
       "category": "lynx-api/performance-api",
@@ -113670,7 +113740,7 @@
       }
     },
     {
-      "id": "feature-1159",
+      "id": "feature-1160",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.loadBackgroundStart",
       "name": "loadBackgroundStart",
       "category": "lynx-api/performance-api",
@@ -113706,7 +113776,7 @@
       }
     },
     {
-      "id": "feature-1160",
+      "id": "feature-1161",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.loadBackgroundEnd",
       "name": "loadBackgroundEnd",
       "category": "lynx-api/performance-api",
@@ -113742,7 +113812,7 @@
       }
     },
     {
-      "id": "feature-1161",
+      "id": "feature-1162",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.pipelineStart",
       "name": "pipelineStart",
       "category": "lynx-api/performance-api",
@@ -113778,7 +113848,7 @@
       }
     },
     {
-      "id": "feature-1162",
+      "id": "feature-1163",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.pipelineEnd",
       "name": "pipelineEnd",
       "category": "lynx-api/performance-api",
@@ -113814,7 +113884,7 @@
       }
     },
     {
-      "id": "feature-1163",
+      "id": "feature-1164",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.mtsRenderStart",
       "name": "mtsRenderStart",
       "category": "lynx-api/performance-api",
@@ -113850,7 +113920,7 @@
       }
     },
     {
-      "id": "feature-1164",
+      "id": "feature-1165",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.mtsRenderEnd",
       "name": "mtsRenderEnd",
       "category": "lynx-api/performance-api",
@@ -113886,7 +113956,7 @@
       }
     },
     {
-      "id": "feature-1165",
+      "id": "feature-1166",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.resolveStart",
       "name": "resolveStart",
       "category": "lynx-api/performance-api",
@@ -113922,7 +113992,7 @@
       }
     },
     {
-      "id": "feature-1166",
+      "id": "feature-1167",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.resolveEnd",
       "name": "resolveEnd",
       "category": "lynx-api/performance-api",
@@ -113958,7 +114028,7 @@
       }
     },
     {
-      "id": "feature-1167",
+      "id": "feature-1168",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.layoutStart",
       "name": "layoutStart",
       "category": "lynx-api/performance-api",
@@ -113994,7 +114064,7 @@
       }
     },
     {
-      "id": "feature-1168",
+      "id": "feature-1169",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.paintingUiOperationExecuteEnd",
       "name": "paintingUiOperationExecuteEnd",
       "category": "lynx-api/performance-api",
@@ -114030,7 +114100,7 @@
       }
     },
     {
-      "id": "feature-1169",
+      "id": "feature-1170",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.layoutUiOperationExecuteStart",
       "name": "layoutUiOperationExecuteStart",
       "category": "lynx-api/performance-api",
@@ -114066,7 +114136,7 @@
       }
     },
     {
-      "id": "feature-1170",
+      "id": "feature-1171",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.layoutUiOperationExecuteEnd",
       "name": "layoutUiOperationExecuteEnd",
       "category": "lynx-api/performance-api",
@@ -114102,7 +114172,7 @@
       }
     },
     {
-      "id": "feature-1171",
+      "id": "feature-1172",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.paintEnd",
       "name": "paintEnd",
       "category": "lynx-api/performance-api",
@@ -114138,7 +114208,7 @@
       }
     },
     {
-      "id": "feature-1172",
+      "id": "feature-1173",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.frameworkPipelineTiming",
       "name": "frameworkPipelineTiming",
       "category": "lynx-api/performance-api",
@@ -114174,7 +114244,7 @@
       }
     },
     {
-      "id": "feature-1173",
+      "id": "feature-1174",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.loadCoreStart",
       "name": "loadCoreStart",
       "category": "lynx-api/performance-api",
@@ -114210,7 +114280,7 @@
       }
     },
     {
-      "id": "feature-1174",
+      "id": "feature-1175",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.loadCoreEnd",
       "name": "loadCoreEnd",
       "category": "lynx-api/performance-api",
@@ -114246,7 +114316,7 @@
       }
     },
     {
-      "id": "feature-1175",
+      "id": "feature-1176",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.openTime",
       "name": "openTime",
       "category": "lynx-api/performance-api",
@@ -114282,7 +114352,7 @@
       }
     },
     {
-      "id": "feature-1176",
+      "id": "feature-1177",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.containerInitStart",
       "name": "containerInitStart",
       "category": "lynx-api/performance-api",
@@ -114318,7 +114388,7 @@
       }
     },
     {
-      "id": "feature-1177",
+      "id": "feature-1178",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.containerInitEnd",
       "name": "containerInitEnd",
       "category": "lynx-api/performance-api",
@@ -114354,7 +114424,7 @@
       }
     },
     {
-      "id": "feature-1178",
+      "id": "feature-1179",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.prepareTemplateStart",
       "name": "prepareTemplateStart",
       "category": "lynx-api/performance-api",
@@ -114390,7 +114460,7 @@
       }
     },
     {
-      "id": "feature-1179",
+      "id": "feature-1180",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.prepareTemplateEnd",
       "name": "prepareTemplateEnd",
       "category": "lynx-api/performance-api",
@@ -114426,7 +114496,7 @@
       }
     },
     {
-      "id": "feature-1180",
+      "id": "feature-1181",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.createLynxStart",
       "name": "createLynxStart",
       "category": "lynx-api/performance-api",
@@ -114462,7 +114532,7 @@
       }
     },
     {
-      "id": "feature-1181",
+      "id": "feature-1182",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.createLynxEnd",
       "name": "createLynxEnd",
       "category": "lynx-api/performance-api",
@@ -114498,7 +114568,7 @@
       }
     },
     {
-      "id": "feature-1182",
+      "id": "feature-1183",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.fcp",
       "name": "fcp",
       "category": "lynx-api/performance-api",
@@ -114534,7 +114604,7 @@
       }
     },
     {
-      "id": "feature-1183",
+      "id": "feature-1184",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.lynxFcp",
       "name": "lynxFcp",
       "category": "lynx-api/performance-api",
@@ -114570,7 +114640,7 @@
       }
     },
     {
-      "id": "feature-1184",
+      "id": "feature-1185",
       "query": "lynx-api/performance-api/performance-entry/load-bundle-entry.totalFcp",
       "name": "totalFcp",
       "category": "lynx-api/performance-api",
@@ -114606,7 +114676,7 @@
       }
     },
     {
-      "id": "feature-1185",
+      "id": "feature-1186",
       "query": "lynx-api/performance-api/performance-entry/metric-actual-fmp-entry",
       "name": "metric-actual-fmp-entry",
       "category": "lynx-api/performance-api",
@@ -114642,7 +114712,7 @@
       }
     },
     {
-      "id": "feature-1186",
+      "id": "feature-1187",
       "query": "lynx-api/performance-api/performance-entry/metric-fcp-entry",
       "name": "metric-fcp-entry",
       "category": "lynx-api/performance-api",
@@ -114678,7 +114748,7 @@
       }
     },
     {
-      "id": "feature-1187",
+      "id": "feature-1188",
       "query": "lynx-api/performance-api/performance-entry/name",
       "name": "name",
       "category": "lynx-api/performance-api",
@@ -114714,7 +114784,7 @@
       }
     },
     {
-      "id": "feature-1188",
+      "id": "feature-1189",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry",
       "name": "pipeline-entry",
       "category": "lynx-api/performance-api",
@@ -114750,7 +114820,7 @@
       }
     },
     {
-      "id": "feature-1189",
+      "id": "feature-1190",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.entryType",
       "name": "entryType",
       "category": "lynx-api/performance-api",
@@ -114786,7 +114856,7 @@
       }
     },
     {
-      "id": "feature-1190",
+      "id": "feature-1191",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.name",
       "name": "name",
       "category": "lynx-api/performance-api",
@@ -114822,7 +114892,7 @@
       }
     },
     {
-      "id": "feature-1191",
+      "id": "feature-1192",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.identifier",
       "name": "identifier",
       "category": "lynx-api/performance-api",
@@ -114858,7 +114928,7 @@
       }
     },
     {
-      "id": "feature-1192",
+      "id": "feature-1193",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.pipelineStart",
       "name": "pipelineStart",
       "category": "lynx-api/performance-api",
@@ -114894,7 +114964,7 @@
       }
     },
     {
-      "id": "feature-1193",
+      "id": "feature-1194",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.pipelineEnd",
       "name": "pipelineEnd",
       "category": "lynx-api/performance-api",
@@ -114930,7 +115000,7 @@
       }
     },
     {
-      "id": "feature-1194",
+      "id": "feature-1195",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.mtsRenderStart",
       "name": "mtsRenderStart",
       "category": "lynx-api/performance-api",
@@ -114966,7 +115036,7 @@
       }
     },
     {
-      "id": "feature-1195",
+      "id": "feature-1196",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.mtsRenderEnd",
       "name": "mtsRenderEnd",
       "category": "lynx-api/performance-api",
@@ -115002,7 +115072,7 @@
       }
     },
     {
-      "id": "feature-1196",
+      "id": "feature-1197",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.resolveStart",
       "name": "resolveStart",
       "category": "lynx-api/performance-api",
@@ -115038,7 +115108,7 @@
       }
     },
     {
-      "id": "feature-1197",
+      "id": "feature-1198",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.resolveEnd",
       "name": "resolveEnd",
       "category": "lynx-api/performance-api",
@@ -115074,7 +115144,7 @@
       }
     },
     {
-      "id": "feature-1198",
+      "id": "feature-1199",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.layoutStart",
       "name": "layoutStart",
       "category": "lynx-api/performance-api",
@@ -115110,7 +115180,7 @@
       }
     },
     {
-      "id": "feature-1199",
+      "id": "feature-1200",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.paintingUiOperationExecuteEnd",
       "name": "paintingUiOperationExecuteEnd",
       "category": "lynx-api/performance-api",
@@ -115146,7 +115216,7 @@
       }
     },
     {
-      "id": "feature-1200",
+      "id": "feature-1201",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.layoutUiOperationExecuteStart",
       "name": "layoutUiOperationExecuteStart",
       "category": "lynx-api/performance-api",
@@ -115182,7 +115252,7 @@
       }
     },
     {
-      "id": "feature-1201",
+      "id": "feature-1202",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.layoutUiOperationExecuteEnd",
       "name": "layoutUiOperationExecuteEnd",
       "category": "lynx-api/performance-api",
@@ -115218,7 +115288,7 @@
       }
     },
     {
-      "id": "feature-1202",
+      "id": "feature-1203",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.paintEnd",
       "name": "paintEnd",
       "category": "lynx-api/performance-api",
@@ -115254,7 +115324,7 @@
       }
     },
     {
-      "id": "feature-1203",
+      "id": "feature-1204",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.frameworkPipelineTiming",
       "name": "frameworkPipelineTiming",
       "category": "lynx-api/performance-api",
@@ -115290,7 +115360,7 @@
       }
     },
     {
-      "id": "feature-1204",
+      "id": "feature-1205",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.hostPlatformTiming",
       "name": "hostPlatformTiming",
       "category": "lynx-api/performance-api",
@@ -115326,7 +115396,7 @@
       }
     },
     {
-      "id": "feature-1205",
+      "id": "feature-1206",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.actualFmp",
       "name": "actualFmp",
       "category": "lynx-api/performance-api",
@@ -115362,7 +115432,7 @@
       }
     },
     {
-      "id": "feature-1206",
+      "id": "feature-1207",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.lynxActualFmp",
       "name": "lynxActualFmp",
       "category": "lynx-api/performance-api",
@@ -115398,7 +115468,7 @@
       }
     },
     {
-      "id": "feature-1207",
+      "id": "feature-1208",
       "query": "lynx-api/performance-api/performance-entry/pipeline-entry.totalActualFmp",
       "name": "totalActualFmp",
       "category": "lynx-api/performance-api",
@@ -115434,7 +115504,7 @@
       }
     },
     {
-      "id": "feature-1208",
+      "id": "feature-1209",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry",
       "name": "reload-bundle-entry",
       "category": "lynx-api/performance-api",
@@ -115470,7 +115540,7 @@
       }
     },
     {
-      "id": "feature-1209",
+      "id": "feature-1210",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.entryType",
       "name": "entryType",
       "category": "lynx-api/performance-api",
@@ -115506,7 +115576,7 @@
       }
     },
     {
-      "id": "feature-1210",
+      "id": "feature-1211",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.name",
       "name": "name",
       "category": "lynx-api/performance-api",
@@ -115542,7 +115612,7 @@
       }
     },
     {
-      "id": "feature-1211",
+      "id": "feature-1212",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.identifier",
       "name": "identifier",
       "category": "lynx-api/performance-api",
@@ -115578,7 +115648,7 @@
       }
     },
     {
-      "id": "feature-1212",
+      "id": "feature-1213",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.reloadBundleStart",
       "name": "reloadBundleStart",
       "category": "lynx-api/performance-api",
@@ -115614,7 +115684,7 @@
       }
     },
     {
-      "id": "feature-1213",
+      "id": "feature-1214",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.reloadBundleEnd",
       "name": "reloadBundleEnd",
       "category": "lynx-api/performance-api",
@@ -115650,7 +115720,7 @@
       }
     },
     {
-      "id": "feature-1214",
+      "id": "feature-1215",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.reloadBackgroundStart",
       "name": "reloadBackgroundStart",
       "category": "lynx-api/performance-api",
@@ -115686,7 +115756,7 @@
       }
     },
     {
-      "id": "feature-1215",
+      "id": "feature-1216",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.reloadBackgroundEnd",
       "name": "reloadBackgroundEnd",
       "category": "lynx-api/performance-api",
@@ -115722,7 +115792,7 @@
       }
     },
     {
-      "id": "feature-1216",
+      "id": "feature-1217",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.pipelineStart",
       "name": "pipelineStart",
       "category": "lynx-api/performance-api",
@@ -115758,7 +115828,7 @@
       }
     },
     {
-      "id": "feature-1217",
+      "id": "feature-1218",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.pipelineEnd",
       "name": "pipelineEnd",
       "category": "lynx-api/performance-api",
@@ -115794,7 +115864,7 @@
       }
     },
     {
-      "id": "feature-1218",
+      "id": "feature-1219",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.mtsRenderStart",
       "name": "mtsRenderStart",
       "category": "lynx-api/performance-api",
@@ -115830,7 +115900,7 @@
       }
     },
     {
-      "id": "feature-1219",
+      "id": "feature-1220",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.mtsRenderEnd",
       "name": "mtsRenderEnd",
       "category": "lynx-api/performance-api",
@@ -115866,7 +115936,7 @@
       }
     },
     {
-      "id": "feature-1220",
+      "id": "feature-1221",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.resolveStart",
       "name": "resolveStart",
       "category": "lynx-api/performance-api",
@@ -115902,7 +115972,7 @@
       }
     },
     {
-      "id": "feature-1221",
+      "id": "feature-1222",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.resolveEnd",
       "name": "resolveEnd",
       "category": "lynx-api/performance-api",
@@ -115938,7 +116008,7 @@
       }
     },
     {
-      "id": "feature-1222",
+      "id": "feature-1223",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.layoutStart",
       "name": "layoutStart",
       "category": "lynx-api/performance-api",
@@ -115974,7 +116044,7 @@
       }
     },
     {
-      "id": "feature-1223",
+      "id": "feature-1224",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.paintingUiOperationExecuteEnd",
       "name": "paintingUiOperationExecuteEnd",
       "category": "lynx-api/performance-api",
@@ -116010,7 +116080,7 @@
       }
     },
     {
-      "id": "feature-1224",
+      "id": "feature-1225",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.layoutUiOperationExecuteStart",
       "name": "layoutUiOperationExecuteStart",
       "category": "lynx-api/performance-api",
@@ -116046,7 +116116,7 @@
       }
     },
     {
-      "id": "feature-1225",
+      "id": "feature-1226",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.layoutUiOperationExecuteEnd",
       "name": "layoutUiOperationExecuteEnd",
       "category": "lynx-api/performance-api",
@@ -116082,7 +116152,7 @@
       }
     },
     {
-      "id": "feature-1226",
+      "id": "feature-1227",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.paintEnd",
       "name": "paintEnd",
       "category": "lynx-api/performance-api",
@@ -116118,7 +116188,7 @@
       }
     },
     {
-      "id": "feature-1227",
+      "id": "feature-1228",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.frameworkPipelineTiming",
       "name": "frameworkPipelineTiming",
       "category": "lynx-api/performance-api",
@@ -116154,7 +116224,7 @@
       }
     },
     {
-      "id": "feature-1228",
+      "id": "feature-1229",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.loadCoreStart",
       "name": "loadCoreStart",
       "category": "lynx-api/performance-api",
@@ -116190,7 +116260,7 @@
       }
     },
     {
-      "id": "feature-1229",
+      "id": "feature-1230",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.loadCoreEnd",
       "name": "loadCoreEnd",
       "category": "lynx-api/performance-api",
@@ -116226,7 +116296,7 @@
       }
     },
     {
-      "id": "feature-1230",
+      "id": "feature-1231",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.openTime",
       "name": "openTime",
       "category": "lynx-api/performance-api",
@@ -116262,7 +116332,7 @@
       }
     },
     {
-      "id": "feature-1231",
+      "id": "feature-1232",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.containerInitStart",
       "name": "containerInitStart",
       "category": "lynx-api/performance-api",
@@ -116298,7 +116368,7 @@
       }
     },
     {
-      "id": "feature-1232",
+      "id": "feature-1233",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.containerInitEnd",
       "name": "containerInitEnd",
       "category": "lynx-api/performance-api",
@@ -116334,7 +116404,7 @@
       }
     },
     {
-      "id": "feature-1233",
+      "id": "feature-1234",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.prepareTemplateStart",
       "name": "prepareTemplateStart",
       "category": "lynx-api/performance-api",
@@ -116370,7 +116440,7 @@
       }
     },
     {
-      "id": "feature-1234",
+      "id": "feature-1235",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.prepareTemplateEnd",
       "name": "prepareTemplateEnd",
       "category": "lynx-api/performance-api",
@@ -116406,7 +116476,7 @@
       }
     },
     {
-      "id": "feature-1235",
+      "id": "feature-1236",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.createLynxStart",
       "name": "createLynxStart",
       "category": "lynx-api/performance-api",
@@ -116442,7 +116512,7 @@
       }
     },
     {
-      "id": "feature-1236",
+      "id": "feature-1237",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.createLynxEnd",
       "name": "createLynxEnd",
       "category": "lynx-api/performance-api",
@@ -116478,7 +116548,7 @@
       }
     },
     {
-      "id": "feature-1237",
+      "id": "feature-1238",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.fcp",
       "name": "fcp",
       "category": "lynx-api/performance-api",
@@ -116514,7 +116584,7 @@
       }
     },
     {
-      "id": "feature-1238",
+      "id": "feature-1239",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.lynxFcp",
       "name": "lynxFcp",
       "category": "lynx-api/performance-api",
@@ -116550,7 +116620,7 @@
       }
     },
     {
-      "id": "feature-1239",
+      "id": "feature-1240",
       "query": "lynx-api/performance-api/performance-entry/reload-bundle-entry.totalFcp",
       "name": "totalFcp",
       "category": "lynx-api/performance-api",
@@ -116586,7 +116656,7 @@
       }
     },
     {
-      "id": "feature-1240",
+      "id": "feature-1241",
       "query": "lynx-api/performance-api/performance-entry",
       "name": "performance-entry",
       "category": "lynx-api/performance-api",
@@ -116622,7 +116692,7 @@
       }
     },
     {
-      "id": "feature-1241",
+      "id": "feature-1242",
       "query": "lynx-api/performance-api/performance-metric",
       "name": "performance-metric",
       "category": "lynx-api/performance-api",
@@ -116658,7 +116728,7 @@
       }
     },
     {
-      "id": "feature-1242",
+      "id": "feature-1243",
       "query": "lynx-api/performance-api/performance-observer/disconnect",
       "name": "disconnect",
       "category": "lynx-api/performance-api",
@@ -116694,7 +116764,7 @@
       }
     },
     {
-      "id": "feature-1243",
+      "id": "feature-1244",
       "query": "lynx-api/performance-api/performance-observer/observe",
       "name": "observe",
       "category": "lynx-api/performance-api",
@@ -116730,7 +116800,7 @@
       }
     },
     {
-      "id": "feature-1244",
+      "id": "feature-1245",
       "query": "lynx-api/performance-api/performance-observer",
       "name": "performance-observer",
       "category": "lynx-api/performance-api",
@@ -116766,7 +116836,7 @@
       }
     },
     {
-      "id": "feature-1245",
+      "id": "feature-1246",
       "query": "lynx-api/performance-api/timing-flag",
       "name": "timing-flag",
       "category": "lynx-api/performance-api",
@@ -116802,7 +116872,7 @@
       }
     },
     {
-      "id": "feature-1246",
+      "id": "feature-1247",
       "query": "lynx-native-api/lynx-background-runtime/add-lynx-background-runtime-client",
       "name": "register lifecycle observer for background runtime",
       "category": "lynx-native-api",
@@ -116838,7 +116908,7 @@
       }
     },
     {
-      "id": "feature-1247",
+      "id": "feature-1248",
       "query": "lynx-native-api/lynx-background-runtime/call-js-function",
       "name": "invoke js function from background runtime",
       "category": "lynx-native-api",
@@ -116874,7 +116944,7 @@
       }
     },
     {
-      "id": "feature-1248",
+      "id": "feature-1249",
       "query": "lynx-native-api/lynx-background-runtime/destroy",
       "name": "manually destroy background runtime instance",
       "category": "lynx-native-api",
@@ -116910,7 +116980,7 @@
       }
     },
     {
-      "id": "feature-1249",
+      "id": "feature-1250",
       "query": "lynx-native-api/lynx-background-runtime/evaluate-java-script",
       "name": "evaluate background runtime script",
       "category": "lynx-native-api",
@@ -116946,7 +117016,7 @@
       }
     },
     {
-      "id": "feature-1250",
+      "id": "feature-1251",
       "query": "lynx-native-api/lynx-background-runtime/remove-lynx-background-runtime-client",
       "name": "remove lifecycle observer for background runtime",
       "category": "lynx-native-api",
@@ -116982,7 +117052,7 @@
       }
     },
     {
-      "id": "feature-1251",
+      "id": "feature-1252",
       "query": "lynx-native-api/lynx-background-runtime/send-global-event",
       "name": "send global event to js environment from background runtime",
       "category": "lynx-native-api",
@@ -117018,7 +117088,7 @@
       }
     },
     {
-      "id": "feature-1252",
+      "id": "feature-1253",
       "query": "lynx-native-api/lynx-background-runtime-client/on-evaluate-java-script-end",
       "name": "Called when background script evaluation finished.",
       "category": "lynx-native-api",
@@ -117054,7 +117124,7 @@
       }
     },
     {
-      "id": "feature-1253",
+      "id": "feature-1254",
       "query": "lynx-native-api/lynx-background-runtime-client/on-module-method-invoked",
       "name": "Called when a module method invocation completed in background runtime.",
       "category": "lynx-native-api",
@@ -117090,7 +117160,7 @@
       }
     },
     {
-      "id": "feature-1254",
+      "id": "feature-1255",
       "query": "lynx-native-api/lynx-background-runtime-client/on-received-error",
       "name": "Called when an error is received in background runtime.",
       "category": "lynx-native-api",
@@ -117126,7 +117196,7 @@
       }
     },
     {
-      "id": "feature-1255",
+      "id": "feature-1256",
       "query": "lynx-native-api/lynx-context/send-global-event",
       "name": "send global event to js environment",
       "category": "lynx-native-api",
@@ -117162,7 +117232,7 @@
       }
     },
     {
-      "id": "feature-1256",
+      "id": "feature-1257",
       "query": "lynx-native-api/lynx-context/set-extra-timing",
       "name": "set extra timing from outside.",
       "category": "lynx-native-api",
@@ -117198,7 +117268,7 @@
       }
     },
     {
-      "id": "feature-1257",
+      "id": "feature-1258",
       "query": "lynx-native-api/lynx-context/update-font-scale",
       "name": "update font scale of lynxView",
       "category": "lynx-native-api",
@@ -117234,7 +117304,7 @@
       }
     },
     {
-      "id": "feature-1258",
+      "id": "feature-1259",
       "query": "lynx-native-api/lynx-context/update-meta-data",
       "name": "update lynx page by new data.",
       "category": "lynx-native-api",
@@ -117270,7 +117340,7 @@
       }
     },
     {
-      "id": "feature-1259",
+      "id": "feature-1260",
       "query": "lynx-native-api/lynx-context/update-viewport",
       "name": "update viewport of lynxView",
       "category": "lynx-native-api",
@@ -117306,7 +117376,7 @@
       }
     },
     {
-      "id": "feature-1260",
+      "id": "feature-1261",
       "query": "lynx-native-api/lynx-env/trim-memory",
       "name": "dispatch memory pressure signal to registered callbacks",
       "category": "lynx-native-api",
@@ -117342,7 +117412,7 @@
       }
     },
     {
-      "id": "feature-1261",
+      "id": "feature-1262",
       "query": "lynx-native-api/lynx-extension-module",
       "name": "Desktop-only extension module entry for lifecycle hooks, NAPI binding, VSync, and native view registration.",
       "category": "lynx-native-api",
@@ -117378,7 +117448,7 @@
       }
     },
     {
-      "id": "feature-1262",
+      "id": "feature-1263",
       "query": "lynx-native-api/lynx-generic-resource-fetcher/cancel",
       "name": "Cancel the request of the requiring resource.",
       "category": "lynx-native-api",
@@ -117414,7 +117484,7 @@
       }
     },
     {
-      "id": "feature-1263",
+      "id": "feature-1264",
       "query": "lynx-native-api/lynx-generic-resource-fetcher/fetch-resource-path",
       "name": "LynxEngine internally calls this method to obtain the path of the common resource on the local disk, and the return result is required to be of String type.",
       "category": "lynx-native-api",
@@ -117450,7 +117520,7 @@
       }
     },
     {
-      "id": "feature-1264",
+      "id": "feature-1265",
       "query": "lynx-native-api/lynx-generic-resource-fetcher/fetch-resource",
       "name": "LynxEngine internally calls this method to obtain the general resource content, and the return result is required to be the resource content byte[] type.",
       "category": "lynx-native-api",
@@ -117486,7 +117556,7 @@
       }
     },
     {
-      "id": "feature-1265",
+      "id": "feature-1266",
       "query": "lynx-native-api/lynx-generic-resource-fetcher/fetch-stream",
       "name": "LynxEngine internally calls this method to obtain resource content in a streaming manner.",
       "category": "lynx-native-api",
@@ -117522,7 +117592,7 @@
       }
     },
     {
-      "id": "feature-1266",
+      "id": "feature-1267",
       "query": "lynx-native-api/lynx-load-meta",
       "name": "MetaData of LynxEngine loadProcess",
       "category": "lynx-native-api",
@@ -117558,7 +117628,7 @@
       }
     },
     {
-      "id": "feature-1267",
+      "id": "feature-1268",
       "query": "lynx-native-api/lynx-media-resource-fetcher/fetch-image",
       "name": "LynxEngine will use this method to obtain the bitmap information of the image, and the return content must be of Closeable type.",
       "category": "lynx-native-api",
@@ -117594,7 +117664,7 @@
       }
     },
     {
-      "id": "feature-1268",
+      "id": "feature-1269",
       "query": "lynx-native-api/lynx-media-resource-fetcher/is-local-resource",
       "name": "LynxEngine internally calls this method to determine whether the resource path exists on disk.",
       "category": "lynx-native-api",
@@ -117630,7 +117700,7 @@
       }
     },
     {
-      "id": "feature-1269",
+      "id": "feature-1270",
       "query": "lynx-native-api/lynx-media-resource-fetcher/should-redirect-url",
       "name": "LynxEngine redirects the image path by calling this method internally, and the return result is required to be of String type.",
       "category": "lynx-native-api",
@@ -117666,7 +117736,7 @@
       }
     },
     {
-      "id": "feature-1270",
+      "id": "feature-1271",
       "query": "lynx-native-api/lynx-service/lynx-service",
       "name": "LynxService API",
       "category": "lynx-native-api",
@@ -117702,7 +117772,7 @@
       }
     },
     {
-      "id": "feature-1271",
+      "id": "feature-1272",
       "query": "lynx-native-api/lynx-template-resource-fetcher/fetch-template",
       "name": "LynxEngine internally calls this method to obtain the contents of Bundle and Lazy Bundle. The returned result type can contain byte[] or TemplateBundle.",
       "category": "lynx-native-api",
@@ -117738,7 +117808,7 @@
       }
     },
     {
-      "id": "feature-1272",
+      "id": "feature-1273",
       "query": "lynx-native-api/lynx-update-meta",
       "name": "MetaData of LynxEngine updateProcess",
       "category": "lynx-native-api",
@@ -117774,7 +117844,7 @@
       }
     },
     {
-      "id": "feature-1273",
+      "id": "feature-1274",
       "query": "lynx-native-api/lynx-view/add-lynx-view-client",
       "name": "register lifecycle observer for lynxView",
       "category": "lynx-native-api",
@@ -117810,7 +117880,7 @@
       }
     },
     {
-      "id": "feature-1274",
+      "id": "feature-1275",
       "query": "lynx-native-api/lynx-view/destroy",
       "name": "manually destroy lynxView instance",
       "category": "lynx-native-api",
@@ -117846,7 +117916,7 @@
       }
     },
     {
-      "id": "feature-1275",
+      "id": "feature-1276",
       "query": "lynx-native-api/lynx-view/find-ui-by-id-selector",
       "name": "find ui by idselector",
       "category": "lynx-native-api",
@@ -117882,7 +117952,7 @@
       }
     },
     {
-      "id": "feature-1276",
+      "id": "feature-1277",
       "query": "lynx-native-api/lynx-view/find-ui-by-name",
       "name": "find ui by name",
       "category": "lynx-native-api",
@@ -117918,7 +117988,7 @@
       }
     },
     {
-      "id": "feature-1277",
+      "id": "feature-1278",
       "query": "lynx-native-api/lynx-view/find-view-by-id-selector",
       "name": "find view by idselector",
       "category": "lynx-native-api",
@@ -117954,7 +118024,7 @@
       }
     },
     {
-      "id": "feature-1278",
+      "id": "feature-1279",
       "query": "lynx-native-api/lynx-view/find-view-by-name",
       "name": "find view by name",
       "category": "lynx-native-api",
@@ -117990,7 +118060,7 @@
       }
     },
     {
-      "id": "feature-1279",
+      "id": "feature-1280",
       "query": "lynx-native-api/lynx-view/load-template",
       "name": "load a lynx template file by LynxView.",
       "category": "lynx-native-api",
@@ -118026,7 +118096,7 @@
       }
     },
     {
-      "id": "feature-1280",
+      "id": "feature-1281",
       "query": "lynx-native-api/lynx-view/lynx-view-custom-element",
       "name": "<code>lynx-view</code> The custom element of LynxView.",
       "category": "lynx-native-api",
@@ -118062,7 +118132,7 @@
       }
     },
     {
-      "id": "feature-1281",
+      "id": "feature-1282",
       "query": "lynx-native-api/lynx-view/reload",
       "name": "reload lynx page.",
       "category": "lynx-native-api",
@@ -118098,7 +118168,7 @@
       }
     },
     {
-      "id": "feature-1282",
+      "id": "feature-1283",
       "query": "lynx-native-api/lynx-view/remove-lynx-view-client",
       "name": "remove lifecycle observer of lynxView",
       "category": "lynx-native-api",
@@ -118134,7 +118204,7 @@
       }
     },
     {
-      "id": "feature-1283",
+      "id": "feature-1284",
       "query": "lynx-native-api/lynx-view/send-global-event",
       "name": "send global event to js environment",
       "category": "lynx-native-api",
@@ -118170,7 +118240,7 @@
       }
     },
     {
-      "id": "feature-1284",
+      "id": "feature-1285",
       "query": "lynx-native-api/lynx-view/set-extra-timing",
       "name": "set extra timing from outside.",
       "category": "lynx-native-api",
@@ -118206,7 +118276,7 @@
       }
     },
     {
-      "id": "feature-1285",
+      "id": "feature-1286",
       "query": "lynx-native-api/lynx-view/update-font-scale",
       "name": "update font scale of lynxView",
       "category": "lynx-native-api",
@@ -118242,7 +118312,7 @@
       }
     },
     {
-      "id": "feature-1286",
+      "id": "feature-1287",
       "query": "lynx-native-api/lynx-view/update-meta-data",
       "name": "update lynx page by new data.",
       "category": "lynx-native-api",
@@ -118278,7 +118348,7 @@
       }
     },
     {
-      "id": "feature-1287",
+      "id": "feature-1288",
       "query": "lynx-native-api/lynx-view/update-screen-metrics",
       "name": "update screen metrics",
       "category": "lynx-native-api",
@@ -118314,7 +118384,7 @@
       }
     },
     {
-      "id": "feature-1288",
+      "id": "feature-1289",
       "query": "lynx-native-api/lynx-view/update-viewport",
       "name": "update viewport of lynxView",
       "category": "lynx-native-api",
@@ -118350,7 +118420,7 @@
       }
     },
     {
-      "id": "feature-1289",
+      "id": "feature-1290",
       "query": "lynx-native-api/lynx-view-client/on-data-updated",
       "name": "Called when data update, but the view may not be updated.",
       "category": "lynx-native-api",
@@ -118386,7 +118456,7 @@
       }
     },
     {
-      "id": "feature-1290",
+      "id": "feature-1291",
       "query": "lynx-native-api/lynx-view-client/on-destroy",
       "name": "Called after the page is destroyed.",
       "category": "lynx-native-api",
@@ -118422,7 +118492,7 @@
       }
     },
     {
-      "id": "feature-1291",
+      "id": "feature-1292",
       "query": "lynx-native-api/lynx-view-client/on-first-load-perf-ready",
       "name": "Performance data statistics callback after the first load is completed.",
       "category": "lynx-native-api",
@@ -118458,7 +118528,7 @@
       }
     },
     {
-      "id": "feature-1292",
+      "id": "feature-1293",
       "query": "lynx-native-api/lynx-view-client/on-first-screen",
       "name": "Called when first screen layout completed.",
       "category": "lynx-native-api",
@@ -118494,7 +118564,7 @@
       }
     },
     {
-      "id": "feature-1293",
+      "id": "feature-1294",
       "query": "lynx-native-api/lynx-view-client/on-fling",
       "name": "Called when inertial scrolling starts after releasing the finger.",
       "category": "lynx-native-api",
@@ -118530,7 +118600,7 @@
       }
     },
     {
-      "id": "feature-1294",
+      "id": "feature-1295",
       "query": "lynx-native-api/lynx-view-client/on-flush-finish",
       "name": "Called when UI flush end in async render mode.",
       "category": "lynx-native-api",
@@ -118566,7 +118636,7 @@
       }
     },
     {
-      "id": "feature-1295",
+      "id": "feature-1296",
       "query": "lynx-native-api/lynx-view-client/on-key-event",
       "name": "Report all android key events with flag indicating whether has been handled.",
       "category": "lynx-native-api",
@@ -118602,7 +118672,7 @@
       }
     },
     {
-      "id": "feature-1296",
+      "id": "feature-1297",
       "query": "lynx-native-api/lynx-view-client/on-load-success",
       "name": "Called when page load finish.",
       "category": "lynx-native-api",
@@ -118638,7 +118708,7 @@
       }
     },
     {
-      "id": "feature-1297",
+      "id": "feature-1298",
       "query": "lynx-native-api/lynx-view-client/on-lynx-event",
       "name": "Report Lynx events that sended to frontend.",
       "category": "lynx-native-api",
@@ -118674,7 +118744,7 @@
       }
     },
     {
-      "id": "feature-1298",
+      "id": "feature-1299",
       "query": "lynx-native-api/lynx-view-client/on-lynx-view-and-js-runtime-destroy",
       "name": "Called when lynx view and js runtime destroy.",
       "category": "lynx-native-api",
@@ -118710,7 +118780,7 @@
       }
     },
     {
-      "id": "feature-1299",
+      "id": "feature-1300",
       "query": "lynx-native-api/lynx-view-client/on-module-method-invoked",
       "name": "Called when module method invocation completed.",
       "category": "lynx-native-api",
@@ -118746,7 +118816,7 @@
       }
     },
     {
-      "id": "feature-1300",
+      "id": "feature-1301",
       "query": "lynx-native-api/lynx-view-client/on-page-start",
       "name": "Called when page start loading.",
       "category": "lynx-native-api",
@@ -118782,7 +118852,7 @@
       }
     },
     {
-      "id": "feature-1301",
+      "id": "feature-1302",
       "query": "lynx-native-api/lynx-view-client/on-page-update",
       "name": "Called when page update.",
       "category": "lynx-native-api",
@@ -118818,7 +118888,7 @@
       }
     },
     {
-      "id": "feature-1302",
+      "id": "feature-1303",
       "query": "lynx-native-api/lynx-view-client/on-performance-event",
       "name": "Notify the client that a performance event has been sent. It will be called every time a performance event is generated, including but not limited to container initialization, engine rendering, rendering metrics update, etc.",
       "category": "lynx-native-api",
@@ -118854,7 +118924,7 @@
       }
     },
     {
-      "id": "feature-1303",
+      "id": "feature-1304",
       "query": "lynx-native-api/lynx-view-client/on-piper-invoked",
       "name": "Called when JSBridge invoked.",
       "category": "lynx-native-api",
@@ -118890,7 +118960,7 @@
       }
     },
     {
-      "id": "feature-1304",
+      "id": "feature-1305",
       "query": "lynx-native-api/lynx-view-client/on-received-error",
       "name": "Called when error received.",
       "category": "lynx-native-api",
@@ -118926,7 +118996,7 @@
       }
     },
     {
-      "id": "feature-1305",
+      "id": "feature-1306",
       "query": "lynx-native-api/lynx-view-client/on-received-java-error",
       "name": "Called when java error received.",
       "category": "lynx-native-api",
@@ -118962,7 +119032,7 @@
       }
     },
     {
-      "id": "feature-1306",
+      "id": "feature-1307",
       "query": "lynx-native-api/lynx-view-client/on-received-js-error",
       "name": "Called when JS error received.",
       "category": "lynx-native-api",
@@ -118998,7 +119068,7 @@
       }
     },
     {
-      "id": "feature-1307",
+      "id": "feature-1308",
       "query": "lynx-native-api/lynx-view-client/on-received-native-error",
       "name": "Called when C++ layer error received.",
       "category": "lynx-native-api",
@@ -119034,7 +119104,7 @@
       }
     },
     {
-      "id": "feature-1308",
+      "id": "feature-1309",
       "query": "lynx-native-api/lynx-view-client/on-report-component-info",
       "name": "Return the used component tagName.",
       "category": "lynx-native-api",
@@ -119070,7 +119140,7 @@
       }
     },
     {
-      "id": "feature-1309",
+      "id": "feature-1310",
       "query": "lynx-native-api/lynx-view-client/on-runtime-ready",
       "name": "Called when JS environment preparation completed.",
       "category": "lynx-native-api",
@@ -119106,7 +119176,7 @@
       }
     },
     {
-      "id": "feature-1310",
+      "id": "feature-1311",
       "query": "lynx-native-api/lynx-view-client/on-scroll-start",
       "name": "Called when the UI start scrolling.",
       "category": "lynx-native-api",
@@ -119142,7 +119212,7 @@
       }
     },
     {
-      "id": "feature-1311",
+      "id": "feature-1312",
       "query": "lynx-native-api/lynx-view-client/on-scroll-stop",
       "name": "Called when the UI finished scrolling.",
       "category": "lynx-native-api",
@@ -119178,7 +119248,7 @@
       }
     },
     {
-      "id": "feature-1312",
+      "id": "feature-1313",
       "query": "lynx-native-api/lynx-view-client/on-tasm-finished-by-native",
       "name": "Called when native layout finish in ui or most_on_tasm mode, or diff finish in multi_thread mode.",
       "category": "lynx-native-api",
@@ -119214,7 +119284,7 @@
       }
     },
     {
-      "id": "feature-1313",
+      "id": "feature-1314",
       "query": "lynx-native-api/lynx-view-client/on-template-bundle-ready",
       "name": "Provide a reusable TemplateBundle after template is decode.",
       "category": "lynx-native-api",
@@ -119250,7 +119320,7 @@
       }
     },
     {
-      "id": "feature-1314",
+      "id": "feature-1315",
       "query": "lynx-native-api/lynx-view-client/on-update-data-without-change",
       "name": "If there is no need to update the UI after calling updateData, this method is called back.",
       "category": "lynx-native-api",
@@ -119286,7 +119356,7 @@
       }
     },
     {
-      "id": "feature-1315",
+      "id": "feature-1316",
       "query": "lynx-native-api/lynx-view-client/on-update-perf-ready",
       "name": "Performance data statistics callback after the interface update is completed.",
       "category": "lynx-native-api",
@@ -119322,7 +119392,7 @@
       }
     },
     {
-      "id": "feature-1316",
+      "id": "feature-1317",
       "query": "lynx-native-api/template-bundle/from-template-async-with-option",
       "name": "Asynchronously creates a TemplateBundle from a template binary data with options. This method avoids blocking the main thread.",
       "category": "lynx-native-api",
@@ -119358,7 +119428,7 @@
       }
     },
     {
-      "id": "feature-1317",
+      "id": "feature-1318",
       "query": "lynx-native-api/template-bundle/from-template-async",
       "name": "Asynchronously creates a TemplateBundle from a template binary data. This method avoids blocking the main thread.",
       "category": "lynx-native-api",
@@ -119394,7 +119464,7 @@
       }
     },
     {
-      "id": "feature-1318",
+      "id": "feature-1319",
       "query": "lynx-native-api/template-bundle/from-template",
       "name": "Input Lynx template binary content and return the parsed TemplateBundle object.",
       "category": "lynx-native-api",
@@ -119430,7 +119500,7 @@
       }
     },
     {
-      "id": "feature-1319",
+      "id": "feature-1320",
       "query": "lynx-native-api/template-bundle/get-error-message",
       "name": "When TemplateBundle is an invalid object, use this method to obtain the exception information that occurred during template parsing.",
       "category": "lynx-native-api",
@@ -119466,7 +119536,7 @@
       }
     },
     {
-      "id": "feature-1320",
+      "id": "feature-1321",
       "query": "lynx-native-api/template-bundle/get-extra-info",
       "name": "Read the content of the extraInfo field configured in the pageConfig of the front-end template.",
       "category": "lynx-native-api",
@@ -119502,7 +119572,7 @@
       }
     },
     {
-      "id": "feature-1321",
+      "id": "feature-1322",
       "query": "lynx-native-api/template-bundle/get-template-size",
       "name": "Get the size of current template.",
       "category": "lynx-native-api",
@@ -119538,7 +119608,7 @@
       }
     },
     {
-      "id": "feature-1322",
+      "id": "feature-1323",
       "query": "lynx-native-api/template-bundle/is-element-bundle-valid",
       "name": "Whether the TemplateBundle contains a Valid ElementBundle.",
       "category": "lynx-native-api",
@@ -119574,7 +119644,7 @@
       }
     },
     {
-      "id": "feature-1323",
+      "id": "feature-1324",
       "query": "lynx-native-api/template-bundle/is-valid",
       "name": "Determines whether the current TemplateBundle object is valid.",
       "category": "lynx-native-api",
@@ -119610,7 +119680,7 @@
       }
     },
     {
-      "id": "feature-1324",
+      "id": "feature-1325",
       "query": "lynx-native-api/template-bundle/post-js-cache-generation-task",
       "name": "Start a sub-thread task to generate the js code cache of the current template.",
       "category": "lynx-native-api",
@@ -119646,7 +119716,7 @@
       }
     },
     {
-      "id": "feature-1325",
+      "id": "feature-1326",
       "query": "lynx-native-api/template-bundle/release",
       "name": "Release the Native memory held by the current TemplateBundle object. After executing the release method, the TemplateBundle will become the inValid state.",
       "category": "lynx-native-api",
@@ -119682,7 +119752,7 @@
       }
     },
     {
-      "id": "feature-1326",
+      "id": "feature-1327",
       "query": "lynx-native-api/template-data/constructor",
       "name": "Input data in string, key-value or json format and return the parsed TemplateData object.",
       "category": "lynx-native-api",
@@ -119718,7 +119788,7 @@
       }
     },
     {
-      "id": "feature-1327",
+      "id": "feature-1328",
       "query": "lynx-native-api/template-data/data",
       "name": "Get the data in TemplateData object.",
       "category": "lynx-native-api",
@@ -119754,7 +119824,7 @@
       }
     },
     {
-      "id": "feature-1328",
+      "id": "feature-1329",
       "query": "lynx-native-api/template-data/from-map",
       "name": "Input data in key-value format and return the parsed TemplateData object.",
       "category": "lynx-native-api",
@@ -119790,7 +119860,7 @@
       }
     },
     {
-      "id": "feature-1329",
+      "id": "feature-1330",
       "query": "lynx-native-api/template-data/from-string",
       "name": "Input data in json and return the parsed TemplateData object.",
       "category": "lynx-native-api",
@@ -119826,7 +119896,7 @@
       }
     },
     {
-      "id": "feature-1330",
+      "id": "feature-1331",
       "query": "lynx-native-api/template-data/mark-state",
       "name": "Mark the current TemplateData with the associated dataProcessor name. When this TemplateData is used in UpdateData, the corresponding dataProcessor will be found based on this name for data preprocessing.",
       "category": "lynx-native-api",
@@ -119862,7 +119932,7 @@
       }
     },
     {
-      "id": "feature-1331",
+      "id": "feature-1332",
       "query": "lynx-native-api/template-data/merge",
       "name": "Merge the incoming data with the current data.",
       "category": "lynx-native-api",
@@ -119898,7 +119968,7 @@
       }
     },
     {
-      "id": "feature-1332",
+      "id": "feature-1333",
       "query": "lynx-native-api/trace-event",
       "name": "TraceEvent",
       "category": "lynx-native-api",
@@ -119934,7 +120004,7 @@
       }
     },
     {
-      "id": "feature-1333",
+      "id": "feature-1334",
       "query": "react/main-thread/MainThread-APIs",
       "name": "APIs available on the main thread.",
       "category": "react",
@@ -119970,7 +120040,7 @@
       }
     },
     {
-      "id": "feature-1334",
+      "id": "feature-1335",
       "query": "react/main-thread/MainThread-APIs.runOnBackground",
       "name": "runOnBackground: Create a value that can be shared between main thread scripts.",
       "category": "react",
@@ -120006,7 +120076,7 @@
       }
     },
     {
-      "id": "feature-1335",
+      "id": "feature-1336",
       "query": "devtool/integration.lazy_load",
       "name": "Lazy load",
       "category": "devtool",
@@ -120042,7 +120112,7 @@
       }
     },
     {
-      "id": "feature-1336",
+      "id": "feature-1337",
       "query": "devtool/integration.switch.switchPage",
       "name": "Switch page",
       "category": "devtool",
@@ -120078,7 +120148,7 @@
       }
     },
     {
-      "id": "feature-1337",
+      "id": "feature-1338",
       "query": "devtool/integration.connection.usb",
       "name": "USB connection",
       "category": "devtool",
@@ -120114,7 +120184,7 @@
       }
     },
     {
-      "id": "feature-1338",
+      "id": "feature-1339",
       "query": "devtool/logbox",
       "name": "Shows logbox details",
       "category": "devtool",
@@ -120150,7 +120220,7 @@
       }
     },
     {
-      "id": "feature-1339",
+      "id": "feature-1340",
       "query": "devtool/logbox.notification",
       "name": "Notification with a brief message",
       "category": "devtool",
@@ -120186,7 +120256,7 @@
       }
     },
     {
-      "id": "feature-1340",
+      "id": "feature-1341",
       "query": "devtool/logbox.MTS Analysis",
       "name": "MTS Analysis",
       "category": "devtool",
@@ -120222,7 +120292,7 @@
       }
     },
     {
-      "id": "feature-1341",
+      "id": "feature-1342",
       "query": "devtool/logbox.BTS Analysis",
       "name": "BTS Analysis",
       "category": "devtool",
@@ -120258,7 +120328,7 @@
       }
     },
     {
-      "id": "feature-1342",
+      "id": "feature-1343",
       "query": "devtool/panels.elements.preview.reload",
       "name": "Reload",
       "category": "devtool",
@@ -120294,7 +120364,7 @@
       }
     },
     {
-      "id": "feature-1343",
+      "id": "feature-1344",
       "query": "devtool/panels.elements.preview.lynxview",
       "name": "LynxView mirroring",
       "category": "devtool",
@@ -120330,7 +120400,7 @@
       }
     },
     {
-      "id": "feature-1344",
+      "id": "feature-1345",
       "query": "devtool/panels.elements.preview.fullscreen",
       "name": "Fullscreen mirroring",
       "category": "devtool",
@@ -120366,7 +120436,7 @@
       }
     },
     {
-      "id": "feature-1345",
+      "id": "feature-1346",
       "query": "devtool/panels.elements.preview.box_model",
       "name": "Interact via the box model",
       "category": "devtool",
@@ -120402,7 +120472,7 @@
       }
     },
     {
-      "id": "feature-1346",
+      "id": "feature-1347",
       "query": "devtool/panels.elements.view-and-edit.element_tree",
       "name": "View and edit the element tree",
       "category": "devtool",
@@ -120438,7 +120508,7 @@
       }
     },
     {
-      "id": "feature-1347",
+      "id": "feature-1348",
       "query": "devtool/panels.elements.view-and-edit.hot_reload",
       "name": "View and edit CSS styles",
       "category": "devtool",
@@ -120474,7 +120544,7 @@
       }
     },
     {
-      "id": "feature-1348",
+      "id": "feature-1349",
       "query": "devtool/panels.console.print",
       "name": "View Logged messages",
       "category": "devtool",
@@ -120510,7 +120580,7 @@
       }
     },
     {
-      "id": "feature-1349",
+      "id": "feature-1350",
       "query": "devtool/panels.console.execution",
       "name": "Run JavaScript",
       "category": "devtool",
@@ -120546,7 +120616,7 @@
       }
     },
     {
-      "id": "feature-1350",
+      "id": "feature-1351",
       "query": "devtool/panels.sources.breakpoints.BTS",
       "name": "Background thread breakpoints",
       "category": "devtool",
@@ -120582,7 +120652,7 @@
       }
     },
     {
-      "id": "feature-1351",
+      "id": "feature-1352",
       "query": "devtool/panels.sources.breakpoints.MTS",
       "name": "Main thread breakpoints",
       "category": "devtool",
@@ -120618,7 +120688,7 @@
       }
     },
     {
-      "id": "feature-1352",
+      "id": "feature-1353",
       "query": "devtool/panels.sources.JSEngine.PrimJS",
       "name": "PrimJS",
       "category": "devtool",
@@ -120654,7 +120724,7 @@
       }
     },
     {
-      "id": "feature-1353",
+      "id": "feature-1354",
       "query": "devtool/panels.sources.JSEngine.V8",
       "name": "V8",
       "category": "devtool",
@@ -120690,7 +120760,7 @@
       }
     },
     {
-      "id": "feature-1354",
+      "id": "feature-1355",
       "query": "devtool/panels.layers",
       "name": "View page layers",
       "category": "devtool",
@@ -120726,7 +120796,7 @@
       }
     },
     {
-      "id": "feature-1355",
+      "id": "feature-1356",
       "query": "devtool/recorder",
       "name": "Lynx Recorder Support",
       "category": "devtool",
@@ -120762,7 +120832,7 @@
       }
     },
     {
-      "id": "feature-1356",
+      "id": "feature-1357",
       "query": "devtool/trace",
       "name": "Trace Tool",
       "category": "devtool",
@@ -120798,7 +120868,7 @@
       }
     },
     {
-      "id": "feature-1357",
+      "id": "feature-1358",
       "query": "errors/lynx-error",
       "name": "Structure used to represent an error",
       "category": "errors",

--- a/packages/lynx-compat-data/lynx-api/global/WebAssembly.json
+++ b/packages/lynx-compat-data/lynx-api/global/WebAssembly.json
@@ -18,8 +18,7 @@
               "notes": "Available on the background thread only, not on the main thread, via the PrimJS runtime. Supports common module loading and execution flows such as `new WebAssembly.Module()` and `new WebAssembly.Instance()`. The complete WebAssembly JavaScript API is not exposed; static methods such as `WebAssembly.compile()`, `WebAssembly.instantiate()`, `WebAssembly.validate()`, and the streaming variants are not supported yet."
             },
             "ios": {
-              "version_added": false,
-              "notes": "The background thread on iOS uses JavaScriptCore by default, which does not include this WebAssembly integration."
+              "version_added": null
             },
             "harmony": {
               "version_added": null

--- a/packages/lynx-compat-data/lynx-api/global/WebAssembly.json
+++ b/packages/lynx-compat-data/lynx-api/global/WebAssembly.json
@@ -1,0 +1,41 @@
+{
+  "lynx-api": {
+    "global": {
+      "WebAssembly": {
+        "__compat": {
+          "description": "<code>WebAssembly</code>",
+          "lynx_path": "guide/scripting-runtime/webassembly",
+          "mdn_url": "https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/JavaScript_interface",
+          "spec_url": "https://webassembly.github.io/spec/js-api/#webassembly-namespace",
+          "status": {
+            "deprecated": false,
+            "experimental": true
+          },
+          "support": {
+            "android": {
+              "version_added": "3.8",
+              "partial_implementation": true,
+              "notes": "Available on the background thread only, not on the main thread, via the PrimJS runtime. Supports common module loading and execution flows such as `new WebAssembly.Module()` and `new WebAssembly.Instance()`. The complete WebAssembly JavaScript API is not exposed; static methods such as `WebAssembly.compile()`, `WebAssembly.instantiate()`, `WebAssembly.validate()`, and the streaming variants are not supported yet."
+            },
+            "ios": {
+              "version_added": false,
+              "notes": "The background thread on iOS uses JavaScriptCore by default, which does not include this WebAssembly integration."
+            },
+            "harmony": {
+              "version_added": null
+            },
+            "clay_macos": {
+              "version_added": null
+            },
+            "clay_windows": {
+              "version_added": null
+            },
+            "web_lynx": {
+              "version_added": null
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Summary

WebAssembly support currently exists in the docs only as a `<VersionBadge v={3.8} />` and prose on the [WebAssembly guide page](https://lynxjs.org/guide/scripting-runtime/webassembly.html). This PR turns it into structured Lynx Compatibility Data so it can be rendered through `APISummary`/`APITable` and picked up by downstream consumers of `@lynx-js/lynx-compat-data`.

## Changes

**`docs(compat-data): add WebAssembly compat data`**

- Adds `packages/lynx-compat-data/lynx-api/global/WebAssembly.json` with a single `lynx-api.global.WebAssembly` entry (`lynx_path: guide/scripting-runtime/webassembly`).
- Regenerates `api-stats.json` via `pnpm run gen-stats` (the large diff is mostly feature-id renumbering, same as previous data PRs).

**`docs(guide): render WebAssembly compat table from LCD`**

- Adds a "Compatibility" section with `<APITable query="lynx-api/global/WebAssembly" />` as the final section of the en/zh WebAssembly guide pages, matching the heading and placement used by other guide pages (devtool, trace, recorder).

## Data and sources

Every statement is sourced from documentation in this repository; nothing is inferred:

| Platform | Value | Basis |
| --- | --- | --- |
| `android` | `"3.8"` + `partial_implementation: true` | [guide/scripting-runtime/webassembly](https://lynxjs.org/guide/scripting-runtime/webassembly.html): basic support since Lynx 3.8 via PrimJS, background thread only, and "the complete WebAssembly JavaScript API is not available yet" (no `compile`/`instantiate`/`validate`/streaming variants) — captured in `notes` per the schema requirement for partial implementations. |
| `ios` | `null` (unknown) | The 3.8 integration is Android-only, but that alone does not prove the `WebAssembly` global is absent from Lynx's default iOS background JavaScriptCore context (JSC ships its own WebAssembly implementation), so iOS stays unknown until verified against the runtime. |
| `harmony`, `clay_macos`, `clay_windows` | `null` (unknown) | No documented basis in this repository. |
| `web_lynx` | `null` (unknown) | The background thread on Web runs in a real browser worker, so the native `WebAssembly` global is plausibly reachable — but I could not find a documented or audited basis in this repo (the web_lynx audit trail in #1279 covers other APIs), so I left it unknown rather than claiming support. Happy to flip it to `true` with a note if a maintainer can confirm the web-core sandbox exposes it. |

`status.experimental: true` follows the schema guidance for recently shipped features (3.8, 2026-05).

## Verification

- `pnpm --filter @lynx-js/lynx-compat-data run lint` (schema validation) ✅
- `pnpm --filter @lynx-js/lynx-compat-data run lint:keys` ✅
- `pnpm --filter @lynx-js/lynx-compat-data run test` ✅
- `pnpm run format:check` ✅
- `pnpm run build` ✅
