### PR TITLE
fix(compat-data): flip web_lynx to true for already-implemented APIs

### DIFF
--- a/packages/lynx-compat-data/api-stats.json
+++ b/packages/lynx-compat-data/api-stats.json
@@ -261,7 +261,7 @@
           "android": 45,
           "ios": 45,
           "harmony": 40,
-          "web_lynx": 20,
+          "web_lynx": 23,
           "clay_android": 1,
           "clay_ios": 1,
           "clay_macos": 45,
@@ -272,7 +272,7 @@
           "android": 100,
           "ios": 100,
           "harmony": 89,
-          "web_lynx": 44,
+          "web_lynx": 51,
           "clay_android": 2,
           "clay_ios": 2,
           "clay_macos": 100,
@@ -369,7 +369,7 @@
           "android": 11,
           "ios": 11,
           "harmony": 11,
-          "web_lynx": 0,
+          "web_lynx": 11,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 11,
@@ -380,7 +380,7 @@
           "android": 100,
           "ios": 100,
           "harmony": 100,
-          "web_lynx": 0,
+          "web_lynx": 100,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 100,
@@ -633,8 +633,8 @@
         "exclusive_count": 7
       },
       "web_lynx": {
-        "supported_count": 742,
-        "coverage_percent": 65,
+        "supported_count": 756,
+        "coverage_percent": 67,
         "exclusive_count": 30
       },
       "clay_android": {
@@ -48739,7 +48739,7 @@
           "android": 45,
           "ios": 45,
           "harmony": 40,
-          "web_lynx": 20,
+          "web_lynx": 23,
           "clay_android": 1,
           "clay_ios": 1,
           "clay_macos": 45,
@@ -48750,7 +48750,7 @@
           "android": 100,
           "ios": 100,
           "harmony": 89,
-          "web_lynx": 44,
+          "web_lynx": 51,
           "clay_android": 2,
           "clay_ios": 2,
           "clay_macos": 100,
@@ -48921,7 +48921,7 @@
             "android": "1.5",
             "ios": "1.5",
             "harmony": "3.4",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": "3.5",
             "clay_ios": "3.5",
             "clay_macos": "3.5",
@@ -49321,7 +49321,7 @@
             "android": "2.7",
             "ios": "2.7",
             "harmony": "3.4",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -49353,7 +49353,7 @@
             "android": "2.3",
             "ios": "2.3",
             "harmony": "3.4",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -49705,22 +49705,6 @@
             }
           },
           {
-            "path": "lynx-api/lynx/createIntersectionObserver",
-            "name": "Create an IntersectionObserver object.",
-            "doc_url": "api/lynx-api/lynx/lynx-create-intersection-observer",
-            "support": {
-              "android": "1.5",
-              "ios": "1.5",
-              "harmony": "3.4",
-              "web_lynx": false,
-              "clay_android": "3.5",
-              "clay_ios": "3.5",
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
             "path": "lynx-api/lynx/getElementById",
             "name": "Used to import modules.",
             "doc_url": "api/lynx-api/lynx/lynx-get-element-by-id",
@@ -49897,44 +49881,12 @@
             }
           },
           {
-            "path": "lynx-api/lynx/reload",
-            "name": "Reloads the current page, like the Refresh button.",
-            "doc_url": "api/lynx-api/lynx/lynx-reload",
-            "support": {
-              "android": "2.7",
-              "ios": "2.7",
-              "harmony": "3.4",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
             "path": "lynx-api/lynx/removeSharedDataObserver",
             "name": "取消使用 `lynx.registerSharedDataObserver()` 进行的监听。",
             "doc_url": "api/lynx-api/lynx/lynx-remove-shared-data-observer",
             "support": {
               "android": "1.6",
               "ios": "1.6",
-              "harmony": "3.4",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
-            "path": "lynx-api/lynx/reportError",
-            "name": "Used to report a JavaScript Error.",
-            "doc_url": "api/lynx-api/lynx/lynx-report-error",
-            "support": {
-              "android": "2.3",
-              "ios": "2.3",
               "harmony": "3.4",
               "web_lynx": false,
               "clay_android": false,
@@ -50514,7 +50466,7 @@
               "android": "2.7",
               "ios": "2.7",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -50546,7 +50498,7 @@
               "android": "2.3",
               "ios": "2.3",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -51220,7 +51172,7 @@
               "android": "2.7",
               "ios": "2.7",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -51252,7 +51204,7 @@
               "android": "2.3",
               "ios": "2.3",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -52771,7 +52723,7 @@
           "android": 11,
           "ios": 11,
           "harmony": 11,
-          "web_lynx": 0,
+          "web_lynx": 11,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 11,
@@ -52782,7 +52734,7 @@
           "android": 100,
           "ios": 100,
           "harmony": 100,
-          "web_lynx": 0,
+          "web_lynx": 100,
           "clay_android": 0,
           "clay_ios": 0,
           "clay_macos": 100,
@@ -52823,7 +52775,7 @@
             "android": "1.5",
             "ios": "1.5",
             "harmony": "3.4",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -52839,7 +52791,7 @@
             "android": "1.5",
             "ios": "1.5",
             "harmony": "3.4",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -52855,7 +52807,7 @@
             "android": "1.5",
             "ios": "1.5",
             "harmony": "3.4",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -52871,7 +52823,7 @@
             "android": "2.10",
             "ios": "2.10",
             "harmony": "3.4",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -52887,7 +52839,7 @@
             "android": "1.5",
             "ios": "1.5",
             "harmony": "3.4",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -52903,7 +52855,7 @@
             "android": "1.5",
             "ios": "1.5",
             "harmony": "3.4",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -52919,7 +52871,7 @@
             "android": "1.5",
             "ios": "1.5",
             "harmony": "3.4",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -52935,7 +52887,7 @@
             "android": "1.5",
             "ios": "1.5",
             "harmony": "3.4",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -52951,7 +52903,7 @@
             "android": "1.5",
             "ios": "1.5",
             "harmony": "3.4",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -52967,7 +52919,7 @@
             "android": "2.10",
             "ios": "2.10",
             "harmony": "3.4",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -52983,7 +52935,7 @@
             "android": "1.5",
             "ios": "1.5",
             "harmony": "3.4",
-            "web_lynx": false,
+            "web_lynx": true,
             "clay_android": false,
             "clay_ios": false,
             "clay_macos": "3.5",
@@ -52996,184 +52948,7 @@
         "android": [],
         "ios": [],
         "harmony": [],
-        "web_lynx": [
-          {
-            "path": "lynx-api/intersection-observer/IntersectionObserver",
-            "name": "Observe the intersection status between the target node and the reference node and the target node and the ancestor node. When the intersection status changes, the corresponding callback is triggered. Based on this, you can monitor whether the target node is exposed/de-exposed.",
-            "doc_url": "api/lynx-api/intersection-observer/intersection-observer",
-            "support": {
-              "android": "1.5",
-              "ios": "1.5",
-              "harmony": "3.4",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
-            "path": "lynx-api/intersection-observer/IntersectionObserver.relativeTo",
-            "name": "Specify a reference node. The reference node is specified by id.",
-            "doc_url": "api/lynx-api/intersection-observer/relative-to",
-            "support": {
-              "android": "1.5",
-              "ios": "1.5",
-              "harmony": "3.4",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
-            "path": "lynx-api/intersection-observer/IntersectionObserver.relativeToViewport",
-            "name": "Specify a LynxView as a reference node.",
-            "doc_url": "api/lynx-api/intersection-observer/relative-to-viewport",
-            "support": {
-              "android": "1.5",
-              "ios": "1.5",
-              "harmony": "3.4",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
-            "path": "lynx-api/intersection-observer/IntersectionObserver.relativeToScreen",
-            "name": "Specify the screen as the reference node.",
-            "doc_url": "api/lynx-api/intersection-observer/relative-to-screen",
-            "support": {
-              "android": "2.10",
-              "ios": "2.10",
-              "harmony": "3.4",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
-            "path": "lynx-api/intersection-observer/IntersectionObserver.observe",
-            "name": "Specify the target node and callback, and the target node is specified according to id.",
-            "doc_url": "api/lynx-api/intersection-observer/observe",
-            "support": {
-              "android": "1.5",
-              "ios": "1.5",
-              "harmony": "3.4",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
-            "path": "lynx-api/intersection-observer/IntersectionObserver.disconnect",
-            "name": "Clear the target node and callback. The target node will no longer be observed and the corresponding callback will not be triggered.",
-            "doc_url": "api/lynx-api/intersection-observer/disconnect",
-            "support": {
-              "android": "1.5",
-              "ios": "1.5",
-              "harmony": "3.4",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
-            "path": "lynx-api/intersection-observer/disconnect",
-            "name": "Clear the target node and callback. The target node will no longer be observed and the corresponding callback will not be triggered.",
-            "doc_url": "api/lynx-api/intersection-observer/disconnect",
-            "support": {
-              "android": "1.5",
-              "ios": "1.5",
-              "harmony": "3.4",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
-            "path": "lynx-api/intersection-observer/observe",
-            "name": "Specify the target node and callback, and the target node is specified according to id.",
-            "doc_url": "api/lynx-api/intersection-observer/observe",
-            "support": {
-              "android": "1.5",
-              "ios": "1.5",
-              "harmony": "3.4",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
-            "path": "lynx-api/intersection-observer/relativeTo",
-            "name": "Specify a reference node. The reference node is specified by id.",
-            "doc_url": "api/lynx-api/intersection-observer/relative-to",
-            "support": {
-              "android": "1.5",
-              "ios": "1.5",
-              "harmony": "3.4",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
-            "path": "lynx-api/intersection-observer/relativeToScreen",
-            "name": "Specify the screen as the reference node.",
-            "doc_url": "api/lynx-api/intersection-observer/relative-to-screen",
-            "support": {
-              "android": "2.10",
-              "ios": "2.10",
-              "harmony": "3.4",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          },
-          {
-            "path": "lynx-api/intersection-observer/relativeToViewport",
-            "name": "Specify a LynxView as a reference node.",
-            "doc_url": "api/lynx-api/intersection-observer/relative-to-viewport",
-            "support": {
-              "android": "1.5",
-              "ios": "1.5",
-              "harmony": "3.4",
-              "web_lynx": false,
-              "clay_android": false,
-              "clay_ios": false,
-              "clay_macos": "3.5",
-              "clay_windows": "3.5",
-              "clay": "3.5"
-            }
-          }
-        ],
+        "web_lynx": [],
         "clay_android": [
           {
             "path": "lynx-api/intersection-observer/IntersectionObserver",
@@ -53183,7 +52958,7 @@
               "android": "1.5",
               "ios": "1.5",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -53199,7 +52974,7 @@
               "android": "1.5",
               "ios": "1.5",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -53215,7 +52990,7 @@
               "android": "1.5",
               "ios": "1.5",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -53231,7 +53006,7 @@
               "android": "2.10",
               "ios": "2.10",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -53247,7 +53022,7 @@
               "android": "1.5",
               "ios": "1.5",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -53263,7 +53038,7 @@
               "android": "1.5",
               "ios": "1.5",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -53279,7 +53054,7 @@
               "android": "1.5",
               "ios": "1.5",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -53295,7 +53070,7 @@
               "android": "1.5",
               "ios": "1.5",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -53311,7 +53086,7 @@
               "android": "1.5",
               "ios": "1.5",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -53327,7 +53102,7 @@
               "android": "2.10",
               "ios": "2.10",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -53343,7 +53118,7 @@
               "android": "1.5",
               "ios": "1.5",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -53361,7 +53136,7 @@
               "android": "1.5",
               "ios": "1.5",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -53377,7 +53152,7 @@
               "android": "1.5",
               "ios": "1.5",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -53393,7 +53168,7 @@
               "android": "1.5",
               "ios": "1.5",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -53409,7 +53184,7 @@
               "android": "2.10",
               "ios": "2.10",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -53425,7 +53200,7 @@
               "android": "1.5",
               "ios": "1.5",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -53441,7 +53216,7 @@
               "android": "1.5",
               "ios": "1.5",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -53457,7 +53232,7 @@
               "android": "1.5",
               "ios": "1.5",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -53473,7 +53248,7 @@
               "android": "1.5",
               "ios": "1.5",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -53489,7 +53264,7 @@
               "android": "1.5",
               "ios": "1.5",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -53505,7 +53280,7 @@
               "android": "2.10",
               "ios": "2.10",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -53521,7 +53296,7 @@
               "android": "1.5",
               "ios": "1.5",
               "harmony": "3.4",
-              "web_lynx": false,
+              "web_lynx": true,
               "clay_android": false,
               "clay_ios": false,
               "clay_macos": "3.5",
@@ -109762,7 +109537,7 @@
           "version_added": "3.4"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": "3.5"
@@ -110662,7 +110437,7 @@
           "version_added": "3.4"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -110734,7 +110509,7 @@
           "version_added": "3.4"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -112030,7 +111805,7 @@
           "version_added": "3.4"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -112066,7 +111841,7 @@
           "version_added": "3.4"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -112102,7 +111877,7 @@
           "version_added": "3.4"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -112138,7 +111913,7 @@
           "version_added": "3.4"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -112174,7 +111949,7 @@
           "version_added": "3.4"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -112210,7 +111985,7 @@
           "version_added": "3.4"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -112246,7 +112021,7 @@
           "version_added": "3.4"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -112282,7 +112057,7 @@
           "version_added": "3.4"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -112318,7 +112093,7 @@
           "version_added": "3.4"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -112354,7 +112129,7 @@
           "version_added": "3.4"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -112390,7 +112165,7 @@
           "version_added": "3.4"
         },
         "web_lynx": {
-          "version_added": false
+          "version_added": true
         },
         "clay_android": {
           "version_added": false
@@ -120852,8 +120627,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 722,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 222,
@@ -120894,8 +120669,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 722,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 234,
@@ -120936,8 +120711,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 722,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 385,
@@ -120978,8 +120753,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 722,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 391,
@@ -121020,8 +120795,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 722,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 403,
@@ -121062,8 +120837,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 722,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 454,
@@ -121104,8 +120879,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 722,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 466,
@@ -121146,8 +120921,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 722,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 466,
@@ -121188,8 +120963,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 722,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 466,
@@ -121230,8 +121005,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 722,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 466,
@@ -121272,8 +121047,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 722,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 467,
@@ -121314,8 +121089,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 722,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 469,
@@ -121356,8 +121131,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 722,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 469,
@@ -121398,8 +121173,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 722,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 469,
@@ -121440,8 +121215,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 722,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 469,
@@ -121482,8 +121257,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 722,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 469,
@@ -121524,8 +121299,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 722,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 470,
@@ -121566,8 +121341,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 722,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 470,
@@ -121608,8 +121383,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 722,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 490,
@@ -121650,8 +121425,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 722,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 490,
@@ -121692,8 +121467,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 722,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 496,
@@ -121734,8 +121509,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 722,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 496,
@@ -121776,8 +121551,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 722,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 507,
@@ -121818,8 +121593,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 722,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 511,
@@ -121860,8 +121635,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 722,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 511,
@@ -121902,8 +121677,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 722,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 516,
@@ -121944,8 +121719,8 @@
           "coverage": 0
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 722,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 516,
@@ -121986,8 +121761,8 @@
           "coverage": 59
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 722,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 544,
@@ -122028,8 +121803,8 @@
           "coverage": 65
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 722,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 561,
@@ -122070,8 +121845,8 @@
           "coverage": 67
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 722,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 568,
@@ -122112,8 +121887,8 @@
           "coverage": 70
         },
         "web_lynx": {
-          "supported": 708,
-          "coverage": 62
+          "supported": 722,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 576,
@@ -122154,8 +121929,8 @@
           "coverage": 72
         },
         "web_lynx": {
-          "supported": 716,
-          "coverage": 63
+          "supported": 730,
+          "coverage": 64
         },
         "clay_android": {
           "supported": 576,
@@ -122196,8 +121971,8 @@
           "coverage": 74
         },
         "web_lynx": {
-          "supported": 736,
-          "coverage": 65
+          "supported": 750,
+          "coverage": 66
         },
         "clay_android": {
           "supported": 598,
@@ -122238,8 +122013,8 @@
           "coverage": 75
         },
         "web_lynx": {
-          "supported": 736,
-          "coverage": 65
+          "supported": 750,
+          "coverage": 66
         },
         "clay_android": {
           "supported": 625,

--- a/packages/lynx-compat-data/lynx-api/intersection-observer/IntersectionObserver.json
+++ b/packages/lynx-compat-data/lynx-api/intersection-observer/IntersectionObserver.json
@@ -22,7 +22,8 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented since `@lynx-js/web-core@0.25.0` (lynx-family/lynx-stack#3383)."
             }
           }
         },
@@ -47,7 +48,8 @@
                 "version_added": "3.5"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": true,
+                "notes": "Implemented since `@lynx-js/web-core@0.25.0` (lynx-family/lynx-stack#3383)."
               }
             }
           }
@@ -73,7 +75,8 @@
                 "version_added": "3.5"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": true,
+                "notes": "Implemented since `@lynx-js/web-core@0.25.0` (lynx-family/lynx-stack#3383)."
               }
             }
           }
@@ -99,7 +102,8 @@
                 "version_added": "3.5"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": true,
+                "notes": "Implemented since `@lynx-js/web-core@0.25.0` (lynx-family/lynx-stack#3383)."
               }
             }
           }
@@ -125,7 +129,8 @@
                 "version_added": "3.5"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": true,
+                "notes": "Implemented since `@lynx-js/web-core@0.25.0` (lynx-family/lynx-stack#3383)."
               }
             }
           }
@@ -151,7 +156,8 @@
                 "version_added": "3.5"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": true,
+                "notes": "Implemented since `@lynx-js/web-core@0.25.0` (lynx-family/lynx-stack#3383)."
               }
             }
           }

--- a/packages/lynx-compat-data/lynx-api/intersection-observer/disconnect.json
+++ b/packages/lynx-compat-data/lynx-api/intersection-observer/disconnect.json
@@ -22,7 +22,8 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented since `@lynx-js/web-core@0.25.0` (lynx-family/lynx-stack#3383)."
             }
           }
         }

--- a/packages/lynx-compat-data/lynx-api/intersection-observer/observe.json
+++ b/packages/lynx-compat-data/lynx-api/intersection-observer/observe.json
@@ -22,7 +22,8 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented since `@lynx-js/web-core@0.25.0` (lynx-family/lynx-stack#3383)."
             }
           }
         }

--- a/packages/lynx-compat-data/lynx-api/intersection-observer/relativeTo.json
+++ b/packages/lynx-compat-data/lynx-api/intersection-observer/relativeTo.json
@@ -22,7 +22,8 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented since `@lynx-js/web-core@0.25.0` (lynx-family/lynx-stack#3383)."
             }
           }
         }

--- a/packages/lynx-compat-data/lynx-api/intersection-observer/relativeToScreen.json
+++ b/packages/lynx-compat-data/lynx-api/intersection-observer/relativeToScreen.json
@@ -22,7 +22,8 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented since `@lynx-js/web-core@0.25.0` (lynx-family/lynx-stack#3383)."
             }
           }
         }

--- a/packages/lynx-compat-data/lynx-api/intersection-observer/relativeToViewport.json
+++ b/packages/lynx-compat-data/lynx-api/intersection-observer/relativeToViewport.json
@@ -22,7 +22,8 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented since `@lynx-js/web-core@0.25.0` (lynx-family/lynx-stack#3383)."
             }
           }
         }

--- a/packages/lynx-compat-data/lynx-api/lynx/createIntersectionObserver.json
+++ b/packages/lynx-compat-data/lynx-api/lynx/createIntersectionObserver.json
@@ -28,7 +28,8 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented since `@lynx-js/web-core@0.25.0` (lynx-family/lynx-stack#3383)."
             }
           }
         }

--- a/packages/lynx-compat-data/lynx-api/lynx/reload.json
+++ b/packages/lynx-compat-data/lynx-api/lynx/reload.json
@@ -33,7 +33,9 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Reloads the `<lynx-view>` (`LynxView.reload()` re-renders the card), but the `value` (new init data) and `callback` parameters are both ignored — the card reloads with whatever `initData`/attributes are already on the element, and no completion callback is invoked. Implemented since `@lynx-js/web-core@0.19.6` (lynx-family/lynx-stack#2127)."
             }
           }
         }

--- a/packages/lynx-compat-data/lynx-api/lynx/reportError.json
+++ b/packages/lynx-compat-data/lynx-api/lynx/reportError.json
@@ -22,7 +22,9 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Reports the error via a `error` `CustomEvent` dispatched on `<lynx-view>` (`LynxViewInstance.reportError`, `web-core/ts/client/mainthread/LynxViewInstance.ts`), matching the string/`Error` normalization other platforms use. The `options.level` parameter (`warning`/`error`/`fatal`) is accepted but dropped on the wire (`reportErrorEndpoint` only forwards `[error, release, fileName]`), so a `fatal` report does not interrupt the execution environment on web the way it does on native. Implemented since `@lynx-js/web-core@0.14.1` (lynx-family/lynx-stack#1059)."
             }
           }
         }


### PR DESCRIPTION
Reverse-drift fixes found by the weekly Web Platform gap audit (see `.claude` scheduled task) — these are all implemented in `lynx-family/lynx-stack`'s `web-core`, but `lynx-compat-data` still marked `web_lynx` as unsupported.

## What changed

- **`lynx.createIntersectionObserver()`** and the whole `IntersectionObserver` surface (`relativeTo`, `relativeToViewport`, `relativeToScreen`, `observe`, `disconnect`) → `version_added: true`.
  Fully implemented and E2E-tested since `@lynx-js/web-core@0.25.0` ([lynx-family/lynx-stack#3383](https://github.com/lynx-family/lynx-stack/pull/3383), merged this week). `createIntersectionObserverModule.ts` wires all five methods through `IntersectionObserverService` on the main thread, and `web-core-e2e/tests/web-core.test.ts` exercises `lynx.createIntersectionObserver` observing real web elements with threshold semantics.
  - `packages/lynx-compat-data/lynx-api/lynx/createIntersectionObserver.json`
  - `packages/lynx-compat-data/lynx-api/intersection-observer/*.json`

- **`lynx.reportError()`** → `version_added: true`, `partial_implementation: true`.
  Implemented since `@lynx-js/web-core@0.14.1` ([lynx-family/lynx-stack#1059](https://github.com/lynx-family/lynx-stack/pull/1059)) via `LynxViewInstance.reportError`, which dispatches an `error` `CustomEvent` on `<lynx-view>` and is covered by an E2E test (`api-report-error`). Marked partial: `options.level` (`warning`/`error`/`fatal`) is accepted at the call site but dropped on the wire (`reportErrorEndpoint` only forwards `[error, release, fileName]`), so a `fatal` report does not interrupt the execution environment on web the way it does on native.

- **`lynx.reload()`** → `version_added: true`, `partial_implementation: true`.
  Implemented since `@lynx-js/web-core@0.19.6` ([lynx-family/lynx-stack#2127](https://github.com/lynx-family/lynx-stack/pull/2127)) via `LynxView.reload()`, covered by an E2E test (`basic-lynx-reload`). Marked partial: the `value` (new init data) and `callback` parameters are both ignored — the card reloads with whatever `initData`/attributes are already on the `<lynx-view>` element.

## Validation

- `pnpm --filter @lynx-js/lynx-compat-data run lint` — passes
- `pnpm --filter @lynx-js/lynx-compat-data run gen-stats` — regenerated `api-stats.json` (web_lynx coverage in the `lynx-api/lynx` category: 20 → 23; `lynx-api/intersection-observer`: 0% → 100%)

## Compat-data / doc references

- [`lynx-api/lynx/lynx-create-intersection-observer`](https://lynxjs.org/api/lynx-api/lynx/lynx-create-intersection-observer)
- [`lynx-api/intersection-observer`](https://lynxjs.org/api/lynx-api/intersection-observer)
- [`lynx-api/lynx/lynx-report-error`](https://lynxjs.org/api/lynx-api/lynx/lynx-report-error)
- [`lynx-api/lynx/lynx-reload`](https://lynxjs.org/api/lynx-api/lynx/lynx-reload)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01JQ8rqE8dQJb3ZTU9uzWviw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Mark `IntersectionObserver` APIs as supported on `web_lynx`.
- Mark `lynx.createIntersectionObserver()` as supported on `web_lynx`.
- Mark `lynx.reportError()` and `lynx.reload()` as partially implemented on `web_lynx`.
- Regenerate API statistics and update Web Lynx coverage data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->