### PR TITLE
fix(blog): correct the truncated dependency version in the 3.2 post

### DIFF
--- a/docs/en/blog/lynx-3-2.mdx
+++ b/docs/en/blog/lynx-3-2.mdx
@@ -259,7 +259,7 @@ dependencies {
     implementation("org.lynxsdk.lynx:primjs:2.12.0")
 
     // integrating image-service
-    implementation("org.lynxsdk.lynx:lynx-service-image:3.2.0-")
+    implementation("org.lynxsdk.lynx:lynx-service-image:3.2.0")
 
     // image-service dependencies, if not added, images cannot be loaded; if the host APP needs to use other image libraries, you can customize the image-service and remove this dependency
     implementation("com.facebook.fresco:fresco:2.3.0")

--- a/docs/zh/blog/lynx-3-2.mdx
+++ b/docs/zh/blog/lynx-3-2.mdx
@@ -259,7 +259,7 @@ dependencies {
     implementation("org.lynxsdk.lynx:primjs:2.12.0")
 
     // integrating image-service
-    implementation("org.lynxsdk.lynx:lynx-service-image:3.2.0-")
+    implementation("org.lynxsdk.lynx:lynx-service-image:3.2.0")
 
     // image-service dependencies, if not added, images cannot be loaded; if the host APP needs to use other image libraries, you can customize the image-service and remove this dependency
     implementation("com.facebook.fresco:fresco:2.3.0")


### PR DESCRIPTION
Backport of the Lynx 3.2 blog post typo fix, so the historical post stays
aligned across the versioned site.

The Kotlin DSL tab of `docs/{en,zh}/blog/lynx-3-2.mdx` pins

```kotlin
implementation("org.lynxsdk.lynx:lynx-service-image:3.2.0-")
```

The trailing `-` makes it an unresolvable version. The Groovy tab twelve lines
above already says `3.2.0`, so the intent is unambiguous.

The same line is being corrected on `main` (#1332), `release/4.0` (#1333),
`release/3.9` (#1334) and `release/3.7` (#1335). `release/3.8` carries it too
and is queued behind a token-permission issue on the fork, not a content one.
