### PR TITLE
fix(docs): configure DevTool before LynxEnv initialization

### DIFF
--- a/docs/en/guide/start/integrate-lynx-devtool.mdx
+++ b/docs/en/guide/start/integrate-lynx-devtool.mdx
@@ -64,7 +64,8 @@ You can configure these switches during [Lynx Environment Initialization](/guide
 <Tabs groupId='integrating-lynx-with-existing-app-ios'>
 <Tab label="Objective-C">
 
-```objective-c title=AppDelegate.m {9-18}
+```objective-c title=AppDelegate.m {10-19}
+#import <Lynx/DevToolSettings.h>
 #import <Lynx/LynxEnv.h>
 #import <Lynx/LynxService.h>
 #import <Lynx/LynxServiceDevToolProtocol.h>
@@ -73,11 +74,11 @@ You can configure these switches during [Lynx Environment Initialization](/guide
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   // ...
+  // set devtool bootstrap defaults
+  [[DevToolSettings sharedInstance].bootstrap applyDevelopmentDefaultsIfUnset];
   LynxEnv *lynxEnv = [LynxEnv sharedInstance];
   // Enable all sessions debugging for DevTool (required for Lynx DevTool Desktop connection)
   [LynxService(LynxServiceDevToolProtocol) enableAllSessions];
-  // set devtool bootstrap defaults
-  [[DevToolSettings sharedInstance].bootstrap applyDevelopmentDefaultsIfUnset];
   // Enable Lynx DevTool Switch
   lynxEnv.devtoolEnabled = YES;
   // Enable Lynx LogBox Switch
@@ -90,6 +91,7 @@ You can configure these switches during [Lynx Environment Initialization](/guide
 <Tab label="Swift">
 
 ```objective-c title="YourTarget-Bridging-Header.h"
+#import <Lynx/DevToolSettings.h>
 #import <Lynx/LynxEnv.h>
 #import <Lynx/LynxService.h>
 #import <Lynx/LynxServiceDevToolProtocol.h>
@@ -100,11 +102,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     // ...
+    // set devtool bootstrap defaults
+    DevToolSettings.sharedInstance().bootstrap.applyDevelopmentDefaultsIfUnset()
     let lynxEnv = LynxEnv.sharedInstance()
     // Enable all sessions debugging for DevTool (required for Lynx DevTool Desktop connection)
     (LynxServices.getInstanceWith(LynxServiceDevToolProtocol.self, bizID: DEFAULT_LYNX_SERVICE) as? LynxServiceDevToolProtocol)?.enableAllSessions()
-    // set devtool bootstrap defaults
-    DevToolSettings.sharedInstance().bootstrap.applyDevelopmentDefaultsIfUnset()
     // Enable Lynx DevTool Switch
     lynxEnv.devtoolEnabled = true
     // Enable Lynx LogBox Switch

--- a/docs/zh/guide/start/integrate-lynx-devtool.mdx
+++ b/docs/zh/guide/start/integrate-lynx-devtool.mdx
@@ -63,7 +63,8 @@ DevTool 提供了一些调试功能开关，
 <Tabs groupId='integrating-lynx-with-existing-app-ios'>
 <Tab label="Objective-C">
 
-```objective-c title=AppDelegate.m {9-18}
+```objective-c title=AppDelegate.m {10-19}
+#import <Lynx/DevToolSettings.h>
 #import <Lynx/LynxEnv.h>
 #import <Lynx/LynxService.h>
 #import <Lynx/LynxServiceDevToolProtocol.h>
@@ -72,11 +73,11 @@ DevTool 提供了一些调试功能开关，
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   // ...
+  // 设置 DevTool 启动配置的默认值
+  [[DevToolSettings sharedInstance].bootstrap applyDevelopmentDefaultsIfUnset];
   LynxEnv *lynxEnv = [LynxEnv sharedInstance];
   // 允许 DevTool 调试所有 Lynx 页面（连接 Lynx DevTool 桌面应用必需）
   [LynxService(LynxServiceDevToolProtocol) enableAllSessions];
-  // 设置 DevTool 启动配置的默认值
-  [[DevToolSettings sharedInstance].bootstrap applyDevelopmentDefaultsIfUnset];
   // 打开 Lynx DevTool 开关
   lynxEnv.devtoolEnabled = YES;
   // 打开 Lynx LogBox 开关
@@ -89,6 +90,7 @@ DevTool 提供了一些调试功能开关，
 <Tab label="Swift">
 
 ```objective-c title="YourTarget-Bridging-Header.h"
+#import <Lynx/DevToolSettings.h>
 #import <Lynx/LynxEnv.h>
 #import <Lynx/LynxService.h>
 #import <Lynx/LynxServiceDevToolProtocol.h>
@@ -99,11 +101,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     // ...
+    // 设置 DevTool 启动配置的默认值
+    DevToolSettings.sharedInstance().bootstrap.applyDevelopmentDefaultsIfUnset()
     let lynxEnv = LynxEnv.sharedInstance()
     // 允许 DevTool 调试所有 Lynx 页面（连接 DevTool 桌面应用必需）
     (LynxServices.getInstanceWith(LynxServiceDevToolProtocol.self, bizID: DEFAULT_LYNX_SERVICE) as? LynxServiceDevToolProtocol)?.enableAllSessions()
-    // 设置 DevTool 启动配置的默认值
-    DevToolSettings.sharedInstance().bootstrap.applyDevelopmentDefaultsIfUnset()
     // 打开 Lynx DevTool 开关
     lynxEnv.devtoolEnabled = true
     // 打开 Lynx LogBox 开关


### PR DESCRIPTION
## Summary

Follow up on #1134 to make the iOS DevTool bootstrap examples compile and apply their defaults at the required time.

- import `<Lynx/DevToolSettings.h>` in the Objective-C example and Swift bridging header
- call `applyDevelopmentDefaultsIfUnset` before the first `LynxEnv.sharedInstance` access
- keep the highlighted code ranges aligned with the updated snippets

`LynxEnv.sharedInstance` initializes the DevTool lifecycle, which reads the bootstrap values during initialization, so applying them afterward is too late.

## Validation

- `python3 -m scripts.check_api_doc.index` (1725 files, no issues)
- Prettier check on both changed files
- `git diff --check`

Signed-off-by: Xuan Huang (黄玄) <5563315+Huxpro@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Update iOS DevTool examples in English and Chinese documentation.
- Import `DevToolSettings` in Objective-C and Swift examples.
- Apply development defaults before `LynxEnv` initialization.
- Align highlighted code ranges with the updated snippets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->