### PR TITLE
fix(docs): repair dead links

### DIFF
--- a/docs/en/guide/styling/appearance.mdx
+++ b/docs/en/guide/styling/appearance.mdx
@@ -33,7 +33,7 @@ With Lynx CSS, you can apply color values to various properties to create the lo
 #### Text
 
 - [`color`](/api/css/properties/color): The color to use when drawing the text.
-- [`-x-handle-color`](): The color of selection handlers (the cursor on the two ends of the selected text) when text is selected.
+- [`-x-handle-color`](/api/css/properties/-x-handle-color): The color of selection handlers (the cursor on the two ends of the selected text) when text is selected.
 - [`text-shadow`](/api/css/properties/text-shadow): The color of the shadow in the shape of text.
 - [`text-decoration-color`](/api/css/properties/text-decoration#text-decoration-color): The color to use when drawing the decoration line on the text.
 
@@ -41,7 +41,7 @@ With Lynx CSS, you can apply color values to various properties to create the lo
 
 - [`background-color`](/api/css/properties/background-color): The background color of the element.
 - [`box-shadow`](/api/css/properties/box-shadow): The color of shadow.
-- [`border-color`](/api/css/properties/border-color): The color to use when drawing the border. Can be set separately for the foursides via [`border-top-color`](/api/css/properties/border-color), [`border-top-color`](/api/css/properties/border-color), [`border-top-color`](/api/css/properties/border-color) or [`border-top-color`](/api/css/properties/border-color) as well.
+- [`border-color`](/api/css/properties/border-color): The color to use when drawing the border. Can be set separately for the four sides via [`border-top-color`](/api/css/properties/border-top-color), [`border-right-color`](/api/css/properties/border-right-color), [`border-bottom-color`](/api/css/properties/border-bottom-color), or [`border-left-color`](/api/css/properties/border-left-color) as well.
 
 Colors can be set to the property via [`selectors`](/api/css/selectors) or the `style` property of the element directly.
 The color value should be a hex number start with a '#', or a value calculated by function `rgb()`, `rgba()` or `hsl()`. View the specification for [`<color>`](/api/css/data-type/color) value for more details.

--- a/docs/zh/api/css/properties/mask.mdx
+++ b/docs/zh/api/css/properties/mask.mdx
@@ -74,7 +74,7 @@ mask:
 
 #### `<geometry-box>`
 
-如果只有一个 `<geometry-box>` 值被赋予，他将会设置 [mask-origin](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-origin) and [mask-clip](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-clip). 如果两个 `<geometry-box>` 值显示，第一个值代表 `mask-origin`, 第二个值代表 `mask-clip`.
+如果只有一个 `<geometry-box>` 值被赋予，它将会设置 [mask-origin](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-origin) 和 [mask-clip](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-clip)。如果两个 `<geometry-box>` 值显示，第一个值代表 [mask-origin](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-origin)，第二个值代表 [mask-clip](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-clip)。
 
 #### `<geometry-box> | no-clip`
 

--- a/docs/zh/guide/styling/appearance.mdx
+++ b/docs/zh/guide/styling/appearance.mdx
@@ -33,7 +33,7 @@ import { Go } from '@lynx';
 #### 文本
 
 - [`color`](/api/css/properties/color)：修改用于绘制文本的颜色。
-- [`-x-handle-color`]()：用于调整选中文本时，选中区域两段浮标的颜色。
+- [`-x-handle-color`](/api/css/properties/-x-handle-color)：用于调整选中文本时，选中区域两段浮标的颜色。
 - [`text-shadow`](/api/css/properties/text-shadow)：设置文本的阴影特效的颜色。
 - [`text-decoration-color`](/api/css/properties/text-decoration#text-decoration-color)：文本装饰线的颜色。
 
@@ -41,7 +41,7 @@ import { Go } from '@lynx';
 
 - [`background-color`](/api/css/properties/background-color)：元件的背景填充色。
 - [`box-shadow`](/api/css/properties/box-shadow)：配置阴影区域的颜色。
-- [`border-color`](/api/css/properties/border-color)：设置用于绘制边框的颜色。也可以通过 [`border-top-color`](/api/css/properties/border-color)，[`border-top-color`](/api/css/properties/border-color)，[`border-top-color`](/api/css/properties/border-color) 和 [`border-top-color`](/api/css/properties/border-color) 分别设置各个方向的边框的颜色。
+- [`border-color`](/api/css/properties/border-color)：设置用于绘制边框的颜色。也可以通过 [`border-top-color`](/api/css/properties/border-top-color)、[`border-right-color`](/api/css/properties/border-right-color)、[`border-bottom-color`](/api/css/properties/border-bottom-color) 和 [`border-left-color`](/api/css/properties/border-left-color) 分别设置各个方向的边框颜色。
 
 你可以将颜色定义在 CSS 文件中设置给对应属性或是通过 `style` 属性直接设置给元件。
 颜色的值可以通过一个以“#”开头的十六进制数来分别表示对应的红、绿、蓝和透明度通道的值。这个值也可以通过 `rgb()`、`hsl()` 等相关函数定义。更多关于颜色的取值可以参考 [`<color>`](/api/css/data-type/color)。


### PR DESCRIPTION
Conflict-resolved replacement for #1146. The original fork enables maintainer modifications, but the repository GitHub App cannot write to that fork.

This carries forward the changes still needed on current `main` and fixes both review findings:

- link `-x-handle-color` correctly in EN/ZH
- use the correct top/right/bottom/left border-color labels and destinations in EN/ZH
- keep the corrected Chinese `mask` wording and links

Changes from #1146 that are already present on current `main` are intentionally omitted.

## Validation

- `python3 -m scripts.check_api_doc.index` (1725 files, no issues)
- Prettier check on all changed files
- `git diff --check`

Co-authored-by: toretto <tomcatswt@gmail.com>
Signed-off-by: Xuan Huang (黄玄) <5563315+Huxpro@users.noreply.github.com>