### PR TITLE
fix(docs): repair mangled code blocks and dead links

### DIFF
--- a/docs/en/api/elements/built-in/input-API.mdx
+++ b/docs/en/api/elements/built-in/input-API.mdx
@@ -295,50 +295,50 @@ Require focus
 ```ts
 
 lynx.createSelectorQuery()
-.select('#id')
-.invoke({
-method: 'getValue',
-success: Callback<{
-/**
-_ Is composing or not, iOS only
-_ @Android
-_ @iOS
-_ @Harmony
-_ @Web
-_ @since 3.4
-\*/
-isComposing: boolean;
-/**
-_ End position of the selection
-_ @Android
-_ @iOS
-_ @Harmony
-_ @Web
-_ @since 3.4
-_/
-selectionEnd: number;
-/\*\*
-_ Begin position of the selection
-_ @Android
-_ @iOS
-_ @Harmony
-_ @Web
-_ @since 3.4
-_/
-selectionStart: number;
-/\*\*
-_ Input content
-_ @Android
-_ @iOS
-_ @Harmony
-_ @Web
-_ @since 3.4
-\*/
-value: string;
-}>;
-fail: function (res) {},
-})
-.exec();
+     .select('#id')
+     .invoke({
+      method: 'getValue',
+      success: Callback<{
+        /**
+         * Is composing or not, iOS only
+         * @Android
+         * @iOS
+         * @Harmony
+         * @Web
+         * @since 3.4
+         */
+        isComposing: boolean;
+        /**
+         * End position of the selection
+         * @Android
+         * @iOS
+         * @Harmony
+         * @Web
+         * @since 3.4
+         */
+        selectionEnd: number;
+        /**
+         * Begin position of the selection
+         * @Android
+         * @iOS
+         * @Harmony
+         * @Web
+         * @since 3.4
+         */
+        selectionStart: number;
+        /**
+         * Input content
+         * @Android
+         * @iOS
+         * @Harmony
+         * @Web
+         * @since 3.4
+         */
+        value: string;
+      }>;
+      fail: function (res) {},
+    })
+    .exec();
 
 ````
 
@@ -391,24 +391,24 @@ Set selection range
 ```ts
 
 lynx.createSelectorQuery()
-.select('#id')
-.invoke({
-method: 'setValue',
-params: {
-/\*\*
-_ Input content
-_ @Android
-_ @iOS
-_ @Harmony
-_ @Web
-_ @since 3.4
-\*/
-value: string;
-};
-success: function (res) {},
-fail: function (res) {},
-})
-.exec();
+     .select('#id')
+     .invoke({
+      method: 'setValue',
+      params: {
+        /**
+         * Input content
+         * @Android
+         * @iOS
+         * @Harmony
+         * @Web
+         * @since 3.4
+         */
+        value: string;
+      };
+      success: function (res) {},
+      fail: function (res) {},
+    })
+    .exec();
 
 ```
 

--- a/docs/en/api/elements/built-in/scroll-view-API.mdx
+++ b/docs/en/api/elements/built-in/scroll-view-API.mdx
@@ -210,31 +210,31 @@ Frontend can invoke component methods via the [SelectorQuery](/api/lynx-api/node
 ```ts
 
 lynx.createSelectorQuery()
-.select('#id')
-.invoke({
-method: 'autoScroll',
-params: {
-/**
-_ The distance of each second's scrolling, which supports positive and negative values. The unit of distance can be "px", "rpx", "ppx", or null (for iOS, the value must be greater than 1/screen.scale px).
-_ @Android
-_ @iOS
-_ @Harmony
-_ @PC
-_/
-rate: number;
-/**
-_ Start/stop automatic scrolling.
-_ @Android
-_ @iOS
-_ @Harmony
-_ @PC
-_/
-start: boolean;
-};
-success: function (res) {},
-fail: function (res) {},
-})
-.exec();
+     .select('#id')
+     .invoke({
+      method: 'autoScroll',
+      params: {
+        /**
+         * The distance of each second's scrolling, which supports positive and negative values. The unit of distance can be "px", "rpx", "ppx", or null (for iOS, the value must be greater than 1/screen.scale px).
+         * @Android
+         * @iOS
+         * @Harmony
+         * @PC
+         */
+        rate: number;
+        /**
+         * Start/stop automatic scrolling.
+         * @Android
+         * @iOS
+         * @Harmony
+         * @PC
+         */
+        start: boolean;
+      };
+      success: function (res) {},
+      fail: function (res) {},
+    })
+    .exec();
 
 ````
 
@@ -292,19 +292,19 @@ Get scroll info
 ```ts
 
 lynx.createSelectorQuery()
-.select('#id')
-.invoke({
-method: 'scrollBy',
-params: {
-/\*\*
-_ Offset to scroll
-_/
-offset?: number;
-};
-success: function (res) {},
-fail: function (res) {},
-})
-.exec();
+     .select('#id')
+     .invoke({
+      method: 'scrollBy',
+      params: {
+        /**
+         * Offset to scroll
+         */
+        offset?: number;
+      };
+      success: function (res) {},
+      fail: function (res) {},
+    })
+    .exec();
 
 ````
 

--- a/docs/en/api/elements/built-in/textarea-API.mdx
+++ b/docs/en/api/elements/built-in/textarea-API.mdx
@@ -347,50 +347,50 @@ Require focus
 ```ts
 
 lynx.createSelectorQuery()
-.select('#id')
-.invoke({
-method: 'getValue',
-success: Callback<{
-/**
-_ Is composing or not, iOS only
-_ @Android
-_ @iOS
-_ @Harmony
-_ @Web
-_ @since 3.4
-\*/
-isComposing: boolean;
-/**
-_ End position of the cursor
-_ @Android
-_ @iOS
-_ @Harmony
-_ @Web
-_ @since 3.4
-_/
-selectionEnd: number;
-/\*\*
-_ Begin position of the cursor
-_ @Android
-_ @iOS
-_ @Harmony
-_ @Web
-_ @since 3.4
-_/
-selectionStart: number;
-/\*\*
-_ Input content
-_ @Android
-_ @iOS
-_ @Harmony
-_ @Web
-_ @since 3.4
-\*/
-value: string;
-}>;
-fail: function (res) {},
-})
-.exec();
+     .select('#id')
+     .invoke({
+      method: 'getValue',
+      success: Callback<{
+        /**
+         * Is composing or not, iOS only
+         * @Android
+         * @iOS
+         * @Harmony
+         * @Web
+         * @since 3.4
+         */
+        isComposing: boolean;
+        /**
+         * End position of the cursor
+         * @Android
+         * @iOS
+         * @Harmony
+         * @Web
+         * @since 3.4
+         */
+        selectionEnd: number;
+        /**
+         * Begin position of the cursor
+         * @Android
+         * @iOS
+         * @Harmony
+         * @Web
+         * @since 3.4
+         */
+        selectionStart: number;
+        /**
+         * Input content
+         * @Android
+         * @iOS
+         * @Harmony
+         * @Web
+         * @since 3.4
+         */
+        value: string;
+      }>;
+      fail: function (res) {},
+    })
+    .exec();
 
 ````
 
@@ -443,24 +443,24 @@ Set selection range
 ```ts
 
 lynx.createSelectorQuery()
-.select('#id')
-.invoke({
-method: 'setValue',
-params: {
-/\*\*
-_ Input content
-_ @Android
-_ @iOS
-_ @Harmony
-_ @Web
-_ @since 3.4
-\*/
-value: string;
-};
-success: function (res) {},
-fail: function (res) {},
-})
-.exec();
+     .select('#id')
+     .invoke({
+      method: 'setValue',
+      params: {
+        /**
+         * Input content
+         * @Android
+         * @iOS
+         * @Harmony
+         * @Web
+         * @since 3.4
+         */
+        value: string;
+      };
+      success: function (res) {},
+      fail: function (res) {},
+    })
+    .exec();
 
 ```
 

--- a/docs/en/blog/lynx-3-2.mdx
+++ b/docs/en/blog/lynx-3-2.mdx
@@ -258,7 +258,7 @@ dependencies {
     implementation("org.lynxsdk.lynx:primjs:2.12.0")
 
     // integrating image-service
-    implementation("org.lynxsdk.lynx:lynx-service-image:3.2.0-")
+    implementation("org.lynxsdk.lynx:lynx-service-image:3.2.0")
 
     // image-service dependencies, if not added, images cannot be loaded; if the host APP needs to use other image libraries, you can customize the image-service and remove this dependency
     implementation("com.facebook.fresco:fresco:2.3.0")

--- a/docs/en/guide/custom-native-component/custom-component-iOS.mdx
+++ b/docs/en/guide/custom-native-component/custom-component-iOS.mdx
@@ -275,7 +275,7 @@ LYNX_LAZY_REGISTER_UI("explorer-input")
   self.view.padding = self.padding;
   }
 
-LYNX_PROP_SETTER("value", setValue, NSString \*) {
+LYNX_PROP_SETTER("value", setValue, NSString *) {
 self.view.text = value;
 }
 
@@ -295,7 +295,7 @@ self.view.text = value;
   }
 
 - (void)setPadding:(UIEdgeInsets)padding {
-  \_padding = padding;
+  _padding = padding;
   [self setNeedsLayout];
   }
 

--- a/docs/en/guide/interaction/visibility-detection/exposure-ability.mdx
+++ b/docs/en/guide/interaction/visibility-detection/exposure-ability.mdx
@@ -51,9 +51,9 @@ The format of the exposure/anti-exposure event is an array, which contains the t
 
 ## Monitor the exposure of a certain node
 
-When the developer only needs to listen to the exposure/anti-exposure events of a certain node, you can set the [event handler](../event-handling/event-listening.mdx#Event handler properties) to listen to the node's [`uiappear`](../../../api/elements/built-in/view.mdx#binduiappear) and [`uidisappear`](../../../api/elements/built-in/view.mdx#binduidisappear) events.
+When the developer only needs to listen to the exposure/anti-exposure events of a certain node, you can set the [event handler](../event-handling/event-propagation.mdx#event-handler-property) to listen to the node's [`uiappear`](../../../api/elements/built-in/view.mdx#binduiappear) and [`uidisappear`](../../../api/elements/built-in/view.mdx#binduidisappear) events.
 
-In the following example, the developer sets the [event handler](../event-handling/event-listening.mdx#Event handler properties) to listen to whether the node is exposed, and outputs the exposed node [`id`](../../../api/elements/built-in/view.mdx#id) when it is exposed.
+In the following example, the developer sets the [event handler](../event-handling/event-propagation.mdx#event-handler-property) to listen to whether the node is exposed, and outputs the exposed node [`id`](../../../api/elements/built-in/view.mdx#id) when it is exposed.
 
 **Example 2:**
 

--- a/docs/en/guide/start/fragments/macos/integrating-lynx-with-existing-app-macos.mdx
+++ b/docs/en/guide/start/fragments/macos/integrating-lynx-with-existing-app-macos.mdx
@@ -92,6 +92,7 @@ target_link_options(${PROJECT_NAME} PRIVATE
 - Lynx Service needs to be actively injected
 
 <CodeFold height={360} toggle>
+
 ```objective-c title=AppDelegate.mm {17,20-30}
 #import "AppDelegate.h"
 #import "ViewController.h"
@@ -116,13 +117,15 @@ void Request(std::shared_ptr<lynx::pub::LynxHttpRequest> request, std::shared_pt
 @implementation AppDelegate {
 }
 
-- (void)applicationDidFinishLaunching:(NSNotification \*)aNotification {
+- (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
   // Register http service for lynx.fetch.
   lynx::pub::LynxServiceCenter::GetInstance().RegisterService(std::make_shared<LynxHttpServiceImpl>());
 
   }
 
-````
+@end
+```
+
 </CodeFold>
 
 <div style={{ marginBottom: 30 }} />
@@ -132,13 +135,24 @@ void Request(std::shared_ptr<lynx::pub::LynxHttpRequest> request, std::shared_pt
 LynxEnv provides the global initialization interface for the Lynx Engine. Please ensure that the initialization of LynxEnv occurs before any interface calls to the Lynx Engine. It is recommended to complete the initialization of LynxEnv before LynxView creation.
 
 <CodeFold height={360} toggle>
-```objective-c title=AppDelegate.mm {9,12-19}
+
+```objective-c title=AppDelegate.mm {19,22-29}
 #import "AppDelegate.h"
 #import "ViewController.h"
 
 #import "lynx_env.h"
 #import "lynx_http_service.h"
 #import "lynx_view.h"
+
+// Implements the http service if needed.
+class LynxHttpServiceImpl : public lynx::pub::LynxHttpService {
+public:
+LynxHttpServiceImpl() = default;
+~LynxHttpServiceImpl() = default;
+void Request(std::shared_ptr<lynx::pub::LynxHttpRequest> request, std::shared_ptr<lynx::pub::LynxHttpResponse> response) override {
+// TODO
+}
+};
 
 @interface AppDelegate ()
 @end
@@ -160,7 +174,8 @@ LynxEnv provides the global initialization interface for the Lynx Engine. Please
   // lynx_env.RegisterNativeModule("ExplorerModule", ExplorerModuleCreator, nullptr);
 }
 
-````
+@end
+```
 
 </CodeFold>
 
@@ -182,24 +197,27 @@ Bundle Example:
 Impl Resource Fetcher
 
 <CodeFold toggle>
+
 ```objective-c title=ExampleGenericResourceFetcher.h {9,12-19}
 #import <Foundation/Foundation.h>
 #import "lynx_generic_resource_fetcher.h"
 
 class ExampleGenericResourceFetcher : public lynx::pub::LynxGenericResourceFetcher {
 public:
-void FetchResource(std::shared_ptr<lynx::pub::LynxResourceRequest> request, std::shared_ptr<lynx::pub::LynxResourceResponse> response) override;
+void FetchResource(std::shared_ptr<lynx::pub::resource::LynxResourceRequest> request, std::shared_ptr<lynx::pub::resource::LynxResourceResponse> response) override;
 };
 
-````
+```
+
 </CodeFold>
 
 <CodeFold height={360} toggle>
+
 ```objective-c title=ExampleGenericResourceFetcher.mm {9,12-19}
 #import <Foundation/Foundation.h>
 #import "ExampleGenericResourceFetcher.h"
 
-void ExampleGenericResourceFetcher::FetchResource(std::shared_ptr<lynx::pub::LynxResourceRequest> request, std::shared_ptr<lynx::pub::LynxResourceResponse> response) {
+void ExampleGenericResourceFetcher::FetchResource(std::shared_ptr<lynx::pub::resource::LynxResourceRequest> request, std::shared_ptr<lynx::pub::resource::LynxResourceResponse> response) {
   const char *url_str = request->GetUrl();
   NSString *ns_string = [NSString stringWithUTF8String:url_str];
 
@@ -226,7 +244,7 @@ void ExampleGenericResourceFetcher::FetchResource(std::shared_ptr<lynx::pub::Lyn
   [dataTask resume];
 }
 
-````
+```
 
 </CodeFold>
 
@@ -235,6 +253,7 @@ void ExampleGenericResourceFetcher::FetchResource(std::shared_ptr<lynx::pub::Lyn
 `LynxView` is the basic rendering view provided by `Lynx Engine`. You can quickly construct a LynxView and provide a NSView as it's parent.
 
 <CodeFold height={360} toggle>
+
 ```objective-c title=ViewController.mm {9,12-19}
 #import "ViewController.h"
 #import "ExampleGenericResourceFetcher.h"
@@ -256,7 +275,7 @@ void ExampleGenericResourceFetcher::FetchResource(std::shared_ptr<lynx::pub::Lyn
   lynx::pub::LynxView::Builder builder;
   builder.SetScreenSize(self.view.frame.size.width, self.view.frame.size.height, 1.0)
   .SetFrame(0, 0, self.view.frame.size.width, self.view.frame.size.height)
-  .SetParent((\_\_bridge NativeWindow)self.view)
+  .SetParent((__bridge NativeWindow)self.view)
   .SetGenericResourceFetcher(std::make_shared<ExampleGenericResourceFetcher>());
   self.lynxView = builder.Build();
   }
@@ -269,7 +288,8 @@ void ExampleGenericResourceFetcher::FetchResource(std::shared_ptr<lynx::pub::Lyn
   self.lynxView->SetFrame(0, 0, self.view.frame.size.width, self.view.frame.size.height);
   }
 
-````
+@end
+```
 
 </CodeFold>
 
@@ -280,6 +300,7 @@ void ExampleGenericResourceFetcher::FetchResource(std::shared_ptr<lynx::pub::Lyn
 After completing the above steps, all the work of initializing LynxView have been completed. Call the `lynxView->LoadTemplate` method to render the corresponding Bundle onto the LynxView.
 
 <CodeFold height={360} toggle>
+
 ```objective-c title=ViewController.mm {9,12-19}
 #import "ViewController.h"
 #import "ExampleGenericResourceFetcher.h"
@@ -315,13 +336,18 @@ After completing the above steps, all the work of initializing LynxView have bee
   self.lynxView->LoadTemplate(meta_data);
   }
 
+@end
 ```
+
 </CodeFold>
 
 Then you will see the following interface on the screen:
 
 <center>
-  <img src="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/plugin/static/hello-world-showcase-macos.png" width="800" />
+  <img
+    src="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/plugin/static/hello-world-showcase-macos.png"
+    width="800"
+  />
 </center>
 
 </Steps>
@@ -331,4 +357,3 @@ Congratulations, you have now completed all the work of rendering the LynxView!
 ## 4. Now what?
 
 At this stage, you have successfully integrated Lynx into your App. Refer to our [developing](/guide/start/quick-start) and [debugging](/guide/devtool/panels) docs for in-depth insights on working with Lynx.
-````

--- a/docs/public/AGENTS.md
+++ b/docs/public/AGENTS.md
@@ -150,12 +150,12 @@ Common APIs:
 - **Main Thread Script**: Keep animations/gestures responsive while respecting thread isolation and data synchronization. (See [Main Thread Script](/react/main-thread-script.md))
 - **NodesRef.invoke**: Batch native operations (for example `autoScroll`) to avoid cross-thread overhead. (See [Direct Manipulation](/guide/interaction/event-handling/manipulating-element.react.md))
 - **Lynx DevTool & Trace**: The desktop DevTool offers Elements/Console/Sources/Trace panels to record render pipelines and analyze the ReactLynx render process. (See [Lynx DevTool](/guide/devtool.md), [Trace](/guide/devtool/trace.md))
-- **Performance metrics**: Use `lynx.performance` and `PerformanceObserver` to capture metrics such as FCP and InitContainer. (See [Performance API](/guide/performance/metrics/performance-api.md))
+- **Performance metrics**: Use `lynx.performance` and `PerformanceObserver` to capture metrics such as FCP and InitContainer. (See [Performance API](/guide/performance/monitor-performance/performance-api.md))
 
 ## 15. Engineering Practices and Tooling
 
-- **Project initialization**: `pnpm create rspeedy` scaffolds a ReactLynx project with Rspeedy configuration and sample code. (See [Quick Start](/rspeedy/start/quick-start.md))
-- **Development and debugging**: `pnpm dev` starts the Rspeedy dev server. The terminal prints a QR code—scan it with the LynxExample app (iOS/Android/Harmony emulator) for hot-update previews. (See [Quick Start](/rspeedy/start/quick-start.md))
+- **Project initialization**: `pnpm create rspeedy` scaffolds a ReactLynx project with Rspeedy configuration and sample code. (See [Quick Start](/guide/start/quick-start.md))
+- **Development and debugging**: `pnpm dev` starts the Rspeedy dev server. The terminal prints a QR code—scan it with the LynxExample app (iOS/Android/Harmony emulator) for hot-update previews. (See [Quick Start](/guide/start/quick-start.md))
 - **DevTool debugging**: After connecting a device, use the desktop Lynx DevTool to debug JS, inspect nodes, and record performance. (See [Lynx DevTool](/guide/devtool.md))
 - **Build artifacts**: Rspeedy outputs a bundle that includes the background-thread script (text), main-thread bytecode, styles, and other assets. Set `DEBUG=rspeedy` to dump intermediate artifacts (background script, main-thread bytecode, styles, source maps, etc.) into `dist/.rspeedy`; otherwise only the final bundle is produced. (See [Output Files](/rspeedy/output.md))
 - **Docs asset references**: In MDX, prefer the `@assets` alias for local assets (for example `import demoImg from '@assets/foo.png?url'`) and pass the imported variable to components such as `<Go img={demoImg} />`. Do not hardcode `/assets/...` paths in MDX props.

--- a/docs/public/zh/AGENTS.md
+++ b/docs/public/zh/AGENTS.md
@@ -150,12 +150,12 @@
 - **Main Thread Script**：确保动画/手势无延迟，注意线程隔离与数据同步。（参考：[Main Thread Script](/zh/react/main-thread-script.md)）
 - **NodesRef.invoke**：批量调用原生特性（如 `autoScroll`）避免跨线程瓶颈。（参考：[Direct Manipulation](/zh/guide/interaction/event-handling/manipulating-element.react.md)）
 - **Lynx DevTool & Trace**：桌面 DevTool 提供 Elements/Console/Sources/Trace 面板，可记录渲染流水、分析 ReactLynx Render Pipeline。（参考：[Lynx DevTool](/zh/guide/devtool.md), [Trace](/zh/guide/devtool/trace.md)）
-- **Performance Metrics**：通过 `lynx.performance`、`PerformanceObserver` 采集 FCP、InitContainer 等指标。（参考：[Performance API](/zh/guide/performance/metrics/performance-api.md)）
+- **Performance Metrics**：通过 `lynx.performance`、`PerformanceObserver` 采集 FCP、InitContainer 等指标。（参考：[Performance API](/zh/guide/performance/monitor-performance/performance-api.md)）
 
 ## 15. 工程实践与工具链
 
-- **项目初始化**：`pnpm create rspeedy` 一键生成 ReactLynx 工程，自动带上 Rspeedy 配置、脚手架示例。（参考：[Quick Start](/zh/rspeedy/start/quick-start.md)）
-- **开发调试**：`pnpm dev` 启动 Rspeedy Dev Server，终端输出二维码，使用 LynxExample App（iOS/Android/Harmony 模拟器）扫描即可热更新预览。（参考：[Quick Start](/zh/rspeedy/start/quick-start.md)）
+- **项目初始化**：`pnpm create rspeedy` 一键生成 ReactLynx 工程，自动带上 Rspeedy 配置、脚手架示例。（参考：[Quick Start](/zh/guide/start/quick-start.md)）
+- **开发调试**：`pnpm dev` 启动 Rspeedy Dev Server，终端输出二维码，使用 LynxExample App（iOS/Android/Harmony 模拟器）扫描即可热更新预览。（参考：[Quick Start](/zh/guide/start/quick-start.md)）
 - **DevTool 调试**：连接设备后使用 Lynx DevTool 桌面端调试 JS、查看节点、性能记录。（参考：[Lynx DevTool](/zh/guide/devtool.md)）
 - **构建产物**：Rspeedy 输出的 Bundle 包含后台线程脚本（文本）、主线程字节码、样式等资源；需要 `DEBUG=rspeedy` 环境变量以输出中间产物（组成Lynx Bundle 的后台线程脚本（文本）、主线程字节码、样式、SourceMap 等）到 `dist/.rspeedy` 目录，否则只会输出最终的 Lynx Bundle 文件。（参考：[Output Files](/zh/rspeedy/output.md)）
 - **文档资源引用**：在 MDX 中引用本地图片或文件时，优先使用 `@assets` alias（例如 `import demoImg from '@assets/foo.png?url'`），再传给 `<Go img={demoImg} />` 这类组件。不要在 MDX 的组件参数里直接硬编码 `/assets/...` 路径。

--- a/docs/zh/blog/lynx-3-2.mdx
+++ b/docs/zh/blog/lynx-3-2.mdx
@@ -258,7 +258,7 @@ dependencies {
     implementation("org.lynxsdk.lynx:primjs:2.12.0")
 
     // integrating image-service
-    implementation("org.lynxsdk.lynx:lynx-service-image:3.2.0-")
+    implementation("org.lynxsdk.lynx:lynx-service-image:3.2.0")
 
     // image-service dependencies, if not added, images cannot be loaded; if the host APP needs to use other image libraries, you can customize the image-service and remove this dependency
     implementation("com.facebook.fresco:fresco:2.3.0")

--- a/docs/zh/guide/custom-native-component/custom-component-iOS.mdx
+++ b/docs/zh/guide/custom-native-component/custom-component-iOS.mdx
@@ -297,7 +297,7 @@ LYNX_LAZY_REGISTER_UI("explorer-input")
   self.view.padding = self.padding;
   }
 
-LYNX_PROP_SETTER("value", setValue, NSString \*) {
+LYNX_PROP_SETTER("value", setValue, NSString *) {
 self.view.text = value;
 }
 
@@ -317,7 +317,7 @@ self.view.text = value;
   }
 
 - (void)setPadding:(UIEdgeInsets)padding {
-  \_padding = padding;
+  _padding = padding;
   [self setNeedsLayout];
   }
 

--- a/docs/zh/guide/start/fragments/macos/integrating-lynx-with-existing-app-macos.mdx
+++ b/docs/zh/guide/start/fragments/macos/integrating-lynx-with-existing-app-macos.mdx
@@ -91,6 +91,7 @@ target_link_options(${PROJECT_NAME} PRIVATE
 - Lynx Service 需主动注入。
 
 <CodeFold height={360} toggle>
+
 ```objective-c title=AppDelegate.mm {17,20-30}
 #import "AppDelegate.h"
 #import "ViewController.h"
@@ -115,12 +116,14 @@ void Request(std::shared_ptr<lynx::pub::LynxHttpRequest> request, std::shared_pt
 @implementation AppDelegate {
 }
 
-- (void)applicationDidFinishLaunching:(NSNotification \*)aNotification {
+- (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
   // Register http service for lynx.fetch.
   lynx::pub::LynxServiceCenter::GetInstance().RegisterService(std::make_shared<LynxHttpServiceImpl>());
   }
 
-````
+@end
+```
+
 </CodeFold>
 
 <div style={{ marginBottom: 30 }} />
@@ -130,13 +133,24 @@ void Request(std::shared_ptr<lynx::pub::LynxHttpRequest> request, std::shared_pt
 LynxEnv 提供了 Lynx Engine 的全局初始化接口, 请保证 LynxEnv 的初始化发生在 Lynx Engine 的任何接口调用之前。
 
 <CodeFold height={360} toggle>
-```objective-c title=AppDelegate.mm {9,12-19}
+
+```objective-c title=AppDelegate.mm {19,22-29}
 #import "AppDelegate.h"
 #import "ViewController.h"
 
 #import "lynx_env.h"
 #import "lynx_http_service.h"
 #import "lynx_view.h"
+
+// Implements the http service if needed.
+class LynxHttpServiceImpl : public lynx::pub::LynxHttpService {
+public:
+LynxHttpServiceImpl() = default;
+~LynxHttpServiceImpl() = default;
+void Request(std::shared_ptr<lynx::pub::LynxHttpRequest> request, std::shared_ptr<lynx::pub::LynxHttpResponse> response) override {
+// TODO
+}
+};
 
 @interface AppDelegate ()
 @end
@@ -158,7 +172,8 @@ LynxEnv 提供了 Lynx Engine 的全局初始化接口, 请保证 LynxEnv 的初
   // lynx_env.RegisterNativeModule("ExplorerModule", ExplorerModuleCreator, nullptr);
 }
 
-````
+@end
+```
 
 </CodeFold>
 
@@ -181,24 +196,27 @@ Bundle 示例:
 实现 Resource Fetcher
 
 <CodeFold toggle>
+
 ```objective-c title=ExampleGenericResourceFetcher.h {9,12-19}
 #import <Foundation/Foundation.h>
 #import "lynx_generic_resource_fetcher.h"
 
 class ExampleGenericResourceFetcher : public lynx::pub::LynxGenericResourceFetcher {
 public:
-void FetchResource(std::shared_ptr<lynx::pub::LynxResourceRequest> request, std::shared_ptr<lynx::pub::LynxResourceResponse> response) override;
+void FetchResource(std::shared_ptr<lynx::pub::resource::LynxResourceRequest> request, std::shared_ptr<lynx::pub::resource::LynxResourceResponse> response) override;
 };
 
-````
+```
+
 </CodeFold>
 
 <CodeFold height={360} toggle>
+
 ```objective-c title=ExampleGenericResourceFetcher.mm {9,12-19}
 #import <Foundation/Foundation.h>
 #import "ExampleGenericResourceFetcher.h"
 
-void ExampleGenericResourceFetcher::FetchResource(std::shared_ptr<lynx::pub::LynxResourceRequest> request, std::shared_ptr<lynx::pub::LynxResourceResponse> response) {
+void ExampleGenericResourceFetcher::FetchResource(std::shared_ptr<lynx::pub::resource::LynxResourceRequest> request, std::shared_ptr<lynx::pub::resource::LynxResourceResponse> response) {
   const char *url_str = request->GetUrl();
   NSString *ns_string = [NSString stringWithUTF8String:url_str];
 
@@ -225,7 +243,7 @@ void ExampleGenericResourceFetcher::FetchResource(std::shared_ptr<lynx::pub::Lyn
   [dataTask resume];
 }
 
-````
+```
 
 </CodeFold>
 
@@ -234,6 +252,7 @@ void ExampleGenericResourceFetcher::FetchResource(std::shared_ptr<lynx::pub::Lyn
 LynxView 是 Lynx Engine 提供的渲染基本单元，你可以快速的构造一个 LynxView，并通过设置一个NSView作为父容器将其任意添加到原生macOS的视图树上。
 
 <CodeFold height={360} toggle>
+
 ```objective-c title=ViewController.mm {9,12-19}
 #import "ViewController.h"
 #import "ExampleGenericResourceFetcher.h"
@@ -255,7 +274,7 @@ LynxView 是 Lynx Engine 提供的渲染基本单元，你可以快速的构造�
   lynx::pub::LynxView::Builder builder;
   builder.SetScreenSize(self.view.frame.size.width, self.view.frame.size.height, 1.0)
   .SetFrame(0, 0, self.view.frame.size.width, self.view.frame.size.height)
-  .SetParent((\_\_bridge NativeWindow)self.view)
+  .SetParent((__bridge NativeWindow)self.view)
   .SetGenericResourceFetcher(std::make_shared<ExampleGenericResourceFetcher>());
   self.lynxView = builder.Build();
   }
@@ -268,7 +287,8 @@ LynxView 是 Lynx Engine 提供的渲染基本单元，你可以快速的构造�
   self.lynxView->SetFrame(0, 0, self.view.frame.size.width, self.view.frame.size.height);
   }
 
-````
+@end
+```
 
 </CodeFold>
 
@@ -279,6 +299,7 @@ LynxView 是 Lynx Engine 提供的渲染基本单元，你可以快速的构造�
 当你完成以上步骤之后，已经完成了 LynxView 创建与资源读取的全部工作，调用 `lynxView->LoadTemplate` 方法，即可将对应的 Bundle 内容渲染到 LynxView 视图上。
 
 <CodeFold height={360} toggle>
+
 ```objective-c title=ViewController.mm {9,12-19}
 #import "ViewController.h"
 #import "ExampleGenericResourceFetcher.h"
@@ -314,13 +335,18 @@ LynxView 是 Lynx Engine 提供的渲染基本单元，你可以快速的构造�
   self.lynxView->LoadTemplate(meta_data);
   }
 
+@end
 ```
+
 </CodeFold>
 
 然后你将在屏幕上看到如下内容：
 
 <center>
-  <img src="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/plugin/static/hello-world-showcase-macos.png" width="800" />
+  <img
+    src="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/plugin/static/hello-world-showcase-macos.png"
+    width="800"
+  />
 </center>
 
 </Steps>
@@ -330,4 +356,3 @@ LynxView 是 Lynx Engine 提供的渲染基本单元，你可以快速的构造�
 ## 4. 进入 Lynx 世界
 
 现在你已经将 Lynx 集成到你的应用中了。请参考[开发](/guide/start/quick-start)和[调试](/guide/devtool/panels)文档进一步在 Lynx 的世界里遨游吧！
-````


### PR DESCRIPTION
CI-capable replacement for #1335. The original fork PR has no normal GitHub Actions run attached, and the repository GitHub App cannot approve or update that fork workflow.

This branch points at the exact original head commit `5b7921dd637b551389b61c51e0e57b98be560c44`; the code, commit, and authorship are unchanged.

The mixed type/runtime `invoke()` convention is a pre-existing cross-site issue tracked separately in #1347. This PR restores the mangled JSDoc and fixes the scoped documentation defects without attempting that sitewide representation migration.