### PR TITLE
docs(react): clarify Snapshot runtime pseudocode

### DIFF
--- a/docs/en/react/compiler-informed-rendering.mdx
+++ b/docs/en/react/compiler-informed-rendering.mdx
@@ -256,33 +256,93 @@ The `$0` and `__DynamicPartSlotV2` representation shown here reflects `@lynx-js/
 
 One characteristic of ReactLynx is that this compiled representation participates not only in update-time reconciliation, but also in Lynx's dual-thread [Instant First-Frame Rendering (IFR)](/guide/interaction/ifr) pipeline.
 
-The same compiled definition can be reused by multiple `Greeting` instances. Each render creates a corresponding pair of runtime instances: the main-thread instance owns the Lynx elements it creates, while the background-thread instance stores the logical tree and dynamic data used for reconciliation. The runtime consumes the compiled output in two stages: initial rendering and subsequent updates.
+#### Concepts Used in the Following Pseudocode
+
+The folded block above shows the current Snapshot IR in implementation-level terms. To explain how its data moves through the runtime without depending on those internal names, the following pseudocode uses a few simplified concepts. They are explanatory types, not ReactLynx APIs:
+
+```ts
+// An opaque reference to an element created by Lynx Engine.
+type LynxElement = unknown;
+
+type SnapshotDefinition = {
+  // Creates the stable Lynx element structure.
+  create: (instance: MainThreadInstance) => LynxElement[];
+
+  // Position N updates the dynamic property stored at values[N].
+  update: Array<(instance: MainThreadInstance) => void>;
+
+  // Slot N stores the element index where dynamicChildren[N] is inserted.
+  slots: number[];
+};
+
+type MainThreadInstance = {
+  id: number;
+  definition: SnapshotDefinition;
+  elements: LynxElement[];
+  values: unknown[];
+};
+
+type BackgroundInstance = {
+  id: number;
+  definition: SnapshotDefinition;
+  values: unknown[];
+  dynamicChildren: unknown[];
+};
+
+type PropertyPatch = {
+  instanceId: number;
+  propertyPosition: number;
+  value: unknown;
+};
+```
+
+In the current source, these concepts correspond to `Snapshot`, `SnapshotInstance`, and `BackgroundSnapshotInstance`, respectively. `createSnapshot` registers a `Snapshot` definition; each `SnapshotInstance` owns actual Lynx elements, while its `BackgroundSnapshotInstance` counterpart participates in reconciliation. The real field names, methods, and serialized Patch format are internal and are intentionally simplified here.
+
+The array indexes connect the compiler output to runtime data. For `Greeting`, `values[0]`, `update[0]`, and `propertyPosition: 0` all refer to the dynamic `className`. Separately, `dynamicChildren[0]` and `slots[0]` refer to the dynamic `name` child and its insertion point.
+
+The same `SnapshotDefinition` can be reused by multiple mounted `Greeting` components. Each mounted component has a corresponding pair of instances: the main-thread instance owns its Lynx elements, while the background instance stores the logical tree and dynamic data used for reconciliation. The runtime consumes the compiled output in two stages: initial rendering and subsequent updates.
 
 #### Initial Render: Create an Instance from the Compiled Definition
 
-The UI elements for the initial render are created directly on the main thread. The runtime first finds the compiled definition from the VNode type, then creates a main-thread instance for this `Greeting`. The instance owns the Lynx elements returned by the static creator. Initial dynamic values are passed to their corresponding updaters, and dynamic children are inserted into the slots reserved by the compiler.
+The UI elements for the initial render are created directly on the main thread. The runtime first finds the `SnapshotDefinition` from the VNode type, then creates a `MainThreadInstance` for this `Greeting`. The instance owns the Lynx elements returned by `definition.create()`. Initial dynamic values are passed to their corresponding updaters, and dynamic children are inserted into the slots reserved by the compiler.
 
 The following pseudocode illustrates this process:
 
-```js
-function renderFirstScreen(vnode) {
-  const definition = getCompiledDefinition(vnode.type);
-  const instance = createMainThreadInstance(vnode.type);
+```ts
+function createMainThreadInstance(
+  definition: SnapshotDefinition,
+  initialValues: unknown[],
+  dynamicChildren: unknown[],
+): MainThreadInstance {
+  const instance: MainThreadInstance = {
+    id: allocateInstanceId(),
+    definition,
+    elements: [],
+    values: initialValues,
+  };
 
   instance.elements = definition.create(instance);
-  instance.values = vnode.props.values;
-  definition.update[0](instance); // Write values[0] to className
-  insertDynamicChild(instance, 0, vnode.props.$0);
+
+  // Apply every initial dynamic property to the newly created elements.
+  for (let position = 0; position < initialValues.length; position++) {
+    definition.update[position](instance);
+  }
+
+  // Insert every dynamic child at the element selected by its slot.
+  for (let slot = 0; slot < dynamicChildren.length; slot++) {
+    const elementIndex = definition.slots[slot];
+    insertDynamicChild(instance.elements[elementIndex], dynamicChildren[slot]);
+  }
 
   return instance;
 }
 ```
 
-In this example, `definition.create()` creates the `view`, `text`, and fixed text; `definition.update[0]()` writes `values[0]` to `className`; and `insertDynamicChild()` places the `name` from `$0` into the reserved slot. This still creates the complete Lynx element tree. The difference is that `definition.create()` expands the static hierarchy directly instead of sending every host VNode through reconciliation level by level.
+For `Greeting`, `definition.create()` creates the `view`, `text`, fixed text, and insertion-point wrapper. The only property updater writes `initialValues[0]`, the computed `className`, to the root `view`. The only child slot places `dynamicChildren[0]`, the `name`, at that insertion point inside `text`. This still creates the complete Lynx element tree. The difference is that the compiled creator expands the stable hierarchy directly instead of sending every host VNode through reconciliation level by level.
 
 From another perspective, this can be understood as precomputing part of the render, analogous to [Next.js Partial Prerendering](https://nextjs.org/docs/app/getting-started/partial-prerendering). The artifacts are different: Next.js produces a static HTML shell and a serialized React Server Component payload, while ReactLynx further lowers the stable host structure into element-creation operations understood directly by the Lynx platform. Dynamic values and subtrees are still supplied when the page starts.
 
-The initial background-thread reconciliation also creates a logical instance tree that corresponds to the main-thread instance tree. During first-screen synchronization, hydration establishes the mapping between instances on the two threads, allowing subsequent updates to locate the main-thread instance created for the first screen by `instanceId`.
+In parallel, initial background-thread reconciliation creates the corresponding `BackgroundInstance` and logical instance tree from the same dynamic values and children. During first-screen synchronization, hydration maps each background instance to the main-thread instance already created for the first screen. After that mapping, both sides use the same `instanceId`, so later Patches can locate the correct main-thread instance without comparing the two trees again.
 
 #### Updates: Process Only Changes to Dynamic Positions
 
@@ -290,36 +350,39 @@ After the mapping is established, the background thread compares old and new dyn
 
 The following pseudocode continues with `Greeting`. `highlighted` corresponds to dynamic position `0`, so changing it produces a property update. `name` is in a dynamic child slot and continues to be reconciled by React:
 
-```js
+```ts
 // Background thread: compare dynamic properties and reconcile dynamic children
-function reconcileGreeting(previous, next, instanceId) {
-  if (!isEqual(previous.values[0], next.values[0])) {
-    emitAttributePatch({
-      instanceId,
-      dynamicPartIndex: 0,
-      value: next.values[0],
-    });
+function updateInBackground(
+  instance: BackgroundInstance,
+  nextValues: unknown[],
+  nextDynamicChildren: unknown[],
+) {
+  for (let position = 0; position < nextValues.length; position++) {
+    if (!isEqual(instance.values[position], nextValues[position])) {
+      emitPropertyPatch({
+        instanceId: instance.id,
+        propertyPosition: position,
+        value: nextValues[position],
+      });
+    }
   }
 
-  // $0 remains a React child; reconciliation produces tree operations
-  // such as insertions and removals.
-  reconcileChildren(previous.$0, next.$0, {
-    parentInstanceId: instanceId,
-    slotIndex: 0,
-  });
+  instance.values = nextValues;
+  reconcileDynamicChildren(instance, nextDynamicChildren);
+  instance.dynamicChildren = nextDynamicChildren;
 }
 
 // Main thread: apply a property update using the instance and dynamic position
-function applyAttributePatch(patch) {
-  const instance = findCompiledInstance(patch.instanceId);
-  const index = patch.dynamicPartIndex;
+function applyPropertyPatch(patch: PropertyPatch) {
+  const instance = findMainThreadInstance(patch.instanceId);
+  const position = patch.propertyPosition;
 
-  instance.values[index] = patch.value;
-  instance.definition.update[index](instance);
+  instance.values[position] = patch.value;
+  instance.definition.update[position](instance);
 }
 ```
 
-For the property path, `reconcileGreeting()` only describes which dynamic position changed on which instance. `applyAttributePatch()` then calls the targeted update function generated by the compiler. Dynamic children do not pass through these property updaters; React reconciliation produces the corresponding tree operations instead. The current implementation encodes these operations in a serialized Patch.
+For the property path, `updateInBackground()` emits only the instance ID, dynamic property position, and new value. `applyPropertyPatch()` uses that position to select the updater generated by the compiler. Dynamic children do not pass through these property updaters; `reconcileDynamicChildren()` produces insertion, removal, and other tree operations instead. The current implementation serializes both kinds of operations into a compact Patch rather than sending the explanatory objects shown here.
 
 ## Back to Application Code
 

--- a/docs/zh/react/compiler-informed-rendering.mdx
+++ b/docs/zh/react/compiler-informed-rendering.mdx
@@ -256,33 +256,93 @@ ReactLynx.snapshotCreatorMap[__snapshot_xxx] = (__snapshot_xxx) =>
 
 ReactLynx 的一个特点是：这份编译表示不仅参与更新阶段的协调，也参与 Lynx 双线程的[首帧直出（IFR）](/guide/interaction/ifr)链路。
 
-同一份编译定义可以被多个 `Greeting` 实例复用。每次实际渲染都会产生一组彼此对应的运行时实例：主线程实例持有创建出的 Lynx 元件，后台实例保存参与协调的逻辑树和动态数据。运行时消费编译产物的过程可以分为首屏创建和后续更新两个阶段。
+#### 下文伪代码使用的概念
+
+上面的折叠区使用接近实现的方式展示了当前 Snapshot IR。为了在不依赖内部名称的前提下说明数据如何进入运行时，下文伪代码使用几个经过简化的概念。它们只用于解释机制，并不是 ReactLynx API：
+
+```ts
+// Lynx Engine 创建的元件的不透明引用。
+type LynxElement = unknown;
+
+type SnapshotDefinition = {
+  // 创建稳定的 Lynx 元件结构。
+  create: (instance: MainThreadInstance) => LynxElement[];
+
+  // 第 N 个位置负责更新 values[N] 保存的动态属性。
+  update: Array<(instance: MainThreadInstance) => void>;
+
+  // 第 N 个插槽记录 dynamicChildren[N] 应插入的元件索引。
+  slots: number[];
+};
+
+type MainThreadInstance = {
+  id: number;
+  definition: SnapshotDefinition;
+  elements: LynxElement[];
+  values: unknown[];
+};
+
+type BackgroundInstance = {
+  id: number;
+  definition: SnapshotDefinition;
+  values: unknown[];
+  dynamicChildren: unknown[];
+};
+
+type PropertyPatch = {
+  instanceId: number;
+  propertyPosition: number;
+  value: unknown;
+};
+```
+
+在当前源码中，这三个概念分别对应 `Snapshot`、`SnapshotInstance` 和 `BackgroundSnapshotInstance`。`createSnapshot` 负责注册 `Snapshot` 定义；每个 `SnapshotInstance` 持有实际的 Lynx 元件，对应的 `BackgroundSnapshotInstance` 则参与协调。真实字段名、方法和序列化 Patch 格式都属于内部实现，这里有意做了简化。
+
+数组索引把编译产物和运行时数据连接起来。对于 `Greeting`，`values[0]`、`update[0]` 和 `propertyPosition: 0` 都指向动态 `className`。与它分开的是，`dynamicChildren[0]` 和 `slots[0]` 分别表示动态 `name` 子节点及其插入位置。
+
+同一份 `SnapshotDefinition` 可以被多个已挂载的 `Greeting` 组件复用。每个已挂载组件都有一组彼此对应的实例：主线程实例持有它的 Lynx 元件，后台实例保存参与协调的逻辑树和动态数据。运行时消费编译产物的过程可以分为首屏创建和后续更新两个阶段。
 
 #### 首屏：根据编译定义创建实例
 
-首屏的 UI 元件由主线程直接创建。运行时先根据 VNode 的类型找到编译定义，再为这次 `Greeting` 创建主线程实例。静态创建函数返回的 Lynx 元件由这个实例持有；初始动态值随后交给对应的更新函数，动态子节点则插入编译器预留的插槽。
+首屏的 UI 元件由主线程直接创建。运行时先根据 VNode 的类型找到 `SnapshotDefinition`，再为这次 `Greeting` 创建 `MainThreadInstance`。`definition.create()` 返回的 Lynx 元件由这个实例持有；初始动态值随后交给对应的更新函数，动态子节点则插入编译器预留的插槽。
 
 下面是这一过程的概念伪代码：
 
-```js
-function renderFirstScreen(vnode) {
-  const definition = getCompiledDefinition(vnode.type);
-  const instance = createMainThreadInstance(vnode.type);
+```ts
+function createMainThreadInstance(
+  definition: SnapshotDefinition,
+  initialValues: unknown[],
+  dynamicChildren: unknown[],
+): MainThreadInstance {
+  const instance: MainThreadInstance = {
+    id: allocateInstanceId(),
+    definition,
+    elements: [],
+    values: initialValues,
+  };
 
   instance.elements = definition.create(instance);
-  instance.values = vnode.props.values;
-  definition.update[0](instance); // 将 values[0] 写入 className
-  insertDynamicChild(instance, 0, vnode.props.$0);
+
+  // 将每个初始动态属性应用到新创建的元件。
+  for (let position = 0; position < initialValues.length; position++) {
+    definition.update[position](instance);
+  }
+
+  // 根据插槽选出的元件位置，插入每个动态子节点。
+  for (let slot = 0; slot < dynamicChildren.length; slot++) {
+    const elementIndex = definition.slots[slot];
+    insertDynamicChild(instance.elements[elementIndex], dynamicChildren[slot]);
+  }
 
   return instance;
 }
 ```
 
-对于当前例子，`definition.create()` 创建 `view`、`text` 和固定文本；`definition.update[0]()` 将 `values[0]` 写入 `className`；`insertDynamicChild()` 则把 `$0` 对应的 `name` 放进预留插槽。这里仍会创建完整的 Lynx 元件树，差别在于静态层级由 `definition.create()` 直接展开，不再通过每个宿主 VNode 逐层协调。
+对于 `Greeting`，`definition.create()` 创建 `view`、`text`、固定文本和表示插入位置的 wrapper。唯一的属性更新函数将 `initialValues[0]`，也就是计算出的 `className`，写入根 `view`；唯一的子节点插槽则把 `dynamicChildren[0]`，也就是 `name`，放进 `text` 内的这个插入位置。这里仍会创建完整的 Lynx 元件树，差别在于编译生成的创建函数直接展开稳定层级，不再让每个宿主 VNode 逐层参与协调。
 
 换一个角度，也可以把它理解为预先计算一部分渲染工作，类似于 [Next.js 的 Partial Prerendering](https://nextjs.org/docs/app/getting-started/partial-prerendering)。不过，两者的产物不同：Next.js 生成静态 HTML 外壳和序列化的 React Server Component 载荷；ReactLynx 则把稳定的宿主结构继续降级为 Lynx 平台可以直接理解的元件创建操作。动态值和动态子树仍会在页面启动时传入。
 
-后台首轮协调也会生成与主线程实例树对应的逻辑实例树。首屏同步通过 hydration 建立两侧实例的对应关系，使后续更新可以用 `instanceId` 定位首屏时创建的主线程实例。
+与此同时，后台首轮协调会根据同一组动态值和子节点创建对应的 `BackgroundInstance` 和逻辑实例树。首屏同步通过 hydration 将每个后台实例映射到已经为首屏创建的主线程实例。映射建立后，两侧使用相同的 `instanceId`，后续 Patch 因此可以直接定位正确的主线程实例，不需要再次比较两棵树。
 
 #### 更新：只处理动态位置的变化
 
@@ -290,35 +350,39 @@ function renderFirstScreen(vnode) {
 
 下面的伪代码继续使用 `Greeting`。`highlighted` 对应动态位置 `0`，因此它变化时会生成一条属性更新；`name` 位于动态子节点插槽中，继续由 React 协调：
 
-```js
+```ts
 // 后台线程：比较动态属性，并继续协调动态子节点
-function reconcileGreeting(previous, next, instanceId) {
-  if (!isEqual(previous.values[0], next.values[0])) {
-    emitAttributePatch({
-      instanceId,
-      dynamicPartIndex: 0,
-      value: next.values[0],
-    });
+function updateInBackground(
+  instance: BackgroundInstance,
+  nextValues: unknown[],
+  nextDynamicChildren: unknown[],
+) {
+  for (let position = 0; position < nextValues.length; position++) {
+    if (!isEqual(instance.values[position], nextValues[position])) {
+      emitPropertyPatch({
+        instanceId: instance.id,
+        propertyPosition: position,
+        value: nextValues[position],
+      });
+    }
   }
 
-  // $0 仍作为 React 子节点参与协调，结果会变成插入、移除等树操作。
-  reconcileChildren(previous.$0, next.$0, {
-    parentInstanceId: instanceId,
-    slotIndex: 0,
-  });
+  instance.values = nextValues;
+  reconcileDynamicChildren(instance, nextDynamicChildren);
+  instance.dynamicChildren = nextDynamicChildren;
 }
 
 // 主线程根据实例和动态位置应用属性更新
-function applyAttributePatch(patch) {
-  const instance = findCompiledInstance(patch.instanceId);
-  const index = patch.dynamicPartIndex;
+function applyPropertyPatch(patch: PropertyPatch) {
+  const instance = findMainThreadInstance(patch.instanceId);
+  const position = patch.propertyPosition;
 
-  instance.values[index] = patch.value;
-  instance.definition.update[index](instance);
+  instance.values[position] = patch.value;
+  instance.definition.update[position](instance);
 }
 ```
 
-对于属性路径，`reconcileGreeting()` 只描述“哪个实例的哪个动态位置发生了变化”，`applyAttributePatch()` 再调用编译器生成的定向更新函数。动态子节点不经过这组属性更新函数，而是由 React 协调后产生相应的树操作。当前实现会将这些操作编码进序列化的 Patch。
+对于属性路径，`updateInBackground()` 只发出实例 ID、动态属性位置和新值；`applyPropertyPatch()` 再使用该位置选择编译器生成的更新函数。动态子节点不经过这组属性更新函数，`reconcileDynamicChildren()` 会为它们生成插入、移除等树操作。当前实现会把两类操作都序列化进紧凑的 Patch，而不是发送这里用于解释的对象结构。
 
 ## 回到应用代码
 


### PR DESCRIPTION
## Summary

Follow-up to #1277.

- define the Snapshot pseudocode concepts before using them and map them to the current source types
- rewrite the initial-render and update flows around SnapshotDefinition, MainThreadInstance, and BackgroundInstance
- keep the English and Chinese explanations aligned

## Validation

- Prettier check passed
- CSpell check passed
- zhlint passed
- Rspress compiled the site through processAssets; the local build then stopped while writing SSG artifacts because the machine ran out of disk space

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Define Snapshot pseudocode concepts and map them to current source types.
- Rewrite initial-render and update flows around `SnapshotDefinition`, `MainThreadInstance`, and `BackgroundInstance`.
- Align the English and Chinese React documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->