### PR TITLE
fix(docs): make element API invoke() examples parse as real code

### DIFF
--- a/docs/en/api/elements/built-in/input-API.mdx
+++ b/docs/en/api/elements/built-in/input-API.mdx
@@ -263,49 +263,50 @@ Require focus
 
  <AndroidOnly /> <IOSOnly /> <HarmonyOnly /> <VersionBadge>3.4</VersionBadge>
 ```ts
+interface GetValueResult {
+  /**
+   * Is composing or not, iOS only
+   * @Android
+   * @iOS
+   * @Harmony
+   * @Web
+   * @since 3.4
+   */
+  isComposing: boolean;
+  /**
+   * End position of the selection
+   * @Android
+   * @iOS
+   * @Harmony
+   * @Web
+   * @since 3.4
+   */
+  selectionEnd: number;
+  /**
+   * Begin position of the selection
+   * @Android
+   * @iOS
+   * @Harmony
+   * @Web
+   * @since 3.4
+   */
+  selectionStart: number;
+  /**
+   * Input content
+   * @Android
+   * @iOS
+   * @Harmony
+   * @Web
+   * @since 3.4
+   */
+  value: string;
+}
 
 lynx.createSelectorQuery()
      .select('#id')
      .invoke({
       method: 'getValue',
-      success: Callback<{
-        /**
-         * Is composing or not, iOS only
-         * @Android
-         * @iOS
-         * @Harmony
-         * @Web
-         * @since 3.4
-         */
-        isComposing: boolean;
-        /**
-         * End position of the selection
-         * @Android
-         * @iOS
-         * @Harmony
-         * @Web
-         * @since 3.4
-         */
-        selectionEnd: number;
-        /**
-         * Begin position of the selection
-         * @Android
-         * @iOS
-         * @Harmony
-         * @Web
-         * @since 3.4
-         */
-        selectionStart: number;
-        /**
-         * Input content
-         * @Android
-         * @iOS
-         * @Harmony
-         * @Web
-         * @since 3.4
-         */
-        value: string;
-      }>;
+      success: function (res: GetValueResult) {},
       fail: function (res) {},
     })
     .exec();
@@ -333,7 +334,7 @@ lynx.createSelectorQuery()
          * @Web
          * @since 3.4
          */
-        selectionEnd: number;
+        selectionEnd: 5,
         /**
          * Start position of the selection
          * @Android
@@ -342,8 +343,8 @@ lynx.createSelectorQuery()
          * @Web
          * @since 3.4
          */
-        selectionStart: number;
-      };
+        selectionStart: 0,
+      },
       success: function (res) {},
       fail: function (res) {},
     })
@@ -372,8 +373,8 @@ lynx.createSelectorQuery()
          * @Web
          * @since 3.4
          */
-        value: string;
-      };
+        value: 'hello',
+      },
       success: function (res) {},
       fail: function (res) {},
     })

--- a/docs/en/api/elements/built-in/list.mdx
+++ b/docs/en/api/elements/built-in/list.mdx
@@ -770,7 +770,7 @@ this.createSelectorQuery()
       position: 10,
       offset: 100,
       alignTo: 'top',
-      itemKey: `${itemKey}`
+      itemKey: `${itemKey}`,
       smooth: true,
     },
     success: function (res) {},
@@ -797,9 +797,9 @@ this.createSelectorQuery()
   .invoke({
     method: 'autoScroll',
     params: {
-      rate: string, //  The distance scrolled per second, supports positive and negative. Distance supports units "px/rpx/ppx" default->null (iOS value must be greater than 1/screen.scale px)
-      start: bool, //  Start/pause auto-scrolling default->false
-      autoStop: bool, // Whether to automatically stop when reaching the bottom default->true
+      rate: '60px', //  The distance scrolled per second, supports positive and negative. Distance supports units "px/rpx/ppx" default->null (iOS value must be greater than 1/screen.scale px)
+      start: true, //  Start/pause auto-scrolling default->false
+      autoStop: true, // Whether to automatically stop when reaching the bottom default->true
     },
     success: function (res) {},
     fail: function (res) {},
@@ -840,7 +840,7 @@ attachedCells: [
   {
     id: number, // Node id
     itemKey: string, // Node item-key
-    index: number, // Node index in list
+    index: 0, // Node index in list
     left: number, // Node left boundary position relative to list, in px
     top: number, // Node top boundary position relative to list, in px
     right: number, // Node right boundary position relative to list, in px
@@ -858,7 +858,7 @@ lynx
   .invoke({
     method: 'scrollBy',
     params: {
-      offset: number,
+      offset: 100,
     },
     success(res) {
       console.log('succ ');

--- a/docs/en/api/elements/built-in/scroll-view-API.mdx
+++ b/docs/en/api/elements/built-in/scroll-view-API.mdx
@@ -174,7 +174,7 @@ lynx.createSelectorQuery()
          * @Harmony
          * @PC
          */
-        rate: number;
+        rate: 60,
         /**
          * Start/stop automatic scrolling.
          * @Android
@@ -182,8 +182,8 @@ lynx.createSelectorQuery()
          * @Harmony
          * @PC
          */
-        start: boolean;
-      };
+        start: true,
+      },
       success: function (res) {},
       fail: function (res) {},
     })
@@ -198,37 +198,38 @@ Automatic scrolling
 
  <AndroidOnly /> <IOSOnly /> <ClayOnly /> <HarmonyOnly />
 ```ts
+interface GetScrollInfoResult {
+  /**
+   * Total scrollable range along orientation, in PX
+   * @Android
+   * @iOS
+   * @Harmony
+   * @PC
+   */
+  scrollRange: number;
+  /**
+   * Content offset on X-axis, in PX
+   * @Android
+   * @iOS
+   * @Harmony
+   * @PC
+   */
+  scrollX: number;
+  /**
+   * Content offset on Y-axis, in PX
+   * @Android
+   * @iOS
+   * @Harmony
+   * @PC
+   */
+  scrollY: number;
+}
 
 lynx.createSelectorQuery()
      .select('#id')
      .invoke({
       method: 'getScrollInfo',
-      success: Callback<{
-        /**
-         * Total scrollable range along orientation, in PX
-         * @Android
-         * @iOS
-         * @Harmony
-         * @PC
-         */
-        scrollRange: number;
-        /**
-         * Content offset on X-axis, in PX
-         * @Android
-         * @iOS
-         * @Harmony
-         * @PC
-         */
-        scrollX: number;
-        /**
-         * Content offset on Y-axis, in PX
-         * @Android
-         * @iOS
-         * @Harmony
-         * @PC
-         */
-        scrollY: number;
-      }>;
+      success: function (res: GetScrollInfoResult) {},
       fail: function (res) {},
     })
     .exec();
@@ -242,17 +243,20 @@ Get scroll info
 
  <AndroidOnly /> <IOSOnly /> <ClayOnly /> <HarmonyOnly />
 ```ts
+interface ScrollByParams {
+  /**
+   * Offset to scroll
+   */
+  offset?: number;
+}
+
+const params: ScrollByParams = { offset: 100 };
 
 lynx.createSelectorQuery()
      .select('#id')
      .invoke({
       method: 'scrollBy',
-      params: {
-        /**
-         * Offset to scroll
-         */
-        offset?: number;
-      };
+      params,
       success: function (res) {},
       fail: function (res) {},
     })
@@ -267,26 +271,29 @@ Scroll by specified offset
 
  <AndroidOnly /> <IOSOnly /> <ClayOnly /> <HarmonyOnly />
 ```ts
+interface ScrollToParams {
+  /**
+   * Target item index
+   * @defaultValue 0
+   */
+  index?: number;
+  /**
+   * Offset relative to target node
+   */
+  offset?: number;
+  /**
+   * Enable scroll animation
+   */
+  smooth?: boolean;
+}
+
+const params: ScrollToParams = { index: 0, offset: 0, smooth: true };
 
 lynx.createSelectorQuery()
      .select('#id')
      .invoke({
       method: 'scrollTo',
-      params: {
-        /**
-         * Target item index
-         * @defaultValue 0
-         */
-        index?: number;
-        /**
-         * Offset relative to target node
-         */
-        offset?: number;
-        /**
-         * Enable scroll animation
-         */
-        smooth?: boolean;
-      };
+      params,
       success: function (res) {},
       fail: function (res) {},
     })

--- a/docs/en/api/elements/built-in/text.mdx
+++ b/docs/en/api/elements/built-in/text.mdx
@@ -256,7 +256,7 @@ You can invoke element methods from the frontend using the [SelectorQuery](/api/
 
 ### `setTextSelection`
 
-```ts
+```tsx
 <text id="test" text-selection={true} flatten={false}></text>
 
 lynx.createSelectorQuery()
@@ -316,7 +316,7 @@ interface Handle {
 
 ### `getTextBoundingRect`
 
-```ts
+```tsx
 <text id="test"></text>
 
 lynx.createSelectorQuery()
@@ -353,7 +353,7 @@ This method retrieves the bounding box of a specific range of text. The response
 
 ### `getSelectedText`
 
-```ts
+```tsx
 <text id="test" text-selection={true} flatten={false}></text>
 
 lynx.createSelectorQuery()
@@ -594,7 +594,8 @@ Bind long-press, tap, and touch events on the outer `<view>` container. These wi
 const CrossTextSelection = () => {
   useEffect(() => {
     getTextNodeRect();
-}, []);
+  }, []);
+};
 
 // Asynchronous function to get the bounding rectangles of text nodes
 async function getTextNodeRect() {

--- a/docs/en/api/elements/built-in/textarea-API.mdx
+++ b/docs/en/api/elements/built-in/textarea-API.mdx
@@ -311,49 +311,50 @@ Require focus
 
  <AndroidOnly /> <IOSOnly /> <HarmonyOnly /> <VersionBadge>3.4</VersionBadge>
 ```ts
+interface GetValueResult {
+  /**
+   * Is composing or not, iOS only
+   * @Android
+   * @iOS
+   * @Harmony
+   * @Web
+   * @since 3.4
+   */
+  isComposing: boolean;
+  /**
+   * End position of the cursor
+   * @Android
+   * @iOS
+   * @Harmony
+   * @Web
+   * @since 3.4
+   */
+  selectionEnd: number;
+  /**
+   * Begin position of the cursor
+   * @Android
+   * @iOS
+   * @Harmony
+   * @Web
+   * @since 3.4
+   */
+  selectionStart: number;
+  /**
+   * Input content
+   * @Android
+   * @iOS
+   * @Harmony
+   * @Web
+   * @since 3.4
+   */
+  value: string;
+}
 
 lynx.createSelectorQuery()
      .select('#id')
      .invoke({
       method: 'getValue',
-      success: Callback<{
-        /**
-         * Is composing or not, iOS only
-         * @Android
-         * @iOS
-         * @Harmony
-         * @Web
-         * @since 3.4
-         */
-        isComposing: boolean;
-        /**
-         * End position of the cursor
-         * @Android
-         * @iOS
-         * @Harmony
-         * @Web
-         * @since 3.4
-         */
-        selectionEnd: number;
-        /**
-         * Begin position of the cursor
-         * @Android
-         * @iOS
-         * @Harmony
-         * @Web
-         * @since 3.4
-         */
-        selectionStart: number;
-        /**
-         * Input content
-         * @Android
-         * @iOS
-         * @Harmony
-         * @Web
-         * @since 3.4
-         */
-        value: string;
-      }>;
+      success: function (res: GetValueResult) {},
       fail: function (res) {},
     })
     .exec();
@@ -381,7 +382,7 @@ lynx.createSelectorQuery()
          * @Web
          * @since 3.4
          */
-        selectionEnd: number;
+        selectionEnd: 5,
         /**
          * Start position of the selection
          * @Android
@@ -390,8 +391,8 @@ lynx.createSelectorQuery()
          * @Web
          * @since 3.4
          */
-        selectionStart: number;
-      };
+        selectionStart: 0,
+      },
       success: function (res) {},
       fail: function (res) {},
     })
@@ -420,8 +421,8 @@ lynx.createSelectorQuery()
          * @Web
          * @since 3.4
          */
-        value: string;
-      };
+        value: 'hello',
+      },
       success: function (res) {},
       fail: function (res) {},
     })

--- a/docs/en/guide/custom-native-component/custom-component-harmony.mdx
+++ b/docs/en/guide/custom-native-component/custom-component-harmony.mdx
@@ -529,7 +529,7 @@ export class LynxExplorerInput extends UIBase {
 
 On the front-end, bind the corresponding input event to listen for and handle the text input data sent by the client.
 
-```jsx title="App.tsx"
+```tsx title="App.tsx"
 const handleInput = (e) => {
   const currentValue = e.detail.value.trim();
   setInputValue(currentValue);
@@ -552,7 +552,7 @@ In some cases, the front-end may need to directly manipulate custom elements via
 
 The following code shows how to use [SelectorQuery](/api/lynx-api/selector-query) to call the `focus` method and focus the `<explorer-input>` element:
 
-```jsx title="App.tsx"
+```tsx title="App.tsx"
 lynx
   .createSelectorQuery()
   .select('#input-id')
@@ -562,7 +562,7 @@ lynx
     success: function (res) {
       console.log('lynx', 'request focus success');
     },
-    fail: function (res : {code: number, data: any}) {
+    fail: function (res: { code: number; data: any }) {
       console.log('lynx', 'request focus fail');
     },
   })

--- a/docs/en/guide/custom-native-component/custom-component-iOS.mdx
+++ b/docs/en/guide/custom-native-component/custom-component-iOS.mdx
@@ -407,7 +407,7 @@ LYNX_PROP_SETTER("value", setValue, NSString *) {
 
 On the front-end, bind the corresponding input event to listen for and handle the text input data sent by the client.
 
-```jsx title="App.tsx"
+```tsx title="App.tsx"
 const handleInput = (e) => {
   const currentValue = e.detail.value.trim();
   setInputValue(currentValue);
@@ -430,7 +430,7 @@ In some cases, the front-end may need to directly manipulate custom elements via
 
 The following code shows how to use [SelectorQuery](/api/lynx-api/selector-query) to call the `focus` method and focus the `<explorer-input>` element:
 
-```jsx title="App.tsx"
+```tsx title="App.tsx"
 lynx
   .createSelectorQuery()
   .select('#input-id')

--- a/docs/zh/api/elements/built-in/image.mdx
+++ b/docs/zh/api/elements/built-in/image.mdx
@@ -336,7 +336,7 @@ interface ImageErrorEvent {
 lynx.createSelectorQuery()
      .select('#gifs')
      .invoke({
-      method: 'startAnimate'，
+      method: 'startAnimate',
     })
     .exec();
 
@@ -351,7 +351,7 @@ lynx.createSelectorQuery()
 lynx.createSelectorQuery()
      .select('#gifs')
      .invoke({
-      method: 'pauseAnimation'，
+      method: 'pauseAnimation',
     })
     .exec();
 
@@ -366,7 +366,7 @@ lynx.createSelectorQuery()
 lynx.createSelectorQuery()
      .select('#gifs')
      .invoke({
-      method: 'resumeAnimation'，
+      method: 'resumeAnimation',
     })
     .exec();
 
@@ -381,7 +381,7 @@ lynx.createSelectorQuery()
 lynx.createSelectorQuery()
      .select('#gifs')
      .invoke({
-      method: 'stopAnimation'，
+      method: 'stopAnimation',
     })
     .exec();
 

--- a/docs/zh/api/elements/built-in/input-API.mdx
+++ b/docs/zh/api/elements/built-in/input-API.mdx
@@ -255,49 +255,50 @@ lynx.createSelectorQuery()
 
  <AndroidOnly /> <IOSOnly /> <HarmonyOnly /> <VersionBadge>3.4</VersionBadge>
 ```ts
+interface GetValueResult {
+  /**
+   * 是否正在输入，仅 iOS 支持
+   * @Android
+   * @iOS
+   * @Harmony
+   * @Web
+   * @since 3.4
+   */
+  isComposing: boolean;
+  /**
+   * 选中文本的结束位置
+   * @Android
+   * @iOS
+   * @Harmony
+   * @Web
+   * @since 3.4
+   */
+  selectionEnd: number;
+  /**
+   * 选中文本的开始位置
+   * @Android
+   * @iOS
+   * @Harmony
+   * @Web
+   * @since 3.4
+   */
+  selectionStart: number;
+  /**
+   * 输入内容
+   * @Android
+   * @iOS
+   * @Harmony
+   * @Web
+   * @since 3.4
+   */
+  value: string;
+}
 
 lynx.createSelectorQuery()
      .select('#id')
      .invoke({
       method: 'getValue',
-      success: Callback<{
-        /**
-         * 是否正在输入，仅 iOS 支持
-         * @Android
-         * @iOS
-         * @Harmony
-         * @Web
-         * @since 3.4
-         */
-        isComposing: boolean;
-        /**
-         * 选中文本的结束位置
-         * @Android
-         * @iOS
-         * @Harmony
-         * @Web
-         * @since 3.4
-         */
-        selectionEnd: number;
-        /**
-         * 选中文本的开始位置
-         * @Android
-         * @iOS
-         * @Harmony
-         * @Web
-         * @since 3.4
-         */
-        selectionStart: number;
-        /**
-         * 输入内容
-         * @Android
-         * @iOS
-         * @Harmony
-         * @Web
-         * @since 3.4
-         */
-        value: string;
-      }>;
+      success: function (res: GetValueResult) {},
       fail: function (res) {},
     })
     .exec();
@@ -324,7 +325,7 @@ lynx.createSelectorQuery()
          * @Web
          * @since 3.4
          */
-        selectionEnd: number;
+        selectionEnd: 5,
         /**
          * 选中文本的开始位置
          * @Android
@@ -333,8 +334,8 @@ lynx.createSelectorQuery()
          * @Web
          * @since 3.4
          */
-        selectionStart: number;
-      };
+        selectionStart: 0,
+      },
       success: function (res) {},
       fail: function (res) {},
     })
@@ -362,8 +363,8 @@ lynx.createSelectorQuery()
          * @Web
          * @since 3.4
          */
-        value: string;
-      };
+        value: 'hello',
+      },
       success: function (res) {},
       fail: function (res) {},
     })

--- a/docs/zh/api/elements/built-in/list.mdx
+++ b/docs/zh/api/elements/built-in/list.mdx
@@ -754,7 +754,7 @@ this.createSelectorQuery()
       position: 10,
       offset: 100,
       alignTo: 'top',
-      itemKey: `${itemKey}`
+      itemKey: `${itemKey}`,
       smooth: true,
     },
     success: function (res) {},
@@ -781,9 +781,9 @@ this.createSelectorQuery()
   .invoke({
     method: 'autoScroll',
     params: {
-      rate: string, //  每一秒滚动的间距，支持正负。间距支持单位"px/rpx/ppx" default->null (iOS 取值必须大于 1/screen.scale px)
-      start: bool, //  开始/暂停自动滚动 default->false
-      autoStop: bool, // 滑到底部是否自动停止 default->true
+      rate: '60px', //  每一秒滚动的间距，支持正负。间距支持单位"px/rpx/ppx" default->null (iOS 取值必须大于 1/screen.scale px)
+      start: true, //  开始/暂停自动滚动 default->false
+      autoStop: true, // 滑到底部是否自动停止 default->true
     },
     success: function (res) {},
     fail: function (res) {},
@@ -824,7 +824,7 @@ attachedCells: [
   {
     id: number, // 节点 id
     itemKey: string, // 节点 item-key
-    index: number, // 节点在 list 中的 index
+    index: 0, // 节点在 list 中的 index
     left: number, // 节点左边界相对于 list 的位置，单位 px
     top: number, // 节点上边界相对于 list 的位置，单位 px
     right: number, // 节点右边界相对于 list 的位置，单位 px
@@ -842,7 +842,7 @@ lynx
   .invoke({
     method: 'scrollBy',
     params: {
-      offset: number,
+      offset: 100,
     },
     success(res) {
       console.log('succ ');

--- a/docs/zh/api/elements/built-in/scroll-view-API.mdx
+++ b/docs/zh/api/elements/built-in/scroll-view-API.mdx
@@ -168,7 +168,7 @@ lynx.createSelectorQuery()
          * @Harmony
          * @PC
          */
-        rate: number;
+        rate: 60,
         /**
          * 开始/停止自动滚动。
          * @Android
@@ -176,8 +176,8 @@ lynx.createSelectorQuery()
          * @Harmony
          * @PC
          */
-        start: boolean;
-      };
+        start: true,
+      },
       success: function (res) {},
       fail: function (res) {},
     })
@@ -192,37 +192,38 @@ lynx.createSelectorQuery()
 
  <AndroidOnly /> <IOSOnly /> <ClayOnly /> <HarmonyOnly />
 ```ts
+interface GetScrollInfoResult {
+  /**
+   * 沿方向的总可滚动范围，单位为 PX
+   * @Android
+   * @iOS
+   * @Harmony
+   * @PC
+   */
+  scrollRange: number;
+  /**
+   * X 轴上的内容偏移量，单位为 PX
+   * @Android
+   * @iOS
+   * @Harmony
+   * @PC
+   */
+  scrollX: number;
+  /**
+   * Y 轴上的内容偏移量，单位为 PX
+   * @Android
+   * @iOS
+   * @Harmony
+   * @PC
+   */
+  scrollY: number;
+}
 
 lynx.createSelectorQuery()
      .select('#id')
      .invoke({
       method: 'getScrollInfo',
-      success: Callback<{
-        /**
-         * 沿方向的总可滚动范围，单位为 PX
-         * @Android
-         * @iOS
-         * @Harmony
-         * @PC
-         */
-        scrollRange: number;
-        /**
-         * X 轴上的内容偏移量，单位为 PX
-         * @Android
-         * @iOS
-         * @Harmony
-         * @PC
-         */
-        scrollX: number;
-        /**
-         * Y 轴上的内容偏移量，单位为 PX
-         * @Android
-         * @iOS
-         * @Harmony
-         * @PC
-         */
-        scrollY: number;
-      }>;
+      success: function (res: GetScrollInfoResult) {},
       fail: function (res) {},
     })
     .exec();
@@ -236,17 +237,20 @@ lynx.createSelectorQuery()
 
  <AndroidOnly /> <IOSOnly /> <ClayOnly /> <HarmonyOnly />
 ```ts
+interface ScrollByParams {
+  /**
+   * 滚动的偏移量
+   */
+  offset?: number;
+}
+
+const params: ScrollByParams = { offset: 100 };
 
 lynx.createSelectorQuery()
      .select('#id')
      .invoke({
       method: 'scrollBy',
-      params: {
-        /**
-         * 滚动的偏移量
-         */
-        offset?: number;
-      };
+      params,
       success: function (res) {},
       fail: function (res) {},
     })
@@ -261,26 +265,29 @@ lynx.createSelectorQuery()
 
  <AndroidOnly /> <IOSOnly /> <ClayOnly /> <HarmonyOnly />
 ```ts
+interface ScrollToParams {
+  /**
+   * 目标项索引
+   * @defaultValue 0
+   */
+  index?: number;
+  /**
+   * 相对于目标节点的偏移量
+   */
+  offset?: number;
+  /**
+   * 启用滚动动画
+   */
+  smooth?: boolean;
+}
+
+const params: ScrollToParams = { index: 0, offset: 0, smooth: true };
 
 lynx.createSelectorQuery()
      .select('#id')
      .invoke({
       method: 'scrollTo',
-      params: {
-        /**
-         * 目标项索引
-         * @defaultValue 0
-         */
-        index?: number;
-        /**
-         * 相对于目标节点的偏移量
-         */
-        offset?: number;
-        /**
-         * 启用滚动动画
-         */
-        smooth?: boolean;
-      };
+      params,
       success: function (res) {},
       fail: function (res) {},
     })

--- a/docs/zh/api/elements/built-in/scroll-view.mdx
+++ b/docs/zh/api/elements/built-in/scroll-view.mdx
@@ -365,8 +365,8 @@ lynx
 
 ### `scrollTo`
 
-```ts
-<`<scroll-view>`id="scroll"/>
+```tsx
+<scroll-view id="scroll" />
 // 目标滚动位置的计算方法：MIN(可滚动区域，child(index).position + offset)
 lynx.createSelectorQuery()
   .select(`#scroll`)
@@ -385,8 +385,8 @@ lynx.createSelectorQuery()
 
 ### `autoScroll`
 
-```ts
-<`<scroll-view>`id="scroll"/>
+```tsx
+<scroll-view id="scroll" />
 
 lynx.createSelectorQuery()
   .select(`#scroll`)
@@ -404,7 +404,7 @@ lynx.createSelectorQuery()
 
 ### `scrollIntoView`
 
-```ts
+```tsx
 <scroll-view>
   <text id="targetnode">"click me, scrollIntoView"</text>
 </scroll-view>
@@ -428,15 +428,15 @@ lynx.createSelectorQuery()
 
 ### `scrollBy`
 
-```ts
-<`<scroll-view>`id="scrollview"/>
+```tsx
+<scroll-view id="scrollview" />
 
 lynx.createSelectorQuery()
   .select('#scrollview')
   .invoke({
     method: 'scrollBy',
     params: {
-      offset: number, // 滚动的距离, 单位 px
+      offset: 100, // 滚动的距离, 单位 px
     },
     success(res) {
       console.log('succ ');

--- a/docs/zh/api/elements/built-in/text.mdx
+++ b/docs/zh/api/elements/built-in/text.mdx
@@ -264,7 +264,7 @@ interface selectionChangeEvent extends CustomEvent {
 
 ### `setTextSelection`
 
-```ts
+```tsx
 <text id="test" text-selection={true} flatten={false}></text>
 
 lynx.createSelectorQuery()
@@ -324,7 +324,7 @@ interface Handle {
 
 ### `getTextBoundingRect`
 
-```ts
+```tsx
 <text id="test"></text>
 
 lynx.createSelectorQuery()
@@ -361,7 +361,7 @@ lynx.createSelectorQuery()
 
 ### `getSelectedText`
 
-```ts
+```tsx
 <text id="test" text-selection={true} flatten={false}></text>
 
 lynx.createSelectorQuery()
@@ -601,7 +601,8 @@ const YourComponent = () => {
 const CrossTextSelection = () => {
   useEffect(() => {
     getTextNodeRect();
-}, []);
+  }, []);
+};
 
 // Asynchronous function to get the bounding rectangles of text nodes
 async function getTextNodeRect() {

--- a/docs/zh/api/elements/built-in/textarea-API.mdx
+++ b/docs/zh/api/elements/built-in/textarea-API.mdx
@@ -291,49 +291,50 @@ lynx.createSelectorQuery()
 
  <AndroidOnly /> <IOSOnly /> <HarmonyOnly /> <VersionBadge>3.4</VersionBadge>
 ```ts
+interface GetValueResult {
+  /**
+   * 是否正在输入，仅 iOS 支持
+   * @Android
+   * @iOS
+   * @Harmony
+   * @Web
+   * @since 3.4
+   */
+  isComposing: boolean;
+  /**
+   * 光标结束位置
+   * @Android
+   * @iOS
+   * @Harmony
+   * @Web
+   * @since 3.4
+   */
+  selectionEnd: number;
+  /**
+   * 光标开始位置
+   * @Android
+   * @iOS
+   * @Harmony
+   * @Web
+   * @since 3.4
+   */
+  selectionStart: number;
+  /**
+   * 输入内容
+   * @Android
+   * @iOS
+   * @Harmony
+   * @Web
+   * @since 3.4
+   */
+  value: string;
+}
 
 lynx.createSelectorQuery()
      .select('#id')
      .invoke({
       method: 'getValue',
-      success: Callback<{
-        /**
-         * 是否正在输入，仅 iOS 支持
-         * @Android
-         * @iOS
-         * @Harmony
-         * @Web
-         * @since 3.4
-         */
-        isComposing: boolean;
-        /**
-         * 光标结束位置
-         * @Android
-         * @iOS
-         * @Harmony
-         * @Web
-         * @since 3.4
-         */
-        selectionEnd: number;
-        /**
-         * 光标开始位置
-         * @Android
-         * @iOS
-         * @Harmony
-         * @Web
-         * @since 3.4
-         */
-        selectionStart: number;
-        /**
-         * 输入内容
-         * @Android
-         * @iOS
-         * @Harmony
-         * @Web
-         * @since 3.4
-         */
-        value: string;
-      }>;
+      success: function (res: GetValueResult) {},
       fail: function (res) {},
     })
     .exec();
@@ -361,7 +362,7 @@ lynx.createSelectorQuery()
          * @Web
          * @since 3.4
          */
-        selectionEnd: number;
+        selectionEnd: 5,
         /**
          * 选择区域的开始位置
          * @Android
@@ -370,8 +371,8 @@ lynx.createSelectorQuery()
          * @Web
          * @since 3.4
          */
-        selectionStart: number;
-      };
+        selectionStart: 0,
+      },
       success: function (res) {},
       fail: function (res) {},
     })
@@ -400,8 +401,8 @@ lynx.createSelectorQuery()
          * @Web
          * @since 3.4
          */
-        value: string;
-      };
+        value: 'hello',
+      },
       success: function (res) {},
       fail: function (res) {},
     })

--- a/docs/zh/api/lynx-api/selector-query/selector-query-select.mdx
+++ b/docs/zh/api/lynx-api/selector-query/selector-query-select.mdx
@@ -158,19 +158,25 @@ enum ErrorCode {
 
 一种常见的找不到节点的情况是，在 `exec()` 函数调用时节点没有渲染，例如此时节点在条件不满足的条件语句中。
 
-例如以下伪代码中，首屏渲染时，由于 `should_render` 为 `false`，`<view id="xxx">` 节点不会渲染。此时在 `componentDidMount()` 中进行节点获取会失败。
+例如以下伪代码中，首屏渲染时，由于 `show` 为 `false`，`<view id="xxx" />` 节点不会渲染。此时在 `useEffect()` 中进行节点获取会失败。
 
-```js
-this.state = {
-  should_render: false,
-}
+```jsx
+import { useEffect, useState } from '@lynx-js/react';
 
-componentDidMount() {
-  lynx.createSelectorQuery().select("#xxx").invoke(...).exec();
-}
+function App() {
+  const [show, setShow] = useState(false);
 
-render() {
-  return should_render ? (<view id="xxx"> : null);
+  useEffect(() => {
+    lynx
+      .createSelectorQuery()
+      .select('#xxx')
+      .invoke({
+        /** Args */
+      })
+      .exec();
+  }, []);
+
+  return show ? <view id="xxx" /> : null;
 }
 ```
 

--- a/docs/zh/guide/custom-native-component/custom-component-harmony.mdx
+++ b/docs/zh/guide/custom-native-component/custom-component-harmony.mdx
@@ -530,7 +530,7 @@ export class LynxExplorerInput extends UIBase {
 
 在前端，需要绑定相应的文本框输入事件。通过以下代码，前端将监听客户端发送的事件，并根据需要处理输入的数据。
 
-```jsx title="App.tsx"
+```tsx title="App.tsx"
 const handleInput = (e) => {
   const currentValue = e.detail.value.trim();
   setInputValue(currentValue);
@@ -553,7 +553,7 @@ const handleInput = (e) => {
 
 以下代码展示了如何在前端通过 [SelectorQuery](/api/lynx-api/selector-query) 调用 `focus` 方法让 `<explorer-input>` 元件获取焦点：
 
-```jsx title="App.tsx"
+```tsx title="App.tsx"
 lynx
   .createSelectorQuery()
   .select('#input-id')
@@ -563,7 +563,7 @@ lynx
     success: function (res) {
       console.log('lynx', 'request focus success');
     },
-    fail: function (res : {code: number, data: any}) {
+    fail: function (res: { code: number; data: any }) {
       console.log('lynx', 'request focus fail');
     },
   })

--- a/docs/zh/guide/custom-native-component/custom-component-iOS.mdx
+++ b/docs/zh/guide/custom-native-component/custom-component-iOS.mdx
@@ -434,7 +434,7 @@ LYNX_PROP_SETTER("value", setValue, NSString *) {
 
 在前端，需要绑定相应的文本框输入事件。通过以下代码，前端将监听客户端发送的事件，并根据需要处理输入的数据。
 
-```jsx title="App.tsx"
+```tsx title="App.tsx"
 const handleInput = (e) => {
   const currentValue = e.detail.value.trim();
   setInputValue(currentValue);
@@ -457,7 +457,7 @@ const handleInput = (e) => {
 
 以下代码展示了如何在前端通过 [SelectorQuery](/api/lynx-api/selector-query) 调用 `focus` 方法让 `<explorer-input>` 元件获取焦点：
 
-```jsx title="App.tsx"
+```tsx title="App.tsx"
 lynx
   .createSelectorQuery()
   .select('#input-id')
@@ -467,7 +467,7 @@ lynx
     success: function (res) {
       console.log('lynx', 'request focus success');
     },
-    fail: function (res : {code: number, data: any}) {
+    fail: function (res: { code: number; data: any }) {
       console.log('lynx', 'request focus fail');
     },
   })


### PR DESCRIPTION
Backport of #1350 to `release/3.8`, so the same page does not disagree with
itself depending on the selected site version. Part of #1347.

Element API pages document `invoke()` calls with blocks that mix a type shape
into what reads as runnable code:

```ts
params: {
  /** Input content */
  value: string;      // a type, not a value
};                    // ends the property with `;` instead of `,`
```

The block is presented as something you can paste, and it does not parse. Every
such block on this branch now does — measured with esbuild's TypeScript parser
over every fenced JS/TS block containing a real `invoke({...})` call.

## Representation

- **All-required `params`** get concrete values inline; the per-field JSDoc
  stays attached.
- **Any optional field**, and every `success: Callback<{...}>` result shape, is
  declared as an `interface` above the call and referenced from it. Writing
  `name: 'session'` in place of `name?: string` would silently drop the fact
  that a field is optional.

## Defects fixed in the same blocks

- **Full-width commas (U+FF0C)** used as code punctuation on the Chinese pages.
- **A garbled JSX tag** — `<`<scroll-view>`id="scroll"/>`.
- **An unterminated arrow function** in the cross-text-selection example.
- **Bare type names used as values** — `rate: string,`, `offset: number,`.
  These *parse* as JavaScript, since `number` is a valid identifier, so no
  syntax check can see them; they are the same defect all the same.
- **Wrong fence languages** — JSX and TypeScript annotations in `ts`/`jsx`
  fences, which need `tsx`.

The Chinese `selector-query-select` page also still taught class components
(`componentDidMount`, `should_render`) where the English page had moved to
hooks, and its example did not parse. It now matches, with the Chinese prose
updated.

## Verification against this branch's own SDK

This branch pins **Lynx 3.8.0**. A ReactLynx page calls the documented
`<scroll-view>` methods with exactly the values now shown and checks results
against the declared types, run on **Android 3.8.0**, and on iOS 3.8.0:

| Call | Result |
| --- | --- |
| `scrollTo({ index: 0, offset: 0, smooth: true })` | accepted |
| `scrollBy({ offset: 100 })` | accepted, view moves |
| `getScrollInfo` | returns `scrollX` / `scrollY` / `scrollRange` — the fields now declared as `GetScrollInfoResult` |

All five Objective-C++ samples in this branch's **macOS** integration guide
still compile against the released macOS SDK headers, in both locales.

Syntax check on this head: `docs/en` 53 checked, 0 failed.

## One observation for a maintainer

Left as-is because it is a runtime question rather than a documentation one: the
`autoScroll` example shows `success` and `fail` callbacks, and neither is
invoked, for `start: true` or `start: false`. Reproduced on every SDK line
tested.
