### PR TITLE
fix(docs): restore index: number in the getVisibleCells return shape

### DIFF
--- a/docs/en/api/elements/built-in/list.mdx
+++ b/docs/en/api/elements/built-in/list.mdx
@@ -840,7 +840,7 @@ attachedCells: [
   {
     id: number, // Node id
     itemKey: string, // Node item-key
-    index: 0, // Node index in list
+    index: number, // Node index in list
     left: number, // Node left boundary position relative to list, in px
     top: number, // Node top boundary position relative to list, in px
     right: number, // Node right boundary position relative to list, in px

--- a/docs/zh/api/elements/built-in/list.mdx
+++ b/docs/zh/api/elements/built-in/list.mdx
@@ -824,7 +824,7 @@ attachedCells: [
   {
     id: number, // 节点 id
     itemKey: string, // 节点 item-key
-    index: 0, // 节点在 list 中的 index
+    index: number, // 节点在 list 中的 index
     left: number, // 节点左边界相对于 list 的位置，单位 px
     top: number, // 节点上边界相对于 list 的位置，单位 px
     right: number, // 节点右边界相对于 list 的位置，单位 px


### PR DESCRIPTION
Minimal follow-up to the `invoke()` example normalization that landed on this
branch. Raised in review on #1354; the same regression reached #1351–#1353.

The `getVisibleCells` block documents the shape of what the call **returns**,
not a call you make. The earlier change turned `index: number` into `index: 0`
there, while every neighbouring field stayed a type:

```ts
attachedCells: [
  {
    id: number,        // Node id
    itemKey: string,   // Node item-key
    index: 0,          // <- reads as "always the literal 0"
    left: number,      // Node left boundary position relative to list, in px
    ...
```

That happened because the value pass matched on field name across the whole
file rather than only inside call examples, so it reached a return-shape block
it should not have touched. Auditing the same pattern across every affected
branch found **exactly this one line per locale** and nothing else.

`index: number` is restored in EN and ZH. `main` was never affected, so this
brings the versioned copies back into agreement.

## Verification

Checked against a real engine rather than assumed. A ReactLynx page renders a
`<list>` with six `<list-item>`s and calls `getVisibleCells` on it, asserting
that the returned indices are numbers and that they vary:

| Platform | Result |
| --- | --- |
| Android 3.9.0 — this branch's pinned SDK | `index = [0, 1, 2]` |
| Android 4.0.0 | `index = [0, 1, 2]` |
| iOS 4.0.0 | `index = [0, 1, 2]` |

Varying numbers, so `number` is the correct annotation and `0` was wrong.

The macOS app built from this repo's integration guide renders the same page
over HTTP without error, and all five Objective-C++ samples in that guide
compile against the released macOS SDK headers.

Every `invoke()` example on this branch still parses — 0 failures in `docs/en`
and `docs/zh`.

