### PR TITLE
docs: update Miso logo and website link

### DIFF
--- a/docs/public/assets/home/miso-mark-gradient.svg
+++ b/docs/public/assets/home/miso-mark-gradient.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="512" height="512" role="img" aria-label="miso">
+  <title>miso</title>
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ffb84a"/>
+      <stop offset="0.55" stop-color="#f08a24"/>
+      <stop offset="1" stop-color="#e2531f"/>
+    </linearGradient>
+  </defs>
+  <polygon points="0.93,21.65 6.37,21.65 12.25,13.6 9.3,10.1" fill="none" stroke="url(#g)" stroke-width="0.7" stroke-linejoin="miter"/>
+  <polygon points="1.5,2 7.8,2 22.5,22 16.2,22" fill="url(#g)"/>
+</svg>

--- a/src/components/home-comps/features/icon.tsx
+++ b/src/components/home-comps/features/icon.tsx
@@ -40,7 +40,7 @@ const IconOctaneLynx = () => {
 const IconMisoLynx = () => {
   return (
     <img
-      src={withBase('/assets/home/miso-lynx-logo.png')}
+      src={withBase('/assets/home/miso-mark-gradient.svg')}
       alt=""
       className={styles['miso-icon']}
     />

--- a/src/components/home-comps/features/index.tsx
+++ b/src/components/home-comps/features/index.tsx
@@ -184,7 +184,7 @@ const featuresConfig: Record<FeaturesConfigKey, FeatureCardItem[]> = {
             </Space>
           ),
           size: 'large',
-          link: 'https://github.com/haskell-miso/miso-lynx',
+          link: 'https://haskell-miso.org/',
         },
       ],
     },


### PR DESCRIPTION
## Summary

- replace the Miso homepage logo with the new gradient mark
- update the Miso destination link to https://haskell-miso.org/

## Testing

- Prettier check on the modified TSX files
- SVG structure validation
- git diff --check
- Rspress production build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Replace the Miso homepage logo with the `miso-mark-gradient.svg` asset.
- Set the Miso framework link to `https://haskell-miso.org/`.
- Run Prettier, SVG validation, `git diff --check`, and the Rspress production build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->