### PR TITLE
fix(docs): list the viewpager2 dependency xelement-refresh needs

### DIFF
--- a/docs/en/guide/start/fragments/android/integrating-lynx-with-existing-app-android.mdx
+++ b/docs/en/guide/start/fragments/android/integrating-lynx-with-existing-app-android.mdx
@@ -601,6 +601,8 @@ dependencies {
     implementation "org.lynxsdk.lynx:xelement-scroll-coordinator:{versionJson.LYNX_VERSION}"
     // Required when templates use pull-to-refresh.
     implementation "org.lynxsdk.lynx:xelement-refresh:{versionJson.LYNX_VERSION}"
+    // xelement-refresh reaches ViewPager2 through refresh-layout-kernel, which does not declare it.
+    implementation "androidx.viewpager2:viewpager2:1.1.0"
     // Required when templates use <blur-view>.
     implementation "org.lynxsdk.lynx:xelement-blur-view:{versionJson.LYNX_VERSION}"
     // Required when templates use <video>.
@@ -663,6 +665,8 @@ dependencies {
     implementation("org.lynxsdk.lynx:xelement-scroll-coordinator:{versionJson.LYNX_VERSION}")
     // Required when templates use pull-to-refresh.
     implementation("org.lynxsdk.lynx:xelement-refresh:{versionJson.LYNX_VERSION}")
+    // xelement-refresh reaches ViewPager2 through refresh-layout-kernel, which does not declare it.
+    implementation("androidx.viewpager2:viewpager2:1.1.0")
     // Required when templates use <blur-view>.
     implementation("org.lynxsdk.lynx:xelement-blur-view:{versionJson.LYNX_VERSION}")
     // Required when templates use <video>.

--- a/docs/zh/guide/start/fragments/android/integrating-lynx-with-existing-app-android.mdx
+++ b/docs/zh/guide/start/fragments/android/integrating-lynx-with-existing-app-android.mdx
@@ -183,6 +183,8 @@ dependencies {
     implementation "org.lynxsdk.lynx:xelement-scroll-coordinator:{versionJson.LYNX_VERSION}"
     // 仅在模板使用下拉刷新时需要。
     implementation "org.lynxsdk.lynx:xelement-refresh:{versionJson.LYNX_VERSION}"
+    // xelement-refresh 通过 refresh-layout-kernel 间接使用 ViewPager2，但后者并未声明该依赖。
+    implementation "androidx.viewpager2:viewpager2:1.1.0"
     // 仅在模板使用 <blur-view> 时需要。
     implementation "org.lynxsdk.lynx:xelement-blur-view:{versionJson.LYNX_VERSION}"
     // 仅在模板使用 <video> 时需要。
@@ -245,6 +247,8 @@ dependencies {
     implementation("org.lynxsdk.lynx:xelement-scroll-coordinator:{versionJson.LYNX_VERSION}")
     // 仅在模板使用下拉刷新时需要。
     implementation("org.lynxsdk.lynx:xelement-refresh:{versionJson.LYNX_VERSION}")
+    // xelement-refresh 通过 refresh-layout-kernel 间接使用 ViewPager2，但后者并未声明该依赖。
+    implementation("androidx.viewpager2:viewpager2:1.1.0")
     // 仅在模板使用 <blur-view> 时需要。
     implementation("org.lynxsdk.lynx:xelement-blur-view:{versionJson.LYNX_VERSION}")
     // 仅在模板使用 <video> 时需要。


### PR DESCRIPTION
Following the Android guide exactly — adding the XElement artifacts and
registering `XElementBehaviors().create()` — and then rendering the documented
`<refresh>` element kills the process the moment the view attaches:

```
java.lang.NoClassDefFoundError: Failed resolution of: Landroidx/viewpager2/widget/ViewPager2;
  at com.scwang.smart.refresh.layout.util.SmartUtil.isContentView
  at com.scwang.smart.refresh.layout.wrapper.RefreshContentWrapper.findScrollableViewInternal
  at com.scwang.smart.refresh.layout.SmartRefreshLayout.onAttachedToWindow
```

## Why nothing supplies it

| Artifact | Declares in its POM |
| --- | --- |
| `xelement-refresh` | kotlin-stdlib, appcompat, **refresh-layout-kernel** |
| `io.github.scwang90:refresh-layout-kernel:3.0.0-alpha` | **nothing at all** |
| `xelement-viewpager` | kotlin-stdlib, appcompat, material — *not* viewpager2 |

`refresh-layout-kernel`'s code references `androidx.viewpager2.widget.ViewPager2`
but its published POM declares no dependencies, so the class never reaches the
classpath. Confirmed by resolving the guide's exact block: `viewpager2` is
absent from `debugRuntimeClasspath`.

## Why this belongs in the guide

The guide already lists a companion artifact wherever an XElement needs one it
does not pull itself:

- `servalsvg` beside `xelement-svg`
- `lynxtextra` and `serval_markdown` beside `xelement-markdown`
- fresco / okhttp beside the image service

`xelement-refresh` is the same case. This adds the one line it needs, in the
same style and position — 8 added lines total across both locales and both
dependency tabs, nothing else touched.

## Verification

Rebuilt the app from the patched dependency block and re-ran a conformance suite
against **Lynx 4.0.0** on Android:

| | before | after |
| --- | --- | --- |
| `FATAL EXCEPTION` count | 1 (crash on attach) | **0** |
| `<refresh>` element | app dies | **registers**, measures 11.8 × 8 |
| Conformance total | — | **43 pass, 0 fail, 3 skip** of 46 |

The guide's coordinates still resolve (99 artifacts, 0 unresolved beyond the two
already-known unpublished ones, `xelement-animax` and `xelement-video`).

Applies to `main`, `release/3.9` and `release/3.8` — the only branches whose
guide lists `xelement-refresh`. `release/4.0`, `release/3.7` and older do not
document it and are unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Document the `androidx.viewpager2:viewpager2:1.1.0` dependency in English and Chinese Android integration guides.
- Include the dependency in both Groovy and Kotlin Gradle examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->