### PR TITLE
fix(scripts): make fetch-lynx-ui recover from a broken .lynx-ui-source

### DIFF
--- a/scripts/fetch-lynx-ui.mjs
+++ b/scripts/fetch-lynx-ui.mjs
@@ -34,7 +34,27 @@ const targetPath = resolve(process.cwd(), TARGET_DIR);
 const run = (command, options = {}) =>
   execSync(command, { stdio: 'inherit', ...options });
 
+// git commands run inside a directory that is not itself a repository walk up
+// to the enclosing one. Since this script runs from a lynx-website checkout,
+// a leftover or partially cloned .lynx-ui-source would otherwise make
+// `rev-parse HEAD` report lynx-website's HEAD and `remote get-url origin`
+// report lynx-website's URL -- and the fetch below would then ask
+// lynx-website for a lynx-ui commit and fail with "not our ref".
+const isOwnRepo = () => {
+  try {
+    const top = execSync('git rev-parse --show-toplevel', {
+      cwd: targetPath,
+      encoding: 'utf8',
+      stdio: 'pipe',
+    }).trim();
+    return resolve(top) === targetPath;
+  } catch {
+    return false;
+  }
+};
+
 const readHead = () => {
+  if (!isOwnRepo()) return null;
   try {
     return execSync('git rev-parse HEAD', {
       cwd: targetPath,
@@ -56,10 +76,16 @@ if (existsSync(targetPath)) {
   }
 
   if (current) {
+    // Point origin at lynx-ui whatever it currently says: an origin that
+    // exists but refers to another repository would otherwise be used as-is,
+    // and the fetch below would look for a lynx-ui commit in the wrong place.
     try {
-      run('git remote get-url origin', { cwd: targetPath });
+      run(`git remote set-url origin ${REPO}`, {
+        cwd: targetPath,
+        stdio: 'pipe',
+      });
     } catch {
-      run(`git remote add origin ${REPO}`, { cwd: targetPath });
+      run(`git remote add origin ${REPO}`, { cwd: targetPath, stdio: 'pipe' });
     }
 
     console.log(`Updating lynx-ui to ${sha.slice(0, SHORT_SHA_LEN)}...`);


### PR DESCRIPTION
`pnpm install` can fail with a message that points at lynx-ui, when neither
lynx-ui nor the pinned SHA is at fault:

```
$ node scripts/fetch-lynx-ui.mjs
https://github.com/lynx-family/lynx-website.git
Updating lynx-ui to 332e7b89...
fatal: remote error: upload-pack: not our ref 332e7b89ed9752ba575763014e67bc5fee0fb940
```

## What is actually happening

git commands run inside a directory that is not itself a repository walk **up**
to the enclosing one. This script runs from a lynx-website checkout, so when
`.lynx-ui-source` exists without its own `.git` — an interrupted clone leaves
exactly that state — every git call in the update path silently targets
lynx-website:

| call | intended | actual |
| --- | --- | --- |
| `rev-parse HEAD` | lynx-ui HEAD | **lynx-website HEAD** — so `current` looks valid |
| `remote get-url origin` | lynx-ui URL | **lynx-website URL** — printed in the log above |
| `fetch origin <sha>` | from lynx-ui | **from lynx-website**, which has no such commit |

The pinned SHA is a real lynx-ui commit
(`332e7b89` — *docs: generate component intros by locale (#173)*) and is not in
lynx-website at all, which is exactly why the fetch reports "not our ref".

The `rmSync`-and-clone path further down already handles a broken directory, but
it is unreachable because `current` is non-null.

## The change

Two guards, both in the update path, 25 lines:

- `readHead()` returns `null` unless `.lynx-ui-source` is its **own** repository
  root, so a directory in that state falls through to the clean re-clone that
  already exists.
- `origin` is *set* to the lynx-ui URL rather than merely checked for existence.
  An origin that exists but points elsewhere was previously used as-is.

## Verification

Reproduced the original failure byte for byte, then re-ran with the patch:

| state | before | after |
| --- | --- | --- |
| directory exists, not a repo | `not our ref`, install fails | re-clones, checks out the pinned SHA |
| repo with a wrong `origin` | fetches from the wrong remote | fetches the requested commit, origin corrected |
| already at the pinned SHA | skips | skips (unchanged) |

This is why it is worth fixing rather than working around: the failure names
lynx-ui and a SHA, so the natural reading is that the pin is stale or the
upstream ref was force-pushed away. Neither is true, and the real cause —
a stray directory — is invisible from the message.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Validate `.lynx-ui-source` as a standalone Git repository before reading `HEAD`.
- Set `origin` to the configured `lynx-ui` URL before updating an existing repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->