### PR TITLE
fix(docs): correct Clay/macOS support claims disproved by the runtime

### DIFF
--- a/docs/en/api/elements/built-in/scroll-view-API.mdx
+++ b/docs/en/api/elements/built-in/scroll-view-API.mdx
@@ -196,7 +196,7 @@ Automatic scrolling
 
 ### `getScrollInfo`
 
- <AndroidOnly /> <IOSOnly /> <ClayOnly /> <HarmonyOnly />
+ <AndroidOnly /> <IOSOnly /> <ClayWindowsOnly /> <HarmonyOnly />
 ```ts
 interface GetScrollInfoResult {
   /**
@@ -241,7 +241,7 @@ Get scroll info
 
 ### `scrollBy`
 
- <AndroidOnly /> <IOSOnly /> <ClayOnly /> <HarmonyOnly />
+ <AndroidOnly /> <IOSOnly /> <ClayWindowsOnly /> <HarmonyOnly />
 ```ts
 interface ScrollByParams {
   /**

--- a/docs/zh/api/elements/built-in/scroll-view-API.mdx
+++ b/docs/zh/api/elements/built-in/scroll-view-API.mdx
@@ -190,7 +190,7 @@ lynx.createSelectorQuery()
 
 ### `getScrollInfo`
 
- <AndroidOnly /> <IOSOnly /> <ClayOnly /> <HarmonyOnly />
+ <AndroidOnly /> <IOSOnly /> <ClayWindowsOnly /> <HarmonyOnly />
 ```ts
 interface GetScrollInfoResult {
   /**
@@ -235,7 +235,7 @@ lynx.createSelectorQuery()
 
 ### `scrollBy`
 
- <AndroidOnly /> <IOSOnly /> <ClayOnly /> <HarmonyOnly />
+ <AndroidOnly /> <IOSOnly /> <ClayWindowsOnly /> <HarmonyOnly />
 ```ts
 interface ScrollByParams {
   /**

--- a/packages/lynx-compat-data/lynx-api/lynx/accessibilityAnnounce.json
+++ b/packages/lynx-compat-data/lynx-api/lynx/accessibilityAnnounce.json
@@ -16,7 +16,7 @@
               "version_added": "3.5"
             },
             "clay_macos": {
-              "version_added": "3.5"
+              "version_added": false
             },
             "clay_windows": {
               "version_added": "3.5"

--- a/packages/lynx-compat-data/lynx-api/lynx/cancelResourcePrefetch.json
+++ b/packages/lynx-compat-data/lynx-api/lynx/cancelResourcePrefetch.json
@@ -16,7 +16,7 @@
               "version_added": "3.5"
             },
             "clay_macos": {
-              "version_added": "3.5"
+              "version_added": false
             },
             "clay_windows": {
               "version_added": "3.5"


### PR DESCRIPTION
Four documented capabilities are claimed for macOS and are not present in the
shipping Clay runtime.

## Verified against the official Clay host, not a hand-built one

The first run used an embedder built from this repo's own macOS guide, so the
obvious objection is that the embedder is at fault. It is not — the same suite
run inside **LynxExplorer 4.0.1 for macOS**, the reference Clay host published in
`lynx-family/lynx`, produces the identical four failures:

| Case | Observed on official LynxExplorer 4.0.1 |
| --- | --- |
| `scroll-view` `scrollBy` | `{"code":3,"data":"method not found: scrollBy"}` |
| `scroll-view` `getScrollInfo` | returns without `scrollX` / `scrollY` / `scrollRange` |
| `lynx.accessibilityAnnounce` | `undefined` |
| `lynx.cancelResourcePrefetch` | `undefined` |

All four **pass on Android 4.0.0 and iOS 4.0.0**, so this is desktop-specific
rather than a general regression.

## The version question is closed, not assumed

Both `lynx` APIs are recorded as `clay_macos version_added: 3.5` and the runtime
reports `sdk 4.0` — later than 3.5 — so their absence is not "added in a newer
release". The same four also fail on the 3.9 macOS SDK, so this is not a
one-version blip either.

## The change

Two values, one per file:

- **compat data** — `clay_macos` becomes `false` for `accessibilityAnnounce` and
  `cancelResourcePrefetch`.
- **`scroll-view-API`** — the `scrollBy` and `getScrollInfo` badges move from
  `<ClayOnly />`, which asserts *every* Clay platform, to `<ClayWindowsOnly />`.

## What is deliberately left alone

`clay_windows` is untouched. **Only macOS was tested here**, and narrowing a
claim further than the evidence supports would trade one inaccuracy for another.
If Windows also lacks these, the Windows half should be dropped too — but that
needs a Windows run, not an assumption. Happy to follow up if someone can
confirm.

Worth noting for whoever picks this up: `scrollTo` and `autoScroll` carry the
same `<ClayOnly />` badge and **do** work on macOS. The desktop `scroll-view`
implements part of the documented method set, which is why the badge is wrong
per-method rather than for the element as a whole.

## Reproducing

The check is a case in a conformance suite that runs the same bundle on every
host, so this is re-runnable rather than a one-off observation:

```
scroll-view scrollBy       → method not found          (macOS)   accepted (Android, iOS)
scroll-view getScrollInfo  → missing documented fields (macOS)   x/y/range (Android, iOS)
```

Applies equally to `release/4.0` and `release/3.9`, where I have the same direct
macOS evidence. `release/3.8` and `release/3.7` carry the same claims but were
not run on macOS, so I have not proposed changes there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Mark `clay_macos` as unsupported for `lynx.accessibilityAnnounce`.
- Mark `clay_macos` as unsupported for `lynx.cancelResourcePrefetch`.
- Restrict `scrollBy` and `getScrollInfo` documentation to `ClayWindowsOnly`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->