### PR TITLE
fix(ci): narrow coderabbit lynx-ui naming rule

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,8 +9,9 @@ reviews:
     Write the high-level summary in a commit-message style:
     - Use the imperative mood and present tense, such as "Update reference links" or "Refine documentation formatting".
     - Do not use past-tense verbs such as "Updated", "Refined", "Added", "Fixed", or "Changed".
+    - Prefer a structured summary that highlights the main intent and impact instead of listing every touched file.
     - Keep each bullet concise and action-oriented, with one clear change per bullet.
-    - Prefer repository terminology exactly as written, especially `lynx-ui`.
+    - Prefer repository terminology exactly as written in the changed files.
   poem: false
   review_status: true
   collapse_walkthrough: false
@@ -33,8 +34,9 @@ reviews:
            If this PR changes generated or synced documentation outputs under `sharedDocs/`, `docs/public/lynx-compat-data`, or lynx-ui package docs, verify that the corresponding source or sync script change is present when applicable.
            - If the generated output appears stale or source-less, ask for the source update or regeneration command.
 
-        3. **Naming Conventions**:
-           Ensure the project name is always referred to as **lynx-ui** (lowercase).
-           - If you find "Lynx UI" or "Lynx-UI", provide a replacement suggestion immediately.
+        3. **lynx-ui Subproject Naming Convention**:
+           When referring to the lynx-ui subproject, package, routes, or synchronized docs, use **lynx-ui** (lowercase).
+           - Do not rewrite references to the overall Lynx website, Lynx documentation, or Lynx runtime as lynx-ui.
+           - If you find "Lynx UI" or "Lynx-UI" where it refers to the lynx-ui subproject or package, provide a replacement suggestion immediately.
 chat:
   auto_reply: true


### PR DESCRIPTION
Clarify the CodeRabbit naming instruction so the lowercase `lynx-ui` convention only applies when referring to the lynx-ui subproject, package, routes, or synchronized docs.

This avoids incorrect review suggestions that rewrite references to the overall Lynx website, Lynx documentation, or Lynx runtime as `lynx-ui`.

Change-Id: Ia1970de0aff1f9fa84a18c02feea1cf409460e8b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Refine CodeRabbit naming guidance for `lynx-ui` subproject references.
- Preserve Lynx naming for the broader website, documentation, and runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->