### PR TITLE
fix(docs): Clay does not support scroll-view scrollBy/getScrollInfo o…

### DIFF
--- a/docs/en/api/elements/built-in/scroll-view-API.mdx
+++ b/docs/en/api/elements/built-in/scroll-view-API.mdx
@@ -196,7 +196,7 @@ Automatic scrolling
 
 ### `getScrollInfo`
 
- <AndroidOnly /> <IOSOnly /> <ClayWindowsOnly /> <HarmonyOnly />
+ <AndroidOnly /> <IOSOnly /> <HarmonyOnly />
 ```ts
 interface GetScrollInfoResult {
   /**
@@ -241,7 +241,7 @@ Get scroll info
 
 ### `scrollBy`
 
- <AndroidOnly /> <IOSOnly /> <ClayWindowsOnly /> <HarmonyOnly />
+ <AndroidOnly /> <IOSOnly /> <HarmonyOnly />
 ```ts
 interface ScrollByParams {
   /**

--- a/docs/zh/api/elements/built-in/scroll-view-API.mdx
+++ b/docs/zh/api/elements/built-in/scroll-view-API.mdx
@@ -190,7 +190,7 @@ lynx.createSelectorQuery()
 
 ### `getScrollInfo`
 
- <AndroidOnly /> <IOSOnly /> <ClayWindowsOnly /> <HarmonyOnly />
+ <AndroidOnly /> <IOSOnly /> <HarmonyOnly />
 ```ts
 interface GetScrollInfoResult {
   /**
@@ -235,7 +235,7 @@ lynx.createSelectorQuery()
 
 ### `scrollBy`
 
- <AndroidOnly /> <IOSOnly /> <ClayWindowsOnly /> <HarmonyOnly />
+ <AndroidOnly /> <IOSOnly /> <HarmonyOnly />
 ```ts
 interface ScrollByParams {
   /**

--- a/packages/lynx-compat-data/lynx-api/lynx/accessibilityAnnounce.json
+++ b/packages/lynx-compat-data/lynx-api/lynx/accessibilityAnnounce.json
@@ -19,7 +19,7 @@
               "version_added": false
             },
             "clay_windows": {
-              "version_added": "3.5"
+              "version_added": false
             },
             "web_lynx": {
               "version_added": false

--- a/packages/lynx-compat-data/lynx-api/lynx/cancelResourcePrefetch.json
+++ b/packages/lynx-compat-data/lynx-api/lynx/cancelResourcePrefetch.json
@@ -19,7 +19,7 @@
               "version_added": false
             },
             "clay_windows": {
-              "version_added": "3.5"
+              "version_added": false
             },
             "web_lynx": {
               "version_added": false


### PR DESCRIPTION
…r accessibilityAnnounce/cancelResourcePrefetch

PR #1363 only removed clay_macos support, but Clay Windows also does not support these APIs. Additionally, scroll-view's scrollBy and getScrollInfo are not supported on any Clay platform (not just macOS).

Changes:
- scroll-view-API: remove all Clay badges from scrollBy and getScrollInfo
- compat data: set clay_windows to false for accessibilityAnnounce and cancelResourcePrefetch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Remove Clay support badges from `scrollBy` and `getScrollInfo` documentation.
- Mark `accessibilityAnnounce` and `cancelResourcePrefetch` as unsupported on Clay Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->