### PR TITLE
ci: run checks for merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   pull_request:
+  merge_group:
+    types: [checks_requested]
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary
- run the CI workflow for merge queue merge groups
- ensure the required Done check is reported before queued merges land

## Testing
- pnpm exec prettier --check .github/workflows/ci.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Configure CI to run for `merge_group` events with `checks_requested`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->