### PR TITLE
[Doc] Generate public Element compatibility data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ lynx-examples/
 packages/lynx-compat-data/css/properties/*.json
 packages/lynx-compat-data/api-stats.json
 
+# Element compat source indexes are regenerated on demand by tooling.
+packages/lynx-compat-data/.generated/
+
 !*logger.md
 .reference/
 .trae/

--- a/packages/lynx-compat-data/elements/blur-view.json
+++ b/packages/lynx-compat-data/elements/blur-view.json
@@ -91,6 +91,9 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -125,6 +128,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -161,6 +167,9 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -195,6 +204,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -231,6 +243,9 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -265,6 +280,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -301,6 +319,9 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -335,6 +356,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -371,6 +395,9 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -405,6 +432,201 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "ios-user-interface-style": {
+          "__compat": {
+            "description": "<code>ios-user-interface-style</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": "4.1"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      },
+      "methods": {
+        "boundingClientRect": {
+          "__compat": {
+            "description": "<code>boundingClientRect</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "4.0"
+              },
+              "ios": {
+                "version_added": "4.0"
+              },
+              "harmony": {
+                "version_added": "4.0"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "scrollIntoView": {
+          "__compat": {
+            "description": "<code>scrollIntoView</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "4.0"
+              },
+              "ios": {
+                "version_added": "4.0"
+              },
+              "harmony": {
+                "version_added": "4.0"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "setFocus": {
+          "__compat": {
+            "description": "<code>setFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "takeScreenshot": {
+          "__compat": {
+            "description": "<code>takeScreenshot</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "4.0"
+              },
+              "ios": {
+                "version_added": "4.0"
+              },
+              "harmony": {
+                "version_added": "4.0"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }

--- a/packages/lynx-compat-data/elements/common.json
+++ b/packages/lynx-compat-data/elements/common.json
@@ -35,29 +35,36 @@
           "description": "",
           "support": {
             "android": {
-              "version_added": "1.5"
+              "version_added": "1.0"
             },
             "ios": {
-              "version_added": "1.5"
+              "version_added": "1.0"
             },
             "harmony": {
               "version_added": false
             },
             "clay_android": {
-              "version_added": "1.5"
+              "version_added": "2.15"
             },
             "clay_ios": {
-              "version_added": "1.5"
+              "version_added": "2.18"
             },
             "clay_windows": {
-              "version_added": "1.5"
+              "version_added": "2.15"
             },
             "clay_macos": {
-              "version_added": "1.5"
+              "version_added": "2.15"
             },
             "web_lynx": {
-              "version_added": true
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": "2.17"
             }
+          },
+          "status": {
+            "deprecated": true,
+            "experimental": false
           }
         }
       },
@@ -66,29 +73,36 @@
           "description": "",
           "support": {
             "android": {
-              "version_added": "1.5"
+              "version_added": "1.0"
             },
             "ios": {
-              "version_added": "1.5"
+              "version_added": "1.0"
             },
             "harmony": {
-              "version_added": "3.4"
+              "version_added": "2.16"
             },
             "clay_android": {
-              "version_added": "1.5"
+              "version_added": "2.14"
             },
             "clay_ios": {
-              "version_added": "1.5"
+              "version_added": "2.18"
             },
             "clay_windows": {
-              "version_added": "1.5"
+              "version_added": "2.14"
             },
             "clay_macos": {
-              "version_added": "1.5"
+              "version_added": "2.14"
             },
             "web_lynx": {
               "version_added": true
+            },
+            "clay_harmony": {
+              "version_added": "2.17"
             }
+          },
+          "status": {
+            "deprecated": false,
+            "experimental": false
           }
         }
       },
@@ -97,21 +111,2580 @@
           "description": "",
           "support": {
             "android": {
-              "version_added": "1.5"
+              "version_added": "1.0"
             },
             "clay_android": {
-              "version_added": "1.5"
+              "version_added": "2.14"
             },
             "clay_ios": {
-              "version_added": "1.5"
+              "version_added": "2.18"
             },
             "clay_windows": {
-              "version_added": "1.5"
+              "version_added": "2.14"
             },
             "clay_macos": {
-              "version_added": "1.5"
+              "version_added": "2.14"
             },
             "web_lynx": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": "2.17"
+            }
+          },
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          }
+        }
+      },
+      "__lynx_timing_flag": {
+        "__compat": {
+          "description": "<code>__lynx_timing_flag</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.16"
+            },
+            "ios": {
+              "version_added": "2.16"
+            },
+            "harmony": {
+              "version_added": "2.16"
+            },
+            "web_lynx": {
+              "version_added": true
+            },
+            "clay_android": {
+              "version_added": "3.0"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "3.6"
+            },
+            "clay_windows": {
+              "version_added": "3.6"
+            },
+            "clay_harmony": {
+              "version_added": "2.17"
+            }
+          }
+        }
+      },
+      "accessibility-actions": {
+        "__compat": {
+          "description": "<code>accessibility-actions</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": "2.14"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "accessibility-element": {
+        "__compat": {
+          "description": "<code>accessibility-element</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "1.1"
+            },
+            "ios": {
+              "version_added": "1.0"
+            },
+            "harmony": {
+              "version_added": "3.3"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "2.17"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "accessibility-elements-hidden": {
+        "__compat": {
+          "description": "<code>accessibility-elements-hidden</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": "2.14"
+            },
+            "harmony": {
+              "version_added": "3.3"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "accessibility-exclusive-focus": {
+        "__compat": {
+          "description": "<code>accessibility-exclusive-focus</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.12"
+            },
+            "ios": {
+              "version_added": "2.12"
+            },
+            "harmony": {
+              "version_added": "3.3"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "accessibility-heading": {
+        "__compat": {
+          "description": "<code>accessibility-heading</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "accessibility-label": {
+        "__compat": {
+          "description": "<code>accessibility-label</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "1.1"
+            },
+            "ios": {
+              "version_added": "1.0"
+            },
+            "harmony": {
+              "version_added": "3.3"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "2.17"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "accessibility-role-description": {
+        "__compat": {
+          "description": "<code>accessibility-role-description</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "accessibility-traits": {
+        "__compat": {
+          "description": "<code>accessibility-traits</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": "1.7"
+            },
+            "harmony": {
+              "version_added": "3.4"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "accessibility-value": {
+        "__compat": {
+          "description": "<code>accessibility-value</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": "2.18"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "animation": {
+        "__compat": {
+          "description": "<code>animation</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": "1.0"
+            },
+            "harmony": {
+              "version_added": "3.8"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "3.0"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "3.6"
+            },
+            "clay_windows": {
+              "version_added": "3.6"
+            },
+            "clay_harmony": {
+              "version_added": "2.17"
+            }
+          }
+        }
+      },
+      "block-native-event": {
+        "__compat": {
+          "description": "<code>block-native-event</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.1"
+            },
+            "ios": {
+              "version_added": "1.0"
+            },
+            "harmony": {
+              "version_added": "2.17"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "2.17"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": "2.17"
+            }
+          }
+        }
+      },
+      "block-native-event-areas": {
+        "__compat": {
+          "description": "<code>block-native-event-areas</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.8"
+            },
+            "ios": {
+              "version_added": "2.8"
+            },
+            "harmony": {
+              "version_added": "3.4"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "class": {
+        "__compat": {
+          "description": "<code>class</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "0.1"
+            },
+            "ios": {
+              "version_added": "1.0"
+            },
+            "harmony": {
+              "version_added": "2.16"
+            },
+            "web_lynx": {
+              "version_added": true
+            },
+            "clay_android": {
+              "version_added": "3.0"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "3.6"
+            },
+            "clay_windows": {
+              "version_added": "3.6"
+            },
+            "clay_harmony": {
+              "version_added": "2.17"
+            }
+          }
+        }
+      },
+      "className": {
+        "__compat": {
+          "description": "<code>className</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "0.1"
+            },
+            "ios": {
+              "version_added": "1.0"
+            },
+            "harmony": {
+              "version_added": "2.16"
+            },
+            "web_lynx": {
+              "version_added": true
+            },
+            "clay_android": {
+              "version_added": "3.0"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "3.6"
+            },
+            "clay_windows": {
+              "version_added": "3.6"
+            },
+            "clay_harmony": {
+              "version_added": "2.17"
+            }
+          }
+        }
+      },
+      "consume-slide-event": {
+        "__compat": {
+          "description": "<code>consume-slide-event</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.8"
+            },
+            "ios": {
+              "version_added": "2.8"
+            },
+            "harmony": {
+              "version_added": "2.17"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "2.17"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "2.17"
+            },
+            "clay_windows": {
+              "version_added": "2.17"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "cssAlignWithLegacyW3C": {
+        "__compat": {
+          "description": "<code>cssAlignWithLegacyW3C</code>",
+          "status": {
+            "deprecated": true,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "enable-exposure-ui-clip": {
+        "__compat": {
+          "description": "<code>enable-exposure-ui-clip</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "3.4"
+            },
+            "ios": {
+              "version_added": "3.4"
+            },
+            "harmony": {
+              "version_added": "3.4"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "4.0"
+            },
+            "clay_ios": {
+              "version_added": "3.4"
+            },
+            "clay_macos": {
+              "version_added": "3.7"
+            },
+            "clay_windows": {
+              "version_added": "3.7"
+            },
+            "clay_harmony": {
+              "version_added": "4.2"
+            }
+          }
+        }
+      },
+      "enable-exposure-ui-margin": {
+        "__compat": {
+          "description": "<code>enable-exposure-ui-margin</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.8"
+            },
+            "ios": {
+              "version_added": "2.6"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "2.15"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "2.15"
+            },
+            "clay_windows": {
+              "version_added": "2.15"
+            },
+            "clay_harmony": {
+              "version_added": "2.17"
+            }
+          }
+        }
+      },
+      "enable-touch-pseudo-propagation": {
+        "__compat": {
+          "description": "<code>enable-touch-pseudo-propagation</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.8"
+            },
+            "ios": {
+              "version_added": "2.8"
+            },
+            "harmony": {
+              "version_added": "2.17"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "enableLayoutOnly": {
+        "__compat": {
+          "description": "<code>enableLayoutOnly</code>",
+          "status": {
+            "deprecated": true,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "event-through": {
+        "__compat": {
+          "description": "<code>event-through</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.6"
+            },
+            "ios": {
+              "version_added": "1.0"
+            },
+            "harmony": {
+              "version_added": "2.17"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "3.0"
+            },
+            "clay_ios": {
+              "version_added": "3.0"
+            },
+            "clay_macos": {
+              "version_added": "3.0"
+            },
+            "clay_windows": {
+              "version_added": "3.0"
+            },
+            "clay_harmony": {
+              "version_added": "3.1"
+            }
+          }
+        }
+      },
+      "event-through-active-regions": {
+        "__compat": {
+          "description": "<code>event-through-active-regions</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "3.5"
+            },
+            "ios": {
+              "version_added": "3.4"
+            },
+            "harmony": {
+              "version_added": "3.4"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "exposure-area": {
+        "__compat": {
+          "description": "<code>exposure-area</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.8"
+            },
+            "ios": {
+              "version_added": "2.8"
+            },
+            "harmony": {
+              "version_added": "2.17"
+            },
+            "web_lynx": {
+              "version_added": true
+            },
+            "clay_android": {
+              "version_added": "3.0"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "3.6"
+            },
+            "clay_windows": {
+              "version_added": "3.6"
+            },
+            "clay_harmony": {
+              "version_added": "2.17"
+            }
+          }
+        }
+      },
+      "exposure-id": {
+        "__compat": {
+          "description": "<code>exposure-id</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "1.1"
+            },
+            "ios": {
+              "version_added": "2.0"
+            },
+            "harmony": {
+              "version_added": "2.17"
+            },
+            "web_lynx": {
+              "version_added": true
+            },
+            "clay_android": {
+              "version_added": "3.0"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "3.6"
+            },
+            "clay_windows": {
+              "version_added": "3.6"
+            },
+            "clay_harmony": {
+              "version_added": "2.17"
+            }
+          }
+        }
+      },
+      "exposure-scene": {
+        "__compat": {
+          "description": "<code>exposure-scene</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "1.1"
+            },
+            "ios": {
+              "version_added": "2.0"
+            },
+            "harmony": {
+              "version_added": "2.17"
+            },
+            "web_lynx": {
+              "version_added": true
+            },
+            "clay_android": {
+              "version_added": "3.0"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "3.6"
+            },
+            "clay_windows": {
+              "version_added": "3.6"
+            },
+            "clay_harmony": {
+              "version_added": "2.17"
+            }
+          }
+        }
+      },
+      "exposure-screen-margin-bottom": {
+        "__compat": {
+          "description": "<code>exposure-screen-margin-bottom</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.3"
+            },
+            "ios": {
+              "version_added": "2.5"
+            },
+            "harmony": {
+              "version_added": "2.17"
+            },
+            "web_lynx": {
+              "version_added": true
+            },
+            "clay_android": {
+              "version_added": "3.0"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "3.6"
+            },
+            "clay_windows": {
+              "version_added": "3.6"
+            },
+            "clay_harmony": {
+              "version_added": "2.17"
+            }
+          }
+        }
+      },
+      "exposure-screen-margin-left": {
+        "__compat": {
+          "description": "<code>exposure-screen-margin-left</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.3"
+            },
+            "ios": {
+              "version_added": "2.5"
+            },
+            "harmony": {
+              "version_added": "2.17"
+            },
+            "web_lynx": {
+              "version_added": true
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "exposure-screen-margin-right": {
+        "__compat": {
+          "description": "<code>exposure-screen-margin-right</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.3"
+            },
+            "ios": {
+              "version_added": "2.5"
+            },
+            "harmony": {
+              "version_added": "2.17"
+            },
+            "web_lynx": {
+              "version_added": true
+            },
+            "clay_android": {
+              "version_added": "3.0"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "3.6"
+            },
+            "clay_windows": {
+              "version_added": "3.6"
+            },
+            "clay_harmony": {
+              "version_added": "2.17"
+            }
+          }
+        }
+      },
+      "exposure-screen-margin-top": {
+        "__compat": {
+          "description": "<code>exposure-screen-margin-top</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.3"
+            },
+            "ios": {
+              "version_added": "2.5"
+            },
+            "harmony": {
+              "version_added": "2.17"
+            },
+            "web_lynx": {
+              "version_added": true
+            },
+            "clay_android": {
+              "version_added": "3.0"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "3.6"
+            },
+            "clay_windows": {
+              "version_added": "3.6"
+            },
+            "clay_harmony": {
+              "version_added": "2.17"
+            }
+          }
+        }
+      },
+      "exposure-ui-margin-bottom": {
+        "__compat": {
+          "description": "<code>exposure-ui-margin-bottom</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.8"
+            },
+            "ios": {
+              "version_added": "2.6"
+            },
+            "harmony": {
+              "version_added": "2.17"
+            },
+            "web_lynx": {
+              "version_added": true
+            },
+            "clay_android": {
+              "version_added": "3.0"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "3.6"
+            },
+            "clay_windows": {
+              "version_added": "3.6"
+            },
+            "clay_harmony": {
+              "version_added": "2.17"
+            }
+          }
+        }
+      },
+      "exposure-ui-margin-left": {
+        "__compat": {
+          "description": "<code>exposure-ui-margin-left</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.8"
+            },
+            "ios": {
+              "version_added": "2.6"
+            },
+            "harmony": {
+              "version_added": "2.17"
+            },
+            "web_lynx": {
+              "version_added": true
+            },
+            "clay_android": {
+              "version_added": "3.0"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "3.6"
+            },
+            "clay_windows": {
+              "version_added": "3.6"
+            },
+            "clay_harmony": {
+              "version_added": "2.17"
+            }
+          }
+        }
+      },
+      "exposure-ui-margin-right": {
+        "__compat": {
+          "description": "<code>exposure-ui-margin-right</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.8"
+            },
+            "ios": {
+              "version_added": "2.6"
+            },
+            "harmony": {
+              "version_added": "2.17"
+            },
+            "web_lynx": {
+              "version_added": true
+            },
+            "clay_android": {
+              "version_added": "3.0"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "3.6"
+            },
+            "clay_windows": {
+              "version_added": "3.6"
+            },
+            "clay_harmony": {
+              "version_added": "2.17"
+            }
+          }
+        }
+      },
+      "exposure-ui-margin-top": {
+        "__compat": {
+          "description": "<code>exposure-ui-margin-top</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.8"
+            },
+            "ios": {
+              "version_added": "2.6"
+            },
+            "harmony": {
+              "version_added": "2.17"
+            },
+            "web_lynx": {
+              "version_added": true
+            },
+            "clay_android": {
+              "version_added": "3.0"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "3.6"
+            },
+            "clay_windows": {
+              "version_added": "3.6"
+            },
+            "clay_harmony": {
+              "version_added": "2.17"
+            }
+          }
+        }
+      },
+      "focus-index": {
+        "__compat": {
+          "description": "<code>focus-index</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "3.0"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "3.6"
+            },
+            "clay_windows": {
+              "version_added": "3.6"
+            },
+            "clay_harmony": {
+              "version_added": "2.17"
+            }
+          }
+        }
+      },
+      "focusable": {
+        "__compat": {
+          "description": "<code>focusable</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "1.3"
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "3.0"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "3.6"
+            },
+            "clay_windows": {
+              "version_added": "3.6"
+            },
+            "clay_harmony": {
+              "version_added": "2.17"
+            }
+          }
+        }
+      },
+      "hidden": {
+        "__compat": {
+          "description": "<code>hidden</code>",
+          "status": {
+            "deprecated": true,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": true
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "hit-slop": {
+        "__compat": {
+          "description": "<code>hit-slop</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.14"
+            },
+            "ios": {
+              "version_added": "2.14"
+            },
+            "harmony": {
+              "version_added": "2.17"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "3.0"
+            },
+            "clay_ios": {
+              "version_added": "3.0"
+            },
+            "clay_macos": {
+              "version_added": "3.0"
+            },
+            "clay_windows": {
+              "version_added": "3.0"
+            },
+            "clay_harmony": {
+              "version_added": "3.1"
+            }
+          }
+        }
+      },
+      "ignore-focus": {
+        "__compat": {
+          "description": "<code>ignore-focus</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "1.1"
+            },
+            "ios": {
+              "version_added": "1.0"
+            },
+            "harmony": {
+              "version_added": "2.17"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "3.0"
+            },
+            "clay_ios": {
+              "version_added": "3.0"
+            },
+            "clay_macos": {
+              "version_added": "3.0"
+            },
+            "clay_windows": {
+              "version_added": "3.0"
+            },
+            "clay_harmony": {
+              "version_added": "3.1"
+            }
+          }
+        }
+      },
+      "ios-background-shape-layer": {
+        "__compat": {
+          "description": "<code>ios-background-shape-layer</code>",
+          "status": {
+            "deprecated": true,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "ios-enable-simultaneous-touch": {
+        "__compat": {
+          "description": "<code>ios-enable-simultaneous-touch</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": "2.6"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "ios-pan-intercept-gesture-class": {
+        "__compat": {
+          "description": "<code>ios-pan-intercept-gesture-class</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": "4.1"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "ios-pan-intercept-view-class": {
+        "__compat": {
+          "description": "<code>ios-pan-intercept-view-class</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": "4.1"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "ios-pan-intercept-view-tag": {
+        "__compat": {
+          "description": "<code>ios-pan-intercept-view-tag</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": "4.1"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "ios-platform-accessibility-id": {
+        "__compat": {
+          "description": "<code>ios-platform-accessibility-id</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": "2.14"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "native-interaction-enabled": {
+        "__compat": {
+          "description": "<code>native-interaction-enabled</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": "1.0"
+            },
+            "harmony": {
+              "version_added": "2.17"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "next-focus-down": {
+        "__compat": {
+          "description": "<code>next-focus-down</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "3.0"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "3.6"
+            },
+            "clay_windows": {
+              "version_added": "3.6"
+            },
+            "clay_harmony": {
+              "version_added": "2.17"
+            }
+          }
+        }
+      },
+      "next-focus-left": {
+        "__compat": {
+          "description": "<code>next-focus-left</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "3.0"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "3.6"
+            },
+            "clay_windows": {
+              "version_added": "3.6"
+            },
+            "clay_harmony": {
+              "version_added": "2.17"
+            }
+          }
+        }
+      },
+      "next-focus-right": {
+        "__compat": {
+          "description": "<code>next-focus-right</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "3.0"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "3.6"
+            },
+            "clay_windows": {
+              "version_added": "3.6"
+            },
+            "clay_harmony": {
+              "version_added": "2.17"
+            }
+          }
+        }
+      },
+      "next-focus-up": {
+        "__compat": {
+          "description": "<code>next-focus-up</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "3.0"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "3.6"
+            },
+            "clay_windows": {
+              "version_added": "3.6"
+            },
+            "clay_harmony": {
+              "version_added": "2.17"
+            }
+          }
+        }
+      },
+      "overlap": {
+        "__compat": {
+          "description": "<code>overlap</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": "4.2"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "overlap-ios": {
+        "__compat": {
+          "description": "<code>overlap-ios</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": "2.5"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "pan-intercept-direction": {
+        "__compat": {
+          "description": "<code>pan-intercept-direction</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "3.6"
+            },
+            "ios": {
+              "version_added": "3.4"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "pan-intercept-scope": {
+        "__compat": {
+          "description": "<code>pan-intercept-scope</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "3.6"
+            },
+            "ios": {
+              "version_added": "3.4"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "style": {
+        "__compat": {
+          "description": "<code>style</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "0.1"
+            },
+            "ios": {
+              "version_added": "1.0"
+            },
+            "harmony": {
+              "version_added": "2.16"
+            },
+            "web_lynx": {
+              "version_added": true
+            },
+            "clay_android": {
+              "version_added": "3.0"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "3.6"
+            },
+            "clay_windows": {
+              "version_added": "3.6"
+            },
+            "clay_harmony": {
+              "version_added": "2.17"
+            }
+          }
+        }
+      },
+      "user-interaction-enabled": {
+        "__compat": {
+          "description": "<code>user-interaction-enabled</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "1.1"
+            },
+            "ios": {
+              "version_added": "1.0"
+            },
+            "harmony": {
+              "version_added": "2.17"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "2.14"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "2.14"
+            },
+            "clay_windows": {
+              "version_added": "2.14"
+            },
+            "clay_harmony": {
+              "version_added": "2.17"
+            }
+          }
+        }
+      },
+      "enable-scrollbar": {
+        "__compat": {
+          "description": "<code>enable-scrollbar</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "3.0"
+            },
+            "clay_windows": {
+              "version_added": "3.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "scroll-bar-auto-hide": {
+        "__compat": {
+          "description": "<code>scroll-bar-auto-hide</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "3.0"
+            },
+            "clay_windows": {
+              "version_added": "3.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "scroll-bar-auto-hide-delay": {
+        "__compat": {
+          "description": "<code>scroll-bar-auto-hide-delay</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "3.0"
+            },
+            "clay_windows": {
+              "version_added": "3.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "scroll-bar-thumb-active-color": {
+        "__compat": {
+          "description": "<code>scroll-bar-thumb-active-color</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "3.0"
+            },
+            "clay_windows": {
+              "version_added": "3.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "scroll-bar-thumb-color": {
+        "__compat": {
+          "description": "<code>scroll-bar-thumb-color</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "3.0"
+            },
+            "clay_windows": {
+              "version_added": "3.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "scroll-bar-thumb-hover-color": {
+        "__compat": {
+          "description": "<code>scroll-bar-thumb-hover-color</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "3.0"
+            },
+            "clay_windows": {
+              "version_added": "3.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "scroll-bar-thumb-min-length": {
+        "__compat": {
+          "description": "<code>scroll-bar-thumb-min-length</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "3.0"
+            },
+            "clay_windows": {
+              "version_added": "3.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "scroll-bar-thumb-radius": {
+        "__compat": {
+          "description": "<code>scroll-bar-thumb-radius</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "3.0"
+            },
+            "clay_windows": {
+              "version_added": "3.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "scroll-bar-thumb-width": {
+        "__compat": {
+          "description": "<code>scroll-bar-thumb-width</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "3.0"
+            },
+            "clay_windows": {
+              "version_added": "3.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "scroll-bar-track-color": {
+        "__compat": {
+          "description": "<code>scroll-bar-track-color</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "3.0"
+            },
+            "clay_windows": {
+              "version_added": "3.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "scroll-bar-width": {
+        "__compat": {
+          "description": "<code>scroll-bar-width</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "3.0"
+            },
+            "clay_windows": {
+              "version_added": "3.0"
+            },
+            "clay_harmony": {
               "version_added": false
             }
           }

--- a/packages/lynx-compat-data/elements/component.json
+++ b/packages/lynx-compat-data/elements/component.json
@@ -1,70 +1,41 @@
 {
   "elements": {
-    "title-bar-view": {
-      "__compat": {
-        "description": "title-bar-view",
-        "support": {
-          "android": {
-            "version_added": false
-          },
-          "ios": {
-            "version_added": false
-          },
-          "harmony": {
-            "version_added": false
-          },
-          "clay_android": {
-            "version_added": false
-          },
-          "clay_ios": {
-            "version_added": false
-          },
-          "clay_windows": {
-            "version_added": "3.8"
-          },
-          "clay_macos": {
-            "version_added": "3.8"
-          },
-          "web_lynx": {
-            "version_added": false
-          }
-        }
-      },
-      "moveable": {
+    "component": {
+      "is": {
         "__compat": {
-          "description": "<code>moveable</code>",
+          "description": "<code>is</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
-              "version_added": false
+              "version_added": "3.5"
             },
             "ios": {
-              "version_added": false
+              "version_added": "3.8"
             },
             "harmony": {
-              "version_added": false
-            },
-            "clay_android": {
-              "version_added": false
-            },
-            "clay_ios": {
-              "version_added": false
-            },
-            "clay_windows": {
-              "version_added": "3.8"
-            },
-            "clay_macos": {
-              "version_added": "3.8"
+              "version_added": "4.1"
             },
             "web_lynx": {
               "version_added": false
             },
+            "clay_android": {
+              "version_added": "4.0"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
             "clay_harmony": {
-              "version_added": false
+              "version_added": "4.0"
             }
-          },
-          "status": {
-            "deprecated": false,
-            "experimental": false
           }
         }
       },
@@ -77,22 +48,22 @@
           },
           "support": {
             "android": {
-              "version_added": false
+              "version_added": "3.5"
             },
             "ios": {
-              "version_added": false
+              "version_added": "3.8"
             },
             "harmony": {
-              "version_added": false
+              "version_added": "2.16"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
-              "version_added": false
+              "version_added": "4.0"
             },
             "clay_ios": {
-              "version_added": false
+              "version_added": "4.0"
             },
             "clay_macos": {
               "version_added": "4.0"
@@ -101,7 +72,7 @@
               "version_added": "4.0"
             },
             "clay_harmony": {
-              "version_added": false
+              "version_added": "4.0"
             }
           }
         }
@@ -115,10 +86,10 @@
           },
           "support": {
             "android": {
-              "version_added": false
+              "version_added": "3.5"
             },
             "ios": {
-              "version_added": false
+              "version_added": "3.8"
             },
             "harmony": {
               "version_added": false
@@ -153,22 +124,22 @@
           },
           "support": {
             "android": {
-              "version_added": false
+              "version_added": "3.5"
             },
             "ios": {
-              "version_added": false
+              "version_added": "3.8"
             },
             "harmony": {
-              "version_added": false
+              "version_added": "2.17"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
-              "version_added": false
+              "version_added": "4.0"
             },
             "clay_ios": {
-              "version_added": false
+              "version_added": "4.0"
             },
             "clay_macos": {
               "version_added": "4.0"
@@ -177,45 +148,7 @@
               "version_added": "4.0"
             },
             "clay_harmony": {
-              "version_added": false
-            }
-          }
-        }
-      },
-      "setFocus": {
-        "__compat": {
-          "description": "<code>setFocus</code>",
-          "status": {
-            "deprecated": false,
-            "experimental": false
-          },
-          "support": {
-            "android": {
-              "version_added": false
-            },
-            "ios": {
-              "version_added": false
-            },
-            "harmony": {
-              "version_added": false
-            },
-            "web_lynx": {
-              "version_added": false
-            },
-            "clay_android": {
-              "version_added": false
-            },
-            "clay_ios": {
-              "version_added": false
-            },
-            "clay_macos": {
               "version_added": "4.0"
-            },
-            "clay_windows": {
-              "version_added": "4.0"
-            },
-            "clay_harmony": {
-              "version_added": false
             }
           }
         }
@@ -229,22 +162,22 @@
           },
           "support": {
             "android": {
-              "version_added": false
+              "version_added": "3.5"
             },
             "ios": {
-              "version_added": false
+              "version_added": "3.8"
             },
             "harmony": {
-              "version_added": false
+              "version_added": "3.3"
             },
             "web_lynx": {
               "version_added": false
             },
             "clay_android": {
-              "version_added": false
+              "version_added": "4.0"
             },
             "clay_ios": {
-              "version_added": false
+              "version_added": "4.0"
             },
             "clay_macos": {
               "version_added": "4.0"
@@ -253,7 +186,7 @@
               "version_added": "4.0"
             },
             "clay_harmony": {
-              "version_added": false
+              "version_added": "4.0"
             }
           }
         }

--- a/packages/lynx-compat-data/elements/filter-image.json
+++ b/packages/lynx-compat-data/elements/filter-image.json
@@ -1,130 +1,25 @@
 {
   "elements": {
-    "title-bar-view": {
-      "__compat": {
-        "description": "title-bar-view",
-        "support": {
-          "android": {
-            "version_added": false
-          },
-          "ios": {
-            "version_added": false
-          },
-          "harmony": {
-            "version_added": false
-          },
-          "clay_android": {
-            "version_added": false
-          },
-          "clay_ios": {
-            "version_added": false
-          },
-          "clay_windows": {
-            "version_added": "3.8"
-          },
-          "clay_macos": {
-            "version_added": "3.8"
-          },
-          "web_lynx": {
-            "version_added": false
-          }
-        }
-      },
-      "moveable": {
+    "filter-image": {
+      "blur-radius": {
         "__compat": {
-          "description": "<code>moveable</code>",
-          "support": {
-            "android": {
-              "version_added": false
-            },
-            "ios": {
-              "version_added": false
-            },
-            "harmony": {
-              "version_added": false
-            },
-            "clay_android": {
-              "version_added": false
-            },
-            "clay_ios": {
-              "version_added": false
-            },
-            "clay_windows": {
-              "version_added": "3.8"
-            },
-            "clay_macos": {
-              "version_added": "3.8"
-            },
-            "web_lynx": {
-              "version_added": false
-            },
-            "clay_harmony": {
-              "version_added": false
-            }
-          },
-          "status": {
-            "deprecated": false,
-            "experimental": false
-          }
-        }
-      },
-      "boundingClientRect": {
-        "__compat": {
-          "description": "<code>boundingClientRect</code>",
+          "description": "<code>blur-radius</code>",
           "status": {
             "deprecated": false,
             "experimental": false
           },
           "support": {
             "android": {
-              "version_added": false
+              "version_added": "0.1"
             },
             "ios": {
-              "version_added": false
+              "version_added": "2.18"
             },
             "harmony": {
-              "version_added": false
+              "version_added": "2.15"
             },
             "web_lynx": {
-              "version_added": false
-            },
-            "clay_android": {
-              "version_added": false
-            },
-            "clay_ios": {
-              "version_added": false
-            },
-            "clay_macos": {
-              "version_added": "4.0"
-            },
-            "clay_windows": {
-              "version_added": "4.0"
-            },
-            "clay_harmony": {
-              "version_added": false
-            }
-          }
-        }
-      },
-      "requestAccessibilityFocus": {
-        "__compat": {
-          "description": "<code>requestAccessibilityFocus</code>",
-          "status": {
-            "deprecated": false,
-            "experimental": false
-          },
-          "support": {
-            "android": {
-              "version_added": false
-            },
-            "ios": {
-              "version_added": false
-            },
-            "harmony": {
-              "version_added": false
-            },
-            "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": false
@@ -144,25 +39,25 @@
           }
         }
       },
-      "scrollIntoView": {
+      "drop-shadow": {
         "__compat": {
-          "description": "<code>scrollIntoView</code>",
+          "description": "<code>drop-shadow</code>",
           "status": {
             "deprecated": false,
             "experimental": false
           },
           "support": {
             "android": {
-              "version_added": false
+              "version_added": "0.1"
             },
             "ios": {
-              "version_added": false
+              "version_added": "2.18"
             },
             "harmony": {
-              "version_added": false
+              "version_added": "3.1"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": false
@@ -171,10 +66,162 @@
               "version_added": false
             },
             "clay_macos": {
-              "version_added": "4.0"
+              "version_added": false
             },
             "clay_windows": {
-              "version_added": "4.0"
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "mode": {
+        "__compat": {
+          "description": "<code>mode</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "0.1"
+            },
+            "ios": {
+              "version_added": "2.18"
+            },
+            "harmony": {
+              "version_added": "2.15"
+            },
+            "web_lynx": {
+              "version_added": true
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "src": {
+        "__compat": {
+          "description": "<code>src</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "0.1"
+            },
+            "ios": {
+              "version_added": "2.18"
+            },
+            "harmony": {
+              "version_added": "2.14"
+            },
+            "web_lynx": {
+              "version_added": true
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "binderror": {
+        "__compat": {
+          "description": "<code>binderror</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "0.1"
+            },
+            "ios": {
+              "version_added": "2.18"
+            },
+            "harmony": {
+              "version_added": "2.15"
+            },
+            "web_lynx": {
+              "version_added": true
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "bindload": {
+        "__compat": {
+          "description": "<code>bindload</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "0.1"
+            },
+            "ios": {
+              "version_added": "2.18"
+            },
+            "harmony": {
+              "version_added": "2.16"
+            },
+            "web_lynx": {
+              "version_added": true
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
             },
             "clay_harmony": {
               "version_added": false
@@ -203,10 +250,10 @@
               "version_added": false
             },
             "clay_android": {
-              "version_added": false
+              "version_added": "2.14"
             },
             "clay_ios": {
-              "version_added": false
+              "version_added": "4.0"
             },
             "clay_macos": {
               "version_added": "4.0"
@@ -215,45 +262,7 @@
               "version_added": "4.0"
             },
             "clay_harmony": {
-              "version_added": false
-            }
-          }
-        }
-      },
-      "takeScreenshot": {
-        "__compat": {
-          "description": "<code>takeScreenshot</code>",
-          "status": {
-            "deprecated": false,
-            "experimental": false
-          },
-          "support": {
-            "android": {
-              "version_added": false
-            },
-            "ios": {
-              "version_added": false
-            },
-            "harmony": {
-              "version_added": false
-            },
-            "web_lynx": {
-              "version_added": false
-            },
-            "clay_android": {
-              "version_added": false
-            },
-            "clay_ios": {
-              "version_added": false
-            },
-            "clay_macos": {
               "version_added": "4.0"
-            },
-            "clay_windows": {
-              "version_added": "4.0"
-            },
-            "clay_harmony": {
-              "version_added": false
             }
           }
         }

--- a/packages/lynx-compat-data/elements/frame.json
+++ b/packages/lynx-compat-data/elements/frame.json
@@ -30,7 +30,7 @@
             "version_added": false
           },
           "web_lynx": {
-            "version_added": false
+            "version_added": true
           }
         }
       },
@@ -64,6 +64,9 @@
               "version_added": false
             },
             "web_lynx": {
+              "version_added": true
+            },
+            "clay_harmony": {
               "version_added": false
             }
           }
@@ -99,6 +102,9 @@
               "version_added": false
             },
             "web_lynx": {
+              "version_added": true
+            },
+            "clay_harmony": {
               "version_added": false
             }
           }
@@ -116,7 +122,7 @@
               "version_added": "3.6"
             },
             "ios": {
-              "version_added": "3.6"
+              "version_added": "3.5"
             },
             "harmony": {
               "version_added": false
@@ -134,6 +140,9 @@
               "version_added": false
             },
             "web_lynx": {
+              "version_added": true
+            },
+            "clay_harmony": {
               "version_added": false
             }
           }
@@ -170,6 +179,9 @@
             },
             "web_lynx": {
               "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
             }
           }
         }
@@ -204,6 +216,9 @@
               "version_added": false
             },
             "web_lynx": {
+              "version_added": true
+            },
+            "clay_harmony": {
               "version_added": false
             }
           }
@@ -218,10 +233,10 @@
           },
           "support": {
             "android": {
-              "version_added": "3.9"
+              "version_added": "4.0"
             },
             "ios": {
-              "version_added": "3.9"
+              "version_added": "3.7"
             },
             "harmony": {
               "version_added": false
@@ -239,6 +254,9 @@
               "version_added": false
             },
             "web_lynx": {
+              "version_added": false
+            },
+            "clay_harmony": {
               "version_added": false
             }
           }
@@ -253,10 +271,10 @@
           },
           "support": {
             "android": {
-              "version_added": "3.9"
+              "version_added": "4.0"
             },
             "ios": {
-              "version_added": "3.9"
+              "version_added": "3.7"
             },
             "harmony": {
               "version_added": false
@@ -274,6 +292,9 @@
               "version_added": false
             },
             "web_lynx": {
+              "version_added": false
+            },
+            "clay_harmony": {
               "version_added": false
             }
           }
@@ -310,6 +331,9 @@
             },
             "web_lynx": {
               "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
             }
           }
         }
@@ -326,7 +350,7 @@
               "version_added": "3.6"
             },
             "ios": {
-              "version_added": "3.6"
+              "version_added": "3.5"
             },
             "harmony": {
               "version_added": false
@@ -344,6 +368,9 @@
               "version_added": false
             },
             "web_lynx": {
+              "version_added": true
+            },
+            "clay_harmony": {
               "version_added": false
             }
           }
@@ -379,6 +406,199 @@
               "version_added": false
             },
             "web_lynx": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "boundingClientRect": {
+        "__compat": {
+          "description": "<code>boundingClientRect</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "3.4"
+            },
+            "ios": {
+              "version_added": "3.4"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": true
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "requestAccessibilityFocus": {
+        "__compat": {
+          "description": "<code>requestAccessibilityFocus</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "3.4"
+            },
+            "ios": {
+              "version_added": "3.4"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "scrollIntoView": {
+        "__compat": {
+          "description": "<code>scrollIntoView</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "3.4"
+            },
+            "ios": {
+              "version_added": "3.4"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": true
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "setFocus": {
+        "__compat": {
+          "description": "<code>setFocus</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "takeScreenshot": {
+        "__compat": {
+          "description": "<code>takeScreenshot</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "3.4"
+            },
+            "ios": {
+              "version_added": "3.4"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
               "version_added": false
             }
           }

--- a/packages/lynx-compat-data/elements/image.json
+++ b/packages/lynx-compat-data/elements/image.json
@@ -57,7 +57,14 @@
             },
             "web_lynx": {
               "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
             }
+          },
+          "status": {
+            "deprecated": false,
+            "experimental": false
           }
         }
       },
@@ -88,7 +95,14 @@
             },
             "web_lynx": {
               "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
             }
+          },
+          "status": {
+            "deprecated": false,
+            "experimental": false
           }
         }
       },
@@ -119,7 +133,14 @@
             },
             "web_lynx": {
               "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
             }
+          },
+          "status": {
+            "deprecated": false,
+            "experimental": false
           }
         }
       },
@@ -150,7 +171,14 @@
             },
             "web_lynx": {
               "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
             }
+          },
+          "status": {
+            "deprecated": false,
+            "experimental": false
           }
         }
       },
@@ -181,7 +209,14 @@
             },
             "web_lynx": {
               "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
             }
+          },
+          "status": {
+            "deprecated": false,
+            "experimental": false
           }
         }
       },
@@ -212,7 +247,14 @@
             },
             "web_lynx": {
               "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
             }
+          },
+          "status": {
+            "deprecated": false,
+            "experimental": false
           }
         }
       },
@@ -224,7 +266,7 @@
               "version_added": "1.5"
             },
             "ios": {
-              "version_added": "1.5"
+              "version_added": "2.8"
             },
             "harmony": {
               "version_added": "3.4"
@@ -243,7 +285,14 @@
             },
             "web_lynx": {
               "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
             }
+          },
+          "status": {
+            "deprecated": false,
+            "experimental": false
           }
         }
       },
@@ -255,7 +304,7 @@
               "version_added": "1.5"
             },
             "ios": {
-              "version_added": "1.5"
+              "version_added": "2.11"
             },
             "harmony": {
               "version_added": "3.4"
@@ -274,7 +323,14 @@
             },
             "web_lynx": {
               "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
             }
+          },
+          "status": {
+            "deprecated": false,
+            "experimental": false
           }
         }
       },
@@ -286,7 +342,7 @@
               "version_added": "1.5"
             },
             "ios": {
-              "version_added": "1.5"
+              "version_added": "2.11"
             },
             "harmony": {
               "version_added": "3.4"
@@ -305,7 +361,14 @@
             },
             "web_lynx": {
               "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
             }
+          },
+          "status": {
+            "deprecated": false,
+            "experimental": false
           }
         }
       },
@@ -345,15 +408,15 @@
           "__compat": {
             "description": "<code>startAnimate</code>",
             "status": {
-              "deprecated": false,
+              "deprecated": true,
               "experimental": false
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "harmony": {
                 "version_added": "3.4"
@@ -371,7 +434,10 @@
                 "version_added": "1.5"
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -385,10 +451,10 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "harmony": {
                 "version_added": "3.4"
@@ -406,7 +472,10 @@
                 "version_added": "1.5"
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -420,10 +489,10 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "harmony": {
                 "version_added": "3.4"
@@ -441,7 +510,10 @@
                 "version_added": "1.5"
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -455,10 +527,10 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "harmony": {
                 "version_added": "3.4"
@@ -476,7 +548,48 @@
                 "version_added": "1.5"
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "boundingClientRect": {
+          "__compat": {
+            "description": "<code>boundingClientRect</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
                 "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -509,6 +622,390 @@
             },
             "web_lynx": {
               "version_added": true
+            }
+          }
+        }
+      },
+      "attributes": {
+        "auto-size": {
+          "__compat": {
+            "description": "<code>auto-size</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.0"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.18"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": "2.18"
+              },
+              "clay_windows": {
+                "version_added": "2.18"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "blur-radius": {
+          "__compat": {
+            "description": "<code>blur-radius</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": "2.14"
+              },
+              "clay_windows": {
+                "version_added": "2.14"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "mode": {
+          "__compat": {
+            "description": "<code>mode</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.1"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "placeholder": {
+          "__compat": {
+            "description": "<code>placeholder</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": "2.14"
+              },
+              "clay_windows": {
+                "version_added": "2.14"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "src": {
+          "__compat": {
+            "description": "<code>src</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": "2.14"
+              },
+              "clay_windows": {
+                "version_added": "2.14"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      },
+      "events": {
+        "bindcurrentloopcomplete": {
+          "__compat": {
+            "description": "<code>bindcurrentloopcomplete</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.11"
+              },
+              "ios": {
+                "version_added": "3.2"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "3.1"
+              },
+              "clay_ios": {
+                "version_added": "3.2"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "binderror": {
+          "__compat": {
+            "description": "<code>binderror</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.1"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": "2.14"
+              },
+              "clay_windows": {
+                "version_added": "2.14"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindfinalloopcomplete": {
+          "__compat": {
+            "description": "<code>bindfinalloopcomplete</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.11"
+              },
+              "ios": {
+                "version_added": "3.2"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "3.1"
+              },
+              "clay_ios": {
+                "version_added": "3.2"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindload": {
+          "__compat": {
+            "description": "<code>bindload</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": "2.14"
+              },
+              "clay_windows": {
+                "version_added": "2.14"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindstartplay": {
+          "__compat": {
+            "description": "<code>bindstartplay</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.11"
+              },
+              "ios": {
+                "version_added": "3.2"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "3.1"
+              },
+              "clay_ios": {
+                "version_added": "3.2"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
             }
           }
         }

--- a/packages/lynx-compat-data/elements/inline-truncation.json
+++ b/packages/lynx-compat-data/elements/inline-truncation.json
@@ -153,6 +153,198 @@
             }
           }
         }
+      },
+      "methods": {
+        "boundingClientRect": {
+          "__compat": {
+            "description": "<code>boundingClientRect</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "2.14"
+              },
+              "clay_macos": {
+                "version_added": "2.14"
+              },
+              "clay_windows": {
+                "version_added": "2.14"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "requestAccessibilityFocus": {
+          "__compat": {
+            "description": "<code>requestAccessibilityFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "scrollIntoView": {
+          "__compat": {
+            "description": "<code>scrollIntoView</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "2.14"
+              },
+              "clay_macos": {
+                "version_added": "2.14"
+              },
+              "clay_windows": {
+                "version_added": "2.14"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "setFocus": {
+          "__compat": {
+            "description": "<code>setFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "2.14"
+              },
+              "clay_macos": {
+                "version_added": "2.14"
+              },
+              "clay_windows": {
+                "version_added": "2.14"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "takeScreenshot": {
+          "__compat": {
+            "description": "<code>takeScreenshot</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/packages/lynx-compat-data/elements/input.json
+++ b/packages/lynx-compat-data/elements/input.json
@@ -56,7 +56,9 @@
               "version_added": "3.4"
             },
             "web_lynx": {
-              "version_added": true
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Web Lynx implements only part of this grouped feature."
             }
           }
         },
@@ -74,10 +76,10 @@
                 "version_added": "3.4"
               },
               "clay_android": {
-                "version_added": "3.4"
+                "version_added": "3.9"
               },
               "clay_ios": {
-                "version_added": "3.4"
+                "version_added": "3.9"
               },
               "clay_windows": {
                 "version_added": "3.4"
@@ -87,7 +89,14 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -118,7 +127,14 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -149,7 +165,14 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -180,7 +203,14 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -201,17 +231,24 @@
                 "version_added": "3.4"
               },
               "clay_ios": {
-                "version_added": "3.4"
+                "version_added": false
               },
               "clay_windows": {
-                "version_added": "3.4"
+                "version_added": false
               },
               "clay_macos": {
-                "version_added": "3.4"
+                "version_added": false
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -229,10 +266,10 @@
                 "version_added": "3.4"
               },
               "clay_android": {
-                "version_added": "3.4"
+                "version_added": false
               },
               "clay_ios": {
-                "version_added": "3.4"
+                "version_added": false
               },
               "clay_windows": {
                 "version_added": "3.4"
@@ -242,7 +279,14 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -263,16 +307,213 @@
                 "version_added": "3.4"
               },
               "clay_ios": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            }
+          }
+        },
+        "android-fullscreen-mode": {
+          "__compat": {
+            "description": "<code>android-fullscreen-mode</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.4"
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "3.4"
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "default-value": {
+          "__compat": {
+            "description": "<code>default-value</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "4.0"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "4.0"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "3.4"
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "disabled": {
+          "__compat": {
+            "description": "<code>disabled</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.4"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.4"
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
                 "version_added": "3.4"
               },
               "clay_windows": {
                 "version_added": "3.4"
               },
-              "clay_macos": {
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "ios-auto-correct": {
+          "__compat": {
+            "description": "<code>ios-auto-correct</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
                 "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "ios-spell-check": {
+          "__compat": {
+            "description": "<code>ios-spell-check</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": false
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -305,6 +546,504 @@
             },
             "web_lynx": {
               "version_added": true
+            }
+          }
+        }
+      },
+      "events": {
+        "bindblur": {
+          "__compat": {
+            "description": "<code>bindblur</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.4"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.4"
+              },
+              "clay_ios": {
+                "version_added": "3.4"
+              },
+              "clay_macos": {
+                "version_added": "3.4"
+              },
+              "clay_windows": {
+                "version_added": "3.4"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindconfirm": {
+          "__compat": {
+            "description": "<code>bindconfirm</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.4"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.4"
+              },
+              "clay_ios": {
+                "version_added": "3.4"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindfocus": {
+          "__compat": {
+            "description": "<code>bindfocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.4"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.4"
+              },
+              "clay_ios": {
+                "version_added": "3.4"
+              },
+              "clay_macos": {
+                "version_added": "3.4"
+              },
+              "clay_windows": {
+                "version_added": "3.4"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindinput": {
+          "__compat": {
+            "description": "<code>bindinput</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.4"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.4"
+              },
+              "clay_ios": {
+                "version_added": "3.4"
+              },
+              "clay_macos": {
+                "version_added": "3.4"
+              },
+              "clay_windows": {
+                "version_added": "3.4"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindselection": {
+          "__compat": {
+            "description": "<code>bindselection</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.4"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.4"
+              },
+              "clay_ios": {
+                "version_added": "3.4"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      },
+      "methods": {
+        "blur": {
+          "__compat": {
+            "description": "<code>blur</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.4"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.4"
+              },
+              "clay_ios": {
+                "version_added": "3.4"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "focus": {
+          "__compat": {
+            "description": "<code>focus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.4"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.4"
+              },
+              "clay_ios": {
+                "version_added": "3.4"
+              },
+              "clay_macos": {
+                "version_added": "3.4"
+              },
+              "clay_windows": {
+                "version_added": "3.4"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "getValue": {
+          "__compat": {
+            "description": "<code>getValue</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.4"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.4"
+              },
+              "clay_ios": {
+                "version_added": "3.4"
+              },
+              "clay_macos": {
+                "version_added": "3.4"
+              },
+              "clay_windows": {
+                "version_added": "3.4"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "setSelectionRange": {
+          "__compat": {
+            "description": "<code>setSelectionRange</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.4"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.4"
+              },
+              "clay_ios": {
+                "version_added": "3.4"
+              },
+              "clay_macos": {
+                "version_added": "3.4"
+              },
+              "clay_windows": {
+                "version_added": "3.4"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "setValue": {
+          "__compat": {
+            "description": "<code>setValue</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.4"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.4"
+              },
+              "clay_ios": {
+                "version_added": "3.4"
+              },
+              "clay_macos": {
+                "version_added": "3.4"
+              },
+              "clay_windows": {
+                "version_added": "3.4"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "boundingClientRect": {
+          "__compat": {
+            "description": "<code>boundingClientRect</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.4"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.4"
+              },
+              "clay_ios": {
+                "version_added": "3.4"
+              },
+              "clay_macos": {
+                "version_added": "3.4"
+              },
+              "clay_windows": {
+                "version_added": "3.4"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "scrollIntoView": {
+          "__compat": {
+            "description": "<code>scrollIntoView</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.4"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.4"
+              },
+              "clay_ios": {
+                "version_added": "3.4"
+              },
+              "clay_macos": {
+                "version_added": "3.4"
+              },
+              "clay_windows": {
+                "version_added": "3.4"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "setFocus": {
+          "__compat": {
+            "description": "<code>setFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "3.4"
+              },
+              "clay_ios": {
+                "version_added": "3.4"
+              },
+              "clay_macos": {
+                "version_added": "3.4"
+              },
+              "clay_windows": {
+                "version_added": "3.4"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
             }
           }
         }

--- a/packages/lynx-compat-data/elements/list-item.json
+++ b/packages/lynx-compat-data/elements/list-item.json
@@ -56,7 +56,9 @@
               "version_added": "1.5"
             },
             "web_lynx": {
-              "version_added": true
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Web Lynx implements only part of this grouped feature."
             }
           }
         },
@@ -86,6 +88,234 @@
                 "version_added": "3.2"
               },
               "web_lynx": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "estimated-main-axis-size-px": {
+          "__compat": {
+            "description": "<code>estimated-main-axis-size-px</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.1"
+              },
+              "ios": {
+                "version_added": "3.1"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.1"
+              },
+              "clay_ios": {
+                "version_added": "3.1"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "full-span": {
+          "__compat": {
+            "description": "<code>full-span</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.6"
+              },
+              "ios": {
+                "version_added": "1.6"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.6"
+              },
+              "clay_ios": {
+                "version_added": "1.6"
+              },
+              "clay_macos": {
+                "version_added": "1.6"
+              },
+              "clay_windows": {
+                "version_added": "1.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "item-key": {
+          "__compat": {
+            "description": "<code>item-key</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "2.18"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "recyclable": {
+          "__compat": {
+            "description": "<code>recyclable</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.3"
+              },
+              "ios": {
+                "version_added": "3.3"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.3"
+              },
+              "clay_ios": {
+                "version_added": "3.3"
+              },
+              "clay_macos": {
+                "version_added": "3.3"
+              },
+              "clay_windows": {
+                "version_added": "3.3"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "sticky-bottom": {
+          "__compat": {
+            "description": "<code>sticky-bottom</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.6"
+              },
+              "ios": {
+                "version_added": "1.6"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.6"
+              },
+              "clay_ios": {
+                "version_added": "1.6"
+              },
+              "clay_macos": {
+                "version_added": "1.6"
+              },
+              "clay_windows": {
+                "version_added": "1.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "sticky-top": {
+          "__compat": {
+            "description": "<code>sticky-top</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.6"
+              },
+              "ios": {
+                "version_added": "1.6"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.6"
+              },
+              "clay_ios": {
+                "version_added": "1.6"
+              },
+              "clay_macos": {
+                "version_added": "1.6"
+              },
+              "clay_windows": {
+                "version_added": "1.6"
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -207,6 +437,160 @@
             },
             "web_lynx": {
               "version_added": true
+            }
+          }
+        }
+      },
+      "methods": {
+        "boundingClientRect": {
+          "__compat": {
+            "description": "<code>boundingClientRect</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "3.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "requestAccessibilityFocus": {
+          "__compat": {
+            "description": "<code>requestAccessibilityFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.8"
+              },
+              "ios": {
+                "version_added": "3.5"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "scrollIntoView": {
+          "__compat": {
+            "description": "<code>scrollIntoView</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "3.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "takeScreenshot": {
+          "__compat": {
+            "description": "<code>takeScreenshot</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.5"
+              },
+              "ios": {
+                "version_added": "3.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
             }
           }
         }

--- a/packages/lynx-compat-data/elements/list-row.json
+++ b/packages/lynx-compat-data/elements/list-row.json
@@ -1,0 +1,160 @@
+{
+  "elements": {
+    "list-row": {
+      "methods": {
+        "boundingClientRect": {
+          "__compat": {
+            "description": "<code>boundingClientRect</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.1"
+              },
+              "ios": {
+                "version_added": "3.5"
+              },
+              "harmony": {
+                "version_added": "2.16"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": "4.0"
+              }
+            }
+          }
+        },
+        "requestAccessibilityFocus": {
+          "__compat": {
+            "description": "<code>requestAccessibilityFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.5"
+              },
+              "ios": {
+                "version_added": "3.5"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "scrollIntoView": {
+          "__compat": {
+            "description": "<code>scrollIntoView</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.5"
+              },
+              "ios": {
+                "version_added": "3.5"
+              },
+              "harmony": {
+                "version_added": "2.17"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": "4.0"
+              }
+            }
+          }
+        },
+        "takeScreenshot": {
+          "__compat": {
+            "description": "<code>takeScreenshot</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.5"
+              },
+              "ios": {
+                "version_added": "3.5"
+              },
+              "harmony": {
+                "version_added": "3.3"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": "4.0"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/lynx-compat-data/elements/list.json
+++ b/packages/lynx-compat-data/elements/list.json
@@ -56,7 +56,9 @@
               "version_added": "1.5"
             },
             "web_lynx": {
-              "version_added": true
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Web Lynx implements only part of this grouped feature."
             }
           }
         },
@@ -87,7 +89,14 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -118,7 +127,14 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -149,7 +165,14 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -180,7 +203,14 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -242,6 +272,621 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            }
+          }
+        },
+        "enable-insert-platform-view-operation": {
+          "__compat": {
+            "description": "<code>enable-insert-platform-view-operation</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.5"
+              },
+              "ios": {
+                "version_added": "4.0"
+              },
+              "harmony": {
+                "version_added": "3.5"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "3.5"
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": "3.5"
+              },
+              "clay_windows": {
+                "version_added": "3.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "enable-nested-scroll": {
+          "__compat": {
+            "description": "<code>enable-nested-scroll</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.14"
+              },
+              "ios": {
+                "version_added": "2.16"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "2.16"
+              },
+              "clay_ios": {
+                "version_added": "2.16"
+              },
+              "clay_macos": {
+                "version_added": "2.16"
+              },
+              "clay_windows": {
+                "version_added": "2.16"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "enable-scroll": {
+          "__compat": {
+            "description": "<code>enable-scroll</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.6"
+              },
+              "ios": {
+                "version_added": "1.6"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.16"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": "2.16"
+              },
+              "clay_windows": {
+                "version_added": "2.16"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "experimental-search-ref-anchor-strategy": {
+          "__compat": {
+            "description": "<code>experimental-search-ref-anchor-strategy</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": true
+            },
+            "support": {
+              "android": {
+                "version_added": "4.0"
+              },
+              "ios": {
+                "version_added": "4.0"
+              },
+              "harmony": {
+                "version_added": "4.0"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "harmony-scroll-edge-effect": {
+          "__compat": {
+            "description": "<code>harmony-scroll-edge-effect</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "initial-scroll-index": {
+          "__compat": {
+            "description": "<code>initial-scroll-index</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.6"
+              },
+              "ios": {
+                "version_added": "1.6"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": "2.14"
+              },
+              "clay_windows": {
+                "version_added": "2.14"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "item-snap": {
+          "__compat": {
+            "description": "<code>item-snap</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.16"
+              },
+              "ios": {
+                "version_added": "2.16"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.18"
+              },
+              "clay_ios": {
+                "version_added": "2.16"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "list-type": {
+          "__compat": {
+            "description": "<code>list-type</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": "2.14"
+              },
+              "clay_windows": {
+                "version_added": "2.14"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "lower-threshold-item-count": {
+          "__compat": {
+            "description": "<code>lower-threshold-item-count</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": "2.14"
+              },
+              "clay_windows": {
+                "version_added": "2.14"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "need-visible-item-info": {
+          "__compat": {
+            "description": "<code>need-visible-item-info</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.1"
+              },
+              "ios": {
+                "version_added": "3.1"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.1"
+              },
+              "clay_ios": {
+                "version_added": "3.1"
+              },
+              "clay_macos": {
+                "version_added": "3.1"
+              },
+              "clay_windows": {
+                "version_added": "3.1"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "scroll-bar-enable": {
+          "__compat": {
+            "description": "<code>scroll-bar-enable</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "2.17"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": "2.17"
+              },
+              "clay_windows": {
+                "version_added": "2.17"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "scroll-orientation": {
+          "__compat": {
+            "description": "<code>scroll-orientation</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.0"
+              },
+              "ios": {
+                "version_added": "3.1"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.16"
+              },
+              "clay_ios": {
+                "version_added": "2.16"
+              },
+              "clay_macos": {
+                "version_added": "2.16"
+              },
+              "clay_windows": {
+                "version_added": "2.16"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "span-count": {
+          "__compat": {
+            "description": "<code>span-count</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "2.16"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "2.16"
+              },
+              "clay_macos": {
+                "version_added": "2.14"
+              },
+              "clay_windows": {
+                "version_added": "2.14"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "sticky": {
+          "__compat": {
+            "description": "<code>sticky</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.6"
+              },
+              "ios": {
+                "version_added": "1.6"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.6"
+              },
+              "clay_ios": {
+                "version_added": "1.6"
+              },
+              "clay_macos": {
+                "version_added": "1.6"
+              },
+              "clay_windows": {
+                "version_added": "1.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "sticky-offset": {
+          "__compat": {
+            "description": "<code>sticky-offset</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.3"
+              },
+              "ios": {
+                "version_added": "2.3"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": "2.14"
+              },
+              "clay_windows": {
+                "version_added": "2.14"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "upper-threshold-item-count": {
+          "__compat": {
+            "description": "<code>upper-threshold-item-count</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": "2.14"
+              },
+              "clay_windows": {
+                "version_added": "2.14"
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -273,7 +918,9 @@
               "version_added": "1.5"
             },
             "web_lynx": {
-              "version_added": true
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Web Lynx implements only part of this grouped feature."
             }
           }
         },
@@ -285,24 +932,221 @@
                 "version_added": "1.5"
               },
               "ios": {
-                "version_added": "1.5"
+                "version_added": "2.18"
               },
               "harmony": {
                 "version_added": "3.4"
               },
               "clay_android": {
-                "version_added": "1.5"
+                "version_added": "2.17"
               },
               "clay_ios": {
-                "version_added": "1.5"
+                "version_added": "2.8"
               },
               "clay_windows": {
-                "version_added": "1.5"
+                "version_added": "2.17"
               },
               "clay_macos": {
-                "version_added": "1.5"
+                "version_added": "2.17"
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            }
+          }
+        },
+        "bindlayoutcomplete": {
+          "__compat": {
+            "description": "<code>bindlayoutcomplete</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.6"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": "2.14"
+              },
+              "clay_windows": {
+                "version_added": "2.14"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindscroll": {
+          "__compat": {
+            "description": "<code>bindscroll</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": "2.14"
+              },
+              "clay_windows": {
+                "version_added": "2.14"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindscrolltolower": {
+          "__compat": {
+            "description": "<code>bindscrolltolower</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": "2.14"
+              },
+              "clay_windows": {
+                "version_added": "2.14"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindscrolltoupper": {
+          "__compat": {
+            "description": "<code>bindscrolltoupper</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": "2.14"
+              },
+              "clay_windows": {
+                "version_added": "2.14"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindsnap": {
+          "__compat": {
+            "description": "<code>bindsnap</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.16"
+              },
+              "ios": {
+                "version_added": "2.16"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.18"
+              },
+              "clay_ios": {
+                "version_added": "2.18"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -429,6 +1273,350 @@
             },
             "web_lynx": {
               "version_added": true
+            }
+          }
+        }
+      },
+      "methods": {
+        "autoScroll": {
+          "__compat": {
+            "description": "<code>autoScroll</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.8"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.1"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "getScrollInfo": {
+          "__compat": {
+            "description": "<code>getScrollInfo</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.13"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "4.0"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "3.1"
+              },
+              "clay_ios": {
+                "version_added": "2.16"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "getVisibleCells": {
+          "__compat": {
+            "description": "<code>getVisibleCells</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.15"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": "2.15"
+              },
+              "clay_windows": {
+                "version_added": "2.15"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "scrollBy": {
+          "__compat": {
+            "description": "<code>scrollBy</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "scrollToPosition": {
+          "__compat": {
+            "description": "<code>scrollToPosition</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": "2.14"
+              },
+              "clay_windows": {
+                "version_added": "2.14"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "boundingClientRect": {
+          "__compat": {
+            "description": "<code>boundingClientRect</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "3.8"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "requestAccessibilityFocus": {
+          "__compat": {
+            "description": "<code>requestAccessibilityFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.8"
+              },
+              "ios": {
+                "version_added": "3.8"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "scrollIntoView": {
+          "__compat": {
+            "description": "<code>scrollIntoView</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "3.8"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "takeScreenshot": {
+          "__compat": {
+            "description": "<code>takeScreenshot</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.5"
+              },
+              "ios": {
+                "version_added": "3.8"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
             }
           }
         }

--- a/packages/lynx-compat-data/elements/markdown.json
+++ b/packages/lynx-compat-data/elements/markdown.json
@@ -1,0 +1,1374 @@
+{
+  "elements": {
+    "markdown": {
+      "allow-break-around-punctuation": {
+        "__compat": {
+          "description": "<code>allow-break-around-punctuation</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "3.2"
+            },
+            "ios": {
+              "version_added": "3.2"
+            },
+            "harmony": {
+              "version_added": "4.0"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "animation-frame-rate": {
+        "__compat": {
+          "description": "<code>animation-frame-rate</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "3.2"
+            },
+            "ios": {
+              "version_added": "3.2"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "animation-type": {
+        "__compat": {
+          "description": "<code>animation-type</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.15"
+            },
+            "ios": {
+              "version_added": "2.16"
+            },
+            "harmony": {
+              "version_added": "3.1"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "2.18"
+            },
+            "clay_windows": {
+              "version_added": "2.18"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "animation-velocity": {
+        "__compat": {
+          "description": "<code>animation-velocity</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.15"
+            },
+            "ios": {
+              "version_added": "2.16"
+            },
+            "harmony": {
+              "version_added": "3.1"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "2.18"
+            },
+            "clay_windows": {
+              "version_added": "2.18"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "content": {
+        "__compat": {
+          "description": "<code>content</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.15"
+            },
+            "ios": {
+              "version_added": "2.16"
+            },
+            "harmony": {
+              "version_added": "3.1"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "2.18"
+            },
+            "clay_windows": {
+              "version_added": "2.18"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "content-complete": {
+        "__compat": {
+          "description": "<code>content-complete</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.17"
+            },
+            "ios": {
+              "version_added": "3.1"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "content-id": {
+        "__compat": {
+          "description": "<code>content-id</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "3.1"
+            },
+            "ios": {
+              "version_added": "3.2"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "content-range": {
+        "__compat": {
+          "description": "<code>content-range</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.18"
+            },
+            "ios": {
+              "version_added": "3.1"
+            },
+            "harmony": {
+              "version_added": "3.1"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "enable-break-around-punctuation": {
+        "__compat": {
+          "description": "<code>enable-break-around-punctuation</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": "4.0"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "enable-selection": {
+        "__compat": {
+          "description": "<code>enable-selection</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": "4.0"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "initial-animation-step": {
+        "__compat": {
+          "description": "<code>initial-animation-step</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.17"
+            },
+            "ios": {
+              "version_added": "2.18"
+            },
+            "harmony": {
+              "version_added": "3.1"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "markdown-effect": {
+        "__compat": {
+          "description": "<code>markdown-effect</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "3.1"
+            },
+            "ios": {
+              "version_added": "3.2"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "markdown-style": {
+        "__compat": {
+          "description": "<code>markdown-style</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.15"
+            },
+            "ios": {
+              "version_added": "2.16"
+            },
+            "harmony": {
+              "version_added": "3.1"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "2.18"
+            },
+            "clay_windows": {
+              "version_added": "2.18"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "text-maxline": {
+        "__compat": {
+          "description": "<code>text-maxline</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.15"
+            },
+            "ios": {
+              "version_added": "2.16"
+            },
+            "harmony": {
+              "version_added": "3.1"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "2.18"
+            },
+            "clay_windows": {
+              "version_added": "2.18"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "text-selection": {
+        "__compat": {
+          "description": "<code>text-selection</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.17"
+            },
+            "ios": {
+              "version_added": "2.18"
+            },
+            "harmony": {
+              "version_added": "3.1"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "typewriter-dynamic-height": {
+        "__compat": {
+          "description": "<code>typewriter-dynamic-height</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.17"
+            },
+            "ios": {
+              "version_added": "2.18"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "typewriter-height-transition-duration": {
+        "__compat": {
+          "description": "<code>typewriter-height-transition-duration</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "3.2"
+            },
+            "ios": {
+              "version_added": "3.2"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "bindanimationStep": {
+        "__compat": {
+          "description": "<code>bindanimationStep</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.17"
+            },
+            "ios": {
+              "version_added": "2.18"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "binddrawEnd": {
+        "__compat": {
+          "description": "<code>binddrawEnd</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.15"
+            },
+            "ios": {
+              "version_added": "2.16"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "2.18"
+            },
+            "clay_windows": {
+              "version_added": "2.18"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "binddrawStart": {
+        "__compat": {
+          "description": "<code>binddrawStart</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.15"
+            },
+            "ios": {
+              "version_added": "2.16"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "2.18"
+            },
+            "clay_windows": {
+              "version_added": "2.18"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "bindimageTap": {
+        "__compat": {
+          "description": "<code>bindimageTap</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "3.1"
+            },
+            "ios": {
+              "version_added": "3.2"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "bindlink": {
+        "__compat": {
+          "description": "<code>bindlink</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.15"
+            },
+            "ios": {
+              "version_added": "2.16"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "2.18"
+            },
+            "clay_windows": {
+              "version_added": "2.18"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "bindoverflow": {
+        "__compat": {
+          "description": "<code>bindoverflow</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.16"
+            },
+            "ios": {
+              "version_added": "4.0"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "2.18"
+            },
+            "clay_windows": {
+              "version_added": "2.18"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "bindparseEnd": {
+        "__compat": {
+          "description": "<code>bindparseEnd</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "3.1"
+            },
+            "ios": {
+              "version_added": "3.2"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "bindselectionchange": {
+        "__compat": {
+          "description": "<code>bindselectionchange</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.17"
+            },
+            "ios": {
+              "version_added": "3.1"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "getCharIndexByPoint": {
+        "__compat": {
+          "description": "<code>getCharIndexByPoint</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "4.0"
+            },
+            "ios": {
+              "version_added": "4.0"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "getContent": {
+        "__compat": {
+          "description": "<code>getContent</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.17"
+            },
+            "ios": {
+              "version_added": "2.18"
+            },
+            "harmony": {
+              "version_added": "3.1"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "getImages": {
+        "__compat": {
+          "description": "<code>getImages</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "3.1"
+            },
+            "ios": {
+              "version_added": "3.2"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "getParseResult": {
+        "__compat": {
+          "description": "<code>getParseResult</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "3.1"
+            },
+            "ios": {
+              "version_added": "3.2"
+            },
+            "harmony": {
+              "version_added": "4.0"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "getSelectedText": {
+        "__compat": {
+          "description": "<code>getSelectedText</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.17"
+            },
+            "ios": {
+              "version_added": "2.18"
+            },
+            "harmony": {
+              "version_added": "3.1"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "pauseAnimation": {
+        "__compat": {
+          "description": "<code>pauseAnimation</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.17"
+            },
+            "ios": {
+              "version_added": "3.1"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "resumeAnimation": {
+        "__compat": {
+          "description": "<code>resumeAnimation</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.17"
+            },
+            "ios": {
+              "version_added": "3.1"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "setTextSelection": {
+        "__compat": {
+          "description": "<code>setTextSelection</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.17"
+            },
+            "ios": {
+              "version_added": "2.18"
+            },
+            "harmony": {
+              "version_added": "3.1"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "boundingClientRect": {
+        "__compat": {
+          "description": "<code>boundingClientRect</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.15"
+            },
+            "ios": {
+              "version_added": "1.0"
+            },
+            "harmony": {
+              "version_added": "2.16"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "2.15"
+            },
+            "clay_ios": {
+              "version_added": "4.0"
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": "4.0"
+            }
+          }
+        }
+      },
+      "requestAccessibilityFocus": {
+        "__compat": {
+          "description": "<code>requestAccessibilityFocus</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.15"
+            },
+            "ios": {
+              "version_added": "2.18"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "scrollIntoView": {
+        "__compat": {
+          "description": "<code>scrollIntoView</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.15"
+            },
+            "ios": {
+              "version_added": "2.18"
+            },
+            "harmony": {
+              "version_added": "2.17"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "2.15"
+            },
+            "clay_ios": {
+              "version_added": "4.0"
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": "4.0"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/lynx-compat-data/elements/nested-image.json
+++ b/packages/lynx-compat-data/elements/nested-image.json
@@ -339,6 +339,880 @@
             }
           }
         }
+      },
+      "auto-size": {
+        "__compat": {
+          "description": "<code>auto-size</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": "1.5"
+            },
+            "harmony": {
+              "version_added": "3.4"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "2.18"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "2.18"
+            },
+            "clay_windows": {
+              "version_added": "2.18"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "autoplay": {
+        "__compat": {
+          "description": "<code>autoplay</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": "2.11"
+            },
+            "harmony": {
+              "version_added": "4.0"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "4.0"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "blur-radius": {
+        "__compat": {
+          "description": "<code>blur-radius</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": "1.5"
+            },
+            "harmony": {
+              "version_added": "3.4"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "2.14"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "2.14"
+            },
+            "clay_windows": {
+              "version_added": "2.14"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "cap-insets": {
+        "__compat": {
+          "description": "<code>cap-insets</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": "1.5"
+            },
+            "harmony": {
+              "version_added": "3.4"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "2.14"
+            },
+            "clay_ios": {
+              "version_added": "2.16"
+            },
+            "clay_macos": {
+              "version_added": "2.14"
+            },
+            "clay_windows": {
+              "version_added": "2.14"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "cap-insets-scale": {
+        "__compat": {
+          "description": "<code>cap-insets-scale</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": "1.5"
+            },
+            "harmony": {
+              "version_added": "3.4"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "2.14"
+            },
+            "clay_ios": {
+              "version_added": "2.16"
+            },
+            "clay_macos": {
+              "version_added": "2.14"
+            },
+            "clay_windows": {
+              "version_added": "2.14"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "defer-src-invalidation": {
+        "__compat": {
+          "description": "<code>defer-src-invalidation</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": "2.8"
+            },
+            "harmony": {
+              "version_added": "3.4"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "4.0"
+            },
+            "clay_ios": {
+              "version_added": "4.0"
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "image-config": {
+        "__compat": {
+          "description": "<code>image-config</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "3.1"
+            },
+            "clay_ios": {
+              "version_added": "4.0"
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "loop-count": {
+        "__compat": {
+          "description": "<code>loop-count</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "4.2"
+            },
+            "ios": {
+              "version_added": "1.5"
+            },
+            "harmony": {
+              "version_added": "4.0"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "2.18"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "2.18"
+            },
+            "clay_windows": {
+              "version_added": "2.18"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "mode": {
+        "__compat": {
+          "description": "<code>mode</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "1.5"
+            },
+            "ios": {
+              "version_added": "1.5"
+            },
+            "harmony": {
+              "version_added": "3.4"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "2.14"
+            },
+            "clay_ios": {
+              "version_added": "2.10"
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "placeholder": {
+        "__compat": {
+          "description": "<code>placeholder</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": "1.5"
+            },
+            "harmony": {
+              "version_added": "3.4"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "2.14"
+            },
+            "clay_ios": {
+              "version_added": "2.16"
+            },
+            "clay_macos": {
+              "version_added": "2.14"
+            },
+            "clay_windows": {
+              "version_added": "2.14"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "prefetch-height": {
+        "__compat": {
+          "description": "<code>prefetch-height</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": "1.5"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "prefetch-width": {
+        "__compat": {
+          "description": "<code>prefetch-width</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": "1.5"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "src": {
+        "__compat": {
+          "description": "<code>src</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "1.5"
+            },
+            "ios": {
+              "version_added": "1.5"
+            },
+            "harmony": {
+              "version_added": "3.4"
+            },
+            "web_lynx": {
+              "version_added": true
+            },
+            "clay_android": {
+              "version_added": "3.1"
+            },
+            "clay_ios": {
+              "version_added": "2.8"
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "tint-color": {
+        "__compat": {
+          "description": "<code>tint-color</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": "2.11"
+            },
+            "harmony": {
+              "version_added": "3.4"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "4.0"
+            },
+            "clay_ios": {
+              "version_added": "4.0"
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "currentloopcomplete": {
+        "__compat": {
+          "description": "<code>bindcurrentloopcomplete</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": "3.2"
+            },
+            "harmony": {
+              "version_added": "4.1"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "4.0"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "error": {
+        "__compat": {
+          "description": "<code>binderror</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.0"
+            },
+            "ios": {
+              "version_added": "1.5"
+            },
+            "harmony": {
+              "version_added": "3.4"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "2.14"
+            },
+            "clay_ios": {
+              "version_added": "2.8"
+            },
+            "clay_macos": {
+              "version_added": "2.14"
+            },
+            "clay_windows": {
+              "version_added": "2.14"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "finalloopcomplete": {
+        "__compat": {
+          "description": "<code>bindfinalloopcomplete</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": "3.2"
+            },
+            "harmony": {
+              "version_added": "3.4"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "2.18"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "load": {
+        "__compat": {
+          "description": "<code>bindload</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.0"
+            },
+            "ios": {
+              "version_added": "1.5"
+            },
+            "harmony": {
+              "version_added": "3.4"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "2.14"
+            },
+            "clay_ios": {
+              "version_added": "2.8"
+            },
+            "clay_macos": {
+              "version_added": "2.14"
+            },
+            "clay_windows": {
+              "version_added": "2.14"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "startplay": {
+        "__compat": {
+          "description": "<code>bindstartplay</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": "3.2"
+            },
+            "harmony": {
+              "version_added": "4.1"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "4.0"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "requestAccessibilityFocus": {
+        "__compat": {
+          "description": "<code>requestAccessibilityFocus</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": "2.18"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "scrollIntoView": {
+        "__compat": {
+          "description": "<code>scrollIntoView</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": "2.18"
+            },
+            "harmony": {
+              "version_added": "3.4"
+            },
+            "web_lynx": {
+              "version_added": true
+            },
+            "clay_android": {
+              "version_added": "2.14"
+            },
+            "clay_ios": {
+              "version_added": "2.16"
+            },
+            "clay_macos": {
+              "version_added": "2.14"
+            },
+            "clay_windows": {
+              "version_added": "2.14"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "setFocus": {
+        "__compat": {
+          "description": "<code>setFocus</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "2.14"
+            },
+            "clay_ios": {
+              "version_added": "2.16"
+            },
+            "clay_macos": {
+              "version_added": "2.14"
+            },
+            "clay_windows": {
+              "version_added": "2.14"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "takeScreenshot": {
+        "__compat": {
+          "description": "<code>takeScreenshot</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": "2.18"
+            },
+            "harmony": {
+              "version_added": "3.4"
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "4.0"
+            },
+            "clay_ios": {
+              "version_added": "4.0"
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
       }
     }
   }

--- a/packages/lynx-compat-data/elements/nested-text.json
+++ b/packages/lynx-compat-data/elements/nested-text.json
@@ -637,6 +637,728 @@
             }
           }
         }
+      },
+      "custom-context-menu": {
+        "__compat": {
+          "description": "<code>custom-context-menu</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "custom-text-selection": {
+        "__compat": {
+          "description": "<code>custom-text-selection</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "include-font-padding": {
+        "__compat": {
+          "description": "<code>include-font-padding</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "1.5"
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "tail-color-convert": {
+        "__compat": {
+          "description": "<code>tail-color-convert</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "text-maxlength": {
+        "__compat": {
+          "description": "<code>text-maxlength</code>",
+          "status": {
+            "deprecated": true,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "1.5"
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "3.1"
+            },
+            "clay_ios": {
+              "version_added": "2.8"
+            },
+            "clay_macos": {
+              "version_added": "2.18"
+            },
+            "clay_windows": {
+              "version_added": "2.18"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "text-maxline": {
+        "__compat": {
+          "description": "<code>text-maxline</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "text-selection": {
+        "__compat": {
+          "description": "<code>text-selection</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "text-single-line-vertical-align": {
+        "__compat": {
+          "description": "<code>text-single-line-vertical-align</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "3.1"
+            },
+            "clay_ios": {
+              "version_added": "2.12"
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "text-vertical-align": {
+        "__compat": {
+          "description": "<code>text-vertical-align</code>",
+          "status": {
+            "deprecated": true,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "1.5"
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "android-emoji-compat": {
+        "__compat": {
+          "description": "<code>android-emoji-compat</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.10"
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "enable-font-scaling": {
+        "__compat": {
+          "description": "<code>enable-font-scaling</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "1.5"
+            },
+            "ios": {
+              "version_added": "1.5"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "text-fake-bold": {
+        "__compat": {
+          "description": "<code>text-fake-bold</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "2.12"
+            },
+            "ios": {
+              "version_added": "2.18"
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "layout": {
+        "__compat": {
+          "description": "<code>bindlayout</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "selectionchange": {
+        "__compat": {
+          "description": "<code>bindselectionchange</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "boundingClientRect": {
+        "__compat": {
+          "description": "<code>boundingClientRect</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": true
+            },
+            "clay_android": {
+              "version_added": "2.14"
+            },
+            "clay_ios": {
+              "version_added": "2.16"
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "requestAccessibilityFocus": {
+        "__compat": {
+          "description": "<code>requestAccessibilityFocus</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": false
+            },
+            "clay_ios": {
+              "version_added": false
+            },
+            "clay_macos": {
+              "version_added": false
+            },
+            "clay_windows": {
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "scrollIntoView": {
+        "__compat": {
+          "description": "<code>scrollIntoView</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": true
+            },
+            "clay_android": {
+              "version_added": "2.14"
+            },
+            "clay_ios": {
+              "version_added": "2.16"
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "setFocus": {
+        "__compat": {
+          "description": "<code>setFocus</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "4.0"
+            },
+            "clay_ios": {
+              "version_added": "2.16"
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
+      },
+      "takeScreenshot": {
+        "__compat": {
+          "description": "<code>takeScreenshot</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": false
+            },
+            "ios": {
+              "version_added": false
+            },
+            "harmony": {
+              "version_added": false
+            },
+            "web_lynx": {
+              "version_added": false
+            },
+            "clay_android": {
+              "version_added": "4.0"
+            },
+            "clay_ios": {
+              "version_added": "2.18"
+            },
+            "clay_macos": {
+              "version_added": "4.0"
+            },
+            "clay_windows": {
+              "version_added": "4.0"
+            },
+            "clay_harmony": {
+              "version_added": false
+            }
+          }
+        }
       }
     }
   }

--- a/packages/lynx-compat-data/elements/overlay.json
+++ b/packages/lynx-compat-data/elements/overlay.json
@@ -26,9 +26,7 @@
             "version_added": "3.5"
           },
           "web_lynx": {
-            "version_added": true,
-            "partial_implementation": true,
-            "notes": "Web Lynx implements only part of this grouped feature."
+            "version_added": false
           }
         }
       },
@@ -58,9 +56,7 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": true,
-              "partial_implementation": true,
-              "notes": "Web Lynx implements only part of this grouped feature."
+              "version_added": false
             }
           }
         },
@@ -90,8 +86,15 @@
                 "version_added": "3.5"
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -121,8 +124,15 @@
                 "version_added": "3.5"
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -143,7 +153,7 @@
                 "version_added": false
               },
               "clay_ios": {
-                "version_added": false
+                "version_added": "3.8"
               },
               "clay_windows": {
                 "version_added": false
@@ -153,7 +163,14 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -168,13 +185,13 @@
                 "version_added": "3.5"
               },
               "harmony": {
-                "version_added": false
+                "version_added": "4.0"
               },
               "clay_android": {
                 "version_added": false
               },
               "clay_ios": {
-                "version_added": false
+                "version_added": "3.8"
               },
               "clay_windows": {
                 "version_added": false
@@ -184,44 +201,102 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
-        "bindshowoverlay": {
+        "android-navigation-bar-style": {
           "__compat": {
-            "description": "<code>bindshowoverlay</code>",
+            "description": "<code>android-navigation-bar-style</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
             "support": {
               "android": {
-                "version_added": "3.5"
+                "version_added": "4.1"
               },
               "ios": {
-                "version_added": "3.5"
+                "version_added": false
               },
               "harmony": {
-                "version_added": "3.5"
-              },
-              "clay_android": {
-                "version_added": "3.5"
-              },
-              "clay_ios": {
-                "version_added": "3.5"
-              },
-              "clay_windows": {
-                "version_added": "3.5"
-              },
-              "clay_macos": {
-                "version_added": "3.5"
+                "version_added": false
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
         },
+        "android-overlay-scope": {
+          "__compat": {
+            "description": "<code>android-overlay-scope</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "4.3"
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      },
+      "events": {
         "binddismissoverlay": {
           "__compat": {
             "description": "<code>binddismissoverlay</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
             "support": {
               "android": {
                 "version_added": "3.5"
@@ -232,66 +307,7 @@
               "harmony": {
                 "version_added": "3.5"
               },
-              "clay_android": {
-                "version_added": "3.5"
-              },
-              "clay_ios": {
-                "version_added": "3.5"
-              },
-              "clay_windows": {
-                "version_added": "3.5"
-              },
-              "clay_macos": {
-                "version_added": "3.5"
-              },
               "web_lynx": {
-                "version_added": true
-              }
-            }
-          }
-        },
-        "bindrequestclose": {
-          "__compat": {
-            "description": "<code>bindrequestclose</code>",
-            "support": {
-              "android": {
-                "version_added": "3.5"
-              },
-              "ios": {
-                "version_added": false
-              },
-              "harmony": {
-                "version_added": "3.5"
-              },
-              "clay_android": {
-                "version_added": "3.5"
-              },
-              "clay_ios": {
-                "version_added": "3.5"
-              },
-              "clay_windows": {
-                "version_added": "3.5"
-              },
-              "clay_macos": {
-                "version_added": "3.5"
-              },
-              "web_lynx": {
-                "version_added": false
-              }
-            }
-          }
-        },
-        "bindoverlaytouch": {
-          "__compat": {
-            "description": "<code>bindoverlaytouch</code>",
-            "support": {
-              "android": {
-                "version_added": "3.5"
-              },
-              "ios": {
-                "version_added": "3.5"
-              },
-              "harmony": {
                 "version_added": false
               },
               "clay_android": {
@@ -300,13 +316,13 @@
               "clay_ios": {
                 "version_added": "3.5"
               },
-              "clay_windows": {
-                "version_added": "3.5"
-              },
               "clay_macos": {
                 "version_added": "3.5"
               },
-              "web_lynx": {
+              "clay_windows": {
+                "version_added": "3.5"
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -315,14 +331,21 @@
         "binderror": {
           "__compat": {
             "description": "<code>binderror</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
             "support": {
               "android": {
-                "version_added": "3.5"
+                "version_added": false
               },
               "ios": {
                 "version_added": false
               },
               "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
                 "version_added": false
               },
               "clay_android": {
@@ -331,13 +354,319 @@
               "clay_ios": {
                 "version_added": false
               },
+              "clay_macos": {
+                "version_added": false
+              },
               "clay_windows": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindoverlaytouch": {
+          "__compat": {
+            "description": "<code>bindoverlaytouch</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.5"
+              },
+              "ios": {
+                "version_added": "3.5"
+              },
+              "harmony": {
+                "version_added": "4.0"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "3.5"
+              },
+              "clay_ios": {
+                "version_added": "3.5"
+              },
+              "clay_macos": {
+                "version_added": "3.5"
+              },
+              "clay_windows": {
+                "version_added": "3.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindrequestclose": {
+          "__compat": {
+            "description": "<code>bindrequestclose</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.5"
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": "3.5"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "3.5"
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": "3.5"
+              },
+              "clay_windows": {
+                "version_added": "3.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindshowoverlay": {
+          "__compat": {
+            "description": "<code>bindshowoverlay</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.5"
+              },
+              "ios": {
+                "version_added": "3.5"
+              },
+              "harmony": {
+                "version_added": "3.5"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "3.5"
+              },
+              "clay_ios": {
+                "version_added": "3.5"
+              },
+              "clay_macos": {
+                "version_added": "3.5"
+              },
+              "clay_windows": {
+                "version_added": "3.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      },
+      "methods": {
+        "boundingClientRect": {
+          "__compat": {
+            "description": "<code>boundingClientRect</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.5"
+              },
+              "ios": {
+                "version_added": "4.0"
+              },
+              "harmony": {
+                "version_added": "4.0"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "3.5"
+              },
+              "clay_ios": {
+                "version_added": "3.5"
               },
               "clay_macos": {
                 "version_added": false
               },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "requestAccessibilityFocus": {
+          "__compat": {
+            "description": "<code>requestAccessibilityFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.5"
+              },
+              "ios": {
+                "version_added": "3.5"
+              },
+              "harmony": {
+                "version_added": false
+              },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "3.5"
+              },
+              "clay_ios": {
+                "version_added": "3.5"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "scrollIntoView": {
+          "__compat": {
+            "description": "<code>scrollIntoView</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.5"
+              },
+              "ios": {
+                "version_added": "3.5"
+              },
+              "harmony": {
+                "version_added": "3.5"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "3.5"
+              },
+              "clay_ios": {
+                "version_added": "3.5"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "setFocus": {
+          "__compat": {
+            "description": "<code>setFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "3.5"
+              },
+              "clay_ios": {
+                "version_added": "3.5"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "takeScreenshot": {
+          "__compat": {
+            "description": "<code>takeScreenshot</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.5"
+              },
+              "ios": {
+                "version_added": "3.5"
+              },
+              "harmony": {
+                "version_added": "3.5"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }

--- a/packages/lynx-compat-data/elements/page.json
+++ b/packages/lynx-compat-data/elements/page.json
@@ -1,0 +1,198 @@
+{
+  "elements": {
+    "page": {
+      "methods": {
+        "boundingClientRect": {
+          "__compat": {
+            "description": "<code>boundingClientRect</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.1"
+              },
+              "ios": {
+                "version_added": "4.1"
+              },
+              "harmony": {
+                "version_added": "4.1"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "2.16"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": "4.0"
+              }
+            }
+          }
+        },
+        "requestAccessibilityFocus": {
+          "__compat": {
+            "description": "<code>requestAccessibilityFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.8"
+              },
+              "ios": {
+                "version_added": "4.1"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "scrollIntoView": {
+          "__compat": {
+            "description": "<code>scrollIntoView</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.3"
+              },
+              "ios": {
+                "version_added": "4.1"
+              },
+              "harmony": {
+                "version_added": "4.1"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "2.16"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": "4.0"
+              }
+            }
+          }
+        },
+        "setFocus": {
+          "__compat": {
+            "description": "<code>setFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "2.16"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": "4.0"
+              }
+            }
+          }
+        },
+        "takeScreenshot": {
+          "__compat": {
+            "description": "<code>takeScreenshot</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "4.1"
+              },
+              "ios": {
+                "version_added": "4.1"
+              },
+              "harmony": {
+                "version_added": "4.1"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "2.18"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": "4.0"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/lynx-compat-data/elements/raw-text.json
+++ b/packages/lynx-compat-data/elements/raw-text.json
@@ -1,70 +1,41 @@
 {
   "elements": {
-    "title-bar-view": {
-      "__compat": {
-        "description": "title-bar-view",
-        "support": {
-          "android": {
-            "version_added": false
-          },
-          "ios": {
-            "version_added": false
-          },
-          "harmony": {
-            "version_added": false
-          },
-          "clay_android": {
-            "version_added": false
-          },
-          "clay_ios": {
-            "version_added": false
-          },
-          "clay_windows": {
-            "version_added": "3.8"
-          },
-          "clay_macos": {
-            "version_added": "3.8"
-          },
-          "web_lynx": {
-            "version_added": false
-          }
-        }
-      },
-      "moveable": {
+    "raw-text": {
+      "text": {
         "__compat": {
-          "description": "<code>moveable</code>",
-          "support": {
-            "android": {
-              "version_added": false
-            },
-            "ios": {
-              "version_added": false
-            },
-            "harmony": {
-              "version_added": false
-            },
-            "clay_android": {
-              "version_added": false
-            },
-            "clay_ios": {
-              "version_added": false
-            },
-            "clay_windows": {
-              "version_added": "3.8"
-            },
-            "clay_macos": {
-              "version_added": "3.8"
-            },
-            "web_lynx": {
-              "version_added": false
-            },
-            "clay_harmony": {
-              "version_added": false
-            }
-          },
+          "description": "<code>text</code>",
           "status": {
             "deprecated": false,
             "experimental": false
+          },
+          "support": {
+            "android": {
+              "version_added": "0.1"
+            },
+            "ios": {
+              "version_added": "2.18"
+            },
+            "harmony": {
+              "version_added": "2.8"
+            },
+            "web_lynx": {
+              "version_added": true
+            },
+            "clay_android": {
+              "version_added": "1.5"
+            },
+            "clay_ios": {
+              "version_added": "2.8"
+            },
+            "clay_macos": {
+              "version_added": "2.8"
+            },
+            "clay_windows": {
+              "version_added": "2.8"
+            },
+            "clay_harmony": {
+              "version_added": "2.8"
+            }
           }
         }
       },
@@ -86,22 +57,22 @@
               "version_added": false
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
-              "version_added": false
+              "version_added": "2.14"
             },
             "clay_ios": {
-              "version_added": false
+              "version_added": "2.16"
             },
             "clay_macos": {
-              "version_added": "4.0"
+              "version_added": "2.14"
             },
             "clay_windows": {
-              "version_added": "4.0"
+              "version_added": "2.14"
             },
             "clay_harmony": {
-              "version_added": false
+              "version_added": "2.14"
             }
           }
         }
@@ -162,22 +133,22 @@
               "version_added": false
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
-              "version_added": false
+              "version_added": "2.14"
             },
             "clay_ios": {
-              "version_added": false
+              "version_added": "2.16"
             },
             "clay_macos": {
-              "version_added": "4.0"
+              "version_added": "2.14"
             },
             "clay_windows": {
-              "version_added": "4.0"
+              "version_added": "2.14"
             },
             "clay_harmony": {
-              "version_added": false
+              "version_added": "2.14"
             }
           }
         }
@@ -203,19 +174,19 @@
               "version_added": false
             },
             "clay_android": {
-              "version_added": false
+              "version_added": "2.14"
             },
             "clay_ios": {
-              "version_added": false
+              "version_added": "2.16"
             },
             "clay_macos": {
-              "version_added": "4.0"
+              "version_added": "2.14"
             },
             "clay_windows": {
-              "version_added": "4.0"
+              "version_added": "2.14"
             },
             "clay_harmony": {
-              "version_added": false
+              "version_added": "2.14"
             }
           }
         }
@@ -241,10 +212,10 @@
               "version_added": false
             },
             "clay_android": {
-              "version_added": false
+              "version_added": "4.0"
             },
             "clay_ios": {
-              "version_added": false
+              "version_added": "2.18"
             },
             "clay_macos": {
               "version_added": "4.0"
@@ -253,7 +224,7 @@
               "version_added": "4.0"
             },
             "clay_harmony": {
-              "version_added": false
+              "version_added": "4.0"
             }
           }
         }

--- a/packages/lynx-compat-data/elements/refresh-header.json
+++ b/packages/lynx-compat-data/elements/refresh-header.json
@@ -1,0 +1,198 @@
+{
+  "elements": {
+    "refresh-header": {
+      "methods": {
+        "boundingClientRect": {
+          "__compat": {
+            "description": "<code>boundingClientRect</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "4.0"
+              },
+              "harmony": {
+                "version_added": "4.1"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "requestAccessibilityFocus": {
+          "__compat": {
+            "description": "<code>requestAccessibilityFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.8"
+              },
+              "ios": {
+                "version_added": "4.0"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "scrollIntoView": {
+          "__compat": {
+            "description": "<code>scrollIntoView</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "4.0"
+              },
+              "harmony": {
+                "version_added": "4.1"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "setFocus": {
+          "__compat": {
+            "description": "<code>setFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "takeScreenshot": {
+          "__compat": {
+            "description": "<code>takeScreenshot</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "4.0"
+              },
+              "ios": {
+                "version_added": "4.0"
+              },
+              "harmony": {
+                "version_added": "4.1"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/lynx-compat-data/elements/refresh.json
+++ b/packages/lynx-compat-data/elements/refresh.json
@@ -26,7 +26,7 @@
             "version_added": false
           },
           "web_lynx": {
-            "version_added": "3.8"
+            "version_added": false
           }
         }
       },
@@ -56,7 +56,7 @@
               "version_added": false
             },
             "web_lynx": {
-              "version_added": "3.8"
+              "version_added": false
             }
           }
         },
@@ -86,8 +86,15 @@
                 "version_added": false
               },
               "web_lynx": {
-                "version_added": "3.8"
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         }
@@ -118,7 +125,7 @@
               "version_added": false
             },
             "web_lynx": {
-              "version_added": "3.8"
+              "version_added": false
             }
           }
         },
@@ -148,8 +155,15 @@
                 "version_added": false
               },
               "web_lynx": {
-                "version_added": "3.8"
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -179,8 +193,15 @@
                 "version_added": false
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -211,7 +232,14 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         }
@@ -242,7 +270,7 @@
               "version_added": false
             },
             "web_lynx": {
-              "version_added": "3.8"
+              "version_added": false
             }
           }
         },
@@ -272,8 +300,15 @@
                 "version_added": false
               },
               "web_lynx": {
-                "version_added": "3.8"
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -303,7 +338,204 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            }
+          }
+        },
+        "boundingClientRect": {
+          "__compat": {
+            "description": "<code>boundingClientRect</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
                 "version_added": "3.8"
+              },
+              "ios": {
+                "version_added": "3.8"
+              },
+              "harmony": {
+                "version_added": "4.1"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "requestAccessibilityFocus": {
+          "__compat": {
+            "description": "<code>requestAccessibilityFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.8"
+              },
+              "ios": {
+                "version_added": "3.8"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "scrollIntoView": {
+          "__compat": {
+            "description": "<code>scrollIntoView</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.8"
+              },
+              "ios": {
+                "version_added": "3.8"
+              },
+              "harmony": {
+                "version_added": "4.1"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "setFocus": {
+          "__compat": {
+            "description": "<code>setFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "takeScreenshot": {
+          "__compat": {
+            "description": "<code>takeScreenshot</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.8"
+              },
+              "ios": {
+                "version_added": "3.8"
+              },
+              "harmony": {
+                "version_added": "4.1"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }

--- a/packages/lynx-compat-data/elements/scroll-coordinator-header.json
+++ b/packages/lynx-compat-data/elements/scroll-coordinator-header.json
@@ -1,0 +1,198 @@
+{
+  "elements": {
+    "scroll-coordinator-header": {
+      "methods": {
+        "boundingClientRect": {
+          "__compat": {
+            "description": "<code>boundingClientRect</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "4.0"
+              },
+              "harmony": {
+                "version_added": "4.0"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "3.7"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "requestAccessibilityFocus": {
+          "__compat": {
+            "description": "<code>requestAccessibilityFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.8"
+              },
+              "ios": {
+                "version_added": "4.0"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "3.1"
+              },
+              "clay_ios": {
+                "version_added": "3.8"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "scrollIntoView": {
+          "__compat": {
+            "description": "<code>scrollIntoView</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "4.0"
+              },
+              "harmony": {
+                "version_added": "4.0"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "3.7"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "setFocus": {
+          "__compat": {
+            "description": "<code>setFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "3.7"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "takeScreenshot": {
+          "__compat": {
+            "description": "<code>takeScreenshot</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "4.0"
+              },
+              "ios": {
+                "version_added": "4.0"
+              },
+              "harmony": {
+                "version_added": "4.0"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "3.7"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/lynx-compat-data/elements/scroll-coordinator-slot-drag.json
+++ b/packages/lynx-compat-data/elements/scroll-coordinator-slot-drag.json
@@ -1,0 +1,198 @@
+{
+  "elements": {
+    "scroll-coordinator-slot-drag": {
+      "methods": {
+        "boundingClientRect": {
+          "__compat": {
+            "description": "<code>boundingClientRect</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.1"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "4.1"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "requestAccessibilityFocus": {
+          "__compat": {
+            "description": "<code>requestAccessibilityFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.8"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": "3.0"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "scrollIntoView": {
+          "__compat": {
+            "description": "<code>scrollIntoView</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.3"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "4.1"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "setFocus": {
+          "__compat": {
+            "description": "<code>setFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "takeScreenshot": {
+          "__compat": {
+            "description": "<code>takeScreenshot</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.3"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "4.1"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/lynx-compat-data/elements/scroll-coordinator-slot.json
+++ b/packages/lynx-compat-data/elements/scroll-coordinator-slot.json
@@ -1,0 +1,198 @@
+{
+  "elements": {
+    "scroll-coordinator-slot": {
+      "methods": {
+        "boundingClientRect": {
+          "__compat": {
+            "description": "<code>boundingClientRect</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.1"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "2.16"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "2.16"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "requestAccessibilityFocus": {
+          "__compat": {
+            "description": "<code>requestAccessibilityFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.8"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "3.1"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "scrollIntoView": {
+          "__compat": {
+            "description": "<code>scrollIntoView</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.3"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "2.17"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "2.16"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "setFocus": {
+          "__compat": {
+            "description": "<code>setFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "2.16"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "takeScreenshot": {
+          "__compat": {
+            "description": "<code>takeScreenshot</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.3"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.3"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/lynx-compat-data/elements/scroll-coordinator-toolbar.json
+++ b/packages/lynx-compat-data/elements/scroll-coordinator-toolbar.json
@@ -1,0 +1,198 @@
+{
+  "elements": {
+    "scroll-coordinator-toolbar": {
+      "methods": {
+        "boundingClientRect": {
+          "__compat": {
+            "description": "<code>boundingClientRect</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "4.0"
+              },
+              "harmony": {
+                "version_added": "4.0"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "3.7"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "requestAccessibilityFocus": {
+          "__compat": {
+            "description": "<code>requestAccessibilityFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.8"
+              },
+              "ios": {
+                "version_added": "4.0"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": "3.7"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "scrollIntoView": {
+          "__compat": {
+            "description": "<code>scrollIntoView</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "4.0"
+              },
+              "harmony": {
+                "version_added": "4.0"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "3.7"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "setFocus": {
+          "__compat": {
+            "description": "<code>setFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "3.7"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "takeScreenshot": {
+          "__compat": {
+            "description": "<code>takeScreenshot</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "4.0"
+              },
+              "ios": {
+                "version_added": "4.0"
+              },
+              "harmony": {
+                "version_added": "4.0"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/lynx-compat-data/elements/scroll-coordinator.json
+++ b/packages/lynx-compat-data/elements/scroll-coordinator.json
@@ -26,7 +26,7 @@
             "version_added": "3.9"
           },
           "web_lynx": {
-            "version_added": "3.9"
+            "version_added": false
           }
         }
       },
@@ -56,7 +56,7 @@
               "version_added": "3.9"
             },
             "web_lynx": {
-              "version_added": "3.9"
+              "version_added": false
             }
           }
         },
@@ -77,7 +77,7 @@
                 "version_added": false
               },
               "clay_ios": {
-                "version_added": false
+                "version_added": "4.0"
               },
               "clay_windows": {
                 "version_added": false
@@ -87,7 +87,14 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -111,14 +118,21 @@
                 "version_added": "3.9"
               },
               "clay_windows": {
-                "version_added": "3.9"
+                "version_added": false
               },
               "clay_macos": {
-                "version_added": "3.9"
+                "version_added": false
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -142,14 +156,21 @@
                 "version_added": "3.9"
               },
               "clay_windows": {
-                "version_added": "3.9"
+                "version_added": false
               },
               "clay_macos": {
-                "version_added": "3.9"
+                "version_added": false
               },
               "web_lynx": {
-                "version_added": "3.9"
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -170,7 +191,7 @@
                 "version_added": false
               },
               "clay_ios": {
-                "version_added": false
+                "version_added": "4.0"
               },
               "clay_windows": {
                 "version_added": false
@@ -180,7 +201,14 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -201,7 +229,7 @@
                 "version_added": false
               },
               "clay_ios": {
-                "version_added": false
+                "version_added": "4.0"
               },
               "clay_windows": {
                 "version_added": false
@@ -210,8 +238,15 @@
                 "version_added": false
               },
               "web_lynx": {
-                "version_added": "3.9"
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -242,7 +277,14 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -263,7 +305,7 @@
                 "version_added": false
               },
               "clay_ios": {
-                "version_added": false
+                "version_added": "4.0"
               },
               "clay_windows": {
                 "version_added": false
@@ -273,7 +315,14 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -297,14 +346,21 @@
                 "version_added": "3.9"
               },
               "clay_windows": {
-                "version_added": "3.9"
+                "version_added": false
               },
               "clay_macos": {
-                "version_added": "3.9"
+                "version_added": false
               },
               "web_lynx": {
-                "version_added": "3.9"
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -325,7 +381,7 @@
                 "version_added": false
               },
               "clay_ios": {
-                "version_added": false
+                "version_added": "4.0"
               },
               "clay_windows": {
                 "version_added": false
@@ -334,6 +390,51 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            }
+          }
+        },
+        "enable-drag": {
+          "__compat": {
+            "description": "<code>enable-drag</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.9"
+              },
+              "ios": {
+                "version_added": "3.9"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "3.9"
+              },
+              "clay_ios": {
+                "version_added": "3.9"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -366,7 +467,7 @@
               "version_added": "3.9"
             },
             "web_lynx": {
-              "version_added": "3.9"
+              "version_added": false
             }
           }
         },
@@ -394,13 +495,16 @@
                 "version_added": "3.9"
               },
               "clay_windows": {
-                "version_added": "3.9"
+                "version_added": false
               },
               "clay_macos": {
-                "version_added": "3.9"
+                "version_added": false
               },
               "web_lynx": {
-                "version_added": "3.9"
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -432,7 +536,7 @@
               "version_added": "3.9"
             },
             "web_lynx": {
-              "version_added": "3.9"
+              "version_added": false
             }
           }
         },
@@ -460,13 +564,206 @@
                 "version_added": "3.9"
               },
               "clay_windows": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "boundingClientRect": {
+          "__compat": {
+            "description": "<code>boundingClientRect</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.9"
+              },
+              "ios": {
+                "version_added": "4.0"
+              },
+              "harmony": {
+                "version_added": "4.0"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "3.9"
+              },
+              "clay_ios": {
                 "version_added": "3.9"
               },
               "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "requestAccessibilityFocus": {
+          "__compat": {
+            "description": "<code>requestAccessibilityFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
                 "version_added": "3.9"
               },
+              "ios": {
+                "version_added": "4.0"
+              },
+              "harmony": {
+                "version_added": false
+              },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
                 "version_added": "3.9"
+              },
+              "clay_ios": {
+                "version_added": "3.9"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "scrollIntoView": {
+          "__compat": {
+            "description": "<code>scrollIntoView</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "4.0"
+              },
+              "ios": {
+                "version_added": "4.0"
+              },
+              "harmony": {
+                "version_added": "4.0"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "3.9"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "setFocus": {
+          "__compat": {
+            "description": "<code>setFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "3.9"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "takeScreenshot": {
+          "__compat": {
+            "description": "<code>takeScreenshot</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "4.0"
+              },
+              "ios": {
+                "version_added": "4.0"
+              },
+              "harmony": {
+                "version_added": "4.0"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }

--- a/packages/lynx-compat-data/elements/scroll-view.json
+++ b/packages/lynx-compat-data/elements/scroll-view.json
@@ -56,7 +56,9 @@
               "version_added": "1.5"
             },
             "web_lynx": {
-              "version_added": true
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Web Lynx implements only part of this grouped feature."
             }
           }
         },
@@ -74,7 +76,7 @@
                 "version_added": "3.4"
               },
               "clay_android": {
-                "version_added": "3.2"
+                "version_added": false
               },
               "clay_ios": {
                 "version_added": "3.2"
@@ -87,7 +89,14 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -118,7 +127,14 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -149,7 +165,14 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -180,6 +203,241 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            }
+          }
+        },
+        "enable-scroll": {
+          "__compat": {
+            "description": "<code>enable-scroll</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.2"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.5"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "experimental-android-enable-new-overflow": {
+          "__compat": {
+            "description": "<code>experimental-android-enable-new-overflow</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": true
+            },
+            "support": {
+              "android": {
+                "version_added": "4.2"
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "lower-threshold": {
+          "__compat": {
+            "description": "<code>lower-threshold</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.5"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.5"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.5"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "scroll-bar-enable": {
+          "__compat": {
+            "description": "<code>scroll-bar-enable</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.5"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "upper-threshold": {
+          "__compat": {
+            "description": "<code>upper-threshold</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.5"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.5"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.5"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "enable-scrollbar": {
+          "__compat": {
+            "description": "<code>enable-scrollbar</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": "3.0"
+              },
+              "clay_windows": {
+                "version_added": "3.0"
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -211,7 +469,9 @@
               "version_added": "1.5"
             },
             "web_lynx": {
-              "version_added": true
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Web Lynx implements only part of this grouped feature."
             }
           }
         },
@@ -223,24 +483,183 @@
                 "version_added": "1.5"
               },
               "ios": {
-                "version_added": "1.5"
+                "version_added": "4.1"
               },
               "harmony": {
                 "version_added": "3.4"
               },
               "clay_android": {
+                "version_added": "2.15"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_windows": {
+                "version_added": "2.15"
+              },
+              "clay_macos": {
+                "version_added": "2.15"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            }
+          }
+        },
+        "bindscroll": {
+          "__compat": {
+            "description": "<code>bindscroll</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
                 "version_added": "1.5"
               },
               "clay_ios": {
-                "version_added": "1.5"
-              },
-              "clay_windows": {
-                "version_added": "1.5"
+                "version_added": "2.8"
               },
               "clay_macos": {
-                "version_added": "1.5"
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindscrollend": {
+          "__compat": {
+            "description": "<code>bindscrollend</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.5"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "3.4"
               },
               "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.5"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindscrolltolower": {
+          "__compat": {
+            "description": "<code>bindscrolltolower</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindscrolltoupper": {
+          "__compat": {
+            "description": "<code>bindscrolltoupper</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -336,6 +755,350 @@
             },
             "web_lynx": {
               "version_added": true
+            }
+          }
+        }
+      },
+      "methods": {
+        "autoScroll": {
+          "__compat": {
+            "description": "<code>autoScroll</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.0"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": "2.14"
+              },
+              "clay_windows": {
+                "version_added": "2.14"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "getScrollInfo": {
+          "__compat": {
+            "description": "<code>getScrollInfo</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.13"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "4.0"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "3.1"
+              },
+              "clay_ios": {
+                "version_added": "2.16"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "scrollBy": {
+          "__compat": {
+            "description": "<code>scrollBy</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.5"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "scrollTo": {
+          "__compat": {
+            "description": "<code>scrollTo</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.5"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": "2.14"
+              },
+              "clay_windows": {
+                "version_added": "2.14"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "takeContentScreenshot": {
+          "__compat": {
+            "description": "<code>takeContentScreenshot</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "4.0"
+              },
+              "ios": {
+                "version_added": "4.1"
+              },
+              "harmony": {
+                "version_added": "4.0"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "boundingClientRect": {
+          "__compat": {
+            "description": "<code>boundingClientRect</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "4.1"
+              },
+              "harmony": {
+                "version_added": "4.1"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "requestAccessibilityFocus": {
+          "__compat": {
+            "description": "<code>requestAccessibilityFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.8"
+              },
+              "ios": {
+                "version_added": "4.1"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "scrollIntoView": {
+          "__compat": {
+            "description": "<code>scrollIntoView</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "4.1"
+              },
+              "harmony": {
+                "version_added": "3.5"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "takeScreenshot": {
+          "__compat": {
+            "description": "<code>takeScreenshot</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.3"
+              },
+              "ios": {
+                "version_added": "4.1"
+              },
+              "harmony": {
+                "version_added": "4.1"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
             }
           }
         }

--- a/packages/lynx-compat-data/elements/svg.json
+++ b/packages/lynx-compat-data/elements/svg.json
@@ -56,7 +56,9 @@
               "version_added": "3.7"
             },
             "web_lynx": {
-              "version_added": true
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Web Lynx implements only part of this grouped feature."
             }
           }
         },
@@ -87,7 +89,14 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -118,13 +127,64 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
+        "current-color": {
+          "__compat": {
+            "description": "<code>current-color</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.7"
+              },
+              "ios": {
+                "version_added": "4.1"
+              },
+              "harmony": {
+                "version_added": "4.0"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      },
+      "events": {
         "bindload": {
           "__compat": {
             "description": "<code>bindload</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
             "support": {
               "android": {
                 "version_added": "3.7"
@@ -135,20 +195,101 @@
               "harmony": {
                 "version_added": "3.7"
               },
+              "web_lynx": {
+                "version_added": true
+              },
               "clay_android": {
                 "version_added": "3.7"
               },
               "clay_ios": {
                 "version_added": "3.7"
               },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
               "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      },
+      "methods": {
+        "scrollIntoView": {
+          "__compat": {
+            "description": "<code>scrollIntoView</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.7"
+              },
+              "ios": {
+                "version_added": "3.7"
+              },
+              "harmony": {
+                "version_added": "3.7"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.7"
+              },
+              "clay_ios": {
                 "version_added": "3.7"
               },
               "clay_macos": {
                 "version_added": "3.7"
               },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "setFocus": {
+          "__compat": {
+            "description": "<code>setFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
               "web_lynx": {
-                "version_added": true
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "3.7"
+              },
+              "clay_ios": {
+                "version_added": "3.7"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }

--- a/packages/lynx-compat-data/elements/text.json
+++ b/packages/lynx-compat-data/elements/text.json
@@ -93,6 +93,9 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -127,6 +130,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -163,6 +169,9 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -191,12 +200,15 @@
                 "version_added": "1.5"
               },
               "clay_windows": {
-                "version_added": "1.5"
+                "version_added": false
               },
               "clay_macos": {
-                "version_added": "1.5"
+                "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -217,7 +229,7 @@
                 "version_added": "3.2"
               },
               "harmony": {
-                "version_added": false
+                "version_added": "4.0"
               },
               "clay_android": {
                 "version_added": "3.7"
@@ -226,12 +238,15 @@
                 "version_added": "3.7"
               },
               "clay_windows": {
-                "version_added": "3.7"
+                "version_added": "2.14"
               },
               "clay_macos": {
-                "version_added": "3.7"
+                "version_added": "2.14"
               },
               "web_lynx": {
+                "version_added": true
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -252,21 +267,24 @@
                 "version_added": "3.2"
               },
               "harmony": {
-                "version_added": false
+                "version_added": "4.0"
               },
               "clay_android": {
-                "version_added": false
+                "version_added": "4.0"
               },
               "clay_ios": {
-                "version_added": false
+                "version_added": "4.0"
               },
               "clay_windows": {
-                "version_added": false
+                "version_added": "4.0"
               },
               "clay_macos": {
-                "version_added": false
+                "version_added": "4.0"
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -287,6 +305,47 @@
                 "version_added": "3.2"
               },
               "harmony": {
+                "version_added": "4.0"
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "android-emoji-compat": {
+          "__compat": {
+            "description": "<code>android-emoji-compat</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.10"
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
                 "version_added": false
               },
               "clay_android": {
@@ -295,13 +354,165 @@
               "clay_ios": {
                 "version_added": false
               },
+              "clay_macos": {
+                "version_added": false
+              },
               "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "enable-font-scaling": {
+          "__compat": {
+            "description": "<code>enable-font-scaling</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
                 "version_added": false
               },
               "clay_macos": {
                 "version_added": false
               },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "text-fake-bold": {
+          "__compat": {
+            "description": "<code>text-fake-bold</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.12"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": false
+              },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "text-maxlength": {
+          "__compat": {
+            "description": "<code>text-maxlength</code>",
+            "status": {
+              "deprecated": true,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.1"
+              },
+              "clay_ios": {
+                "version_added": "2.8"
+              },
+              "clay_macos": {
+                "version_added": "2.18"
+              },
+              "clay_windows": {
+                "version_added": "2.18"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "text-vertical-align": {
+          "__compat": {
+            "description": "<code>text-vertical-align</code>",
+            "status": {
+              "deprecated": true,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -352,7 +563,7 @@
                 "version_added": "1.5"
               },
               "ios": {
-                "version_added": "1.5"
+                "version_added": "2.18"
               },
               "harmony": {
                 "version_added": "3.4"
@@ -361,16 +572,19 @@
                 "version_added": "1.5"
               },
               "clay_ios": {
-                "version_added": "1.5"
+                "version_added": "2.8"
               },
               "clay_windows": {
-                "version_added": "1.5"
+                "version_added": "2.14"
               },
               "clay_macos": {
-                "version_added": "1.5"
+                "version_added": "2.14"
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -384,27 +598,30 @@
             },
             "support": {
               "android": {
-                "version_added": "3.2"
+                "version_added": "2.17"
               },
               "ios": {
-                "version_added": "3.2"
+                "version_added": "3.1"
               },
               "harmony": {
-                "version_added": false
+                "version_added": "4.0"
               },
               "clay_android": {
-                "version_added": "1.5"
+                "version_added": "3.1"
               },
               "clay_ios": {
-                "version_added": "1.5"
+                "version_added": "3.1"
               },
               "clay_windows": {
-                "version_added": "1.5"
+                "version_added": "4.0"
               },
               "clay_macos": {
-                "version_added": "1.5"
+                "version_added": "4.0"
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -437,7 +654,9 @@
               "version_added": "1.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Web Lynx implements only part of this grouped feature."
             }
           }
         },
@@ -456,21 +675,24 @@
                 "version_added": "3.2"
               },
               "harmony": {
-                "version_added": false
+                "version_added": "4.0"
               },
               "clay_android": {
-                "version_added": false
+                "version_added": "4.0"
               },
               "clay_ios": {
-                "version_added": false
+                "version_added": "4.0"
               },
               "clay_windows": {
-                "version_added": false
+                "version_added": "4.0"
               },
               "clay_macos": {
-                "version_added": false
+                "version_added": "4.0"
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -491,7 +713,7 @@
                 "version_added": "3.2"
               },
               "harmony": {
-                "version_added": false
+                "version_added": "4.0"
               },
               "clay_android": {
                 "version_added": "1.5"
@@ -506,6 +728,9 @@
                 "version_added": "1.5"
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -526,21 +751,100 @@
                 "version_added": "3.2"
               },
               "harmony": {
-                "version_added": false
+                "version_added": "4.0"
               },
               "clay_android": {
-                "version_added": false
+                "version_added": "4.0"
               },
               "clay_ios": {
-                "version_added": false
+                "version_added": "4.0"
               },
               "clay_windows": {
-                "version_added": false
+                "version_added": "4.0"
               },
               "clay_macos": {
+                "version_added": "4.0"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "scrollIntoView": {
+          "__compat": {
+            "description": "<code>scrollIntoView</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "2.16"
+              },
+              "clay_macos": {
+                "version_added": "2.14"
+              },
+              "clay_windows": {
+                "version_added": "2.14"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "setFocus": {
+          "__compat": {
+            "description": "<code>setFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "2.16"
+              },
+              "clay_macos": {
+                "version_added": "2.14"
+              },
+              "clay_windows": {
+                "version_added": "2.14"
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }

--- a/packages/lynx-compat-data/elements/textarea.json
+++ b/packages/lynx-compat-data/elements/textarea.json
@@ -56,7 +56,9 @@
               "version_added": "3.4"
             },
             "web_lynx": {
-              "version_added": true
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Web Lynx implements only part of this grouped feature."
             }
           }
         },
@@ -87,7 +89,14 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -118,7 +127,14 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -149,7 +165,14 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -180,7 +203,14 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -204,14 +234,21 @@
                 "version_added": "3.4"
               },
               "clay_windows": {
-                "version_added": "3.4"
+                "version_added": false
               },
               "clay_macos": {
-                "version_added": "3.4"
+                "version_added": false
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -235,14 +272,21 @@
                 "version_added": "3.4"
               },
               "clay_windows": {
-                "version_added": "3.4"
+                "version_added": false
               },
               "clay_macos": {
-                "version_added": "3.4"
+                "version_added": false
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -260,20 +304,27 @@
                 "version_added": "3.4"
               },
               "clay_android": {
-                "version_added": "3.4"
+                "version_added": false
               },
               "clay_ios": {
                 "version_added": "3.4"
               },
               "clay_windows": {
-                "version_added": "3.4"
+                "version_added": false
               },
               "clay_macos": {
-                "version_added": "3.4"
+                "version_added": false
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -303,7 +354,318 @@
                 "version_added": "3.4"
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            }
+          }
+        },
+        "android-fullscreen-mode": {
+          "__compat": {
+            "description": "<code>android-fullscreen-mode</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.4"
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bounces": {
+          "__compat": {
+            "description": "<code>bounces</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "default-value": {
+          "__compat": {
+            "description": "<code>default-value</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "4.0"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "4.0"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "disabled": {
+          "__compat": {
+            "description": "<code>disabled</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.4"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
                 "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.4"
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": "3.4"
+              },
+              "clay_windows": {
+                "version_added": "3.4"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "enable-scroll-bar": {
+          "__compat": {
+            "description": "<code>enable-scroll-bar</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.6"
+              },
+              "ios": {
+                "version_added": "3.5"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "ios-auto-correct": {
+          "__compat": {
+            "description": "<code>ios-auto-correct</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "ios-spell-check": {
+          "__compat": {
+            "description": "<code>ios-spell-check</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": "3.4"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "line-spacing": {
+          "__compat": {
+            "description": "<code>line-spacing</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.4"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "3.4"
+              },
+              "clay_ios": {
+                "version_added": "3.4"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -336,6 +698,580 @@
             },
             "web_lynx": {
               "version_added": true
+            }
+          }
+        }
+      },
+      "events": {
+        "bindblur": {
+          "__compat": {
+            "description": "<code>bindblur</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.4"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.4"
+              },
+              "clay_ios": {
+                "version_added": "3.4"
+              },
+              "clay_macos": {
+                "version_added": "3.4"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindconfirm": {
+          "__compat": {
+            "description": "<code>bindconfirm</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.4"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.4"
+              },
+              "clay_ios": {
+                "version_added": "3.4"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindfocus": {
+          "__compat": {
+            "description": "<code>bindfocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.4"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.4"
+              },
+              "clay_ios": {
+                "version_added": "3.4"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "3.4"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindinput": {
+          "__compat": {
+            "description": "<code>bindinput</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.4"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.4"
+              },
+              "clay_ios": {
+                "version_added": "3.4"
+              },
+              "clay_macos": {
+                "version_added": "3.4"
+              },
+              "clay_windows": {
+                "version_added": "3.4"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindselection": {
+          "__compat": {
+            "description": "<code>bindselection</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.4"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": "3.4"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      },
+      "methods": {
+        "blur": {
+          "__compat": {
+            "description": "<code>blur</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.4"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.4"
+              },
+              "clay_ios": {
+                "version_added": "3.4"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "focus": {
+          "__compat": {
+            "description": "<code>focus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.4"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.4"
+              },
+              "clay_ios": {
+                "version_added": "3.4"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "3.4"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "getValue": {
+          "__compat": {
+            "description": "<code>getValue</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.4"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.4"
+              },
+              "clay_ios": {
+                "version_added": "3.4"
+              },
+              "clay_macos": {
+                "version_added": "3.4"
+              },
+              "clay_windows": {
+                "version_added": "3.4"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "setSelectionRange": {
+          "__compat": {
+            "description": "<code>setSelectionRange</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.4"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.4"
+              },
+              "clay_ios": {
+                "version_added": "3.4"
+              },
+              "clay_macos": {
+                "version_added": "3.4"
+              },
+              "clay_windows": {
+                "version_added": "3.4"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "setValue": {
+          "__compat": {
+            "description": "<code>setValue</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.4"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.4"
+              },
+              "clay_ios": {
+                "version_added": "3.4"
+              },
+              "clay_macos": {
+                "version_added": "3.4"
+              },
+              "clay_windows": {
+                "version_added": "3.4"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "boundingClientRect": {
+          "__compat": {
+            "description": "<code>boundingClientRect</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.4"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.4"
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "requestAccessibilityFocus": {
+          "__compat": {
+            "description": "<code>requestAccessibilityFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.4"
+              },
+              "ios": {
+                "version_added": "4.1"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": "3.4"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "scrollIntoView": {
+          "__compat": {
+            "description": "<code>scrollIntoView</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.4"
+              },
+              "ios": {
+                "version_added": "3.4"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "3.4"
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "setFocus": {
+          "__compat": {
+            "description": "<code>setFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "3.4"
+              },
+              "clay_ios": {
+                "version_added": "3.4"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "3.4"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "takeScreenshot": {
+          "__compat": {
+            "description": "<code>takeScreenshot</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "4.1"
+              },
+              "ios": {
+                "version_added": "4.1"
+              },
+              "harmony": {
+                "version_added": "4.1"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
             }
           }
         }

--- a/packages/lynx-compat-data/elements/video.json
+++ b/packages/lynx-compat-data/elements/video.json
@@ -30,7 +30,7 @@
             "version_added": false
           },
           "web_lynx": {
-            "version_added": false
+            "version_added": true
           }
         }
       },
@@ -64,7 +64,9 @@
               "version_added": false
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Web Lynx implements only part of this grouped feature."
             }
           }
         },
@@ -98,6 +100,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": true
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -133,6 +138,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": true
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -153,7 +161,7 @@
                 "version_added": "4.1"
               },
               "harmony": {
-                "version_added": "4.1"
+                "version_added": false
               },
               "clay_android": {
                 "version_added": false
@@ -168,6 +176,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -203,6 +214,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": true
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -239,6 +253,9 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -273,6 +290,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -309,6 +329,9 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -343,6 +366,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -379,7 +405,9 @@
               "version_added": false
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Web Lynx implements only part of this grouped feature."
             }
           }
         },
@@ -413,6 +441,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -448,6 +479,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": true
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -484,6 +518,9 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -519,6 +556,9 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -553,6 +593,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": true
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -588,6 +631,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": true
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -624,6 +670,9 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -658,6 +707,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": true
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -694,6 +746,9 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -729,7 +784,9 @@
               "version_added": false
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "partial_implementation": true,
+              "notes": "Web Lynx implements only part of this grouped feature."
             }
           }
         },
@@ -738,7 +795,7 @@
             "description": "<code>play</code>",
             "status": {
               "deprecated": false,
-              "experimental": true
+              "experimental": false
             },
             "support": {
               "android": {
@@ -763,6 +820,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": true
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -773,7 +833,7 @@
             "description": "<code>pause</code>",
             "status": {
               "deprecated": false,
-              "experimental": true
+              "experimental": false
             },
             "support": {
               "android": {
@@ -798,6 +858,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": true
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -808,7 +871,7 @@
             "description": "<code>stop</code>",
             "status": {
               "deprecated": false,
-              "experimental": true
+              "experimental": false
             },
             "support": {
               "android": {
@@ -833,6 +896,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -843,7 +909,7 @@
             "description": "<code>seek</code>",
             "status": {
               "deprecated": false,
-              "experimental": true
+              "experimental": false
             },
             "support": {
               "android": {
@@ -868,6 +934,199 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "boundingClientRect": {
+          "__compat": {
+            "description": "<code>boundingClientRect</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "4.1"
+              },
+              "ios": {
+                "version_added": "4.1"
+              },
+              "harmony": {
+                "version_added": "4.1"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "requestAccessibilityFocus": {
+          "__compat": {
+            "description": "<code>requestAccessibilityFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "4.1"
+              },
+              "ios": {
+                "version_added": "4.1"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "scrollIntoView": {
+          "__compat": {
+            "description": "<code>scrollIntoView</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "4.1"
+              },
+              "ios": {
+                "version_added": "4.1"
+              },
+              "harmony": {
+                "version_added": "4.1"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "setFocus": {
+          "__compat": {
+            "description": "<code>setFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "takeScreenshot": {
+          "__compat": {
+            "description": "<code>takeScreenshot</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "4.1"
+              },
+              "ios": {
+                "version_added": "4.1"
+              },
+              "harmony": {
+                "version_added": "4.1"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }

--- a/packages/lynx-compat-data/elements/view.json
+++ b/packages/lynx-compat-data/elements/view.json
@@ -44,20 +44,27 @@
               "version_added": false
             },
             "clay_android": {
-              "version_added": "1.5"
+              "version_added": "2.15"
             },
             "clay_ios": {
-              "version_added": "1.5"
+              "version_added": "2.18"
             },
             "clay_windows": {
-              "version_added": "1.5"
+              "version_added": "2.15"
             },
             "clay_macos": {
-              "version_added": "1.5"
+              "version_added": "2.15"
             },
             "web_lynx": {
-              "version_added": true
+              "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
             }
+          },
+          "status": {
+            "deprecated": true,
+            "experimental": false
           }
         }
       },
@@ -75,20 +82,27 @@
               "version_added": false
             },
             "clay_android": {
-              "version_added": false
+              "version_added": "2.14"
             },
             "clay_ios": {
-              "version_added": false
+              "version_added": "2.18"
             },
             "clay_windows": {
-              "version_added": false
+              "version_added": "2.14"
             },
             "clay_macos": {
-              "version_added": false
+              "version_added": "2.14"
             },
             "web_lynx": {
               "version_added": false
+            },
+            "clay_harmony": {
+              "version_added": false
             }
+          },
+          "status": {
+            "deprecated": false,
+            "experimental": false
           }
         }
       },
@@ -131,28 +145,31 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "2.8"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "2.6"
               },
               "harmony": {
                 "version_added": false
               },
               "clay_android": {
-                "version_added": "2.18"
+                "version_added": "2.15"
               },
               "clay_ios": {
                 "version_added": "2.18"
               },
               "clay_windows": {
-                "version_added": "2.18"
+                "version_added": "2.15"
               },
               "clay_macos": {
-                "version_added": "2.18"
+                "version_added": "2.15"
               },
               "web_lynx": {
-                "version_added": true
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -197,19 +214,19 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "harmony": {
                 "version_added": "3.4"
               },
               "clay_android": {
-                "version_added": "2.18"
+                "version_added": "2.17"
               },
               "clay_ios": {
-                "version_added": false
+                "version_added": "2.18"
               },
               "clay_windows": {
                 "version_added": false
@@ -218,6 +235,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -232,19 +252,19 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "harmony": {
                 "version_added": "3.4"
               },
               "clay_android": {
-                "version_added": "2.18"
+                "version_added": "2.17"
               },
               "clay_ios": {
-                "version_added": false
+                "version_added": "2.18"
               },
               "clay_windows": {
                 "version_added": false
@@ -253,6 +273,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -372,10 +395,10 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": false
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "2.14"
               },
               "harmony": {
                 "version_added": "3.4"
@@ -393,6 +416,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -407,10 +433,10 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "2.12"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "2.12"
               },
               "harmony": {
                 "version_added": "3.4"
@@ -428,6 +454,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -480,7 +509,7 @@
                 "version_added": false
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "2.14"
               },
               "harmony": {
                 "version_added": false
@@ -498,6 +527,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -543,27 +575,30 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "harmony": {
                 "version_added": "3.4"
               },
               "clay_android": {
-                "version_added": "1.5"
+                "version_added": "2.14"
               },
               "clay_ios": {
-                "version_added": "1.5"
+                "version_added": "2.18"
               },
               "clay_windows": {
-                "version_added": "1.5"
+                "version_added": "2.14"
               },
               "clay_macos": {
-                "version_added": "1.5"
+                "version_added": "2.14"
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -578,10 +613,10 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": false
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "harmony": {
                 "version_added": "3.4"
@@ -599,6 +634,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -616,7 +654,7 @@
                 "version_added": "3.6"
               },
               "ios": {
-                "version_added": "3.6"
+                "version_added": "3.4"
               },
               "harmony": {
                 "version_added": false
@@ -634,6 +672,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -651,7 +692,7 @@
                 "version_added": "3.6"
               },
               "ios": {
-                "version_added": "3.6"
+                "version_added": "3.4"
               },
               "harmony": {
                 "version_added": false
@@ -669,6 +710,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -683,19 +727,19 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "2.1"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "harmony": {
                 "version_added": "3.4"
               },
               "clay_android": {
-                "version_added": "2.18"
+                "version_added": "2.17"
               },
               "clay_ios": {
-                "version_added": false
+                "version_added": "2.18"
               },
               "clay_windows": {
                 "version_added": false
@@ -704,6 +748,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -718,13 +765,13 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "2.8"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "2.8"
               },
               "harmony": {
-                "version_added": false
+                "version_added": "3.4"
               },
               "clay_android": {
                 "version_added": false
@@ -739,6 +786,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -753,27 +803,30 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "2.8"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "2.8"
               },
               "harmony": {
                 "version_added": "3.4"
               },
               "clay_android": {
-                "version_added": false
+                "version_added": "2.17"
               },
               "clay_ios": {
-                "version_added": false
+                "version_added": "2.18"
               },
               "clay_windows": {
-                "version_added": false
+                "version_added": "2.17"
               },
               "clay_macos": {
-                "version_added": false
+                "version_added": "2.17"
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -788,27 +841,30 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "2.6"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "harmony": {
                 "version_added": "3.4"
               },
               "clay_android": {
-                "version_added": false
+                "version_added": "3.0"
               },
               "clay_ios": {
-                "version_added": false
+                "version_added": "3.0"
               },
               "clay_windows": {
-                "version_added": false
+                "version_added": "3.0"
               },
               "clay_macos": {
-                "version_added": false
+                "version_added": "3.0"
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -823,27 +879,30 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "2.8"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "2.8"
               },
               "harmony": {
                 "version_added": "3.4"
               },
               "clay_android": {
-                "version_added": "1.5"
+                "version_added": false
               },
               "clay_ios": {
-                "version_added": "1.5"
+                "version_added": false
               },
               "clay_windows": {
-                "version_added": "1.5"
+                "version_added": false
               },
               "clay_macos": {
-                "version_added": "1.5"
+                "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -858,27 +917,30 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "2.14"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "2.14"
               },
               "harmony": {
                 "version_added": "3.4"
               },
               "clay_android": {
-                "version_added": "1.5"
+                "version_added": "3.0"
               },
               "clay_ios": {
-                "version_added": "1.5"
+                "version_added": "3.0"
               },
               "clay_windows": {
-                "version_added": "1.5"
+                "version_added": "3.0"
               },
               "clay_macos": {
-                "version_added": "1.5"
+                "version_added": "3.0"
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -893,27 +955,30 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "harmony": {
                 "version_added": "3.4"
               },
               "clay_android": {
-                "version_added": "1.5"
+                "version_added": "3.0"
               },
               "clay_ios": {
-                "version_added": "1.5"
+                "version_added": "3.0"
               },
               "clay_windows": {
-                "version_added": "1.5"
+                "version_added": "3.0"
               },
               "clay_macos": {
-                "version_added": "1.5"
+                "version_added": "3.0"
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -928,10 +993,10 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": false
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "2.6"
               },
               "harmony": {
                 "version_added": false
@@ -949,6 +1014,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -996,10 +1064,10 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "harmony": {
                 "version_added": "3.4"
@@ -1018,6 +1086,9 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -1031,10 +1102,10 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "harmony": {
                 "version_added": "3.4"
@@ -1053,6 +1124,9 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -1066,10 +1140,10 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "harmony": {
                 "version_added": "3.4"
@@ -1088,6 +1162,9 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -1101,10 +1178,10 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "harmony": {
                 "version_added": "3.4"
@@ -1123,6 +1200,9 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -1136,10 +1216,10 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "harmony": {
                 "version_added": "3.4"
@@ -1158,6 +1238,9 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -1171,10 +1254,10 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "harmony": {
                 "version_added": "3.4"
@@ -1192,6 +1275,9 @@
                 "version_added": "1.5"
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -1241,10 +1327,10 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "harmony": {
                 "version_added": "3.4"
@@ -1263,6 +1349,9 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -1276,10 +1365,10 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "harmony": {
                 "version_added": "3.4"
@@ -1298,6 +1387,9 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -1311,10 +1403,10 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "harmony": {
                 "version_added": "3.4"
@@ -1333,6 +1425,9 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -1346,10 +1441,10 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "harmony": {
                 "version_added": "3.4"
@@ -1368,6 +1463,9 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -1381,10 +1479,10 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "harmony": {
                 "version_added": "3.4"
@@ -1403,6 +1501,9 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -1416,10 +1517,10 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "harmony": {
                 "version_added": "3.4"
@@ -1438,6 +1539,9 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -1451,10 +1555,10 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "harmony": {
                 "version_added": "3.4"
@@ -1473,6 +1577,9 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -1486,10 +1593,10 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "harmony": {
                 "version_added": "3.4"
@@ -1508,6 +1615,9 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -1521,10 +1631,10 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "harmony": {
                 "version_added": "3.4"
@@ -1543,6 +1653,9 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -1556,10 +1669,10 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "harmony": {
                 "version_added": "3.4"
@@ -1578,6 +1691,5861 @@
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindaccessibilityaction": {
+          "__compat": {
+            "description": "<code>bindaccessibilityaction</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.14"
+              },
+              "ios": {
+                "version_added": "2.14"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindbgerror": {
+          "__compat": {
+            "description": "<code>bindbgerror</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.0"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.8"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindbgload": {
+          "__compat": {
+            "description": "<code>bindbgload</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.0"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.8"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindblur": {
+          "__compat": {
+            "description": "<code>bindblur</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.16"
+              },
+              "ios": {
+                "version_added": "3.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindfocus": {
+          "__compat": {
+            "description": "<code>bindfocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.16"
+              },
+              "ios": {
+                "version_added": "3.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindkeydown": {
+          "__compat": {
+            "description": "<code>bindkeydown</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindkeyup": {
+          "__compat": {
+            "description": "<code>bindkeyup</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindlongtap": {
+          "__compat": {
+            "description": "<code>bindlongtap</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindmouseclick": {
+          "__compat": {
+            "description": "<code>bindmouseclick</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindmousedblclick": {
+          "__compat": {
+            "description": "<code>bindmousedblclick</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindmousedown": {
+          "__compat": {
+            "description": "<code>bindmousedown</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindmouseenter": {
+          "__compat": {
+            "description": "<code>bindmouseenter</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindmouseleave": {
+          "__compat": {
+            "description": "<code>bindmouseleave</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindmouselongpress": {
+          "__compat": {
+            "description": "<code>bindmouselongpress</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindmousemove": {
+          "__compat": {
+            "description": "<code>bindmousemove</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindmouseup": {
+          "__compat": {
+            "description": "<code>bindmouseup</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindwheel": {
+          "__compat": {
+            "description": "<code>bindwheel</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "bindzoom": {
+          "__compat": {
+            "description": "<code>bindzoom</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindaccessibilityaction": {
+          "__compat": {
+            "description": "<code>capture-bindaccessibilityaction</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.14"
+              },
+              "ios": {
+                "version_added": "2.14"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindanimationcancel": {
+          "__compat": {
+            "description": "<code>capture-bindanimationcancel</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindanimationend": {
+          "__compat": {
+            "description": "<code>capture-bindanimationend</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindanimationiteration": {
+          "__compat": {
+            "description": "<code>capture-bindanimationiteration</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindanimationstart": {
+          "__compat": {
+            "description": "<code>capture-bindanimationstart</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindbgerror": {
+          "__compat": {
+            "description": "<code>capture-bindbgerror</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.0"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.8"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindbgload": {
+          "__compat": {
+            "description": "<code>capture-bindbgload</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.0"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.8"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindblur": {
+          "__compat": {
+            "description": "<code>capture-bindblur</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.16"
+              },
+              "ios": {
+                "version_added": "3.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindfocus": {
+          "__compat": {
+            "description": "<code>capture-bindfocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.16"
+              },
+              "ios": {
+                "version_added": "3.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindkeydown": {
+          "__compat": {
+            "description": "<code>capture-bindkeydown</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindkeyup": {
+          "__compat": {
+            "description": "<code>capture-bindkeyup</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindlayoutchange": {
+          "__compat": {
+            "description": "<code>capture-bindlayoutchange</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindlongpress": {
+          "__compat": {
+            "description": "<code>capture-bindlongpress</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindlongtap": {
+          "__compat": {
+            "description": "<code>capture-bindlongtap</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindmouseclick": {
+          "__compat": {
+            "description": "<code>capture-bindmouseclick</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindmousedblclick": {
+          "__compat": {
+            "description": "<code>capture-bindmousedblclick</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindmousedown": {
+          "__compat": {
+            "description": "<code>capture-bindmousedown</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindmouseenter": {
+          "__compat": {
+            "description": "<code>capture-bindmouseenter</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindmouseleave": {
+          "__compat": {
+            "description": "<code>capture-bindmouseleave</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindmouselongpress": {
+          "__compat": {
+            "description": "<code>capture-bindmouselongpress</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindmousemove": {
+          "__compat": {
+            "description": "<code>capture-bindmousemove</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindmouseup": {
+          "__compat": {
+            "description": "<code>capture-bindmouseup</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindtap": {
+          "__compat": {
+            "description": "<code>capture-bindtap</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindtouchcancel": {
+          "__compat": {
+            "description": "<code>capture-bindtouchcancel</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindtouchend": {
+          "__compat": {
+            "description": "<code>capture-bindtouchend</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindtouchmove": {
+          "__compat": {
+            "description": "<code>capture-bindtouchmove</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindtouchstart": {
+          "__compat": {
+            "description": "<code>capture-bindtouchstart</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindtransitioncancel": {
+          "__compat": {
+            "description": "<code>capture-bindtransitioncancel</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindtransitionend": {
+          "__compat": {
+            "description": "<code>capture-bindtransitionend</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindtransitionstart": {
+          "__compat": {
+            "description": "<code>capture-bindtransitionstart</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-binduiappear": {
+          "__compat": {
+            "description": "<code>capture-binduiappear</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-binduidisappear": {
+          "__compat": {
+            "description": "<code>capture-binduidisappear</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindwheel": {
+          "__compat": {
+            "description": "<code>capture-bindwheel</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-bindzoom": {
+          "__compat": {
+            "description": "<code>capture-bindzoom</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchaccessibilityaction": {
+          "__compat": {
+            "description": "<code>capture-catchaccessibilityaction</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.14"
+              },
+              "ios": {
+                "version_added": "2.14"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchanimationcancel": {
+          "__compat": {
+            "description": "<code>capture-catchanimationcancel</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchanimationend": {
+          "__compat": {
+            "description": "<code>capture-catchanimationend</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchanimationiteration": {
+          "__compat": {
+            "description": "<code>capture-catchanimationiteration</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchanimationstart": {
+          "__compat": {
+            "description": "<code>capture-catchanimationstart</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchbgerror": {
+          "__compat": {
+            "description": "<code>capture-catchbgerror</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.0"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.8"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchbgload": {
+          "__compat": {
+            "description": "<code>capture-catchbgload</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.0"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.8"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchblur": {
+          "__compat": {
+            "description": "<code>capture-catchblur</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.16"
+              },
+              "ios": {
+                "version_added": "3.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchfocus": {
+          "__compat": {
+            "description": "<code>capture-catchfocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.16"
+              },
+              "ios": {
+                "version_added": "3.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchkeydown": {
+          "__compat": {
+            "description": "<code>capture-catchkeydown</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchkeyup": {
+          "__compat": {
+            "description": "<code>capture-catchkeyup</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchlayoutchange": {
+          "__compat": {
+            "description": "<code>capture-catchlayoutchange</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchlongpress": {
+          "__compat": {
+            "description": "<code>capture-catchlongpress</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchlongtap": {
+          "__compat": {
+            "description": "<code>capture-catchlongtap</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchmouseclick": {
+          "__compat": {
+            "description": "<code>capture-catchmouseclick</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchmousedblclick": {
+          "__compat": {
+            "description": "<code>capture-catchmousedblclick</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchmousedown": {
+          "__compat": {
+            "description": "<code>capture-catchmousedown</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchmouseenter": {
+          "__compat": {
+            "description": "<code>capture-catchmouseenter</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchmouseleave": {
+          "__compat": {
+            "description": "<code>capture-catchmouseleave</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchmouselongpress": {
+          "__compat": {
+            "description": "<code>capture-catchmouselongpress</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchmousemove": {
+          "__compat": {
+            "description": "<code>capture-catchmousemove</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchmouseup": {
+          "__compat": {
+            "description": "<code>capture-catchmouseup</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchtap": {
+          "__compat": {
+            "description": "<code>capture-catchtap</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchtouchcancel": {
+          "__compat": {
+            "description": "<code>capture-catchtouchcancel</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchtouchend": {
+          "__compat": {
+            "description": "<code>capture-catchtouchend</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchtouchmove": {
+          "__compat": {
+            "description": "<code>capture-catchtouchmove</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchtouchstart": {
+          "__compat": {
+            "description": "<code>capture-catchtouchstart</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchtransitioncancel": {
+          "__compat": {
+            "description": "<code>capture-catchtransitioncancel</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchtransitionend": {
+          "__compat": {
+            "description": "<code>capture-catchtransitionend</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchtransitionstart": {
+          "__compat": {
+            "description": "<code>capture-catchtransitionstart</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchuiappear": {
+          "__compat": {
+            "description": "<code>capture-catchuiappear</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchuidisappear": {
+          "__compat": {
+            "description": "<code>capture-catchuidisappear</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchwheel": {
+          "__compat": {
+            "description": "<code>capture-catchwheel</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "capture-catchzoom": {
+          "__compat": {
+            "description": "<code>capture-catchzoom</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchaccessibilityaction": {
+          "__compat": {
+            "description": "<code>catchaccessibilityaction</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.14"
+              },
+              "ios": {
+                "version_added": "2.14"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchanimationcancel": {
+          "__compat": {
+            "description": "<code>catchanimationcancel</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchanimationend": {
+          "__compat": {
+            "description": "<code>catchanimationend</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchanimationiteration": {
+          "__compat": {
+            "description": "<code>catchanimationiteration</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchanimationstart": {
+          "__compat": {
+            "description": "<code>catchanimationstart</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchbgerror": {
+          "__compat": {
+            "description": "<code>catchbgerror</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.0"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.8"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchbgload": {
+          "__compat": {
+            "description": "<code>catchbgload</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.0"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.8"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchblur": {
+          "__compat": {
+            "description": "<code>catchblur</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.16"
+              },
+              "ios": {
+                "version_added": "3.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchfocus": {
+          "__compat": {
+            "description": "<code>catchfocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.16"
+              },
+              "ios": {
+                "version_added": "3.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchkeydown": {
+          "__compat": {
+            "description": "<code>catchkeydown</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchkeyup": {
+          "__compat": {
+            "description": "<code>catchkeyup</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchlayoutchange": {
+          "__compat": {
+            "description": "<code>catchlayoutchange</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchlongpress": {
+          "__compat": {
+            "description": "<code>catchlongpress</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchlongtap": {
+          "__compat": {
+            "description": "<code>catchlongtap</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchmouseclick": {
+          "__compat": {
+            "description": "<code>catchmouseclick</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchmousedblclick": {
+          "__compat": {
+            "description": "<code>catchmousedblclick</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchmousedown": {
+          "__compat": {
+            "description": "<code>catchmousedown</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchmouseenter": {
+          "__compat": {
+            "description": "<code>catchmouseenter</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchmouseleave": {
+          "__compat": {
+            "description": "<code>catchmouseleave</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchmouselongpress": {
+          "__compat": {
+            "description": "<code>catchmouselongpress</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchmousemove": {
+          "__compat": {
+            "description": "<code>catchmousemove</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchmouseup": {
+          "__compat": {
+            "description": "<code>catchmouseup</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchtap": {
+          "__compat": {
+            "description": "<code>catchtap</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchtouchcancel": {
+          "__compat": {
+            "description": "<code>catchtouchcancel</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchtouchend": {
+          "__compat": {
+            "description": "<code>catchtouchend</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchtouchmove": {
+          "__compat": {
+            "description": "<code>catchtouchmove</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchtouchstart": {
+          "__compat": {
+            "description": "<code>catchtouchstart</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchtransitioncancel": {
+          "__compat": {
+            "description": "<code>catchtransitioncancel</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchtransitionend": {
+          "__compat": {
+            "description": "<code>catchtransitionend</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchtransitionstart": {
+          "__compat": {
+            "description": "<code>catchtransitionstart</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchuiappear": {
+          "__compat": {
+            "description": "<code>catchuiappear</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchuidisappear": {
+          "__compat": {
+            "description": "<code>catchuidisappear</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchwheel": {
+          "__compat": {
+            "description": "<code>catchwheel</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "catchzoom": {
+          "__compat": {
+            "description": "<code>catchzoom</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindaccessibilityaction": {
+          "__compat": {
+            "description": "<code>global-bindaccessibilityaction</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.14"
+              },
+              "ios": {
+                "version_added": "2.14"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindanimationcancel": {
+          "__compat": {
+            "description": "<code>global-bindanimationcancel</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindanimationend": {
+          "__compat": {
+            "description": "<code>global-bindanimationend</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindanimationiteration": {
+          "__compat": {
+            "description": "<code>global-bindanimationiteration</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindanimationstart": {
+          "__compat": {
+            "description": "<code>global-bindanimationstart</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindbgerror": {
+          "__compat": {
+            "description": "<code>global-bindbgerror</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.0"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.8"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindbgload": {
+          "__compat": {
+            "description": "<code>global-bindbgload</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.0"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.8"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindblur": {
+          "__compat": {
+            "description": "<code>global-bindblur</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.16"
+              },
+              "ios": {
+                "version_added": "3.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindfocus": {
+          "__compat": {
+            "description": "<code>global-bindfocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.16"
+              },
+              "ios": {
+                "version_added": "3.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindkeydown": {
+          "__compat": {
+            "description": "<code>global-bindkeydown</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindkeyup": {
+          "__compat": {
+            "description": "<code>global-bindkeyup</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindlayoutchange": {
+          "__compat": {
+            "description": "<code>global-bindlayoutchange</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindlongpress": {
+          "__compat": {
+            "description": "<code>global-bindlongpress</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindlongtap": {
+          "__compat": {
+            "description": "<code>global-bindlongtap</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindmouseclick": {
+          "__compat": {
+            "description": "<code>global-bindmouseclick</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindmousedblclick": {
+          "__compat": {
+            "description": "<code>global-bindmousedblclick</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindmousedown": {
+          "__compat": {
+            "description": "<code>global-bindmousedown</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindmouseenter": {
+          "__compat": {
+            "description": "<code>global-bindmouseenter</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindmouseleave": {
+          "__compat": {
+            "description": "<code>global-bindmouseleave</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindmouselongpress": {
+          "__compat": {
+            "description": "<code>global-bindmouselongpress</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindmousemove": {
+          "__compat": {
+            "description": "<code>global-bindmousemove</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindmouseup": {
+          "__compat": {
+            "description": "<code>global-bindmouseup</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindtap": {
+          "__compat": {
+            "description": "<code>global-bindtap</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindtouchcancel": {
+          "__compat": {
+            "description": "<code>global-bindtouchcancel</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindtouchend": {
+          "__compat": {
+            "description": "<code>global-bindtouchend</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindtouchmove": {
+          "__compat": {
+            "description": "<code>global-bindtouchmove</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindtouchstart": {
+          "__compat": {
+            "description": "<code>global-bindtouchstart</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindtransitioncancel": {
+          "__compat": {
+            "description": "<code>global-bindtransitioncancel</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindtransitionend": {
+          "__compat": {
+            "description": "<code>global-bindtransitionend</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindtransitionstart": {
+          "__compat": {
+            "description": "<code>global-bindtransitionstart</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-binduiappear": {
+          "__compat": {
+            "description": "<code>global-binduiappear</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-binduidisappear": {
+          "__compat": {
+            "description": "<code>global-binduidisappear</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "1.5"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "1.5"
+              },
+              "clay_ios": {
+                "version_added": "1.5"
+              },
+              "clay_macos": {
+                "version_added": "1.5"
+              },
+              "clay_windows": {
+                "version_added": "1.5"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindwheel": {
+          "__compat": {
+            "description": "<code>global-bindwheel</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.7"
+              },
+              "clay_windows": {
+                "version_added": "3.7"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "global-bindzoom": {
+          "__compat": {
+            "description": "<code>global-bindzoom</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": "4.1"
+              },
+              "clay_macos": {
+                "version_added": "3.6"
+              },
+              "clay_windows": {
+                "version_added": "3.6"
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -1624,28 +7592,31 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "1.5"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "2.18"
               },
               "harmony": {
                 "version_added": "3.4"
               },
               "clay_android": {
-                "version_added": "1.5"
+                "version_added": "2.14"
               },
               "clay_ios": {
-                "version_added": "1.5"
+                "version_added": "2.16"
               },
               "clay_windows": {
-                "version_added": "1.5"
+                "version_added": "2.14"
               },
               "clay_macos": {
-                "version_added": "1.5"
+                "version_added": "2.14"
               },
               "web_lynx": {
                 "version_added": true
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -1659,27 +7630,30 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "2.3"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "2.18"
               },
               "harmony": {
                 "version_added": "3.4"
               },
               "clay_android": {
-                "version_added": false
+                "version_added": "4.0"
               },
               "clay_ios": {
-                "version_added": false
+                "version_added": "4.0"
               },
               "clay_windows": {
-                "version_added": false
+                "version_added": "4.0"
               },
               "clay_macos": {
-                "version_added": false
+                "version_added": "4.0"
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -1694,10 +7668,10 @@
             },
             "support": {
               "android": {
-                "version_added": "1.0"
+                "version_added": "2.8"
               },
               "ios": {
-                "version_added": "1.0"
+                "version_added": "2.18"
               },
               "harmony": {
                 "version_added": false
@@ -1715,6 +7689,123 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "isAnimating": {
+          "__compat": {
+            "description": "<code>isAnimating</code>",
+            "status": {
+              "deprecated": true,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "scrollIntoView": {
+          "__compat": {
+            "description": "<code>scrollIntoView</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.5"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.4"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "setFocus": {
+          "__compat": {
+            "description": "<code>setFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": "4.0"
+              },
+              "clay_windows": {
+                "version_added": "4.0"
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }

--- a/packages/lynx-compat-data/elements/viewpager-item.json
+++ b/packages/lynx-compat-data/elements/viewpager-item.json
@@ -1,0 +1,198 @@
+{
+  "elements": {
+    "viewpager-item": {
+      "methods": {
+        "boundingClientRect": {
+          "__compat": {
+            "description": "<code>boundingClientRect</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.1"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "2.16"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "requestAccessibilityFocus": {
+          "__compat": {
+            "description": "<code>requestAccessibilityFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.8"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "3.1"
+              },
+              "clay_ios": {
+                "version_added": "3.0"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "scrollIntoView": {
+          "__compat": {
+            "description": "<code>scrollIntoView</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "1.3"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "2.17"
+              },
+              "web_lynx": {
+                "version_added": true
+              },
+              "clay_android": {
+                "version_added": "2.14"
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "setFocus": {
+          "__compat": {
+            "description": "<code>setFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "takeScreenshot": {
+          "__compat": {
+            "description": "<code>takeScreenshot</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "2.3"
+              },
+              "ios": {
+                "version_added": "2.18"
+              },
+              "harmony": {
+                "version_added": "3.3"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/lynx-compat-data/elements/viewpager.json
+++ b/packages/lynx-compat-data/elements/viewpager.json
@@ -26,7 +26,7 @@
             "version_added": "3.9"
           },
           "web_lynx": {
-            "version_added": "3.9"
+            "version_added": false
           }
         }
       },
@@ -56,7 +56,7 @@
               "version_added": "3.9"
             },
             "web_lynx": {
-              "version_added": "3.9"
+              "version_added": false
             }
           }
         },
@@ -87,7 +87,14 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -118,7 +125,14 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -148,8 +162,15 @@
                 "version_added": "3.9"
               },
               "web_lynx": {
-                "version_added": "3.9"
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -179,8 +200,15 @@
                 "version_added": "3.9"
               },
               "web_lynx": {
-                "version_added": "3.9"
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -210,8 +238,15 @@
                 "version_added": "3.9"
               },
               "web_lynx": {
-                "version_added": "3.9"
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -242,7 +277,14 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -273,7 +315,14 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -308,6 +357,9 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -339,7 +391,14 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         },
@@ -370,7 +429,14 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
+            },
+            "status": {
+              "deprecated": false,
+              "experimental": false
             }
           }
         }
@@ -401,7 +467,7 @@
               "version_added": "3.9"
             },
             "web_lynx": {
-              "version_added": "3.9"
+              "version_added": false
             }
           }
         },
@@ -435,7 +501,10 @@
                 "version_added": "3.9"
               },
               "web_lynx": {
-                "version_added": "3.9"
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -470,7 +539,10 @@
                 "version_added": "3.9"
               },
               "web_lynx": {
-                "version_added": "3.9"
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -505,7 +577,10 @@
                 "version_added": "3.9"
               },
               "web_lynx": {
-                "version_added": "3.9"
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -537,7 +612,7 @@
               "version_added": "3.9"
             },
             "web_lynx": {
-              "version_added": "3.9"
+              "version_added": false
             }
           }
         },
@@ -571,7 +646,200 @@
                 "version_added": "3.9"
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "boundingClientRect": {
+          "__compat": {
+            "description": "<code>boundingClientRect</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
                 "version_added": "3.9"
+              },
+              "ios": {
+                "version_added": "3.9"
+              },
+              "harmony": {
+                "version_added": "3.9"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "3.9"
+              },
+              "clay_ios": {
+                "version_added": "3.9"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "requestAccessibilityFocus": {
+          "__compat": {
+            "description": "<code>requestAccessibilityFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.9"
+              },
+              "ios": {
+                "version_added": "3.9"
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "3.9"
+              },
+              "clay_ios": {
+                "version_added": "3.9"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "scrollIntoView": {
+          "__compat": {
+            "description": "<code>scrollIntoView</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.9"
+              },
+              "ios": {
+                "version_added": "3.9"
+              },
+              "harmony": {
+                "version_added": "3.9"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "3.9"
+              },
+              "clay_ios": {
+                "version_added": "3.9"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "setFocus": {
+          "__compat": {
+            "description": "<code>setFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "3.9"
+              },
+              "clay_ios": {
+                "version_added": "3.9"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "takeScreenshot": {
+          "__compat": {
+            "description": "<code>takeScreenshot</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "3.9"
+              },
+              "ios": {
+                "version_added": "3.9"
+              },
+              "harmony": {
+                "version_added": "3.9"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": "4.0"
+              },
+              "clay_ios": {
+                "version_added": "4.0"
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }

--- a/packages/lynx-compat-data/elements/webview.json
+++ b/packages/lynx-compat-data/elements/webview.json
@@ -91,6 +91,9 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -113,10 +116,10 @@
                 "version_added": "4.0"
               },
               "clay_android": {
-                "version_added": false
+                "version_added": "4.0"
               },
               "clay_ios": {
-                "version_added": false
+                "version_added": "4.0"
               },
               "clay_windows": {
                 "version_added": false
@@ -125,6 +128,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -161,6 +167,9 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -195,6 +204,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -231,6 +243,9 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -265,6 +280,9 @@
                 "version_added": false
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -301,6 +319,9 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -323,10 +344,10 @@
                 "version_added": false
               },
               "clay_android": {
-                "version_added": "4.0"
+                "version_added": false
               },
               "clay_ios": {
-                "version_added": "4.0"
+                "version_added": false
               },
               "clay_windows": {
                 "version_added": "4.0"
@@ -335,6 +356,9 @@
                 "version_added": "4.0"
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -371,6 +395,9 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -405,6 +432,9 @@
                 "version_added": "4.0"
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -472,6 +502,9 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -506,6 +539,9 @@
                 "version_added": "4.0"
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -542,6 +578,9 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -577,6 +616,9 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -611,6 +653,9 @@
                 "version_added": "4.0"
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -678,6 +723,9 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -712,6 +760,9 @@
                 "version_added": "4.0"
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -748,6 +799,9 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -782,6 +836,9 @@
                 "version_added": "4.0"
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }
@@ -818,6 +875,9 @@
               },
               "web_lynx": {
                 "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
               }
             }
           }
@@ -852,6 +912,161 @@
                 "version_added": "4.0"
               },
               "web_lynx": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "boundingClientRect": {
+          "__compat": {
+            "description": "<code>boundingClientRect</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "4.0"
+              },
+              "ios": {
+                "version_added": "4.0"
+              },
+              "harmony": {
+                "version_added": "4.0"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "scrollIntoView": {
+          "__compat": {
+            "description": "<code>scrollIntoView</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "4.0"
+              },
+              "ios": {
+                "version_added": "4.0"
+              },
+              "harmony": {
+                "version_added": "4.0"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "setFocus": {
+          "__compat": {
+            "description": "<code>setFocus</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": false
+              },
+              "ios": {
+                "version_added": false
+              },
+              "harmony": {
+                "version_added": false
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "takeScreenshot": {
+          "__compat": {
+            "description": "<code>takeScreenshot</code>",
+            "status": {
+              "deprecated": false,
+              "experimental": false
+            },
+            "support": {
+              "android": {
+                "version_added": "4.0"
+              },
+              "ios": {
+                "version_added": "4.0"
+              },
+              "harmony": {
+                "version_added": "4.0"
+              },
+              "web_lynx": {
+                "version_added": false
+              },
+              "clay_android": {
+                "version_added": false
+              },
+              "clay_ios": {
+                "version_added": false
+              },
+              "clay_macos": {
+                "version_added": false
+              },
+              "clay_windows": {
+                "version_added": false
+              },
+              "clay_harmony": {
                 "version_added": false
               }
             }


### PR DESCRIPTION
[Doc] Generate public Element compatibility data

- Regenerate public Element compatibility JSON from TypeScript declarations, including surface-specific overrides and nested Element projections.
- Store Web support as boolean values verified against the lynx-stack Web implementation instead of assigning Lynx release versions.
- Apply Element-root Web availability to child APIs and keep generated JSON key order stable.
- Preserve the existing Element support corrections, independent surface files, and android-overlay-scope metadata.
- Keep this change limited to generated compatibility data and its ignore rule.

TEST: With pull request #1380 applied, full compatibility generation has zero unresolved paths; repeated generation has zero add, update, or delete operations; parsed all 39 JSON files; verified zero string or array Web support statements

Change-Id: Iba4eb2d4e036d5e2cc2a159a83945270477b8455