### PR TITLE
[release/3.8] ci: run checks for merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,13 @@ name: CI
 
 on:
   pull_request:
+  merge_group:
+    types: [checks_requested]
+    branches:
+      - release/3.8
   push:
     branches:
-      - main
+      - release/3.8
 
 jobs:
   validate:


### PR DESCRIPTION
## Summary
- run the CI workflow for merge queue merge groups targeting release/3.8
- run post-merge CI on pushes to release/3.8 instead of main
- ensure queued PRs and landed changes are tested against the release branch state

## Testing
- git diff --check -- .github/workflows/ci.yml