### PR TITLE
fix(docs): drop Android dependencies that do not resolve at LYNX_VERSION

### DIFF
--- a/docs/en/guide/start/fragments/android/integrating-lynx-with-existing-app-android.mdx
+++ b/docs/en/guide/start/fragments/android/integrating-lynx-with-existing-app-android.mdx
@@ -605,12 +605,8 @@ dependencies {
     implementation "androidx.viewpager2:viewpager2:1.1.0"
     // Required when templates use <blur-view>.
     implementation "org.lynxsdk.lynx:xelement-blur-view:{versionJson.LYNX_VERSION}"
-    // Required when templates use <video>.
-    implementation "org.lynxsdk.lynx:xelement-video:{versionJson.LYNX_VERSION}"
     // Required when templates use <webview>.
     implementation "org.lynxsdk.lynx:xelement-webview:{versionJson.LYNX_VERSION}"
-    // Required when templates use AnimaX animations.
-    implementation "org.lynxsdk.lynx:xelement-animax:{versionJson.LYNX_VERSION}"
 }
 ```
 
@@ -669,12 +665,8 @@ dependencies {
     implementation("androidx.viewpager2:viewpager2:1.1.0")
     // Required when templates use <blur-view>.
     implementation("org.lynxsdk.lynx:xelement-blur-view:{versionJson.LYNX_VERSION}")
-    // Required when templates use <video>.
-    implementation("org.lynxsdk.lynx:xelement-video:{versionJson.LYNX_VERSION}")
     // Required when templates use <webview>.
     implementation("org.lynxsdk.lynx:xelement-webview:{versionJson.LYNX_VERSION}")
-    // Required when templates use AnimaX animations.
-    implementation("org.lynxsdk.lynx:xelement-animax:{versionJson.LYNX_VERSION}")
 }
 ```
 

--- a/docs/zh/guide/start/fragments/android/integrating-lynx-with-existing-app-android.mdx
+++ b/docs/zh/guide/start/fragments/android/integrating-lynx-with-existing-app-android.mdx
@@ -187,12 +187,8 @@ dependencies {
     implementation "androidx.viewpager2:viewpager2:1.1.0"
     // 仅在模板使用 <blur-view> 时需要。
     implementation "org.lynxsdk.lynx:xelement-blur-view:{versionJson.LYNX_VERSION}"
-    // 仅在模板使用 <video> 时需要。
-    implementation "org.lynxsdk.lynx:xelement-video:{versionJson.LYNX_VERSION}"
     // 仅在模板使用 <webview> 时需要。
     implementation "org.lynxsdk.lynx:xelement-webview:{versionJson.LYNX_VERSION}"
-    // 仅在模板使用 AnimaX 动画时需要。
-    implementation "org.lynxsdk.lynx:xelement-animax:{versionJson.LYNX_VERSION}"
 }
 ```
 
@@ -251,12 +247,8 @@ dependencies {
     implementation("androidx.viewpager2:viewpager2:1.1.0")
     // 仅在模板使用 <blur-view> 时需要。
     implementation("org.lynxsdk.lynx:xelement-blur-view:{versionJson.LYNX_VERSION}")
-    // 仅在模板使用 <video> 时需要。
-    implementation("org.lynxsdk.lynx:xelement-video:{versionJson.LYNX_VERSION}")
     // 仅在模板使用 <webview> 时需要。
     implementation("org.lynxsdk.lynx:xelement-webview:{versionJson.LYNX_VERSION}")
-    // 仅在模板使用 AnimaX 动画时需要。
-    implementation("org.lynxsdk.lynx:xelement-animax:{versionJson.LYNX_VERSION}")
 }
 ```
 


### PR DESCRIPTION
## Problem

The Android integration guide pins every coordinate in its dependency block to `{versionJson.LYNX_VERSION}`, currently `4.0.0`. Two of them cannot resolve there:

| Coordinate | Status on Maven Central |
| --- | --- |
| `org.lynxsdk.lynx:xelement-video` | no stable release at all — only `4.0.0-nightly.*` and `4.1.0-nightly.*` |
| `org.lynxsdk.lynx:xelement-animax` | does not exist under any version |

`xelement-video` having no stable build lines up with `<video>` being documented as `version_added: 4.1` in compat data — the element has not shipped in a stable release yet, so the guide lists its artifact a version early.

AnimaX is published as `animax-sdk` / `animax-napi` / `animax-textra`, versioned independently of `LYNX_VERSION`, and appears nowhere else on the site: no AnimaX page, no compat-data entry.

Either line breaks a copy-paste of the block it sits in, and Gradle's failure names only the coordinate, never the guide that supplied it.

## Fix

Remove the two lines from both tabs (`build.gradle` and `build.gradle.kts`) in `en` and `zh`. The `<video>` line belongs back once 4.1 ships.

## Verification

**Resolution.** A Gradle project was generated from the guide's own dependency block, with the placeholders substituted exactly as the site substitutes them at build time, then every coordinate resolved:

```
before   RESOLVED 99   UNRESOLVED 2
           FAIL org.lynxsdk.lynx:xelement-animax:4.0.0
           FAIL org.lynxsdk.lynx:xelement-video:4.0.0
after    RESOLVED 99   UNRESOLVED 0      (en and zh alike)
```

**End to end.** An Android app was then built from scratch on the corrected list — core SDK, image/log/http services, devtool, and every remaining XElement — following this guide and the devtool guide. It compiles, installs and renders on an API 35 emulator, with **314 element, CSS, API and ReactLynx checks passing and none failing**.