### PR TITLE
fix(docs): make the DevTool integration snippets compile

### DIFF
--- a/docs/en/guide/start/integrate-lynx-devtool.mdx
+++ b/docs/en/guide/start/integrate-lynx-devtool.mdx
@@ -64,8 +64,7 @@ You can configure these switches during [Lynx Environment Initialization](/guide
 <Tabs groupId='integrating-lynx-with-existing-app-ios'>
 <Tab label="Objective-C">
 
-```objective-c title=AppDelegate.m {10-19}
-#import <Lynx/DevToolSettings.h>
+```objective-c title=AppDelegate.m {9-16}
 #import <Lynx/LynxEnv.h>
 #import <Lynx/LynxService.h>
 #import <Lynx/LynxServiceDevToolProtocol.h>
@@ -74,8 +73,6 @@ You can configure these switches during [Lynx Environment Initialization](/guide
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   // ...
-  // set devtool bootstrap defaults
-  [[DevToolSettings sharedInstance].bootstrap applyDevelopmentDefaultsIfUnset];
   LynxEnv *lynxEnv = [LynxEnv sharedInstance];
   // Enable all sessions debugging for DevTool (required for Lynx DevTool Desktop connection)
   [LynxService(LynxServiceDevToolProtocol) enableAllSessions];
@@ -91,22 +88,19 @@ You can configure these switches during [Lynx Environment Initialization](/guide
 <Tab label="Swift">
 
 ```objective-c title="YourTarget-Bridging-Header.h"
-#import <Lynx/DevToolSettings.h>
 #import <Lynx/LynxEnv.h>
 #import <Lynx/LynxService.h>
 #import <Lynx/LynxServiceDevToolProtocol.h>
 ```
 
-```swift title=AppDelegate.swift {5-14}
+```swift title=AppDelegate.swift {5-12}
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     // ...
-    // set devtool bootstrap defaults
-    DevToolSettings.sharedInstance().bootstrap.applyDevelopmentDefaultsIfUnset()
     let lynxEnv = LynxEnv.sharedInstance()
     // Enable all sessions debugging for DevTool (required for Lynx DevTool Desktop connection)
-    (LynxServices.getInstanceWith(LynxServiceDevToolProtocol.self, bizID: DEFAULT_LYNX_SERVICE) as? LynxServiceDevToolProtocol)?.enableAllSessions()
+    (LynxServices.getInstanceWith(LynxServiceDevToolProtocol.self) as? LynxServiceDevToolProtocol)?.enableAllSessions()
     // Enable Lynx DevTool Switch
     lynxEnv.devtoolEnabled = true
     // Enable Lynx LogBox Switch
@@ -163,14 +157,10 @@ It is recommended to use the latest [Lynx version](https://github.com/lynx-famil
 
 ### Registering DevTool Service
 
-DevTool Service provides some bootstrap values to control default behaviors. You can configure them as needed.
-
-In the next chapter, we will introduce these bootstrap values in detail.
-
 <Tabs groupId='register-devtool-service-android'>
 <Tab label="Java">
 
-```java title=YourApplication.java {3-13}
+```java title=YourApplication.java {3-7}
 private void initLynxService() {
   // ...
   // register DevTool service
@@ -178,9 +168,6 @@ private void initLynxService() {
 
   // enable all sessions debug for DevTool (required for Lynx DevTool Desktop connection)
   LynxDevToolService.getINSTANCE().enableAllSessions();
-
-  // set devtool bootstrap defaults
-  DevToolSettings.inst().bootstrap().applyDevelopmentDefaultsIfUnset();
 }
 
 ```
@@ -188,7 +175,7 @@ private void initLynxService() {
 </Tab>
 <Tab label="Kotlin">
 
-```kotlin title=YourApplication.kt {3-13}
+```kotlin title=YourApplication.kt {3-7}
 private fun initLynxService() {
   // ...
   // register DevTool service
@@ -196,9 +183,6 @@ private fun initLynxService() {
 
   // enable all sessions debug for DevTool (required for Lynx DevTool Desktop connection)
   LynxDevToolService.INSTANCE.enableAllSessions()
-
-  // set devtool bootstrap defaults
-  DevToolSettings.inst().bootstrap().applyDevelopmentDefaultsIfUnset()
 }
 ```
 

--- a/docs/zh/guide/start/integrate-lynx-devtool.mdx
+++ b/docs/zh/guide/start/integrate-lynx-devtool.mdx
@@ -63,8 +63,7 @@ DevTool 提供了一些调试功能开关，
 <Tabs groupId='integrating-lynx-with-existing-app-ios'>
 <Tab label="Objective-C">
 
-```objective-c title=AppDelegate.m {10-19}
-#import <Lynx/DevToolSettings.h>
+```objective-c title=AppDelegate.m {9-16}
 #import <Lynx/LynxEnv.h>
 #import <Lynx/LynxService.h>
 #import <Lynx/LynxServiceDevToolProtocol.h>
@@ -73,8 +72,6 @@ DevTool 提供了一些调试功能开关，
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   // ...
-  // 设置 DevTool 启动配置的默认值
-  [[DevToolSettings sharedInstance].bootstrap applyDevelopmentDefaultsIfUnset];
   LynxEnv *lynxEnv = [LynxEnv sharedInstance];
   // 允许 DevTool 调试所有 Lynx 页面（连接 Lynx DevTool 桌面应用必需）
   [LynxService(LynxServiceDevToolProtocol) enableAllSessions];
@@ -90,22 +87,19 @@ DevTool 提供了一些调试功能开关，
 <Tab label="Swift">
 
 ```objective-c title="YourTarget-Bridging-Header.h"
-#import <Lynx/DevToolSettings.h>
 #import <Lynx/LynxEnv.h>
 #import <Lynx/LynxService.h>
 #import <Lynx/LynxServiceDevToolProtocol.h>
 ```
 
-```swift title=AppDelegate.swift {5-14}
+```swift title=AppDelegate.swift {5-12}
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     // ...
-    // 设置 DevTool 启动配置的默认值
-    DevToolSettings.sharedInstance().bootstrap.applyDevelopmentDefaultsIfUnset()
     let lynxEnv = LynxEnv.sharedInstance()
     // 允许 DevTool 调试所有 Lynx 页面（连接 DevTool 桌面应用必需）
-    (LynxServices.getInstanceWith(LynxServiceDevToolProtocol.self, bizID: DEFAULT_LYNX_SERVICE) as? LynxServiceDevToolProtocol)?.enableAllSessions()
+    (LynxServices.getInstanceWith(LynxServiceDevToolProtocol.self) as? LynxServiceDevToolProtocol)?.enableAllSessions()
     // 打开 Lynx DevTool 开关
     lynxEnv.devtoolEnabled = true
     // 打开 Lynx LogBox 开关
@@ -162,14 +156,10 @@ dependencies {
 
 ### 注册 DevTool Service
 
-DevTool Service 提供了一些启动配置值，以控制默认行为，可以根据实际需求进行配置。
-
-在下一章节中，将详细介绍这些启动配置值。
-
 <Tabs groupId='register-devtool-service-android'>
 <Tab label="Java">
 
-```java title=YourApplication.java {3-13}
+```java title=YourApplication.java {3-7}
 private void initLynxService() {
   // ...
   // register DevTool service
@@ -177,9 +167,6 @@ private void initLynxService() {
 
   // 允许 DevTool 调试所有 Lynx 页面（连接 Lynx DevTool 桌面应用必需）
   LynxDevToolService.getINSTANCE().enableAllSessions();
-
-  // 设置 DevTool 启动配置的默认值
-  DevToolSettings.inst().bootstrap().applyDevelopmentDefaultsIfUnset();
 }
 
 ```
@@ -187,7 +174,7 @@ private void initLynxService() {
 </Tab>
 <Tab label="Kotlin">
 
-```kotlin title=YourApplication.kt {3-13}
+```kotlin title=YourApplication.kt {3-7}
 private fun initLynxService() {
   // ...
   // register DevTool service
@@ -195,9 +182,6 @@ private fun initLynxService() {
 
   // 允许 DevTool 调试所有 Lynx 页面（连接 Lynx DevTool 桌面应用必需）
   LynxDevToolService.INSTANCE.enableAllSessions()
-
-  // 设置 DevTool 启动配置的默认值
-  DevToolSettings.inst().bootstrap().applyDevelopmentDefaultsIfUnset()
 }
 ```
 


### PR DESCRIPTION
## Problem

Two calls in `guide/start/integrate-lynx-devtool` do not build against the published 4.0.0 SDKs.

### 1. "set devtool bootstrap defaults", in all four snippets

```kotlin
DevToolSettings.inst().bootstrap().applyDevelopmentDefaultsIfUnset()          // Android
```
```objective-c
[[DevToolSettings sharedInstance].bootstrap applyDevelopmentDefaultsIfUnset]; // iOS
```

`DevToolSettings` exists on both platforms — `inst()` and `+sharedInstance` both resolve — but neither exposes `bootstrap`, and `applyDevelopmentDefaultsIfUnset` appears nowhere in the shipped artifacts. Compiling the snippets verbatim:

| Tab | Compiler says |
| --- | --- |
| Kotlin | `e: Unresolved reference: bootstrap` |
| Objective-C | `error: property 'bootstrap' not found on object of type 'DevToolSettings *'` |
| Swift | `error: value of type 'DevToolSettings' has no member 'bootstrap'` |

The two sentences introducing the step go with it: they promise that *the next chapter* covers these bootstrap values, and **Advanced DevTool Configurations** covers the DevTool switch page instead — "bootstrap" appears nowhere else in the docs. The Objective-C import of `<Lynx/DevToolSettings.h>`, and its bridging-header line, existed only to serve this call.

### 2. The Swift tab passes an argument `LynxServices` does not take

```
error: extra argument 'bizID' in call
```

The class declares `+getInstanceWithProtocol:`, which Swift imports as `getInstanceWith(_:)`. The compiler names it exactly:

```
error: 'getInstanceWithProtocol' has been renamed to 'getInstanceWith(_:)'
```

The Objective-C tab was already correct — it uses the `LynxService()` macro, which expands to the same selector. Only the Swift tab is wrong.

## Fix

Remove the `bootstrap` call and the prose introducing it; drop the now-unused `DevToolSettings` import; drop the `bizID:` argument. Code-fence highlight ranges are moved so they keep covering the configuration lines rather than trailing off the end of the shortened blocks.

## Verification

Each snippet was compiled **as published** and then **as corrected**, in apps built from scratch on the published SDKs (`Lynx` / `LynxService` / `LynxDevtool` / `DebugRouter` on iOS, `lynx-devtool` + `lynx-service-devtool` on Android). The four errors above are the "before"; both apps build clean after.

Then end to end, with DevTool registered and all sessions enabled through these snippets:

| Platform | Result |
| --- | --- |
| Android, API 35 emulator | 540 checks — **384 pass, 0 fail** |
| iOS, iPhone 15 Pro simulator | host-surface audit — **36 of 36** |

## Not changed

`LoadQJSBridge` / `LoadV8Bridge` are still described as "bootstrap values" further down the page. That wording is untouched here — settling it belongs with whoever owns the switch documentation, and this PR is limited to the calls that do not compile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Align DevTool integration snippets with the published 4.0.0 SDKs.
- Remove unsupported bootstrap defaults, unused imports, and the invalid Swift `bizID:` argument.
- Update code-fence highlights and verify Android and iOS compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->