### PR TITLE
fix(docs): Clay macOS does not implement these element methods

### DIFF
--- a/docs/en/api/elements/built-in/viewpager-API.mdx
+++ b/docs/en/api/elements/built-in/viewpager-API.mdx
@@ -182,7 +182,7 @@ Frontend can invoke component methods via the [SelectorQuery](/api/lynx-api/node
 
 ### `selectTab`
 
-<AndroidOnly /> <IOSOnly /> <ClayOnly /> <HarmonyOnly />
+<AndroidOnly /> <IOSOnly /> <ClayWindowsOnly /> <HarmonyOnly />
 ```ts
 
 lynx.createSelectorQuery()

--- a/docs/en/api/elements/built-in/webview-API.mdx
+++ b/docs/en/api/elements/built-in/webview-API.mdx
@@ -201,7 +201,7 @@ Frontend can invoke component methods via the [SelectorQuery](/api/lynx-api/node
 
 ### `cookies.flushStore`
 
- <ClayOnly /> <VersionBadge>Lynx 3.5</VersionBadge>
+ <ClayWindowsOnly /> <VersionBadge>Lynx 3.5</VersionBadge>
 ```ts
 
 lynx.createSelectorQuery()
@@ -220,7 +220,7 @@ Write any unwritten cookies data to disk for webview
 
 ### `cookies.get`
 
- <ClayOnly /> <VersionBadge>Lynx 3.5</VersionBadge>
+ <ClayWindowsOnly /> <VersionBadge>Lynx 3.5</VersionBadge>
 ```ts
 interface CookiesGetParams {
   /**
@@ -279,7 +279,7 @@ Get cookies from webview
 
 ### `cookies.remove`
 
- <ClayOnly /> <VersionBadge>Lynx 3.5</VersionBadge>
+ <ClayWindowsOnly /> <VersionBadge>Lynx 3.5</VersionBadge>
 ```ts
 interface CookiesRemoveParams {
   /**
@@ -313,7 +313,7 @@ Removes the cookies matching url and name
 
 ### `cookies.set`
 
- <ClayOnly /> <VersionBadge>Lynx 3.5</VersionBadge>
+ <ClayWindowsOnly /> <VersionBadge>Lynx 3.5</VersionBadge>
 ```ts
 interface CookiesSetParams {
   /**
@@ -385,7 +385,7 @@ Set a cookie to webview
 
 ### `eval`
 
- <AndroidOnly /> <IOSOnly /> <ClayOnly /> <HarmonyOnly />
+ <AndroidOnly /> <IOSOnly /> <ClayWindowsOnly /> <HarmonyOnly />
 ```ts
 
 lynx.createSelectorQuery()

--- a/docs/zh/api/elements/built-in/viewpager-API.mdx
+++ b/docs/zh/api/elements/built-in/viewpager-API.mdx
@@ -180,7 +180,7 @@ bindwillchange = (e: ViewPagerWillChangeEvent) => {};
 
 ### `selectTab`
 
-<AndroidOnly /> <IOSOnly /> <ClayOnly /> <HarmonyOnly />
+<AndroidOnly /> <IOSOnly /> <ClayWindowsOnly /> <HarmonyOnly />
 ```ts
 
 lynx.createSelectorQuery()

--- a/docs/zh/api/elements/built-in/webview-API.mdx
+++ b/docs/zh/api/elements/built-in/webview-API.mdx
@@ -199,7 +199,7 @@ bindopenwindow = (e: WebviewUrlEvent) => {};
 
 ### `cookies.flushStore`
 
- <ClayOnly /> <VersionBadge>Lynx 3.5</VersionBadge>
+ <ClayWindowsOnly /> <VersionBadge>Lynx 3.5</VersionBadge>
 ```ts
 
 lynx.createSelectorQuery()
@@ -218,7 +218,7 @@ lynx.createSelectorQuery()
 
 ### `cookies.get`
 
- <ClayOnly /> <VersionBadge>Lynx 3.5</VersionBadge>
+ <ClayWindowsOnly /> <VersionBadge>Lynx 3.5</VersionBadge>
 ```ts
 interface CookiesGetParams {
   /**
@@ -277,7 +277,7 @@ lynx.createSelectorQuery()
 
 ### `cookies.remove`
 
- <ClayOnly /> <VersionBadge>Lynx 3.5</VersionBadge>
+ <ClayWindowsOnly /> <VersionBadge>Lynx 3.5</VersionBadge>
 ```ts
 interface CookiesRemoveParams {
   /**
@@ -311,7 +311,7 @@ lynx.createSelectorQuery()
 
 ### `cookies.set`
 
- <ClayOnly /> <VersionBadge>Lynx 3.5</VersionBadge>
+ <ClayWindowsOnly /> <VersionBadge>Lynx 3.5</VersionBadge>
 ```ts
 interface CookiesSetParams {
   /**
@@ -383,7 +383,7 @@ lynx.createSelectorQuery()
 
 ### `eval`
 
- <AndroidOnly /> <IOSOnly /> <ClayOnly /> <HarmonyOnly />
+ <AndroidOnly /> <IOSOnly /> <ClayWindowsOnly /> <HarmonyOnly />
 ```ts
 
 lynx.createSelectorQuery()

--- a/packages/lynx-compat-data/elements/scroll-coordinator.json
+++ b/packages/lynx-compat-data/elements/scroll-coordinator.json
@@ -429,7 +429,7 @@
               "version_added": "3.9"
             },
             "clay_macos": {
-              "version_added": "3.9"
+              "version_added": false
             },
             "web_lynx": {
               "version_added": "3.9"
@@ -463,7 +463,7 @@
                 "version_added": "3.9"
               },
               "clay_macos": {
-                "version_added": "3.9"
+                "version_added": false
               },
               "web_lynx": {
                 "version_added": "3.9"

--- a/packages/lynx-compat-data/elements/viewpager.json
+++ b/packages/lynx-compat-data/elements/viewpager.json
@@ -534,7 +534,7 @@
               "version_added": "3.9"
             },
             "clay_macos": {
-              "version_added": "3.9"
+              "version_added": false
             },
             "web_lynx": {
               "version_added": "3.9"
@@ -568,7 +568,7 @@
                 "version_added": "3.9"
               },
               "clay_macos": {
-                "version_added": "3.9"
+                "version_added": false
               },
               "web_lynx": {
                 "version_added": "3.9"

--- a/packages/lynx-compat-data/elements/webview.json
+++ b/packages/lynx-compat-data/elements/webview.json
@@ -709,7 +709,7 @@
                 "version_added": "4.0"
               },
               "clay_macos": {
-                "version_added": "4.0"
+                "version_added": false
               },
               "web_lynx": {
                 "version_added": false
@@ -744,7 +744,7 @@
                 "version_added": "4.0"
               },
               "clay_macos": {
-                "version_added": "4.0"
+                "version_added": false
               },
               "web_lynx": {
                 "version_added": false
@@ -779,7 +779,7 @@
                 "version_added": "4.0"
               },
               "clay_macos": {
-                "version_added": "4.0"
+                "version_added": false
               },
               "web_lynx": {
                 "version_added": false
@@ -814,7 +814,7 @@
                 "version_added": "4.0"
               },
               "clay_macos": {
-                "version_added": "4.0"
+                "version_added": false
               },
               "web_lynx": {
                 "version_added": false
@@ -849,7 +849,7 @@
                 "version_added": "4.0"
               },
               "clay_macos": {
-                "version_added": "4.0"
+                "version_added": false
               },
               "web_lynx": {
                 "version_added": false


### PR DESCRIPTION
Follow-up to #1363 and #1377, which corrected the `lynx.*` and `scroll-view` half of the same audit. This is the element-method half.

## Problem

Seven element methods are recorded as supported on `clay_macos` but are not reachable there. The **element** works in every case — `<viewpager>` lays its items out as pages, `<webview>` loads — it is the **methods** that are absent.

| Entry | Recorded | Actual |
| --- | --- | --- |
| `elements.viewpager.methods.selectTab` | `3.9` | `false` |
| `elements.scroll-coordinator.methods.setFoldExpanded` | `3.9` | `false` |
| `elements.webview.methods.eval` | `4.0` | `false` |
| `elements.webview.methods.cookies.get` | `4.0` | `false` |
| `elements.webview.methods.cookies.set` | `4.0` | `false` |
| `elements.webview.methods.cookies.remove` | `4.0` | `false` |
| `elements.webview.methods.cookies.flushStore` | `4.0` | `false` |

Every one is recorded as arriving at or before the runtime under test, so none is version skew, and every one passes on Android and iOS. `invoke()` returns error code 3, and Clay's own log says why:

```
ERROR:lynx_ui_method_registrar.cc(61)] UI Method (selectTab) can't match view type
ERROR:lynx_ui_method_registrar.cc(61)] UI Method (setFoldExpanded) can't match view type
ERROR:lynx_ui_method_registrar.cc(61)] UI Method (cookies.get) can't match view type
```

`cookies.get` is worth singling out: it was recorded `android: false, ios: false, clay_macos: 4.0` — a macOS-exclusive API that macOS does not have.

## Reproduced in two independent hosts

So this is not one embedder's mistake:

1. a **C++ embedder** built from `guide/start/fragments/macos/…` against the published Clay macOS SDK 4.0.1;
2. **Lynxtron 0.0.16** — the desktop runtime `clay_macos` describes — with identical results.

The five `<webview>` entries were re-checked with **`@lynx-js/cef-webview` installed and `initialize()` called**, since Lynxtron does not bundle `<webview>` by default. They fail the same way with it loaded.

## Verification

A conformance bundle is driven from this compat data and run on all three platforms. Before the change the seven were reported as support mismatches on Clay; after it they are correctly skipped as undocumented there, and every platform is clean:

| Host | Cases | Pass | Fail |
| --- | --- | --- | --- |
| Lynxtron 0.0.16 + cef-webview | 470 | 292 | **0** |
| Android 4.0.0, API 35 emulator | 540 | 384 | **0** |
| iOS 4.0.0, iPhone 15 Pro simulator | 470 | 322 | **0** |

## Scope

`clay_windows` is left untouched: no Windows host was available to test it, and guessing is what put these entries here. If someone can run Windows, it is worth checking — #1377 found Windows shared the macOS gap for the two `lynx.*` APIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Mark seven unsupported element methods in `clay_macos` compatibility data.
- Preserve support status for the corresponding elements and for `clay_windows`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->