### PR TITLE
fix(scripts): keep fetch-lynx-ui's git commands inside .lynx-ui-source

### DIFF
--- a/scripts/fetch-lynx-ui.mjs
+++ b/scripts/fetch-lynx-ui.mjs
@@ -31,8 +31,33 @@ if (!sha) {
 
 const targetPath = resolve(process.cwd(), TARGET_DIR);
 
+// Git exports GIT_DIR, GIT_INDEX_FILE and friends to the processes it runs --
+// hooks especially, and from a worktree they are absolute paths to the *outer*
+// repository. Those variables outrank `cwd`, so a `git checkout` aimed at
+// .lynx-ui-source with them set silently retargets lynx-website itself: the
+// fetch writes the outer FETCH_HEAD and the checkout detaches the outer HEAD
+// onto a lynx-ui commit, aborting the commit that triggered it. Strip them so
+// every command below is resolved from `cwd`, which is what this script means.
+const GIT_ENV_VARS = [
+  'GIT_DIR',
+  'GIT_WORK_TREE',
+  'GIT_INDEX_FILE',
+  'GIT_PREFIX',
+  'GIT_COMMON_DIR',
+  'GIT_OBJECT_DIRECTORY',
+  'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+  'GIT_CEILING_DIRECTORIES',
+  'GIT_NAMESPACE',
+];
+
+const nestedEnv = () => {
+  const env = { ...process.env };
+  for (const key of GIT_ENV_VARS) delete env[key];
+  return env;
+};
+
 const run = (command, options = {}) =>
-  execSync(command, { stdio: 'inherit', ...options });
+  execSync(command, { stdio: 'inherit', env: nestedEnv(), ...options });
 
 // git commands run inside a directory that is not itself a repository walk up
 // to the enclosing one. Since this script runs from a lynx-website checkout,
@@ -46,6 +71,7 @@ const isOwnRepo = () => {
       cwd: targetPath,
       encoding: 'utf8',
       stdio: 'pipe',
+      env: nestedEnv(),
     }).trim();
     return resolve(top) === targetPath;
   } catch {
@@ -60,6 +86,7 @@ const readHead = () => {
       cwd: targetPath,
       encoding: 'utf8',
       stdio: 'pipe',
+      env: nestedEnv(),
     }).trim();
   } catch {
     return null;


### PR DESCRIPTION
## Problem

Git exports `GIT_DIR`, `GIT_INDEX_FILE` and friends to the processes it runs, and **from a git worktree they are absolute paths to the outer repository**. Those variables outrank `cwd`, so every git command this script aims at `.lynx-ui-source` is silently retargeted at lynx-website itself:

| step | what actually happens |
| --- | --- |
| `isOwnRepo()` | `rev-parse --show-toplevel` answers with the outer work tree |
| `readHead()` | returns lynx-website's HEAD, which never equals the pinned sha, so the update path always runs |
| `git fetch` | writes **lynx-website's** `FETCH_HEAD` |
| `git checkout --force FETCH_HEAD` | detaches **lynx-website's** HEAD onto a lynx-ui commit |

The commit that triggered the script then aborts:

```
fatal: cannot lock ref 'HEAD': is at 332e7b89 but expected ef78a9f8
```

and leaves the checkout on a detached HEAD holding another project's tree. Recovering means noticing what happened, saving your edits, `git switch --force` back, and restoring them.

This reproduces on **any commit made from a worktree**, because that is when git sets `GIT_DIR` for hooks. In a plain clone it is empty, which is why it went unnoticed. Captured from inside the hook:

```
GIT_DIR=/…/lynx-website/.git/worktrees/website-main
GIT_INDEX_FILE=/…/.git/worktrees/website-main/index
```

## Fix

Strip the inherited git variables so each command resolves from `cwd`, which is what the script means.

## Verification

Reproduced the failure conditions exactly — a worktree checkout with `.lynx-ui-source` deliberately moved off the pinned sha, so the update path runs — and committed.

- **Before:** HEAD detached onto the lynx-ui commit, commit aborted.
- **After:** the commit lands on its branch, and `.lynx-ui-source` is updated in place as intended.

Follow-up to #1362, which made the script recover from a broken `.lynx-ui-source`. That fix was correct as far as it went; it could not help here, because the environment was redirecting the commands before `cwd` ever mattered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Run Git commands in `.lynx-ui-source` when invoked from a Git worktree.
- Strip inherited Git environment variables before spawning commands.
- Keep `FETCH_HEAD` and `HEAD` updates within the intended repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->