### PR TITLE
fix(docs): scroll-view initial-scroll-to-index is not supported on Clay

### DIFF
--- a/docs/en/api/elements/built-in/scroll-view-API.mdx
+++ b/docs/en/api/elements/built-in/scroll-view-API.mdx
@@ -41,7 +41,7 @@ Initial scroll position, only effective once, in PX
 
 ### `initial-scroll-to-index`
 
- <AndroidOnly /> <IOSOnly /> <ClayOnly /> <HarmonyOnly /> <VersionBadge>2.17</VersionBadge>
+ <AndroidOnly /> <IOSOnly /> <HarmonyOnly /> <VersionBadge>2.17</VersionBadge>
 
 ```tsx
 // @defaultValue: 0

--- a/docs/zh/api/elements/built-in/scroll-view-API.mdx
+++ b/docs/zh/api/elements/built-in/scroll-view-API.mdx
@@ -41,7 +41,7 @@ bounces?: boolean;
 
 ### `initial-scroll-to-index`
 
- <AndroidOnly /> <IOSOnly /> <ClayOnly /> <HarmonyOnly /> <VersionBadge>2.17</VersionBadge>
+ <AndroidOnly /> <IOSOnly /> <HarmonyOnly /> <VersionBadge>2.17</VersionBadge>
 
 ```tsx
 // @默认值: 0


### PR DESCRIPTION
## Problem

`initial-scroll-to-index`'s badge line claims Clay — which renders as **Desktop** — while the compat data behind the same entry records `clay_android`, `clay_ios`, `clay_macos` and `clay_windows` all `false`.

The page contradicts itself: the badge beside the heading and the support table below it disagree, and a reader scanning badges gets the wrong answer.

## Which side is right

The data. Set on a scroll-view laid out the way the page requires — direct children, each `flatten={false}` — the first row starts exactly five rows above the container top where the attribute is honoured, and flush with it where it is not:

| Host | Observed | |
| --- | --- | --- |
| Android 4.0.0, API 35 emulator | row0 **100.2px** above the top | honoured |
| Lynx for Web, web-core 0.25.0 | row0 **100.0px** above the top | honoured |
| Lynxtron 0.0.16 (Clay macOS) | row0 **0.0px** above the top | ignored |

Its neighbour `initial-scroll-offset` genuinely does support Clay (3.2) and carries an identical badge line — the likely origin of the copy. That one is correct and untouched.

## How it was found

By a consistency check across the whole site that compares every API page's platform badges against the compat data behind the same entry. This is the **only** contradiction it reports, so with it fixed the check is usable as a regression guard.

## Note, not changed here

The same entry records `web_lynx: true`, which the run above confirms, but the badge line carries no `<WebOnly />`. I have left that alone: no API page uses `<WebOnly />` today, so adding one is an editorial decision about whether API pages carry Web badges at all, rather than a correction. Happy to follow up if you want it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Align `initial-scroll-to-index` platform badges with compatibility data in English and Chinese documentation.
- Keep Android, iOS, and Harmony support; remove Clay support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->