### PR TITLE
[release/4.0] fix(compat-data): repoint stale lynx_path values after docs restructuring

### DIFF
--- a/packages/lynx-compat-data/api-stats.json
+++ b/packages/lynx-compat-data/api-stats.json
@@ -21368,7 +21368,7 @@
         {
           "path": "css/properties/custom-property",
           "name": "custom-property",
-          "doc_url": "api/css/properties/custom-properties",
+          "doc_url": "api/css/properties/css-variable",
           "support": {
             "android": "1.0",
             "ios": "1.0",
@@ -32341,7 +32341,7 @@
           {
             "path": "css/properties/custom-property",
             "name": "custom-property",
-            "doc_url": "api/css/properties/custom-properties",
+            "doc_url": "api/css/properties/css-variable",
             "support": {
               "android": "1.0",
               "ios": "1.0",
@@ -44084,7 +44084,7 @@
         {
           "path": "lynx-api/fetch/fetch",
           "name": "<code>fetch</code>",
-          "doc_url": "guide/networking",
+          "doc_url": "guide/interaction/networking",
           "support": {
             "android": "2.18",
             "ios": "2.18",
@@ -44797,7 +44797,7 @@
           {
             "path": "lynx-api/fetch/fetch",
             "name": "<code>fetch</code>",
-            "doc_url": "guide/networking",
+            "doc_url": "guide/interaction/networking",
             "support": {
               "android": "2.18",
               "ios": "2.18",
@@ -45455,7 +45455,7 @@
           {
             "path": "lynx-api/fetch/fetch",
             "name": "<code>fetch</code>",
-            "doc_url": "guide/networking",
+            "doc_url": "guide/interaction/networking",
             "support": {
               "android": "2.18",
               "ios": "2.18",
@@ -45962,7 +45962,7 @@
         {
           "path": "lynx-api/lynx/animateAPI.compat",
           "name": "Used to import modules.",
-          "doc_url": "api/lynx-api/lynx/lynx-animate_api",
+          "doc_url": "api/lynx-api/lynx/lynx-animate-api",
           "support": {
             "android": "1.6",
             "ios": "1.6",
@@ -45978,7 +45978,7 @@
         {
           "path": "lynx-api/lynx/animateAPI.multiple animation implementation",
           "name": "Multiple animate",
-          "doc_url": "api/lynx-api/lynx/lynx-animate_api",
+          "doc_url": "api/lynx-api/lynx/lynx-animate-api",
           "support": {
             "android": "3.4",
             "ios": "3.4",
@@ -46362,7 +46362,7 @@
         {
           "path": "lynx-api/lynx/querySelectorAll",
           "name": "querySelectorAll",
-          "doc_url": "api/lynx-api/main-thread/lynx-query-selector-all",
+          "doc_url": "api/lynx-api/main-thread/lynx-query-select-all",
           "support": {
             "android": "2.14",
             "ios": "2.14",
@@ -46378,7 +46378,7 @@
         {
           "path": "lynx-api/lynx/queueMicrotask",
           "name": "insert a task into microtask queue",
-          "doc_url": "api/lynx-api/lynx/queueMicrotask",
+          "doc_url": "api/lynx-api/lynx/lynx-queue-microtask",
           "support": {
             "android": "3.1",
             "ios": "3.1",
@@ -46538,7 +46538,7 @@
         {
           "path": "lynx-api/lynx/resumeExposure",
           "name": "Turn on exposure detection, that is, to restart the detection of the visibility of the target node, and subsequently trigger the exposure/anti-exposure event normally.",
-          "doc_url": "api/lynx-api/lynx/resume-exposure",
+          "doc_url": "api/lynx-api/lynx/lynx-resume-exposure",
           "support": {
             "android": "2.9",
             "ios": "2.9",
@@ -46554,7 +46554,7 @@
         {
           "path": "lynx-api/lynx/setObserverFrameRate",
           "name": "Set the frequency of exposure detection.",
-          "doc_url": "api/lynx-api/lynx/set-observer-frame-rate",
+          "doc_url": "api/lynx-api/lynx/lynx-set-observer-frame-rate",
           "support": {
             "android": "2.15",
             "ios": "2.15",
@@ -46602,7 +46602,7 @@
         {
           "path": "lynx-api/lynx/stopExposure",
           "name": "Stop exposure detection, that is, the visibility of the target node will no longer be detected, and exposure/anti-exposure events will no longer be triggered in the future.",
-          "doc_url": "api/lynx-api/lynx/stop-exposure",
+          "doc_url": "api/lynx-api/lynx/lynx-stop-exposure",
           "support": {
             "android": "2.9",
             "ios": "2.9",
@@ -46769,7 +46769,7 @@
           {
             "path": "lynx-api/lynx/animateAPI.compat",
             "name": "Used to import modules.",
-            "doc_url": "api/lynx-api/lynx/lynx-animate_api",
+            "doc_url": "api/lynx-api/lynx/lynx-animate-api",
             "support": {
               "android": "1.6",
               "ios": "1.6",
@@ -46785,7 +46785,7 @@
           {
             "path": "lynx-api/lynx/animateAPI.multiple animation implementation",
             "name": "Multiple animate",
-            "doc_url": "api/lynx-api/lynx/lynx-animate_api",
+            "doc_url": "api/lynx-api/lynx/lynx-animate-api",
             "support": {
               "android": "3.4",
               "ios": "3.4",
@@ -47105,7 +47105,7 @@
           {
             "path": "lynx-api/lynx/querySelectorAll",
             "name": "querySelectorAll",
-            "doc_url": "api/lynx-api/main-thread/lynx-query-selector-all",
+            "doc_url": "api/lynx-api/main-thread/lynx-query-select-all",
             "support": {
               "android": "2.14",
               "ios": "2.14",
@@ -47217,7 +47217,7 @@
           {
             "path": "lynx-api/lynx/setObserverFrameRate",
             "name": "Set the frequency of exposure detection.",
-            "doc_url": "api/lynx-api/lynx/set-observer-frame-rate",
+            "doc_url": "api/lynx-api/lynx/lynx-set-observer-frame-rate",
             "support": {
               "android": "2.15",
               "ios": "2.15",
@@ -47331,7 +47331,7 @@
           {
             "path": "lynx-api/lynx/animateAPI.compat",
             "name": "Used to import modules.",
-            "doc_url": "api/lynx-api/lynx/lynx-animate_api",
+            "doc_url": "api/lynx-api/lynx/lynx-animate-api",
             "support": {
               "android": "1.6",
               "ios": "1.6",
@@ -47347,7 +47347,7 @@
           {
             "path": "lynx-api/lynx/animateAPI.multiple animation implementation",
             "name": "Multiple animate",
-            "doc_url": "api/lynx-api/lynx/lynx-animate_api",
+            "doc_url": "api/lynx-api/lynx/lynx-animate-api",
             "support": {
               "android": "3.4",
               "ios": "3.4",
@@ -47715,7 +47715,7 @@
           {
             "path": "lynx-api/lynx/querySelectorAll",
             "name": "querySelectorAll",
-            "doc_url": "api/lynx-api/main-thread/lynx-query-selector-all",
+            "doc_url": "api/lynx-api/main-thread/lynx-query-select-all",
             "support": {
               "android": "2.14",
               "ios": "2.14",
@@ -47731,7 +47731,7 @@
           {
             "path": "lynx-api/lynx/queueMicrotask",
             "name": "insert a task into microtask queue",
-            "doc_url": "api/lynx-api/lynx/queueMicrotask",
+            "doc_url": "api/lynx-api/lynx/lynx-queue-microtask",
             "support": {
               "android": "3.1",
               "ios": "3.1",
@@ -47891,7 +47891,7 @@
           {
             "path": "lynx-api/lynx/resumeExposure",
             "name": "Turn on exposure detection, that is, to restart the detection of the visibility of the target node, and subsequently trigger the exposure/anti-exposure event normally.",
-            "doc_url": "api/lynx-api/lynx/resume-exposure",
+            "doc_url": "api/lynx-api/lynx/lynx-resume-exposure",
             "support": {
               "android": "2.9",
               "ios": "2.9",
@@ -47907,7 +47907,7 @@
           {
             "path": "lynx-api/lynx/setObserverFrameRate",
             "name": "Set the frequency of exposure detection.",
-            "doc_url": "api/lynx-api/lynx/set-observer-frame-rate",
+            "doc_url": "api/lynx-api/lynx/lynx-set-observer-frame-rate",
             "support": {
               "android": "2.15",
               "ios": "2.15",
@@ -47955,7 +47955,7 @@
           {
             "path": "lynx-api/lynx/stopExposure",
             "name": "Stop exposure detection, that is, the visibility of the target node will no longer be detected, and exposure/anti-exposure events will no longer be triggered in the future.",
-            "doc_url": "api/lynx-api/lynx/stop-exposure",
+            "doc_url": "api/lynx-api/lynx/lynx-stop-exposure",
             "support": {
               "android": "2.9",
               "ios": "2.9",
@@ -48037,7 +48037,7 @@
           {
             "path": "lynx-api/lynx/animateAPI.compat",
             "name": "Used to import modules.",
-            "doc_url": "api/lynx-api/lynx/lynx-animate_api",
+            "doc_url": "api/lynx-api/lynx/lynx-animate-api",
             "support": {
               "android": "1.6",
               "ios": "1.6",
@@ -48053,7 +48053,7 @@
           {
             "path": "lynx-api/lynx/animateAPI.multiple animation implementation",
             "name": "Multiple animate",
-            "doc_url": "api/lynx-api/lynx/lynx-animate_api",
+            "doc_url": "api/lynx-api/lynx/lynx-animate-api",
             "support": {
               "android": "3.4",
               "ios": "3.4",
@@ -48421,7 +48421,7 @@
           {
             "path": "lynx-api/lynx/querySelectorAll",
             "name": "querySelectorAll",
-            "doc_url": "api/lynx-api/main-thread/lynx-query-selector-all",
+            "doc_url": "api/lynx-api/main-thread/lynx-query-select-all",
             "support": {
               "android": "2.14",
               "ios": "2.14",
@@ -48437,7 +48437,7 @@
           {
             "path": "lynx-api/lynx/queueMicrotask",
             "name": "insert a task into microtask queue",
-            "doc_url": "api/lynx-api/lynx/queueMicrotask",
+            "doc_url": "api/lynx-api/lynx/lynx-queue-microtask",
             "support": {
               "android": "3.1",
               "ios": "3.1",
@@ -48597,7 +48597,7 @@
           {
             "path": "lynx-api/lynx/resumeExposure",
             "name": "Turn on exposure detection, that is, to restart the detection of the visibility of the target node, and subsequently trigger the exposure/anti-exposure event normally.",
-            "doc_url": "api/lynx-api/lynx/resume-exposure",
+            "doc_url": "api/lynx-api/lynx/lynx-resume-exposure",
             "support": {
               "android": "2.9",
               "ios": "2.9",
@@ -48613,7 +48613,7 @@
           {
             "path": "lynx-api/lynx/setObserverFrameRate",
             "name": "Set the frequency of exposure detection.",
-            "doc_url": "api/lynx-api/lynx/set-observer-frame-rate",
+            "doc_url": "api/lynx-api/lynx/lynx-set-observer-frame-rate",
             "support": {
               "android": "2.15",
               "ios": "2.15",
@@ -48661,7 +48661,7 @@
           {
             "path": "lynx-api/lynx/stopExposure",
             "name": "Stop exposure detection, that is, the visibility of the target node will no longer be detected, and exposure/anti-exposure events will no longer be triggered in the future.",
-            "doc_url": "api/lynx-api/lynx/stop-exposure",
+            "doc_url": "api/lynx-api/lynx/lynx-stop-exposure",
             "support": {
               "android": "2.9",
               "ios": "2.9",
@@ -48781,7 +48781,7 @@
         {
           "path": "lynx-api/selector-query/SelectorQuery",
           "name": "Gets a reference to the specified node in order to call its methods or get its properties.",
-          "doc_url": "api/lynx-api/selector-query/selector-query",
+          "doc_url": "api/lynx-api/selector-query",
           "support": {
             "android": "2.2",
             "ios": "2.2",
@@ -49012,7 +49012,7 @@
           {
             "path": "lynx-api/selector-query/SelectorQuery",
             "name": "Gets a reference to the specified node in order to call its methods or get its properties.",
-            "doc_url": "api/lynx-api/selector-query/selector-query",
+            "doc_url": "api/lynx-api/selector-query",
             "support": {
               "android": "2.2",
               "ios": "2.2",
@@ -49238,7 +49238,7 @@
           {
             "path": "lynx-api/selector-query/SelectorQuery",
             "name": "Gets a reference to the specified node in order to call its methods or get its properties.",
-            "doc_url": "api/lynx-api/selector-query/selector-query",
+            "doc_url": "api/lynx-api/selector-query",
             "support": {
               "android": "2.2",
               "ios": "2.2",
@@ -49530,7 +49530,7 @@
         {
           "path": "lynx-api/nodes-ref/NodesRef",
           "name": "Represents a reference to one or more UI nodes. It can be used to call methods, get and set properties on UI nodes.",
-          "doc_url": "api/lynx-api/nodes-ref/nodes-ref",
+          "doc_url": "api/lynx-api/nodes-ref",
           "support": {
             "android": "2.2",
             "ios": "2.2",
@@ -49697,7 +49697,7 @@
           {
             "path": "lynx-api/nodes-ref/NodesRef",
             "name": "Represents a reference to one or more UI nodes. It can be used to call methods, get and set properties on UI nodes.",
-            "doc_url": "api/lynx-api/nodes-ref/nodes-ref",
+            "doc_url": "api/lynx-api/nodes-ref",
             "support": {
               "android": "2.2",
               "ios": "2.2",
@@ -49859,7 +49859,7 @@
           {
             "path": "lynx-api/nodes-ref/NodesRef",
             "name": "Represents a reference to one or more UI nodes. It can be used to call methods, get and set properties on UI nodes.",
-            "doc_url": "api/lynx-api/nodes-ref/nodes-ref",
+            "doc_url": "api/lynx-api/nodes-ref",
             "support": {
               "android": "2.2",
               "ios": "2.2",
@@ -50088,7 +50088,7 @@
         {
           "path": "lynx-api/intersection-observer/IntersectionObserver",
           "name": "Observe the intersection status between the target node and the reference node and the target node and the ancestor node. When the intersection status changes, the corresponding callback is triggered. Based on this, you can monitor whether the target node is exposed/de-exposed.",
-          "doc_url": "api/lynx-api/intersection-observer/intersection-observer",
+          "doc_url": "api/lynx-api/intersection-observer",
           "support": {
             "android": "1.5",
             "ios": "1.5",
@@ -50104,7 +50104,7 @@
         {
           "path": "lynx-api/intersection-observer/IntersectionObserver.relativeTo",
           "name": "Specify a reference node. The reference node is specified by id.",
-          "doc_url": "api/lynx-api/intersection-observer/relative-to",
+          "doc_url": "api/lynx-api/intersection-observer/intersection-observer-relative-to",
           "support": {
             "android": "1.5",
             "ios": "1.5",
@@ -50120,7 +50120,7 @@
         {
           "path": "lynx-api/intersection-observer/IntersectionObserver.relativeToViewport",
           "name": "Specify a LynxView as a reference node.",
-          "doc_url": "api/lynx-api/intersection-observer/relative-to-viewport",
+          "doc_url": "api/lynx-api/intersection-observer/intersection-observer-relative-to-viewport",
           "support": {
             "android": "1.5",
             "ios": "1.5",
@@ -50136,7 +50136,7 @@
         {
           "path": "lynx-api/intersection-observer/IntersectionObserver.relativeToScreen",
           "name": "Specify the screen as the reference node.",
-          "doc_url": "api/lynx-api/intersection-observer/relative-to-screen",
+          "doc_url": "api/lynx-api/intersection-observer/intersection-observer-relative-to-screen",
           "support": {
             "android": "2.10",
             "ios": "2.10",
@@ -50152,7 +50152,7 @@
         {
           "path": "lynx-api/intersection-observer/IntersectionObserver.observe",
           "name": "Specify the target node and callback, and the target node is specified according to id.",
-          "doc_url": "api/lynx-api/intersection-observer/observe",
+          "doc_url": "api/lynx-api/intersection-observer/intersection-observer-observe",
           "support": {
             "android": "1.5",
             "ios": "1.5",
@@ -50168,7 +50168,7 @@
         {
           "path": "lynx-api/intersection-observer/IntersectionObserver.disconnect",
           "name": "Clear the target node and callback. The target node will no longer be observed and the corresponding callback will not be triggered.",
-          "doc_url": "api/lynx-api/intersection-observer/disconnect",
+          "doc_url": "api/lynx-api/intersection-observer/intersection-observer-disconnect",
           "support": {
             "android": "1.5",
             "ios": "1.5",
@@ -50184,7 +50184,7 @@
         {
           "path": "lynx-api/intersection-observer/disconnect",
           "name": "Clear the target node and callback. The target node will no longer be observed and the corresponding callback will not be triggered.",
-          "doc_url": "api/lynx-api/intersection-observer/disconnect",
+          "doc_url": "api/lynx-api/intersection-observer/intersection-observer-disconnect",
           "support": {
             "android": "1.5",
             "ios": "1.5",
@@ -50200,7 +50200,7 @@
         {
           "path": "lynx-api/intersection-observer/observe",
           "name": "Specify the target node and callback, and the target node is specified according to id.",
-          "doc_url": "api/lynx-api/intersection-observer/observe",
+          "doc_url": "api/lynx-api/intersection-observer/intersection-observer-observe",
           "support": {
             "android": "1.5",
             "ios": "1.5",
@@ -50216,7 +50216,7 @@
         {
           "path": "lynx-api/intersection-observer/relativeTo",
           "name": "Specify a reference node. The reference node is specified by id.",
-          "doc_url": "api/lynx-api/intersection-observer/relative-to",
+          "doc_url": "api/lynx-api/intersection-observer/intersection-observer-relative-to",
           "support": {
             "android": "1.5",
             "ios": "1.5",
@@ -50232,7 +50232,7 @@
         {
           "path": "lynx-api/intersection-observer/relativeToScreen",
           "name": "Specify the screen as the reference node.",
-          "doc_url": "api/lynx-api/intersection-observer/relative-to-screen",
+          "doc_url": "api/lynx-api/intersection-observer/intersection-observer-relative-to-screen",
           "support": {
             "android": "2.10",
             "ios": "2.10",
@@ -50248,7 +50248,7 @@
         {
           "path": "lynx-api/intersection-observer/relativeToViewport",
           "name": "Specify a LynxView as a reference node.",
-          "doc_url": "api/lynx-api/intersection-observer/relative-to-viewport",
+          "doc_url": "api/lynx-api/intersection-observer/intersection-observer-relative-to-viewport",
           "support": {
             "android": "1.5",
             "ios": "1.5",
@@ -50270,7 +50270,7 @@
           {
             "path": "lynx-api/intersection-observer/IntersectionObserver",
             "name": "Observe the intersection status between the target node and the reference node and the target node and the ancestor node. When the intersection status changes, the corresponding callback is triggered. Based on this, you can monitor whether the target node is exposed/de-exposed.",
-            "doc_url": "api/lynx-api/intersection-observer/intersection-observer",
+            "doc_url": "api/lynx-api/intersection-observer",
             "support": {
               "android": "1.5",
               "ios": "1.5",
@@ -50286,7 +50286,7 @@
           {
             "path": "lynx-api/intersection-observer/IntersectionObserver.relativeTo",
             "name": "Specify a reference node. The reference node is specified by id.",
-            "doc_url": "api/lynx-api/intersection-observer/relative-to",
+            "doc_url": "api/lynx-api/intersection-observer/intersection-observer-relative-to",
             "support": {
               "android": "1.5",
               "ios": "1.5",
@@ -50302,7 +50302,7 @@
           {
             "path": "lynx-api/intersection-observer/IntersectionObserver.relativeToViewport",
             "name": "Specify a LynxView as a reference node.",
-            "doc_url": "api/lynx-api/intersection-observer/relative-to-viewport",
+            "doc_url": "api/lynx-api/intersection-observer/intersection-observer-relative-to-viewport",
             "support": {
               "android": "1.5",
               "ios": "1.5",
@@ -50318,7 +50318,7 @@
           {
             "path": "lynx-api/intersection-observer/IntersectionObserver.relativeToScreen",
             "name": "Specify the screen as the reference node.",
-            "doc_url": "api/lynx-api/intersection-observer/relative-to-screen",
+            "doc_url": "api/lynx-api/intersection-observer/intersection-observer-relative-to-screen",
             "support": {
               "android": "2.10",
               "ios": "2.10",
@@ -50334,7 +50334,7 @@
           {
             "path": "lynx-api/intersection-observer/IntersectionObserver.observe",
             "name": "Specify the target node and callback, and the target node is specified according to id.",
-            "doc_url": "api/lynx-api/intersection-observer/observe",
+            "doc_url": "api/lynx-api/intersection-observer/intersection-observer-observe",
             "support": {
               "android": "1.5",
               "ios": "1.5",
@@ -50350,7 +50350,7 @@
           {
             "path": "lynx-api/intersection-observer/IntersectionObserver.disconnect",
             "name": "Clear the target node and callback. The target node will no longer be observed and the corresponding callback will not be triggered.",
-            "doc_url": "api/lynx-api/intersection-observer/disconnect",
+            "doc_url": "api/lynx-api/intersection-observer/intersection-observer-disconnect",
             "support": {
               "android": "1.5",
               "ios": "1.5",
@@ -50366,7 +50366,7 @@
           {
             "path": "lynx-api/intersection-observer/disconnect",
             "name": "Clear the target node and callback. The target node will no longer be observed and the corresponding callback will not be triggered.",
-            "doc_url": "api/lynx-api/intersection-observer/disconnect",
+            "doc_url": "api/lynx-api/intersection-observer/intersection-observer-disconnect",
             "support": {
               "android": "1.5",
               "ios": "1.5",
@@ -50382,7 +50382,7 @@
           {
             "path": "lynx-api/intersection-observer/observe",
             "name": "Specify the target node and callback, and the target node is specified according to id.",
-            "doc_url": "api/lynx-api/intersection-observer/observe",
+            "doc_url": "api/lynx-api/intersection-observer/intersection-observer-observe",
             "support": {
               "android": "1.5",
               "ios": "1.5",
@@ -50398,7 +50398,7 @@
           {
             "path": "lynx-api/intersection-observer/relativeTo",
             "name": "Specify a reference node. The reference node is specified by id.",
-            "doc_url": "api/lynx-api/intersection-observer/relative-to",
+            "doc_url": "api/lynx-api/intersection-observer/intersection-observer-relative-to",
             "support": {
               "android": "1.5",
               "ios": "1.5",
@@ -50414,7 +50414,7 @@
           {
             "path": "lynx-api/intersection-observer/relativeToScreen",
             "name": "Specify the screen as the reference node.",
-            "doc_url": "api/lynx-api/intersection-observer/relative-to-screen",
+            "doc_url": "api/lynx-api/intersection-observer/intersection-observer-relative-to-screen",
             "support": {
               "android": "2.10",
               "ios": "2.10",
@@ -50430,7 +50430,7 @@
           {
             "path": "lynx-api/intersection-observer/relativeToViewport",
             "name": "Specify a LynxView as a reference node.",
-            "doc_url": "api/lynx-api/intersection-observer/relative-to-viewport",
+            "doc_url": "api/lynx-api/intersection-observer/intersection-observer-relative-to-viewport",
             "support": {
               "android": "1.5",
               "ios": "1.5",
@@ -50448,7 +50448,7 @@
           {
             "path": "lynx-api/intersection-observer/IntersectionObserver",
             "name": "Observe the intersection status between the target node and the reference node and the target node and the ancestor node. When the intersection status changes, the corresponding callback is triggered. Based on this, you can monitor whether the target node is exposed/de-exposed.",
-            "doc_url": "api/lynx-api/intersection-observer/intersection-observer",
+            "doc_url": "api/lynx-api/intersection-observer",
             "support": {
               "android": "1.5",
               "ios": "1.5",
@@ -50464,7 +50464,7 @@
           {
             "path": "lynx-api/intersection-observer/IntersectionObserver.relativeTo",
             "name": "Specify a reference node. The reference node is specified by id.",
-            "doc_url": "api/lynx-api/intersection-observer/relative-to",
+            "doc_url": "api/lynx-api/intersection-observer/intersection-observer-relative-to",
             "support": {
               "android": "1.5",
               "ios": "1.5",
@@ -50480,7 +50480,7 @@
           {
             "path": "lynx-api/intersection-observer/IntersectionObserver.relativeToViewport",
             "name": "Specify a LynxView as a reference node.",
-            "doc_url": "api/lynx-api/intersection-observer/relative-to-viewport",
+            "doc_url": "api/lynx-api/intersection-observer/intersection-observer-relative-to-viewport",
             "support": {
               "android": "1.5",
               "ios": "1.5",
@@ -50496,7 +50496,7 @@
           {
             "path": "lynx-api/intersection-observer/IntersectionObserver.relativeToScreen",
             "name": "Specify the screen as the reference node.",
-            "doc_url": "api/lynx-api/intersection-observer/relative-to-screen",
+            "doc_url": "api/lynx-api/intersection-observer/intersection-observer-relative-to-screen",
             "support": {
               "android": "2.10",
               "ios": "2.10",
@@ -50512,7 +50512,7 @@
           {
             "path": "lynx-api/intersection-observer/IntersectionObserver.observe",
             "name": "Specify the target node and callback, and the target node is specified according to id.",
-            "doc_url": "api/lynx-api/intersection-observer/observe",
+            "doc_url": "api/lynx-api/intersection-observer/intersection-observer-observe",
             "support": {
               "android": "1.5",
               "ios": "1.5",
@@ -50528,7 +50528,7 @@
           {
             "path": "lynx-api/intersection-observer/IntersectionObserver.disconnect",
             "name": "Clear the target node and callback. The target node will no longer be observed and the corresponding callback will not be triggered.",
-            "doc_url": "api/lynx-api/intersection-observer/disconnect",
+            "doc_url": "api/lynx-api/intersection-observer/intersection-observer-disconnect",
             "support": {
               "android": "1.5",
               "ios": "1.5",
@@ -50544,7 +50544,7 @@
           {
             "path": "lynx-api/intersection-observer/disconnect",
             "name": "Clear the target node and callback. The target node will no longer be observed and the corresponding callback will not be triggered.",
-            "doc_url": "api/lynx-api/intersection-observer/disconnect",
+            "doc_url": "api/lynx-api/intersection-observer/intersection-observer-disconnect",
             "support": {
               "android": "1.5",
               "ios": "1.5",
@@ -50560,7 +50560,7 @@
           {
             "path": "lynx-api/intersection-observer/observe",
             "name": "Specify the target node and callback, and the target node is specified according to id.",
-            "doc_url": "api/lynx-api/intersection-observer/observe",
+            "doc_url": "api/lynx-api/intersection-observer/intersection-observer-observe",
             "support": {
               "android": "1.5",
               "ios": "1.5",
@@ -50576,7 +50576,7 @@
           {
             "path": "lynx-api/intersection-observer/relativeTo",
             "name": "Specify a reference node. The reference node is specified by id.",
-            "doc_url": "api/lynx-api/intersection-observer/relative-to",
+            "doc_url": "api/lynx-api/intersection-observer/intersection-observer-relative-to",
             "support": {
               "android": "1.5",
               "ios": "1.5",
@@ -50592,7 +50592,7 @@
           {
             "path": "lynx-api/intersection-observer/relativeToScreen",
             "name": "Specify the screen as the reference node.",
-            "doc_url": "api/lynx-api/intersection-observer/relative-to-screen",
+            "doc_url": "api/lynx-api/intersection-observer/intersection-observer-relative-to-screen",
             "support": {
               "android": "2.10",
               "ios": "2.10",
@@ -50608,7 +50608,7 @@
           {
             "path": "lynx-api/intersection-observer/relativeToViewport",
             "name": "Specify a LynxView as a reference node.",
-            "doc_url": "api/lynx-api/intersection-observer/relative-to-viewport",
+            "doc_url": "api/lynx-api/intersection-observer/intersection-observer-relative-to-viewport",
             "support": {
               "android": "1.5",
               "ios": "1.5",
@@ -50626,7 +50626,7 @@
           {
             "path": "lynx-api/intersection-observer/IntersectionObserver",
             "name": "Observe the intersection status between the target node and the reference node and the target node and the ancestor node. When the intersection status changes, the corresponding callback is triggered. Based on this, you can monitor whether the target node is exposed/de-exposed.",
-            "doc_url": "api/lynx-api/intersection-observer/intersection-observer",
+            "doc_url": "api/lynx-api/intersection-observer",
             "support": {
               "android": "1.5",
               "ios": "1.5",
@@ -50642,7 +50642,7 @@
           {
             "path": "lynx-api/intersection-observer/IntersectionObserver.relativeTo",
             "name": "Specify a reference node. The reference node is specified by id.",
-            "doc_url": "api/lynx-api/intersection-observer/relative-to",
+            "doc_url": "api/lynx-api/intersection-observer/intersection-observer-relative-to",
             "support": {
               "android": "1.5",
               "ios": "1.5",
@@ -50658,7 +50658,7 @@
           {
             "path": "lynx-api/intersection-observer/IntersectionObserver.relativeToViewport",
             "name": "Specify a LynxView as a reference node.",
-            "doc_url": "api/lynx-api/intersection-observer/relative-to-viewport",
+            "doc_url": "api/lynx-api/intersection-observer/intersection-observer-relative-to-viewport",
             "support": {
               "android": "1.5",
               "ios": "1.5",
@@ -50674,7 +50674,7 @@
           {
             "path": "lynx-api/intersection-observer/IntersectionObserver.relativeToScreen",
             "name": "Specify the screen as the reference node.",
-            "doc_url": "api/lynx-api/intersection-observer/relative-to-screen",
+            "doc_url": "api/lynx-api/intersection-observer/intersection-observer-relative-to-screen",
             "support": {
               "android": "2.10",
               "ios": "2.10",
@@ -50690,7 +50690,7 @@
           {
             "path": "lynx-api/intersection-observer/IntersectionObserver.observe",
             "name": "Specify the target node and callback, and the target node is specified according to id.",
-            "doc_url": "api/lynx-api/intersection-observer/observe",
+            "doc_url": "api/lynx-api/intersection-observer/intersection-observer-observe",
             "support": {
               "android": "1.5",
               "ios": "1.5",
@@ -50706,7 +50706,7 @@
           {
             "path": "lynx-api/intersection-observer/IntersectionObserver.disconnect",
             "name": "Clear the target node and callback. The target node will no longer be observed and the corresponding callback will not be triggered.",
-            "doc_url": "api/lynx-api/intersection-observer/disconnect",
+            "doc_url": "api/lynx-api/intersection-observer/intersection-observer-disconnect",
             "support": {
               "android": "1.5",
               "ios": "1.5",
@@ -50722,7 +50722,7 @@
           {
             "path": "lynx-api/intersection-observer/disconnect",
             "name": "Clear the target node and callback. The target node will no longer be observed and the corresponding callback will not be triggered.",
-            "doc_url": "api/lynx-api/intersection-observer/disconnect",
+            "doc_url": "api/lynx-api/intersection-observer/intersection-observer-disconnect",
             "support": {
               "android": "1.5",
               "ios": "1.5",
@@ -50738,7 +50738,7 @@
           {
             "path": "lynx-api/intersection-observer/observe",
             "name": "Specify the target node and callback, and the target node is specified according to id.",
-            "doc_url": "api/lynx-api/intersection-observer/observe",
+            "doc_url": "api/lynx-api/intersection-observer/intersection-observer-observe",
             "support": {
               "android": "1.5",
               "ios": "1.5",
@@ -50754,7 +50754,7 @@
           {
             "path": "lynx-api/intersection-observer/relativeTo",
             "name": "Specify a reference node. The reference node is specified by id.",
-            "doc_url": "api/lynx-api/intersection-observer/relative-to",
+            "doc_url": "api/lynx-api/intersection-observer/intersection-observer-relative-to",
             "support": {
               "android": "1.5",
               "ios": "1.5",
@@ -50770,7 +50770,7 @@
           {
             "path": "lynx-api/intersection-observer/relativeToScreen",
             "name": "Specify the screen as the reference node.",
-            "doc_url": "api/lynx-api/intersection-observer/relative-to-screen",
+            "doc_url": "api/lynx-api/intersection-observer/intersection-observer-relative-to-screen",
             "support": {
               "android": "2.10",
               "ios": "2.10",
@@ -50786,7 +50786,7 @@
           {
             "path": "lynx-api/intersection-observer/relativeToViewport",
             "name": "Specify a LynxView as a reference node.",
-            "doc_url": "api/lynx-api/intersection-observer/relative-to-viewport",
+            "doc_url": "api/lynx-api/intersection-observer/intersection-observer-relative-to-viewport",
             "support": {
               "android": "1.5",
               "ios": "1.5",
@@ -50894,7 +50894,7 @@
         {
           "path": "lynx-api/main-thread/Element.Element.animate",
           "name": "animate",
-          "doc_url": "api/lynx-api/main-thread/element-animate",
+          "doc_url": "api/lynx-api/main-thread/main-thread-element#elementanimate",
           "support": {
             "android": "3.4",
             "ios": "3.4",
@@ -50926,7 +50926,7 @@
         {
           "path": "lynx-api/main-thread/ElementAnimate",
           "name": "Create An Animation in MTS",
-          "doc_url": "api/lynx-api/main-thread/ElementAnimate",
+          "doc_url": "api/lynx-api/main-thread/lynx-animate-api",
           "support": {
             "android": "3.4",
             "ios": "3.4",
@@ -50942,7 +50942,7 @@
         {
           "path": "lynx-api/main-thread/ElementAnimate.Animation.play()",
           "name": "play()",
-          "doc_url": "api/lynx-api/main-thread/ElementAnimatePlay",
+          "doc_url": "api/lynx-api/main-thread/lynx-animate-api",
           "support": {
             "android": "3.4",
             "ios": "3.4",
@@ -50958,7 +50958,7 @@
         {
           "path": "lynx-api/main-thread/ElementAnimate.Animation.pause()",
           "name": "pause()",
-          "doc_url": "api/lynx-api/main-thread/ElementAnimatePause",
+          "doc_url": "api/lynx-api/main-thread/lynx-animate-api",
           "support": {
             "android": "3.4",
             "ios": "3.4",
@@ -50974,7 +50974,7 @@
         {
           "path": "lynx-api/main-thread/ElementAnimate.Animation.cancel()",
           "name": "cancel()",
-          "doc_url": "api/lynx-api/main-thread/ElementAnimateCancel",
+          "doc_url": "api/lynx-api/main-thread/lynx-animate-api",
           "support": {
             "android": "3.4",
             "ios": "3.4",
@@ -51006,7 +51006,7 @@
         {
           "path": "lynx-api/main-thread/ElementGetComputedStyle",
           "name": "Create An Animation in MTS",
-          "doc_url": "api/lynx-api/main-thread/ElementGetComputedStyle",
+          "doc_url": "api/lynx-api/main-thread/element-get-computed-style",
           "support": {
             "android": "3.5",
             "ios": "3.5",
@@ -51022,7 +51022,7 @@
         {
           "path": "lynx-api/main-thread/MainThread-APIs",
           "name": "APIs available on the main thread.",
-          "doc_url": "api/lynx-api/main-thread/main-thread",
+          "doc_url": "api/lynx-api/main-thread",
           "support": {
             "android": "2.14",
             "ios": "2.14",
@@ -51054,7 +51054,7 @@
         {
           "path": "lynx-api/main-thread/MainThread-APIs.Element.animate",
           "name": "animate",
-          "doc_url": "api/lynx-api/main-thread/element-animate",
+          "doc_url": "api/lynx-api/main-thread/main-thread-element#elementanimate",
           "support": {
             "android": "3.4",
             "ios": "3.4",
@@ -51118,7 +51118,7 @@
         {
           "path": "lynx-api/main-thread/MainThread-APIs.lynx.querySelectorAll",
           "name": "querySelectorAll",
-          "doc_url": "api/lynx-api/main-thread/lynx-query-selector-all",
+          "doc_url": "api/lynx-api/main-thread/lynx-query-select-all",
           "support": {
             "android": "2.14",
             "ios": "2.14",
@@ -51134,7 +51134,7 @@
         {
           "path": "lynx-api/main-thread/MainThread-APIs.lynx.requestAnimationFrame",
           "name": "requestAnimationFrame",
-          "doc_url": "api/lynx-api/main-thread/main-thread",
+          "doc_url": "api/lynx-api/main-thread/lynx-request-animation-frame",
           "support": {
             "android": "2.16",
             "ios": "2.16",
@@ -51171,7 +51171,7 @@
           {
             "path": "lynx-api/main-thread/Element.Element.animate",
             "name": "animate",
-            "doc_url": "api/lynx-api/main-thread/element-animate",
+            "doc_url": "api/lynx-api/main-thread/main-thread-element#elementanimate",
             "support": {
               "android": "3.4",
               "ios": "3.4",
@@ -51187,7 +51187,7 @@
           {
             "path": "lynx-api/main-thread/ElementAnimate",
             "name": "Create An Animation in MTS",
-            "doc_url": "api/lynx-api/main-thread/ElementAnimate",
+            "doc_url": "api/lynx-api/main-thread/lynx-animate-api",
             "support": {
               "android": "3.4",
               "ios": "3.4",
@@ -51203,7 +51203,7 @@
           {
             "path": "lynx-api/main-thread/ElementAnimate.Animation.play()",
             "name": "play()",
-            "doc_url": "api/lynx-api/main-thread/ElementAnimatePlay",
+            "doc_url": "api/lynx-api/main-thread/lynx-animate-api",
             "support": {
               "android": "3.4",
               "ios": "3.4",
@@ -51219,7 +51219,7 @@
           {
             "path": "lynx-api/main-thread/ElementAnimate.Animation.pause()",
             "name": "pause()",
-            "doc_url": "api/lynx-api/main-thread/ElementAnimatePause",
+            "doc_url": "api/lynx-api/main-thread/lynx-animate-api",
             "support": {
               "android": "3.4",
               "ios": "3.4",
@@ -51235,7 +51235,7 @@
           {
             "path": "lynx-api/main-thread/ElementAnimate.Animation.cancel()",
             "name": "cancel()",
-            "doc_url": "api/lynx-api/main-thread/ElementAnimateCancel",
+            "doc_url": "api/lynx-api/main-thread/lynx-animate-api",
             "support": {
               "android": "3.4",
               "ios": "3.4",
@@ -51267,7 +51267,7 @@
           {
             "path": "lynx-api/main-thread/MainThread-APIs.Element.animate",
             "name": "animate",
-            "doc_url": "api/lynx-api/main-thread/element-animate",
+            "doc_url": "api/lynx-api/main-thread/main-thread-element#elementanimate",
             "support": {
               "android": "3.4",
               "ios": "3.4",
@@ -51301,7 +51301,7 @@
           {
             "path": "lynx-api/main-thread/ElementGetComputedStyle",
             "name": "Create An Animation in MTS",
-            "doc_url": "api/lynx-api/main-thread/ElementGetComputedStyle",
+            "doc_url": "api/lynx-api/main-thread/element-get-computed-style",
             "support": {
               "android": "3.5",
               "ios": "3.5",
@@ -51365,7 +51365,7 @@
           {
             "path": "lynx-api/main-thread/MainThread-APIs.lynx.querySelectorAll",
             "name": "querySelectorAll",
-            "doc_url": "api/lynx-api/main-thread/lynx-query-selector-all",
+            "doc_url": "api/lynx-api/main-thread/lynx-query-select-all",
             "support": {
               "android": "2.14",
               "ios": "2.14",
@@ -51399,7 +51399,7 @@
           {
             "path": "lynx-api/main-thread/Element.Element.animate",
             "name": "animate",
-            "doc_url": "api/lynx-api/main-thread/element-animate",
+            "doc_url": "api/lynx-api/main-thread/main-thread-element#elementanimate",
             "support": {
               "android": "3.4",
               "ios": "3.4",
@@ -51431,7 +51431,7 @@
           {
             "path": "lynx-api/main-thread/ElementAnimate",
             "name": "Create An Animation in MTS",
-            "doc_url": "api/lynx-api/main-thread/ElementAnimate",
+            "doc_url": "api/lynx-api/main-thread/lynx-animate-api",
             "support": {
               "android": "3.4",
               "ios": "3.4",
@@ -51447,7 +51447,7 @@
           {
             "path": "lynx-api/main-thread/ElementAnimate.Animation.play()",
             "name": "play()",
-            "doc_url": "api/lynx-api/main-thread/ElementAnimatePlay",
+            "doc_url": "api/lynx-api/main-thread/lynx-animate-api",
             "support": {
               "android": "3.4",
               "ios": "3.4",
@@ -51463,7 +51463,7 @@
           {
             "path": "lynx-api/main-thread/ElementAnimate.Animation.pause()",
             "name": "pause()",
-            "doc_url": "api/lynx-api/main-thread/ElementAnimatePause",
+            "doc_url": "api/lynx-api/main-thread/lynx-animate-api",
             "support": {
               "android": "3.4",
               "ios": "3.4",
@@ -51479,7 +51479,7 @@
           {
             "path": "lynx-api/main-thread/ElementAnimate.Animation.cancel()",
             "name": "cancel()",
-            "doc_url": "api/lynx-api/main-thread/ElementAnimateCancel",
+            "doc_url": "api/lynx-api/main-thread/lynx-animate-api",
             "support": {
               "android": "3.4",
               "ios": "3.4",
@@ -51511,7 +51511,7 @@
           {
             "path": "lynx-api/main-thread/ElementGetComputedStyle",
             "name": "Create An Animation in MTS",
-            "doc_url": "api/lynx-api/main-thread/ElementGetComputedStyle",
+            "doc_url": "api/lynx-api/main-thread/element-get-computed-style",
             "support": {
               "android": "3.5",
               "ios": "3.5",
@@ -51527,7 +51527,7 @@
           {
             "path": "lynx-api/main-thread/MainThread-APIs",
             "name": "APIs available on the main thread.",
-            "doc_url": "api/lynx-api/main-thread/main-thread",
+            "doc_url": "api/lynx-api/main-thread",
             "support": {
               "android": "2.14",
               "ios": "2.14",
@@ -51559,7 +51559,7 @@
           {
             "path": "lynx-api/main-thread/MainThread-APIs.Element.animate",
             "name": "animate",
-            "doc_url": "api/lynx-api/main-thread/element-animate",
+            "doc_url": "api/lynx-api/main-thread/main-thread-element#elementanimate",
             "support": {
               "android": "3.4",
               "ios": "3.4",
@@ -51623,7 +51623,7 @@
           {
             "path": "lynx-api/main-thread/MainThread-APIs.lynx.querySelectorAll",
             "name": "querySelectorAll",
-            "doc_url": "api/lynx-api/main-thread/lynx-query-selector-all",
+            "doc_url": "api/lynx-api/main-thread/lynx-query-select-all",
             "support": {
               "android": "2.14",
               "ios": "2.14",
@@ -51639,7 +51639,7 @@
           {
             "path": "lynx-api/main-thread/MainThread-APIs.lynx.requestAnimationFrame",
             "name": "requestAnimationFrame",
-            "doc_url": "api/lynx-api/main-thread/main-thread",
+            "doc_url": "api/lynx-api/main-thread/lynx-request-animation-frame",
             "support": {
               "android": "2.16",
               "ios": "2.16",
@@ -51689,7 +51689,7 @@
           {
             "path": "lynx-api/main-thread/Element.Element.animate",
             "name": "animate",
-            "doc_url": "api/lynx-api/main-thread/element-animate",
+            "doc_url": "api/lynx-api/main-thread/main-thread-element#elementanimate",
             "support": {
               "android": "3.4",
               "ios": "3.4",
@@ -51721,7 +51721,7 @@
           {
             "path": "lynx-api/main-thread/ElementAnimate",
             "name": "Create An Animation in MTS",
-            "doc_url": "api/lynx-api/main-thread/ElementAnimate",
+            "doc_url": "api/lynx-api/main-thread/lynx-animate-api",
             "support": {
               "android": "3.4",
               "ios": "3.4",
@@ -51737,7 +51737,7 @@
           {
             "path": "lynx-api/main-thread/ElementAnimate.Animation.play()",
             "name": "play()",
-            "doc_url": "api/lynx-api/main-thread/ElementAnimatePlay",
+            "doc_url": "api/lynx-api/main-thread/lynx-animate-api",
             "support": {
               "android": "3.4",
               "ios": "3.4",
@@ -51753,7 +51753,7 @@
           {
             "path": "lynx-api/main-thread/ElementAnimate.Animation.pause()",
             "name": "pause()",
-            "doc_url": "api/lynx-api/main-thread/ElementAnimatePause",
+            "doc_url": "api/lynx-api/main-thread/lynx-animate-api",
             "support": {
               "android": "3.4",
               "ios": "3.4",
@@ -51769,7 +51769,7 @@
           {
             "path": "lynx-api/main-thread/ElementAnimate.Animation.cancel()",
             "name": "cancel()",
-            "doc_url": "api/lynx-api/main-thread/ElementAnimateCancel",
+            "doc_url": "api/lynx-api/main-thread/lynx-animate-api",
             "support": {
               "android": "3.4",
               "ios": "3.4",
@@ -51801,7 +51801,7 @@
           {
             "path": "lynx-api/main-thread/ElementGetComputedStyle",
             "name": "Create An Animation in MTS",
-            "doc_url": "api/lynx-api/main-thread/ElementGetComputedStyle",
+            "doc_url": "api/lynx-api/main-thread/element-get-computed-style",
             "support": {
               "android": "3.5",
               "ios": "3.5",
@@ -51817,7 +51817,7 @@
           {
             "path": "lynx-api/main-thread/MainThread-APIs",
             "name": "APIs available on the main thread.",
-            "doc_url": "api/lynx-api/main-thread/main-thread",
+            "doc_url": "api/lynx-api/main-thread",
             "support": {
               "android": "2.14",
               "ios": "2.14",
@@ -51849,7 +51849,7 @@
           {
             "path": "lynx-api/main-thread/MainThread-APIs.Element.animate",
             "name": "animate",
-            "doc_url": "api/lynx-api/main-thread/element-animate",
+            "doc_url": "api/lynx-api/main-thread/main-thread-element#elementanimate",
             "support": {
               "android": "3.4",
               "ios": "3.4",
@@ -51913,7 +51913,7 @@
           {
             "path": "lynx-api/main-thread/MainThread-APIs.lynx.querySelectorAll",
             "name": "querySelectorAll",
-            "doc_url": "api/lynx-api/main-thread/lynx-query-selector-all",
+            "doc_url": "api/lynx-api/main-thread/lynx-query-select-all",
             "support": {
               "android": "2.14",
               "ios": "2.14",
@@ -51929,7 +51929,7 @@
           {
             "path": "lynx-api/main-thread/MainThread-APIs.lynx.requestAnimationFrame",
             "name": "requestAnimationFrame",
-            "doc_url": "api/lynx-api/main-thread/main-thread",
+            "doc_url": "api/lynx-api/main-thread/lynx-request-animation-frame",
             "support": {
               "android": "2.16",
               "ios": "2.16",
@@ -52187,7 +52187,7 @@
         {
           "path": "lynx-api/performance-api/performance-entry/entry-type",
           "name": "entry-type",
-          "doc_url": "api/lynx-api/performance-api/performance-entry/entry-type",
+          "doc_url": "api/lynx-api/performance-api/performance-entry#entrytype",
           "support": {
             "android": "3.1",
             "ios": "3.1",
@@ -52843,7 +52843,7 @@
         {
           "path": "lynx-api/performance-api/performance-entry/name",
           "name": "name",
-          "doc_url": "api/lynx-api/performance-api/performance-entry/name",
+          "doc_url": "api/lynx-api/performance-api/performance-entry#name",
           "support": {
             "android": "3.1",
             "ios": "3.1",
@@ -53771,7 +53771,7 @@
         {
           "path": "lynx-api/performance-api/timing-flag",
           "name": "timing-flag",
-          "doc_url": "guide/performance/timing-flag",
+          "doc_url": "guide/performance/monitor-performance/timing-flag",
           "support": {
             "android": "3.1",
             "ios": "3.1",
@@ -53874,7 +53874,7 @@
           {
             "path": "lynx-api/performance-api/performance-entry/entry-type",
             "name": "entry-type",
-            "doc_url": "api/lynx-api/performance-api/performance-entry/entry-type",
+            "doc_url": "api/lynx-api/performance-api/performance-entry#entrytype",
             "support": {
               "android": "3.1",
               "ios": "3.1",
@@ -54530,7 +54530,7 @@
           {
             "path": "lynx-api/performance-api/performance-entry/name",
             "name": "name",
-            "doc_url": "api/lynx-api/performance-api/performance-entry/name",
+            "doc_url": "api/lynx-api/performance-api/performance-entry#name",
             "support": {
               "android": "3.1",
               "ios": "3.1",
@@ -55458,7 +55458,7 @@
           {
             "path": "lynx-api/performance-api/timing-flag",
             "name": "timing-flag",
-            "doc_url": "guide/performance/timing-flag",
+            "doc_url": "guide/performance/monitor-performance/timing-flag",
             "support": {
               "android": "3.1",
               "ios": "3.1",
@@ -55540,7 +55540,7 @@
           {
             "path": "lynx-api/performance-api/performance-entry/entry-type",
             "name": "entry-type",
-            "doc_url": "api/lynx-api/performance-api/performance-entry/entry-type",
+            "doc_url": "api/lynx-api/performance-api/performance-entry#entrytype",
             "support": {
               "android": "3.1",
               "ios": "3.1",
@@ -56196,7 +56196,7 @@
           {
             "path": "lynx-api/performance-api/performance-entry/name",
             "name": "name",
-            "doc_url": "api/lynx-api/performance-api/performance-entry/name",
+            "doc_url": "api/lynx-api/performance-api/performance-entry#name",
             "support": {
               "android": "3.1",
               "ios": "3.1",
@@ -57124,7 +57124,7 @@
           {
             "path": "lynx-api/performance-api/timing-flag",
             "name": "timing-flag",
-            "doc_url": "guide/performance/timing-flag",
+            "doc_url": "guide/performance/monitor-performance/timing-flag",
             "support": {
               "android": "3.1",
               "ios": "3.1",
@@ -64709,7 +64709,7 @@
         {
           "path": "react/main-thread/MainThread-APIs",
           "name": "APIs available on the main thread.",
-          "doc_url": "api/react/main-thread",
+          "doc_url": "react/main-thread-script",
           "support": {
             "android": "2.14",
             "ios": "2.14",
@@ -64725,7 +64725,7 @@
         {
           "path": "react/main-thread/MainThread-APIs.runOnBackground",
           "name": "runOnBackground: Create a value that can be shared between main thread scripts.",
-          "doc_url": "api/react/main-thread",
+          "doc_url": "api/react/Function.runOnBackground",
           "support": {
             "android": "2.16",
             "ios": "2.16",
@@ -64748,7 +64748,7 @@
           {
             "path": "react/main-thread/MainThread-APIs",
             "name": "APIs available on the main thread.",
-            "doc_url": "api/react/main-thread",
+            "doc_url": "react/main-thread-script",
             "support": {
               "android": "2.14",
               "ios": "2.14",
@@ -64764,7 +64764,7 @@
           {
             "path": "react/main-thread/MainThread-APIs.runOnBackground",
             "name": "runOnBackground: Create a value that can be shared between main thread scripts.",
-            "doc_url": "api/react/main-thread",
+            "doc_url": "api/react/Function.runOnBackground",
             "support": {
               "android": "2.16",
               "ios": "2.16",
@@ -64782,7 +64782,7 @@
           {
             "path": "react/main-thread/MainThread-APIs",
             "name": "APIs available on the main thread.",
-            "doc_url": "api/react/main-thread",
+            "doc_url": "react/main-thread-script",
             "support": {
               "android": "2.14",
               "ios": "2.14",
@@ -64798,7 +64798,7 @@
           {
             "path": "react/main-thread/MainThread-APIs.runOnBackground",
             "name": "runOnBackground: Create a value that can be shared between main thread scripts.",
-            "doc_url": "api/react/main-thread",
+            "doc_url": "api/react/Function.runOnBackground",
             "support": {
               "android": "2.16",
               "ios": "2.16",
@@ -64816,7 +64816,7 @@
           {
             "path": "react/main-thread/MainThread-APIs",
             "name": "APIs available on the main thread.",
-            "doc_url": "api/react/main-thread",
+            "doc_url": "react/main-thread-script",
             "support": {
               "android": "2.14",
               "ios": "2.14",
@@ -64832,7 +64832,7 @@
           {
             "path": "react/main-thread/MainThread-APIs.runOnBackground",
             "name": "runOnBackground: Create a value that can be shared between main thread scripts.",
-            "doc_url": "api/react/main-thread",
+            "doc_url": "api/react/Function.runOnBackground",
             "support": {
               "android": "2.16",
               "ios": "2.16",
@@ -64850,7 +64850,7 @@
           {
             "path": "react/main-thread/MainThread-APIs",
             "name": "APIs available on the main thread.",
-            "doc_url": "api/react/main-thread",
+            "doc_url": "react/main-thread-script",
             "support": {
               "android": "2.14",
               "ios": "2.14",
@@ -64866,7 +64866,7 @@
           {
             "path": "react/main-thread/MainThread-APIs.runOnBackground",
             "name": "runOnBackground: Create a value that can be shared between main thread scripts.",
-            "doc_url": "api/react/main-thread",
+            "doc_url": "api/react/Function.runOnBackground",
             "support": {
               "android": "2.16",
               "ios": "2.16",
@@ -64884,7 +64884,7 @@
           {
             "path": "react/main-thread/MainThread-APIs",
             "name": "APIs available on the main thread.",
-            "doc_url": "api/react/main-thread",
+            "doc_url": "react/main-thread-script",
             "support": {
               "android": "2.14",
               "ios": "2.14",
@@ -64900,7 +64900,7 @@
           {
             "path": "react/main-thread/MainThread-APIs.runOnBackground",
             "name": "runOnBackground: Create a value that can be shared between main thread scripts.",
-            "doc_url": "api/react/main-thread",
+            "doc_url": "api/react/Function.runOnBackground",
             "support": {
               "android": "2.16",
               "ios": "2.16",
@@ -68903,7 +68903,7 @@
       "path": "lynx-api/fetch/fetch",
       "name": "<code>fetch</code>",
       "category": "lynx-api/fetch",
-      "doc_url": "guide/networking",
+      "doc_url": "guide/interaction/networking",
       "versions": {
         "android": "2.18",
         "ios": "2.18",

--- a/packages/lynx-compat-data/css/properties-manual/custom-property.json
+++ b/packages/lynx-compat-data/css/properties-manual/custom-property.json
@@ -3,7 +3,7 @@
     "properties": {
       "custom-property": {
         "__compat": {
-          "lynx_path": "api/css/properties/custom-properties",
+          "lynx_path": "api/css/properties/css-variable",
           "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/--%2A",
           "spec_url": [],
           "status": {

--- a/packages/lynx-compat-data/lynx-api/fetch/fetch.json
+++ b/packages/lynx-compat-data/lynx-api/fetch/fetch.json
@@ -4,7 +4,7 @@
       "fetch": {
         "__compat": {
           "description": "<code>fetch</code>",
-          "lynx_path": "guide/networking",
+          "lynx_path": "guide/interaction/networking",
           "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch",
           "support": {
             "android": {

--- a/packages/lynx-compat-data/lynx-api/intersection-observer/IntersectionObserver.json
+++ b/packages/lynx-compat-data/lynx-api/intersection-observer/IntersectionObserver.json
@@ -4,7 +4,7 @@
       "IntersectionObserver": {
         "__compat": {
           "description": "Observe the intersection status between the target node and the reference node and the target node and the ancestor node. When the intersection status changes, the corresponding callback is triggered. Based on this, you can monitor whether the target node is exposed/de-exposed.",
-          "lynx_path": "api/lynx-api/intersection-observer/intersection-observer",
+          "lynx_path": "api/lynx-api/intersection-observer",
           "support": {
             "android": {
               "version_added": "1.5"
@@ -29,7 +29,7 @@
         "relativeTo": {
           "__compat": {
             "description": "Specify a reference node. The reference node is specified by id.",
-            "lynx_path": "api/lynx-api/intersection-observer/relative-to",
+            "lynx_path": "api/lynx-api/intersection-observer/intersection-observer-relative-to",
             "support": {
               "android": {
                 "version_added": "1.5"
@@ -55,7 +55,7 @@
         "relativeToViewport": {
           "__compat": {
             "description": "Specify a LynxView as a reference node.",
-            "lynx_path": "api/lynx-api/intersection-observer/relative-to-viewport",
+            "lynx_path": "api/lynx-api/intersection-observer/intersection-observer-relative-to-viewport",
             "support": {
               "android": {
                 "version_added": "1.5"
@@ -81,7 +81,7 @@
         "relativeToScreen": {
           "__compat": {
             "description": "Specify the screen as the reference node.",
-            "lynx_path": "api/lynx-api/intersection-observer/relative-to-screen",
+            "lynx_path": "api/lynx-api/intersection-observer/intersection-observer-relative-to-screen",
             "support": {
               "android": {
                 "version_added": "2.10"
@@ -107,7 +107,7 @@
         "observe": {
           "__compat": {
             "description": "Specify the target node and callback, and the target node is specified according to id.",
-            "lynx_path": "api/lynx-api/intersection-observer/observe",
+            "lynx_path": "api/lynx-api/intersection-observer/intersection-observer-observe",
             "support": {
               "android": {
                 "version_added": "1.5"
@@ -133,7 +133,7 @@
         "disconnect": {
           "__compat": {
             "description": "Clear the target node and callback. The target node will no longer be observed and the corresponding callback will not be triggered.",
-            "lynx_path": "api/lynx-api/intersection-observer/disconnect",
+            "lynx_path": "api/lynx-api/intersection-observer/intersection-observer-disconnect",
             "support": {
               "android": {
                 "version_added": "1.5"

--- a/packages/lynx-compat-data/lynx-api/intersection-observer/disconnect.json
+++ b/packages/lynx-compat-data/lynx-api/intersection-observer/disconnect.json
@@ -4,7 +4,7 @@
       "disconnect": {
         "__compat": {
           "description": "Clear the target node and callback. The target node will no longer be observed and the corresponding callback will not be triggered.",
-          "lynx_path": "api/lynx-api/intersection-observer/disconnect",
+          "lynx_path": "api/lynx-api/intersection-observer/intersection-observer-disconnect",
           "support": {
             "android": {
               "version_added": "1.5"

--- a/packages/lynx-compat-data/lynx-api/intersection-observer/observe.json
+++ b/packages/lynx-compat-data/lynx-api/intersection-observer/observe.json
@@ -4,7 +4,7 @@
       "observe": {
         "__compat": {
           "description": "Specify the target node and callback, and the target node is specified according to id.",
-          "lynx_path": "api/lynx-api/intersection-observer/observe",
+          "lynx_path": "api/lynx-api/intersection-observer/intersection-observer-observe",
           "support": {
             "android": {
               "version_added": "1.5"

--- a/packages/lynx-compat-data/lynx-api/intersection-observer/relativeTo.json
+++ b/packages/lynx-compat-data/lynx-api/intersection-observer/relativeTo.json
@@ -4,7 +4,7 @@
       "relativeTo": {
         "__compat": {
           "description": "Specify a reference node. The reference node is specified by id.",
-          "lynx_path": "api/lynx-api/intersection-observer/relative-to",
+          "lynx_path": "api/lynx-api/intersection-observer/intersection-observer-relative-to",
           "support": {
             "android": {
               "version_added": "1.5"

--- a/packages/lynx-compat-data/lynx-api/intersection-observer/relativeToScreen.json
+++ b/packages/lynx-compat-data/lynx-api/intersection-observer/relativeToScreen.json
@@ -4,7 +4,7 @@
       "relativeToScreen": {
         "__compat": {
           "description": "Specify the screen as the reference node.",
-          "lynx_path": "api/lynx-api/intersection-observer/relative-to-screen",
+          "lynx_path": "api/lynx-api/intersection-observer/intersection-observer-relative-to-screen",
           "support": {
             "android": {
               "version_added": "2.10"

--- a/packages/lynx-compat-data/lynx-api/intersection-observer/relativeToViewport.json
+++ b/packages/lynx-compat-data/lynx-api/intersection-observer/relativeToViewport.json
@@ -4,7 +4,7 @@
       "relativeToViewport": {
         "__compat": {
           "description": "Specify a LynxView as a reference node.",
-          "lynx_path": "api/lynx-api/intersection-observer/relative-to-viewport",
+          "lynx_path": "api/lynx-api/intersection-observer/intersection-observer-relative-to-viewport",
           "support": {
             "android": {
               "version_added": "1.5"

--- a/packages/lynx-compat-data/lynx-api/lynx/animateAPI.json
+++ b/packages/lynx-compat-data/lynx-api/lynx/animateAPI.json
@@ -5,7 +5,7 @@
         "compat": {
           "__compat": {
             "description": "Used to import modules.",
-            "lynx_path": "api/lynx-api/lynx/lynx-animate_api",
+            "lynx_path": "api/lynx-api/lynx/lynx-animate-api",
             "support": {
               "android": {
                 "version_added": "1.6"
@@ -31,7 +31,7 @@
         "multiple animation implementation": {
           "__compat": {
             "description": "Multiple animate",
-            "lynx_path": "api/lynx-api/lynx/lynx-animate_api",
+            "lynx_path": "api/lynx-api/lynx/lynx-animate-api",
             "support": {
               "android": {
                 "version_added": "3.4"

--- a/packages/lynx-compat-data/lynx-api/lynx/querySelectorAll.json
+++ b/packages/lynx-compat-data/lynx-api/lynx/querySelectorAll.json
@@ -4,7 +4,7 @@
       "querySelectorAll": {
         "__compat": {
           "description": "",
-          "lynx_path": "api/lynx-api/main-thread/lynx-query-selector-all",
+          "lynx_path": "api/lynx-api/main-thread/lynx-query-select-all",
           "spec_url": [],
           "status": {
             "deprecated": false,

--- a/packages/lynx-compat-data/lynx-api/lynx/queueMicrotask.json
+++ b/packages/lynx-compat-data/lynx-api/lynx/queueMicrotask.json
@@ -4,7 +4,7 @@
       "queueMicrotask": {
         "__compat": {
           "description": "insert a task into microtask queue",
-          "lynx_path": "api/lynx-api/lynx/queueMicrotask",
+          "lynx_path": "api/lynx-api/lynx/lynx-queue-microtask",
           "support": {
             "android": {
               "version_added": "3.1"

--- a/packages/lynx-compat-data/lynx-api/lynx/resumeExposure.json
+++ b/packages/lynx-compat-data/lynx-api/lynx/resumeExposure.json
@@ -4,7 +4,7 @@
       "resumeExposure": {
         "__compat": {
           "description": "Turn on exposure detection, that is, to restart the detection of the visibility of the target node, and subsequently trigger the exposure/anti-exposure event normally.",
-          "lynx_path": "api/lynx-api/lynx/resume-exposure",
+          "lynx_path": "api/lynx-api/lynx/lynx-resume-exposure",
           "support": {
             "android": {
               "version_added": "2.9"

--- a/packages/lynx-compat-data/lynx-api/lynx/setObserverFrameRate.json
+++ b/packages/lynx-compat-data/lynx-api/lynx/setObserverFrameRate.json
@@ -4,7 +4,7 @@
       "setObserverFrameRate": {
         "__compat": {
           "description": "Set the frequency of exposure detection.",
-          "lynx_path": "api/lynx-api/lynx/set-observer-frame-rate",
+          "lynx_path": "api/lynx-api/lynx/lynx-set-observer-frame-rate",
           "support": {
             "android": {
               "version_added": "2.15"

--- a/packages/lynx-compat-data/lynx-api/lynx/stopExposure.json
+++ b/packages/lynx-compat-data/lynx-api/lynx/stopExposure.json
@@ -4,7 +4,7 @@
       "stopExposure": {
         "__compat": {
           "description": "Stop exposure detection, that is, the visibility of the target node will no longer be detected, and exposure/anti-exposure events will no longer be triggered in the future.",
-          "lynx_path": "api/lynx-api/lynx/stop-exposure",
+          "lynx_path": "api/lynx-api/lynx/lynx-stop-exposure",
           "support": {
             "android": {
               "version_added": "2.9"

--- a/packages/lynx-compat-data/lynx-api/main-thread/Element.json
+++ b/packages/lynx-compat-data/lynx-api/main-thread/Element.json
@@ -36,7 +36,7 @@
         "Element.animate": {
           "__compat": {
             "description": "",
-            "lynx_path": "api/lynx-api/main-thread/element-animate",
+            "lynx_path": "api/lynx-api/main-thread/main-thread-element#elementanimate",
             "spec_url": [],
             "status": {
               "deprecated": false

--- a/packages/lynx-compat-data/lynx-api/main-thread/ElementAnimate.json
+++ b/packages/lynx-compat-data/lynx-api/main-thread/ElementAnimate.json
@@ -4,7 +4,7 @@
       "ElementAnimate": {
         "__compat": {
           "description": "Create An Animation in MTS",
-          "lynx_path": "api/lynx-api/main-thread/ElementAnimate",
+          "lynx_path": "api/lynx-api/main-thread/lynx-animate-api",
           "spec_url": [],
           "status": {
             "deprecated": false
@@ -30,7 +30,7 @@
         "Animation.play()": {
           "__compat": {
             "description": "",
-            "lynx_path": "api/lynx-api/main-thread/ElementAnimatePlay",
+            "lynx_path": "api/lynx-api/main-thread/lynx-animate-api",
             "spec_url": [],
             "status": {
               "deprecated": false
@@ -57,7 +57,7 @@
         "Animation.pause()": {
           "__compat": {
             "description": "",
-            "lynx_path": "api/lynx-api/main-thread/ElementAnimatePause",
+            "lynx_path": "api/lynx-api/main-thread/lynx-animate-api",
             "spec_url": [],
             "status": {
               "deprecated": false
@@ -84,7 +84,7 @@
         "Animation.cancel()": {
           "__compat": {
             "description": "",
-            "lynx_path": "api/lynx-api/main-thread/ElementAnimateCancel",
+            "lynx_path": "api/lynx-api/main-thread/lynx-animate-api",
             "spec_url": [],
             "status": {
               "deprecated": false

--- a/packages/lynx-compat-data/lynx-api/main-thread/ElementGetComputedStyle.json
+++ b/packages/lynx-compat-data/lynx-api/main-thread/ElementGetComputedStyle.json
@@ -4,7 +4,7 @@
       "ElementGetComputedStyle": {
         "__compat": {
           "description": "Create An Animation in MTS",
-          "lynx_path": "api/lynx-api/main-thread/ElementGetComputedStyle",
+          "lynx_path": "api/lynx-api/main-thread/element-get-computed-style",
           "spec_url": [],
           "status": {
             "deprecated": false

--- a/packages/lynx-compat-data/lynx-api/main-thread/MainThread-APIs.json
+++ b/packages/lynx-compat-data/lynx-api/main-thread/MainThread-APIs.json
@@ -4,7 +4,7 @@
       "MainThread-APIs": {
         "__compat": {
           "description": "APIs available on the main thread.",
-          "lynx_path": "api/lynx-api/main-thread/main-thread",
+          "lynx_path": "api/lynx-api/main-thread",
           "spec_url": [],
           "status": {
             "deprecated": false
@@ -67,7 +67,7 @@
         "Element.animate": {
           "__compat": {
             "description": "",
-            "lynx_path": "api/lynx-api/main-thread/element-animate",
+            "lynx_path": "api/lynx-api/main-thread/main-thread-element#elementanimate",
             "spec_url": [],
             "status": {
               "deprecated": false
@@ -184,7 +184,7 @@
         "lynx.querySelectorAll": {
           "__compat": {
             "description": "",
-            "lynx_path": "api/lynx-api/main-thread/lynx-query-selector-all",
+            "lynx_path": "api/lynx-api/main-thread/lynx-query-select-all",
             "spec_url": [],
             "status": {
               "deprecated": false
@@ -214,7 +214,7 @@
         "lynx.requestAnimationFrame": {
           "__compat": {
             "description": "",
-            "lynx_path": "api/lynx-api/main-thread/main-thread",
+            "lynx_path": "api/lynx-api/main-thread/lynx-request-animation-frame",
             "spec_url": [],
             "status": {
               "deprecated": false

--- a/packages/lynx-compat-data/lynx-api/nodes-ref/NodesRef.json
+++ b/packages/lynx-compat-data/lynx-api/nodes-ref/NodesRef.json
@@ -4,7 +4,7 @@
       "NodesRef": {
         "__compat": {
           "description": "Represents a reference to one or more UI nodes. It can be used to call methods, get and set properties on UI nodes.",
-          "lynx_path": "api/lynx-api/nodes-ref/nodes-ref",
+          "lynx_path": "api/lynx-api/nodes-ref",
           "support": {
             "android": {
               "version_added": "2.2"

--- a/packages/lynx-compat-data/lynx-api/performance-api/performance-entry/entry-type.json
+++ b/packages/lynx-compat-data/lynx-api/performance-api/performance-entry/entry-type.json
@@ -5,7 +5,7 @@
         "entry-type": {
           "__compat": {
             "description": "",
-            "lynx_path": "api/lynx-api/performance-api/performance-entry/entry-type",
+            "lynx_path": "api/lynx-api/performance-api/performance-entry#entrytype",
             "support": {
               "android": {
                 "version_added": "3.1"

--- a/packages/lynx-compat-data/lynx-api/performance-api/performance-entry/name.json
+++ b/packages/lynx-compat-data/lynx-api/performance-api/performance-entry/name.json
@@ -5,7 +5,7 @@
         "name": {
           "__compat": {
             "description": "",
-            "lynx_path": "api/lynx-api/performance-api/performance-entry/name",
+            "lynx_path": "api/lynx-api/performance-api/performance-entry#name",
             "support": {
               "android": {
                 "version_added": "3.1"

--- a/packages/lynx-compat-data/lynx-api/performance-api/timing-flag.json
+++ b/packages/lynx-compat-data/lynx-api/performance-api/timing-flag.json
@@ -4,7 +4,7 @@
       "timing-flag": {
         "__compat": {
           "description": "",
-          "lynx_path": "guide/performance/timing-flag",
+          "lynx_path": "guide/performance/monitor-performance/timing-flag",
           "support": {
             "android": {
               "version_added": "3.1"

--- a/packages/lynx-compat-data/lynx-api/selector-query/SelectorQuery.json
+++ b/packages/lynx-compat-data/lynx-api/selector-query/SelectorQuery.json
@@ -4,7 +4,7 @@
       "SelectorQuery": {
         "__compat": {
           "description": "Gets a reference to the specified node in order to call its methods or get its properties.",
-          "lynx_path": "api/lynx-api/selector-query/selector-query",
+          "lynx_path": "api/lynx-api/selector-query",
           "support": {
             "android": {
               "version_added": "2.2"

--- a/packages/lynx-compat-data/react/main-thread/MainThread-APIs.json
+++ b/packages/lynx-compat-data/react/main-thread/MainThread-APIs.json
@@ -4,7 +4,7 @@
       "MainThread-APIs": {
         "__compat": {
           "description": "APIs available on the main thread.",
-          "lynx_path": "api/react/main-thread",
+          "lynx_path": "react/main-thread-script",
           "spec_url": [],
           "status": {
             "deprecated": false,
@@ -28,7 +28,7 @@
         "runOnBackground": {
           "__compat": {
             "description": "runOnBackground: Create a value that can be shared between main thread scripts.",
-            "lynx_path": "api/react/main-thread",
+            "lynx_path": "api/react/Function.runOnBackground",
             "spec_url": [],
             "status": {
               "deprecated": false,


### PR DESCRIPTION
## Summary

Backport the `lynx_path` data corrections from #1337 to release/4.0, without backporting its stats-generator or documentation-route validation changes.

- Backport 37 verified `lynx_path` redirects to the release/4.0 documentation routes.
- Regenerate the tracked `api-stats.json` so the API Status Dashboard consumes the corrected `doc_url` values.

## Scope

- Deliberately excludes the main branch's `doc-routes` helper, `--docs-root` option, and generated-link validation behavior.
- Retains the six unresolved entries that need generator or API-data follow-up: five undocumented APIs and `Animation.finish()`.

## Validation

- `pnpm run prepare`
- `pnpm --filter @lynx-js/lynx-compat-data run lint`
- `pnpm --filter @lynx-js/lynx-compat-data test`
- `pnpm run build`