### PR TITLE
fix(docs): label code fences with the language they contain

### DIFF
--- a/docs/en/api/elements/built-in/image.mdx
+++ b/docs/en/api/elements/built-in/image.mdx
@@ -176,7 +176,7 @@ The following example shows how to map a URL like `http://localhost/xxx` to an a
 
 <PlatformTabs.Tab platform="android">
 
-```java
+```kotlin
 import com.lynx.tasm.resourceprovider.LynxResourceRequest
 import com.lynx.tasm.resourceprovider.media.LynxMediaResourceFetcher
 import com.lynx.tasm.resourceprovider.media.OptionalBool

--- a/docs/en/api/elements/built-in/scroll-view.mdx
+++ b/docs/en/api/elements/built-in/scroll-view.mdx
@@ -62,7 +62,7 @@ As a child node of `<scroll-view>`, you can set the `sticky` attribute making th
 The direct child nodes of `<scroll-view>` only support `linear` and `sticky`. If you need more complex layouts, such as child nodes adapting to expand, it is recommended to provide a single child view to the `<scroll-view>` and implement more robust CSS capabilities within that single child node.
 
 ```javascript
-<scroll-view> scroll-y>
+<scroll-view scroll-orientation="vertical">
   <view> // do anything you want
   {...}
   </view>

--- a/docs/en/api/lynx-native-api/trace-event.mdx
+++ b/docs/en/api/lynx-native-api/trace-event.mdx
@@ -170,7 +170,7 @@ The name of the trace event.
 
 Marks an instant trace event.
 
-```java
+```objective-c
 + (void)instant:(NSString *)category withName:(NSString *)name
 + (void)instant:(NSString *)category withName:(NSString *)name debugInfo:(NSDictionary *)args
 ```
@@ -201,7 +201,7 @@ Custom arguments for the trace event.
 
 Marks the start of a [trace event](https://perfetto.dev/docs/instrumentation/track-events).
 
-```javascript
+```typescript
 static void beginSection(traceCategory: TraceCategory, name: string, args?: Record<string, string>)
 ```
 
@@ -209,7 +209,7 @@ static void beginSection(traceCategory: TraceCategory, name: string, args?: Reco
 
 ##### category
 The [category](https://perfetto.dev/docs/instrumentation/track-events#category-configuration) of the trace event. 
-```javascript
+```typescript
 export enum TraceCategory {
   Lynx = 'lynx',
   Vitals = 'vitals',
@@ -245,7 +245,7 @@ TraceEvent.endSection(TraceCategory.Other, "draw-image");
 
 Marks the end of a [trace event](https://perfetto.dev/docs/instrumentation/track-events).
 
-```javascript
+```typescript
 static void endSection(traceCategory: TraceCategory, name: string)
 ```
 
@@ -253,7 +253,7 @@ static void endSection(traceCategory: TraceCategory, name: string)
 
 ##### category
 The [category](https://perfetto.dev/docs/instrumentation/track-events#category-configuration) of the trace event.
-```javascript
+```typescript
 export enum TraceCategory {
   Lynx = 'lynx',
   Vitals = 'vitals',
@@ -276,7 +276,7 @@ TraceEvent.endSection(TraceCategory.Other, "parse-data");
 
 Marks an instant trace event.
 
-```javascript
+```typescript
 static instant(traceCategory: TraceCategory, name: string, args?: Record<string, string>)
 ```
 

--- a/docs/en/guide/custom-native-modules/native-module-ios.mdx
+++ b/docs/en/guide/custom-native-modules/native-module-ios.mdx
@@ -106,7 +106,7 @@ static NSString *const NativeLocalStorageKey = @"MyLocalStorage";
 Lynx Explorer is a project built with Objective-C. If you wish to implement a native module with Swift, please refer to [Importing Objective-C into Swift](https://developer.apple.com/documentation/swift/importing-objective-c-into-swift) to import the required Lynx header file `LynxModule.h`.
 :::
 
-```swift title="explorer/darwin/ios/lynx_explorer/LynxExplorer/modules/LynxExplorer-Bridging-Header.h"
+```objective-c title="explorer/darwin/ios/lynx_explorer/LynxExplorer/modules/LynxExplorer-Bridging-Header.h"
 
 //
 //  Use this file to import your target's public headers that you would like to expose to Swift.

--- a/docs/en/guide/start/fragments/macos/integrating-lynx-with-existing-app-macos.mdx
+++ b/docs/en/guide/start/fragments/macos/integrating-lynx-with-existing-app-macos.mdx
@@ -200,7 +200,7 @@ Impl Resource Fetcher
 
 <CodeFold toggle>
 
-```objective-c title=ExampleGenericResourceFetcher.h {9,12-19}
+```cpp title=ExampleGenericResourceFetcher.h {9,12-19}
 #import <Foundation/Foundation.h>
 #import "lynx_generic_resource_fetcher.h"
 

--- a/docs/en/guide/ui/layout/scroll-view.mdx
+++ b/docs/en/guide/ui/layout/scroll-view.mdx
@@ -1,0 +1,1 @@
+# `<scroll-view>`

--- a/docs/zh/api/elements/built-in/image.mdx
+++ b/docs/zh/api/elements/built-in/image.mdx
@@ -473,7 +473,7 @@ lynx.createSelectorQuery()
 
 <PlatformTabs.Tab platform="android">
 
-```java
+```kotlin
 import com.lynx.tasm.resourceprovider.LynxResourceRequest
 import com.lynx.tasm.resourceprovider.media.LynxMediaResourceFetcher
 import com.lynx.tasm.resourceprovider.media.OptionalBool

--- a/docs/zh/api/lynx-native-api/trace-event.mdx
+++ b/docs/zh/api/lynx-native-api/trace-event.mdx
@@ -170,7 +170,7 @@ trace event 的名称。
 
 标记一个即时(没有持续时间) trace event。
 
-```java
+```objective-c
 + (void)instant:(NSString *)category withName:(NSString *)name
 + (void)instant:(NSString *)category withName:(NSString *)name debugInfo:(NSDictionary *)args
 ```
@@ -202,7 +202,7 @@ trace event 的名称。
 
 标记一个 [trace event](https://perfetto.dev/docs/instrumentation/track-events) 的开始。
 
-```java
+```typescript
 static void beginSection(traceCategory: TraceCategory, name: string, args?: Record<string, string>)
 ```
 
@@ -210,7 +210,7 @@ static void beginSection(traceCategory: TraceCategory, name: string, args?: Reco
 
 ##### category
 trace event 的[类别](https://perfetto.dev/docs/instrumentation/track-events#category-configuration)。
-```javascript
+```typescript
 export enum TraceCategory {
   Lynx = 'lynx',
   Vitals = 'vitals',
@@ -246,7 +246,7 @@ TraceEvent.endSection(TraceCategory.Other, "draw-image");
 
 标记一个 [trace event](https://perfetto.dev/docs/instrumentation/track-events) 的结束。
 
-```javascript
+```typescript
 static void endSection(traceCategory: TraceCategory, name: string)
 ```
 
@@ -260,7 +260,7 @@ trace event 的名称。
 
 #### 示例
 
-```java
+```javascript
 TraceEvent.beginSection(TraceCategory.Other, "parse-data");
 // ... 你的代码 ...
 TraceEvent.endSection(TraceCategory.Other, "parse-data");
@@ -270,7 +270,7 @@ TraceEvent.endSection(TraceCategory.Other, "parse-data");
 
 标记一个即时(没有持续时间) trace event。
 
-```java
+```typescript
 static instant(traceCategory: TraceCategory, name: string, args?: Record<string, string>)
 ```
 

--- a/docs/zh/guide/custom-native-modules/native-module-ios.mdx
+++ b/docs/zh/guide/custom-native-modules/native-module-ios.mdx
@@ -101,7 +101,7 @@ static NSString *const NativeLocalStorageKey = @"MyLocalStorage";
 Lynx Explorer 是使用 Objective-C 构建的项目，如果你希望在 Swift 文件中实现原生模块，请参考 [Importing Objective-C into Swift](https://developer.apple.com/documentation/swift/importing-objective-c-into-swift) 引入所需的 Lynx 头文件 `LynxModule.h`。
 :::
 
-```swift title="explorer/darwin/ios/lynx_explorer/LynxExplorer/modules/LynxExplorer-Bridging-Header.h"
+```objective-c title="explorer/darwin/ios/lynx_explorer/LynxExplorer/modules/LynxExplorer-Bridging-Header.h"
 
 //
 //  Use this file to import your target's public headers that you would like to expose to Swift.

--- a/docs/zh/guide/start/fragments/macos/integrating-lynx-with-existing-app-macos.mdx
+++ b/docs/zh/guide/start/fragments/macos/integrating-lynx-with-existing-app-macos.mdx
@@ -199,7 +199,7 @@ Bundle 示例:
 
 <CodeFold toggle>
 
-```objective-c title=ExampleGenericResourceFetcher.h {9,12-19}
+```cpp title=ExampleGenericResourceFetcher.h {9,12-19}
 #import <Foundation/Foundation.h>
 #import "lynx_generic_resource_fetcher.h"
 


### PR DESCRIPTION
A fence that names the wrong language picks the wrong highlighter and tells a reader which toolchain to reach for, so a Kotlin sample fenced as `java` reads as broken Java. Nineteen fences across five pages named a language their contents are not.

Each was confirmed by parsing the block: it fails as the language it declared, and parses cleanly as the one it is changed to.

| Page | Was | Is | Why |
| --- | --- | --- | --- |
| `api/elements/built-in/image` | `java` | `kotlin` | `class X : Y()`, `override fun`, named arguments, elvis |
| `guide/custom-native-modules/native-module-ios` | `swift` | `objective-c` | the bridging header the surrounding tip tells you to add |
| `guide/start/fragments/macos/integrating-lynx-with-existing-app-macos` | `objective-c` | `cpp` | a plain C++ class with `std::shared_ptr` and `public:` |
| `api/lynx-native-api/trace-event` — `## iOS` | `java` | `objective-c` | Objective-C selectors |
| `api/lynx-native-api/trace-event` — `## Harmony` | `javascript` / `java` | `typescript` | annotated parameters, and `enum` has no JavaScript equivalent |

Two of these carry their own evidence. The iOS one is titled `LynxExplorer-Bridging-Header.h` and its body is a single `#import` — the `.swift` block directly below it was already correct. The macOS one is titled `.h` and declares `class ExampleGenericResourceFetcher : public lynx::pub::LynxGenericResourceFetcher`; the five sibling blocks in that file are `.mm` and stay `objective-c`.

In `trace-event`, `### instant` fenced its selectors as `java` while `beginSection` and `endSection` fence the identical construct as `objective-c`. In the Harmony section the typed declarations and the two `export enum TraceCategory` blocks are now `typescript`; the usage examples beside them are plain calls and stay `javascript`. Three Harmony fences in zh also said `java`.

## Two further corrections on the same pages

**`api/elements/built-in/scroll-view`** documented the sticky example as `<scroll-view> scroll-y>`, which is not valid markup, and uses an attribute that `scroll-view-API` records as *"Replacement of scroll-x and scroll-y"*. The zh page already documents the same example as `<scroll-view scroll-orientation="vertical">`; en now matches it.

**`guide/ui/layout/scroll-view`** existed only in zh. Every other placeholder in this repository — `guide/interaction/storage`, `ui/faqs`, `ui/troubleshooting`, `guide/custom-native-component/custom-component-web` — is present in both locales, so this adds the en counterpart rather than removing the zh page. Happy to invert that if you would rather the stub went away.

## Verification

`pnpm build` succeeds, and the rendered pages carry `data-lang="kotlin"`, `"objective-c"`, `"cpp"` and `"typescript"` on the changed blocks, so none of them fell back to plain text.

Also passing: `pnpm format:check`, `pnpm check-docs` (1725 files, no issues), `pnpm cspell:check` (2443 files, 0 issues), and `scripts/ci/check-case-collisions.mjs`, `check-asset-urls.mjs`, `check-lynx-ui-routes.mjs`.

The mislabelled fences were found by parsing every fenced block in `docs/` against the language it declares and reporting only those that fail as declared *and* parse cleanly as a plausibly-confused sibling. Across the site that reported exactly these, and after this change it reports none.

## Not addressed here

The zh Harmony section is missing the second `export enum TraceCategory` block that en carries, so the two pages have 25 and 24 blocks. That is a content gap rather than a fence problem, and is left alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Correct code fence language labels across English and Chinese documentation.
- Align `<scroll-view>` markup with the valid `scroll-orientation="vertical"` syntax.
- Provide the English `guide/ui/layout/scroll-view` page.
- Verify documentation builds, formatting, spelling, routes, assets, and rendered language metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->