### PR TITLE
docs(react): clarify templates in compiler-informed rendering

### DIFF
--- a/docs/en/react/compiler-informed-rendering.mdx
+++ b/docs/en/react/compiler-informed-rendering.mdx
@@ -74,7 +74,7 @@ export function Greeting({ name, highlighted }) {
 
 These names and function shapes only explain the mechanism; they are not actual compiler output that applications can rely on. On the initial render, the compiled `create()` directly builds the known host structure. On subsequent renders, `update()` directly modifies a known element. The runtime does not need to repeatedly create and compare VNodes for this part of the structure, while children that cannot be determined ahead of time, such as `name`, are still handled through dynamic slots.
 
-:::details Current Internal Representation: Snapshot
+:::details Prior Art and the Current Implementation: Snapshot
 
 This approach is similar to [Vue's compiler-informed virtual DOM](https://vuejs.org/guide/extras/rendering-mechanism#compiler-informed-virtual-dom), [Owl's BlockDOM](https://odoo.github.io/owl/documentation/v2/miscellaneous/architecture.html#blockdom), and [Million.js](https://github.com/aidenybai/million): each uses information known at build time to reduce the amount of work required at runtime.
 

--- a/docs/en/react/compiler-informed-rendering.mdx
+++ b/docs/en/react/compiler-informed-rendering.mdx
@@ -170,17 +170,17 @@ On every render, `jsx()` creates virtual nodes (VNodes) that describe the UI str
 In this example, only `className` and `name` can change. The types, hierarchy, and parent-child relationship of `view → text` remain fixed. The compiler can extract this stable information ahead of time. After optimization, the call site is conceptually similar to the following code:
 
 ```js
-const __compiled_greeting = '__compiled_greeting';
+const GreetingTemplate = '__compiled_greeting';
 
 export function Greeting({ name, highlighted }) {
-  return jsx(__compiled_greeting, {
+  return jsx(GreetingTemplate, {
     values: [highlighted ? 'card active' : 'card'], // Dynamic property position 0
     $0: name, // Dynamic child slot 0
   });
 }
 ```
 
-These names are conceptual and exist only to explain the mechanism; they are not actual compiler output that applications can rely on. The key difference is that the regular output expands the complete host VNode hierarchy at runtime, whereas the optimized output references a reusable compiled definition and supplies only the dynamic data required for that render.
+These names are conceptual and exist only to explain the mechanism; they are not actual compiler output that applications can rely on. The key difference is that the regular output expands the complete host VNode hierarchy at runtime, whereas the optimized output references a reusable template and supplies only the dynamic data required for that render.
 
 The compiler separates the JSX into:
 
@@ -188,7 +188,7 @@ The compiler separates the JSX into:
 - **Dynamic property**: the `className` determined by `highlighted`.
 - **Dynamic child**: the text generated from `name`.
 
-The compiler can therefore record static creation logic, targeted update functions, and dynamic child slots ahead of time. The runtime reuses this definition and only supplies each component instance's own dynamic values and children.
+The compiler can therefore record static creation logic, targeted update functions, and dynamic child slots ahead of time. The runtime reuses this template and only supplies each template instance's own dynamic values and children.
 
 This approach is similar to [Vue's compiler-informed virtual DOM](https://vuejs.org/guide/extras/rendering-mechanism#compiler-informed-virtual-dom), [Owl's BlockDOM](https://odoo.github.io/owl/documentation/v2/miscellaneous/architecture.html#blockdom), and [Million.js](https://github.com/aidenybai/million): each uses information known at build time to reduce the amount of work required at runtime.
 
@@ -196,9 +196,9 @@ From a compiler perspective, it can also be understood as a form of [partial eva
 
 ### The Current Intermediate Representation
 
-ReactLynx currently stores this compiler information in an Intermediate Representation (IR) called a **Snapshot**. Snapshot is only the IR used by the current implementation, not the name of the rendering mechanism. It is also unrelated to snapshot testing or the `getSnapshotBeforeUpdate()` method on React class components.
+ReactLynx currently represents these templates with an Intermediate Representation (IR) called a **Snapshot**. Snapshot is only the IR used by the current implementation, not the name of the rendering mechanism. It is also unrelated to snapshot testing or the `getSnapshotBeforeUpdate()` method on React class components.
 
-The IR is an internal implementation detail. It may continue to evolve or be replaced by other representations such as a Template. Application code does not need to create or manipulate it and should not depend on generated names or data structures.
+The IR is an internal implementation detail. It may continue to evolve or be replaced by another representation. Application code does not need to create or manipulate it and should not depend on generated names or data structures.
 
 The current IR has four core parts:
 
@@ -207,9 +207,9 @@ The current IR has four core parts:
 | Static creator      | Directly creates predictable Lynx elements and establishes their parent-child relationships.             |
 | Dynamic updaters    | Updates a property, event, or spread property by index without traversing the complete static structure. |
 | Dynamic child slots | Marks where dynamic subtrees such as components, conditional branches, text expressions, and lists go.   |
-| Representation ID   | Identifies a reusable compiled definition so multiple component instances can share its static data.     |
+| Representation ID   | Identifies a reusable template so multiple template instances can share its static data.                 |
 
-The simplified example below shows how the current IR expresses `Greeting` through [Element PAPI](/api/engine/element-api) creation and update operations. It preserves the static creator, dynamic updater, and slot information while omitting compiler metadata for CSS, entry points, and compatibility.
+The simplified example below shows how the current IR represents the `Greeting` template through [Element PAPI](/api/engine/element-api) creation and update operations. It preserves the static creator, dynamic updater, and slot information while omitting compiler metadata for CSS, entry points, and compatibility.
 
 :::details View a simplified definition of the current IR
 
@@ -256,37 +256,37 @@ The `$0` and `__DynamicPartSlotV2` representation shown here reflects `@lynx-js/
 
 One characteristic of ReactLynx is that this compiled representation participates not only in update-time reconciliation, but also in Lynx's dual-thread [Instant First-Frame Rendering (IFR)](/guide/interaction/ifr) pipeline.
 
-The same compiled definition can be reused by multiple `Greeting` instances. Each render creates a corresponding pair of runtime instances: the main-thread instance owns the Lynx elements it creates, while the background-thread instance stores the logical tree and dynamic data used for reconciliation. The runtime consumes the compiled output in two stages: initial rendering and subsequent updates.
+The same template can be reused by multiple mounted `Greeting` components. Each mounted `Greeting` has a corresponding pair of template instances: the main-thread template instance owns the Lynx elements it creates, while the background template instance stores the logical tree and dynamic data used for reconciliation. The runtime consumes the compiled output in two stages: initial rendering and subsequent updates.
 
-#### Initial Render: Create an Instance from the Compiled Definition
+#### Initial Render: Create a Template Instance
 
-The UI elements for the initial render are created directly on the main thread. The runtime first finds the compiled definition from the VNode type, then creates a main-thread instance for this `Greeting`. The instance owns the Lynx elements returned by the static creator. Initial dynamic values are passed to their corresponding updaters, and dynamic children are inserted into the slots reserved by the compiler.
+The UI elements for the initial render are created directly on the main thread. The runtime first finds the template from the VNode type, then creates a main-thread template instance for this `Greeting`. The template instance owns the Lynx elements returned by the static creator. Initial dynamic values are passed to their corresponding updaters, and dynamic children are inserted into the slots reserved by the compiler.
 
 The following pseudocode illustrates this process:
 
 ```js
 function renderFirstScreen(vnode) {
-  const definition = getCompiledDefinition(vnode.type);
-  const instance = createMainThreadInstance(vnode.type);
+  const template = getTemplate(vnode.type);
+  const instance = createMainThreadTemplateInstance(vnode.type);
 
-  instance.elements = definition.create(instance);
+  instance.elements = template.create(instance);
   instance.values = vnode.props.values;
-  definition.update[0](instance); // Write values[0] to className
+  template.update[0](instance); // Write values[0] to className
   insertDynamicChild(instance, 0, vnode.props.$0);
 
   return instance;
 }
 ```
 
-In this example, `definition.create()` creates the `view`, `text`, and fixed text; `definition.update[0]()` writes `values[0]` to `className`; and `insertDynamicChild()` places the `name` from `$0` into the reserved slot. This still creates the complete Lynx element tree. The difference is that `definition.create()` expands the static hierarchy directly instead of sending every host VNode through reconciliation level by level.
+In this example, `template.create()` creates the `view`, `text`, and fixed text; `template.update[0]()` writes `values[0]` to `className`; and `insertDynamicChild()` places the `name` from `$0` into the reserved slot. This still creates the complete Lynx element tree. The difference is that `template.create()` expands the static hierarchy directly instead of sending every host VNode through reconciliation level by level.
 
 From another perspective, this can be understood as precomputing part of the render, analogous to [Next.js Partial Prerendering](https://nextjs.org/docs/app/getting-started/partial-prerendering). The artifacts are different: Next.js produces a static HTML shell and a serialized React Server Component payload, while ReactLynx further lowers the stable host structure into element-creation operations understood directly by the Lynx platform. Dynamic values and subtrees are still supplied when the page starts.
 
-The initial background-thread reconciliation also creates a logical instance tree that corresponds to the main-thread instance tree. During first-screen synchronization, hydration establishes the mapping between instances on the two threads, allowing subsequent updates to locate the main-thread instance created for the first screen by `instanceId`.
+The initial background-thread reconciliation also creates a background template-instance tree that corresponds to the main-thread template-instance tree. During first-screen synchronization, hydration establishes the mapping between template instances on the two threads, allowing subsequent updates to locate the main-thread template instance created for the first screen by `instanceId`.
 
 #### Updates: Process Only Changes to Dynamic Positions
 
-After the mapping is established, the background thread compares old and new dynamic data and generates updates. The main thread then finds the corresponding runtime instance and applies the changes.
+After the mapping is established, the background thread compares old and new dynamic data and generates updates. The main thread then finds the corresponding template instance and applies the changes.
 
 The following pseudocode continues with `Greeting`. `highlighted` corresponds to dynamic position `0`, so changing it produces a property update. `name` is in a dynamic child slot and continues to be reconciled by React:
 
@@ -309,17 +309,17 @@ function reconcileGreeting(previous, next, instanceId) {
   });
 }
 
-// Main thread: apply a property update using the instance and dynamic position
+// Main thread: apply a property update using the template instance and dynamic position
 function applyAttributePatch(patch) {
-  const instance = findCompiledInstance(patch.instanceId);
+  const instance = findMainThreadTemplateInstance(patch.instanceId);
   const index = patch.dynamicPartIndex;
 
   instance.values[index] = patch.value;
-  instance.definition.update[index](instance);
+  instance.template.update[index](instance);
 }
 ```
 
-For the property path, `reconcileGreeting()` only describes which dynamic position changed on which instance. `applyAttributePatch()` then calls the targeted update function generated by the compiler. Dynamic children do not pass through these property updaters; React reconciliation produces the corresponding tree operations instead. The current implementation encodes these operations in a serialized Patch.
+For the property path, `reconcileGreeting()` only describes which dynamic position changed on which template instance. `applyAttributePatch()` then calls the targeted update function generated by the compiler. Dynamic children do not pass through these property updaters; React reconciliation produces the corresponding tree operations instead. The current implementation encodes these operations in a serialized Patch.
 
 ## Back to Application Code
 

--- a/docs/en/react/compiler-informed-rendering.mdx
+++ b/docs/en/react/compiler-informed-rendering.mdx
@@ -17,6 +17,8 @@ Consider a regular component:
 
 ```tsx
 export function Greeting({ name, highlighted }) {
+  // Static: the view/text hierarchy and "Hello, ".
+  // Dynamic: className and name.
   return (
     <view className={highlighted ? 'card active' : 'card'}>
       <text>Hello, {name}</text>
@@ -167,10 +169,29 @@ export function Greeting({ name, highlighted }) {
 
 On every render, `jsx()` creates virtual nodes (VNodes) that describe the UI structure. The ReactLynx reconciler then compares these nodes level by level to decide which host elements to reuse, create, or update. This process is known as reconciliation.
 
-In this example, only `className` and `name` can change. The types, hierarchy, and parent-child relationship of `view → text` remain fixed. The compiler can extract this stable information ahead of time. After optimization, the call site is conceptually similar to the following code:
+In this example, only `className` and `name` can change. The types, hierarchy, and parent-child relationship of `view → text` remain fixed. The compiler can extract this stable information ahead of time. After optimization, the generated template and call site are conceptually similar to the following code:
 
 ```js
 const GreetingTemplate = '__compiled_greeting';
+
+function GreetingTemplate_create() {
+  const pageId = ReactLynx.__pageId;
+  const view = __CreateView(pageId);
+  const text = __CreateText(pageId);
+  const fixedText = __CreateRawText('Hello, ');
+  const nameSlot = __CreateWrapperElement(pageId);
+
+  __AppendElement(view, text);
+  __AppendElement(text, fixedText);
+  __AppendElement(text, nameSlot);
+
+  return [view, text, fixedText, nameSlot];
+}
+
+function GreetingTemplate_update(instance) {
+  const className = instance.values[0];
+  __SetClasses(instance.elements[0], className || '');
+}
 
 export function Greeting({ name, highlighted }) {
   return jsx(GreetingTemplate, {
@@ -180,7 +201,7 @@ export function Greeting({ name, highlighted }) {
 }
 ```
 
-These names are conceptual and exist only to explain the mechanism; they are not actual compiler output that applications can rely on. The key difference is that the regular output expands the complete host VNode hierarchy at runtime, whereas the optimized output references a reusable template and supplies only the dynamic data required for that render.
+These names and function shapes are conceptual and exist only to explain the mechanism; they are not actual compiler output that applications can rely on. `GreetingTemplate_create()` expands the stable host structure through Element PAPI, while `GreetingTemplate_update()` applies the dynamic `className` directly to the root element. These functions illustrate the creation and property-update parts of `GreetingTemplate`; the current IR also records its dynamic child slot. The call site references this reusable template and supplies only the dynamic data required for that render.
 
 The compiler separates the JSX into:
 

--- a/docs/en/react/compiler-informed-rendering.mdx
+++ b/docs/en/react/compiler-informed-rendering.mdx
@@ -40,7 +40,7 @@ export function Greeting({ name, highlighted }) {
 
 On every render, `jsx()` creates virtual nodes (VNodes) that describe the UI structure. ReactLynx then compares these nodes level by level to decide which host elements to reuse, create, or update. This process is known as [reconciliation](https://react.dev/learn/render-and-commit).
 
-But in this example, the `view`, `text`, fixed text `Hello, `, and their parent-child relationships are static; only `className` and `name` can change. The compiler can therefore extract a reusable template and compile the static structure into [Element PAPI](/api/engine/element-api) operations, so the runtime only needs to supply the dynamic data required for each render. Conceptually, it looks like this:
+But in this example, the `view`, `text`, fixed text `Hello, `, and their parent-child relationships are static; only `className` and `name` can change. The compiler can generate the [Element PAPI](/api/engine/element-api) operations for creating the static structure ahead of time. The resulting static template definition can be reused across the initial renders of different instances and their subsequent re-renders; the runtime only needs to supply the dynamic data for each render. Conceptually, it looks like this:
 
 ```js
 const GreetingTemplate = {

--- a/docs/en/react/compiler-informed-rendering.mdx
+++ b/docs/en/react/compiler-informed-rendering.mdx
@@ -11,14 +11,12 @@ This optimization is applied automatically. Most applications can continue writi
 
 Here, _host elements_ are [Lynx elements](/guide/ui/elements-components) such as `<view>` and `<text>` that ReactLynx renders through the Lynx Engine. User-defined components such as `<ProductCard>` are not host elements.
 
-## Writing Compiler-Friendly JSX
+## What the Compiler Can Do Ahead of Time
 
 Consider a regular component:
 
 ```tsx
 export function Greeting({ name, highlighted }) {
-  // Static: the view/text hierarchy and "Hello, ".
-  // Dynamic: className and name.
   return (
     <view className={highlighted ? 'card active' : 'card'}>
       <text>Hello, {name}</text>
@@ -27,8 +25,128 @@ export function Greeting({ name, highlighted }) {
 }
 ```
 
-This JSX is already compiler-friendly: the `view → text` host types and hierarchy appear directly in the source, while `className` and `name` flow in normally as runtime data.
-The compiler can extract the stable structure and preserve the two expressions as dynamic positions.
+If JSX is transformed only as in a traditional, purely runtime Virtual DOM, without static extraction, the compiled result of `Greeting` is semantically similar to the following code:
+
+```js
+export function Greeting({ name, highlighted }) {
+  return jsx('view', {
+    className: highlighted ? 'card active' : 'card',
+    children: jsx('text', {
+      children: ['Hello, ', name],
+    }),
+  });
+}
+```
+
+On every render, `jsx()` creates virtual nodes (VNodes) that describe the UI structure. The ReactLynx reconciler then compares these nodes level by level to decide which host elements to reuse, create, or update. This process is known as reconciliation.
+
+In this example, only `className` and `name` can change. The types, hierarchy, and parent-child relationship of `view → text` remain fixed. The compiler can extract this stable information ahead of time into a template. After optimization, the generated template and call site are conceptually similar to the following code:
+
+```js
+const GreetingTemplate = '__compiled_greeting';
+
+function GreetingTemplate_create() {
+  const pageId = ReactLynx.__pageId;
+  const view = __CreateView(pageId);
+  const text = __CreateText(pageId);
+  const fixedText = __CreateRawText('Hello, ');
+  const nameSlot = __CreateWrapperElement(pageId);
+
+  __AppendElement(view, text);
+  __AppendElement(text, fixedText);
+  __AppendElement(text, nameSlot);
+
+  return [view, text, fixedText, nameSlot];
+}
+
+function GreetingTemplate_update(instance) {
+  const className = instance.values[0];
+  __SetClasses(instance.elements[0], className || '');
+}
+
+export function Greeting({ name, highlighted }) {
+  return jsx(GreetingTemplate, {
+    values: [highlighted ? 'card active' : 'card'], // Dynamic property position 0
+    $0: name, // Dynamic child slot 0
+  });
+}
+```
+
+These names and function shapes are conceptual and exist only to explain the mechanism; they are not actual compiler output that applications can rely on. `GreetingTemplate_create()` expands the stable host structure through Element PAPI, while `GreetingTemplate_update()` applies the dynamic `className` directly to the root element. These functions illustrate the creation and property-update parts of `GreetingTemplate`; the current IR also records its dynamic child slot. The call site references this reusable template and supplies only the dynamic data required for that render.
+
+The compiler separates the JSX into:
+
+- **Static structure**: `view`, `text`, the fixed text `Hello, `, and their known parent-child relationships.
+- **Dynamic property**: the `className` determined by `highlighted`.
+- **Dynamic child**: the text generated from `name`.
+
+The compiler can therefore record static creation logic, targeted update functions, and dynamic child slots ahead of time. The runtime reuses this template and only supplies each template instance's own dynamic values and children.
+
+This approach is similar to [Vue's compiler-informed virtual DOM](https://vuejs.org/guide/extras/rendering-mechanism#compiler-informed-virtual-dom), [Owl's BlockDOM](https://odoo.github.io/owl/documentation/v2/miscellaneous/architecture.html#blockdom), and [Million.js](https://github.com/aidenybai/million): each uses information known at build time to reduce the amount of work required at runtime.
+
+From a compiler perspective, it can also be understood as a form of [partial evaluation](https://en.wikipedia.org/wiki/Partial_evaluation): ReactLynx specializes the generic rendering process with host structures known from JSX, leaving only the parts that cannot be determined ahead of time for the runtime.
+
+::::details Current implementation: Snapshot IR
+
+ReactLynx currently represents these templates with an Intermediate Representation (IR) called a **Snapshot**. Snapshot is only the IR used by the current implementation, not the name of the rendering mechanism. It is also unrelated to snapshot testing or the `getSnapshotBeforeUpdate()` method on React class components.
+
+The IR is an internal implementation detail. It may continue to evolve or be replaced by another representation. Application code does not need to create or manipulate it and should not depend on generated names or data structures.
+
+The current IR has four core parts:
+
+| Compiled result     | Purpose                                                                                                  |
+| ------------------- | -------------------------------------------------------------------------------------------------------- |
+| Static creator      | Directly creates predictable Lynx elements and establishes their parent-child relationships.             |
+| Dynamic updaters    | Updates a property, event, or spread property by index without traversing the complete static structure. |
+| Dynamic child slots | Marks where dynamic subtrees such as components, conditional branches, text expressions, and lists go.   |
+| Representation ID   | Identifies a reusable template so multiple template instances can share its static data.                 |
+
+The simplified example below shows how the current IR represents the `Greeting` template through [Element PAPI](/api/engine/element-api) creation and update operations. It preserves the static creator, dynamic updater, and slot information while omitting compiler metadata for CSS, entry points, and compatibility.
+
+:::details View a simplified definition of the current IR
+
+```js
+ReactLynx.snapshotCreatorMap[__snapshot_xxx] = (__snapshot_xxx) =>
+  ReactLynx.createSnapshot(
+    __snapshot_xxx,
+    () => {
+      // This part only depends on structure that is statically known in JSX.
+      const pageId = ReactLynx.__pageId;
+      const view = __CreateView(pageId);
+      const text = __CreateText(pageId);
+      const rawText = __CreateRawText('Hello, ');
+      const slot = __CreateWrapperElement(pageId); // Reserve an insertion point for $0
+
+      __AppendElement(view, text);
+      __AppendElement(text, rawText);
+      __AppendElement(text, slot);
+
+      // Updaters and slot descriptors locate elements through these array indexes.
+      return [view, text, rawText, slot];
+    },
+    [
+      function (ctx) {
+        if (ctx.__elements) {
+          // values[0] only updates elements[0], the root view.
+          __SetClasses(ctx.__elements[0], ctx.__values[0] || '');
+        }
+      },
+    ],
+    [[ReactLynx.__DynamicPartSlotV2, 3]], // $0 corresponds to elements[3]
+  );
+```
+
+:::
+
+:::warning
+
+The `$0` and `__DynamicPartSlotV2` representation shown here reflects `@lynx-js/react` 0.120.0 or later. `createSnapshot`, `snapshotCreatorMap`, the global element operation functions, and generated IDs are internal implementation details. Their names and parameters may change with the source code, compiler configuration, or ReactLynx version. Do not depend on or copy these outputs in application code.
+
+:::
+
+::::
+
+## Writing Compiler-Friendly JSX
 
 Dynamic properties, text, and children do not prevent compiler optimization by themselves. For most components, these three principles are enough:
 
@@ -152,134 +270,11 @@ For structures that genuinely need to be determined at runtime, keeping the code
 
 ## How the Compiler and Runtime Work Together
 
-### What the Compiler Does Ahead of Time
-
-With a regular JSX transform and no static extraction, the compiled result of `Greeting` is semantically similar to the following code:
-
-```js
-export function Greeting({ name, highlighted }) {
-  return jsx('view', {
-    className: highlighted ? 'card active' : 'card',
-    children: jsx('text', {
-      children: ['Hello, ', name],
-    }),
-  });
-}
-```
-
-On every render, `jsx()` creates virtual nodes (VNodes) that describe the UI structure. The ReactLynx reconciler then compares these nodes level by level to decide which host elements to reuse, create, or update. This process is known as reconciliation.
-
-In this example, only `className` and `name` can change. The types, hierarchy, and parent-child relationship of `view → text` remain fixed. The compiler can extract this stable information ahead of time. After optimization, the generated template and call site are conceptually similar to the following code:
-
-```js
-const GreetingTemplate = '__compiled_greeting';
-
-function GreetingTemplate_create() {
-  const pageId = ReactLynx.__pageId;
-  const view = __CreateView(pageId);
-  const text = __CreateText(pageId);
-  const fixedText = __CreateRawText('Hello, ');
-  const nameSlot = __CreateWrapperElement(pageId);
-
-  __AppendElement(view, text);
-  __AppendElement(text, fixedText);
-  __AppendElement(text, nameSlot);
-
-  return [view, text, fixedText, nameSlot];
-}
-
-function GreetingTemplate_update(instance) {
-  const className = instance.values[0];
-  __SetClasses(instance.elements[0], className || '');
-}
-
-export function Greeting({ name, highlighted }) {
-  return jsx(GreetingTemplate, {
-    values: [highlighted ? 'card active' : 'card'], // Dynamic property position 0
-    $0: name, // Dynamic child slot 0
-  });
-}
-```
-
-These names and function shapes are conceptual and exist only to explain the mechanism; they are not actual compiler output that applications can rely on. `GreetingTemplate_create()` expands the stable host structure through Element PAPI, while `GreetingTemplate_update()` applies the dynamic `className` directly to the root element. These functions illustrate the creation and property-update parts of `GreetingTemplate`; the current IR also records its dynamic child slot. The call site references this reusable template and supplies only the dynamic data required for that render.
-
-The compiler separates the JSX into:
-
-- **Static structure**: `view`, `text`, the fixed text `Hello, `, and their known parent-child relationships.
-- **Dynamic property**: the `className` determined by `highlighted`.
-- **Dynamic child**: the text generated from `name`.
-
-The compiler can therefore record static creation logic, targeted update functions, and dynamic child slots ahead of time. The runtime reuses this template and only supplies each template instance's own dynamic values and children.
-
-This approach is similar to [Vue's compiler-informed virtual DOM](https://vuejs.org/guide/extras/rendering-mechanism#compiler-informed-virtual-dom), [Owl's BlockDOM](https://odoo.github.io/owl/documentation/v2/miscellaneous/architecture.html#blockdom), and [Million.js](https://github.com/aidenybai/million): each uses information known at build time to reduce the amount of work required at runtime.
-
-From a compiler perspective, it can also be understood as a form of [partial evaluation](https://en.wikipedia.org/wiki/Partial_evaluation): ReactLynx specializes the generic rendering process with host structures known from JSX, leaving only the parts that cannot be determined ahead of time for the runtime.
-
-### The Current Intermediate Representation
-
-ReactLynx currently represents these templates with an Intermediate Representation (IR) called a **Snapshot**. Snapshot is only the IR used by the current implementation, not the name of the rendering mechanism. It is also unrelated to snapshot testing or the `getSnapshotBeforeUpdate()` method on React class components.
-
-The IR is an internal implementation detail. It may continue to evolve or be replaced by another representation. Application code does not need to create or manipulate it and should not depend on generated names or data structures.
-
-The current IR has four core parts:
-
-| Compiled result     | Purpose                                                                                                  |
-| ------------------- | -------------------------------------------------------------------------------------------------------- |
-| Static creator      | Directly creates predictable Lynx elements and establishes their parent-child relationships.             |
-| Dynamic updaters    | Updates a property, event, or spread property by index without traversing the complete static structure. |
-| Dynamic child slots | Marks where dynamic subtrees such as components, conditional branches, text expressions, and lists go.   |
-| Representation ID   | Identifies a reusable template so multiple template instances can share its static data.                 |
-
-The simplified example below shows how the current IR represents the `Greeting` template through [Element PAPI](/api/engine/element-api) creation and update operations. It preserves the static creator, dynamic updater, and slot information while omitting compiler metadata for CSS, entry points, and compatibility.
-
-:::details View a simplified definition of the current IR
-
-```js
-ReactLynx.snapshotCreatorMap[__snapshot_xxx] = (__snapshot_xxx) =>
-  ReactLynx.createSnapshot(
-    __snapshot_xxx,
-    () => {
-      // This part only depends on structure that is statically known in JSX.
-      const pageId = ReactLynx.__pageId;
-      const view = __CreateView(pageId);
-      const text = __CreateText(pageId);
-      const rawText = __CreateRawText('Hello, ');
-      const slot = __CreateWrapperElement(pageId); // Reserve an insertion point for $0
-
-      __AppendElement(view, text);
-      __AppendElement(text, rawText);
-      __AppendElement(text, slot);
-
-      // Updaters and slot descriptors locate elements through these array indexes.
-      return [view, text, rawText, slot];
-    },
-    [
-      function (ctx) {
-        if (ctx.__elements) {
-          // values[0] only updates elements[0], the root view.
-          __SetClasses(ctx.__elements[0], ctx.__values[0] || '');
-        }
-      },
-    ],
-    [[ReactLynx.__DynamicPartSlotV2, 3]], // $0 corresponds to elements[3]
-  );
-```
-
-:::
-
-:::warning
-
-The `$0` and `__DynamicPartSlotV2` representation shown here reflects `@lynx-js/react` 0.120.0 or later. `createSnapshot`, `snapshotCreatorMap`, the global element operation functions, and generated IDs are internal implementation details. Their names and parameters may change with the source code, compiler configuration, or ReactLynx version. Do not depend on or copy these outputs in application code.
-
-:::
-
-### How Compiled Output Enters the Runtime
-
 One characteristic of ReactLynx is that this compiled representation participates not only in update-time reconciliation, but also in Lynx's dual-thread [Instant First-Frame Rendering (IFR)](/guide/interaction/ifr) pipeline.
 
 The same template can be reused by multiple mounted `Greeting` components. Each mounted `Greeting` has a corresponding pair of template instances: the main-thread template instance owns the Lynx elements it creates, while the background template instance stores the logical tree and dynamic data used for reconciliation. The runtime consumes the compiled output in two stages: initial rendering and subsequent updates.
 
-#### Initial Render: Create a Template Instance
+### Initial Render: Create a Template Instance
 
 The UI elements for the initial render are created directly on the main thread. The runtime first finds the template from the VNode type, then creates a main-thread template instance for this `Greeting`. The template instance owns the Lynx elements returned by the static creator. Initial dynamic values are passed to their corresponding updaters, and dynamic children are inserted into the slots reserved by the compiler.
 
@@ -305,7 +300,7 @@ From another perspective, this can be understood as precomputing part of the ren
 
 The initial background-thread reconciliation also creates a background template-instance tree that corresponds to the main-thread template-instance tree. During first-screen synchronization, hydration establishes the mapping between template instances on the two threads, allowing subsequent updates to locate the main-thread template instance created for the first screen by `instanceId`.
 
-#### Updates: Process Only Changes to Dynamic Positions
+### Updates: Process Only Changes to Dynamic Positions
 
 After the mapping is established, the background thread compares old and new dynamic data and generates updates. The main thread then finds the corresponding template instance and applies the changes.
 

--- a/docs/en/react/compiler-informed-rendering.mdx
+++ b/docs/en/react/compiler-informed-rendering.mdx
@@ -45,6 +45,7 @@ But in this example, the `view`, `text`, fixed text `Hello, `, and their parent-
 ```js
 const GreetingTemplate = '__compiled_greeting';
 
+// Compile the static structure ahead of time into Element PAPI operations.
 function GreetingTemplate_create() {
   const pageId = ReactLynx.__pageId;
   const view = __CreateView(pageId);
@@ -59,6 +60,7 @@ function GreetingTemplate_create() {
   return [view, text, fixedText, nameSlot];
 }
 
+// Generate fine-grained update logic for dynamic properties.
 function GreetingTemplate_update(instance) {
   const className = instance.values[0];
   __SetClasses(instance.elements[0], className || '');

--- a/docs/en/react/compiler-informed-rendering.mdx
+++ b/docs/en/react/compiler-informed-rendering.mdx
@@ -40,47 +40,45 @@ export function Greeting({ name, highlighted }) {
 
 On every render, `jsx()` creates virtual nodes (VNodes) that describe the UI structure. ReactLynx then compares these nodes level by level to decide which host elements to reuse, create, or update. This process is known as [reconciliation](https://react.dev/learn/render-and-commit).
 
-But in this example, the `view`, `text`, fixed text `Hello, `, and their parent-child relationships are static; only `className` and `name` can change. The compiler can therefore extract a reusable template, so the runtime only needs to supply the dynamic data required for each render. Conceptually, it looks like this:
+But in this example, the `view`, `text`, fixed text `Hello, `, and their parent-child relationships are static; only `className` and `name` can change. The compiler can therefore extract a reusable template and compile the static structure into [Element PAPI](/api/engine/element-api) operations, so the runtime only needs to supply the dynamic data required for each render. Conceptually, it looks like this:
 
 ```js
-const GreetingTemplate = '__compiled_greeting';
+const GreetingTemplate = {
+  // Create a template instance by directly executing compiled Element PAPI operations.
+  create() {
+    const pageId = ReactLynx.__pageId;
+    const view = __CreateView(pageId);
+    const text = __CreateText(pageId);
+    const nameSlot = __CreateWrapperElement(pageId);
 
-// Compile the static structure ahead of time into Element PAPI operations.
-function GreetingTemplate_create() {
-  const pageId = ReactLynx.__pageId;
-  const view = __CreateView(pageId);
-  const text = __CreateText(pageId);
-  const fixedText = __CreateRawText('Hello, ');
-  const nameSlot = __CreateWrapperElement(pageId);
+    __AppendElement(view, text);
+    __AppendElement(text, __CreateRawText('Hello, '));
+    __AppendElement(text, nameSlot);
 
-  __AppendElement(view, text);
-  __AppendElement(text, fixedText);
-  __AppendElement(text, nameSlot);
+    return { view, nameSlot };
+  },
 
-  return [view, text, fixedText, nameSlot];
-}
-
-// Generate fine-grained update logic for dynamic properties.
-function GreetingTemplate_update(instance) {
-  const className = instance.values[0];
-  __SetClasses(instance.elements[0], className || '');
-}
+  // Update a known element directly without traversing the static structure.
+  update(instance, { className }) {
+    __SetClasses(instance.view, className);
+  },
+};
 
 export function Greeting({ name, highlighted }) {
-  return jsx(GreetingTemplate, {
-    values: [highlighted ? 'card active' : 'card'], // Dynamic property position 0
-    $0: name, // Dynamic child slot 0
+  return renderTemplate(GreetingTemplate, {
+    className: highlighted ? 'card active' : 'card',
+    nameSlot: name,
   });
 }
 ```
 
-These names and function shapes only explain the mechanism; they are not actual compiler output that applications can rely on. `GreetingTemplate_create()` creates the static structure, `GreetingTemplate_update()` directly updates `className`, and `$0` represents the dynamic child slot for `name`.
+These names and function shapes only explain the mechanism; they are not actual compiler output that applications can rely on. On the initial render, the compiled `create()` directly builds the known host structure. On subsequent renders, `update()` directly modifies a known element. The runtime does not need to repeatedly create and compare VNodes for this part of the structure, while children that cannot be determined ahead of time, such as `name`, are still handled through dynamic slots.
+
+:::details Current Internal Representation: Snapshot
 
 This approach is similar to [Vue's compiler-informed virtual DOM](https://vuejs.org/guide/extras/rendering-mechanism#compiler-informed-virtual-dom), [Owl's BlockDOM](https://odoo.github.io/owl/documentation/v2/miscellaneous/architecture.html#blockdom), and [Million.js](https://github.com/aidenybai/million): each uses information known at build time to reduce the amount of work required at runtime.
 
 From a compiler perspective, it can also be understood as a form of [partial evaluation](https://en.wikipedia.org/wiki/Partial_evaluation): ReactLynx specializes the generic rendering process with host structures known from JSX, leaving only the parts that cannot be determined ahead of time for the runtime.
-
-:::details Current Internal Representation: Snapshot
 
 ReactLynx currently uses an Intermediate Representation (IR) called a **Snapshot** to store the compilation information described above. We are also exploring other representations with better performance.
 
@@ -93,40 +91,7 @@ Snapshot follows the simplified model above and can be summarized in four core p
 | Dynamic child slots | Marks where dynamic subtrees such as components, conditional branches, text expressions, and lists go.   |
 | Representation ID   | Identifies a reusable template so multiple template instances can share its static data.                 |
 
-The simplified example below shows how the current IR represents the `Greeting` template through [Element PAPI](/api/engine/element-api) creation and update operations. It preserves the static creator, dynamic updater, and slot information while omitting compiler metadata for CSS, entry points, and compatibility.
-
-```js
-ReactLynx.snapshotCreatorMap[__snapshot_xxx] = (__snapshot_xxx) =>
-  ReactLynx.createSnapshot(
-    __snapshot_xxx,
-    () => {
-      // This part only depends on structure that is statically known in JSX.
-      const pageId = ReactLynx.__pageId;
-      const view = __CreateView(pageId);
-      const text = __CreateText(pageId);
-      const rawText = __CreateRawText('Hello, ');
-      const slot = __CreateWrapperElement(pageId); // Reserve an insertion point for $0
-
-      __AppendElement(view, text);
-      __AppendElement(text, rawText);
-      __AppendElement(text, slot);
-
-      // Updaters and slot descriptors locate elements through these array indexes.
-      return [view, text, rawText, slot];
-    },
-    [
-      function (ctx) {
-        if (ctx.__elements) {
-          // values[0] only updates elements[0], the root view.
-          __SetClasses(ctx.__elements[0], ctx.__values[0] || '');
-        }
-      },
-    ],
-    [[ReactLynx.__DynamicPartSlotV2, 3]], // $0 corresponds to elements[3]
-  );
-```
-
-**Note:** The IR is an internal implementation detail. Do not depend on or copy these outputs in application code. The `$0` and `__DynamicPartSlotV2` representation shown here reflects `@lynx-js/react` 0.120.0 or later. `createSnapshot`, `snapshotCreatorMap`, the global element operation functions, and generated IDs are internal implementation details. Their names and parameters may change with the source code, compiler configuration, or ReactLynx version.
+**Note:** The IR is an internal implementation detail. Do not depend on or copy these outputs in application code. Specific names, parameters, and data structures may change with the source code, compiler configuration, or ReactLynx version.
 
 :::
 

--- a/docs/en/react/compiler-informed-rendering.mdx
+++ b/docs/en/react/compiler-informed-rendering.mdx
@@ -80,13 +80,11 @@ This approach is similar to [Vue's compiler-informed virtual DOM](https://vuejs.
 
 From a compiler perspective, it can also be understood as a form of [partial evaluation](https://en.wikipedia.org/wiki/Partial_evaluation): ReactLynx specializes the generic rendering process with host structures known from JSX, leaving only the parts that cannot be determined ahead of time for the runtime.
 
-:::details Current implementation: Snapshot IR
+:::details Current Internal Representation: Snapshot
 
-ReactLynx currently represents these templates with an Intermediate Representation (IR) called a **Snapshot**. Snapshot is only the IR used by the current implementation, not the name of the rendering mechanism. It is also unrelated to snapshot testing or the `getSnapshotBeforeUpdate()` method on React class components.
+ReactLynx currently uses an Intermediate Representation (IR) called a **Snapshot** to store the compilation information described above. We are also exploring other representations with better performance.
 
-The IR is an internal implementation detail. It may continue to evolve or be replaced by another representation. Application code does not need to create or manipulate it and should not depend on generated names or data structures.
-
-In the current Snapshot IR, this model is represented by four core parts:
+Snapshot follows the simplified model above and can be summarized in four core parts:
 
 | Compiled result     | Purpose                                                                                                  |
 | ------------------- | -------------------------------------------------------------------------------------------------------- |
@@ -128,7 +126,7 @@ ReactLynx.snapshotCreatorMap[__snapshot_xxx] = (__snapshot_xxx) =>
   );
 ```
 
-**Warning:** The `$0` and `__DynamicPartSlotV2` representation shown here reflects `@lynx-js/react` 0.120.0 or later. `createSnapshot`, `snapshotCreatorMap`, the global element operation functions, and generated IDs are internal implementation details. Their names and parameters may change with the source code, compiler configuration, or ReactLynx version. Do not depend on or copy these outputs in application code.
+**Note:** The IR is an internal implementation detail. Do not depend on or copy these outputs in application code. The `$0` and `__DynamicPartSlotV2` representation shown here reflects `@lynx-js/react` 0.120.0 or later. `createSnapshot`, `snapshotCreatorMap`, the global element operation functions, and generated IDs are internal implementation details. Their names and parameters may change with the source code, compiler configuration, or ReactLynx version.
 
 :::
 

--- a/docs/en/react/compiler-informed-rendering.mdx
+++ b/docs/en/react/compiler-informed-rendering.mdx
@@ -40,15 +40,7 @@ export function Greeting({ name, highlighted }) {
 
 On every render, `jsx()` creates virtual nodes (VNodes) that describe the UI structure. ReactLynx then compares these nodes level by level to decide which host elements to reuse, create, or update. This process is known as [reconciliation](https://react.dev/learn/render-and-commit).
 
-But in this example, only `className` and `name` can change. The types, hierarchy, and parent-child relationship of `view → text` remain fixed. The compiler separates the JSX into:
-
-- **Static structure**: `view`, `text`, the fixed text `Hello, `, and their known parent-child relationships.
-- **Dynamic property**: the `className` determined by `highlighted`.
-- **Dynamic child**: the text generated from `name`.
-
-The compiler can therefore record static creation logic, targeted update functions, and dynamic child slots ahead of time. The runtime reuses this template and only supplies each template instance's own dynamic values and children.
-
-After optimization, the generated template and call site are conceptually similar to the following code:
+But in this example, the `view`, `text`, fixed text `Hello, `, and their parent-child relationships are static; only `className` and `name` can change. The compiler can therefore extract a reusable template, so the runtime only needs to supply the dynamic data required for each render. Conceptually, it looks like this:
 
 ```js
 const GreetingTemplate = '__compiled_greeting';
@@ -80,7 +72,7 @@ export function Greeting({ name, highlighted }) {
 }
 ```
 
-These names and function shapes are conceptual and exist only to explain the mechanism; they are not actual compiler output that applications can rely on. `GreetingTemplate_create()` expands the stable host structure through Element PAPI, while `GreetingTemplate_update()` applies the dynamic `className` directly to the root element. These functions illustrate the creation and property-update parts of `GreetingTemplate`; the current IR also records its dynamic child slot. The call site references this reusable template and supplies only the dynamic data required for that render.
+These names and function shapes only explain the mechanism; they are not actual compiler output that applications can rely on. `GreetingTemplate_create()` creates the static structure, `GreetingTemplate_update()` directly updates `className`, and `$0` represents the dynamic child slot for `name`.
 
 This approach is similar to [Vue's compiler-informed virtual DOM](https://vuejs.org/guide/extras/rendering-mechanism#compiler-informed-virtual-dom), [Owl's BlockDOM](https://odoo.github.io/owl/documentation/v2/miscellaneous/architecture.html#blockdom), and [Million.js](https://github.com/aidenybai/million): each uses information known at build time to reduce the amount of work required at runtime.
 
@@ -92,7 +84,7 @@ ReactLynx currently represents these templates with an Intermediate Representati
 
 The IR is an internal implementation detail. It may continue to evolve or be replaced by another representation. Application code does not need to create or manipulate it and should not depend on generated names or data structures.
 
-The current IR has four core parts:
+In the current Snapshot IR, this model is represented by four core parts:
 
 | Compiled result     | Purpose                                                                                                  |
 | ------------------- | -------------------------------------------------------------------------------------------------------- |

--- a/docs/en/react/compiler-informed-rendering.mdx
+++ b/docs/en/react/compiler-informed-rendering.mdx
@@ -76,13 +76,9 @@ These names and function shapes only explain the mechanism; they are not actual 
 
 :::details Prior Art and the Current Implementation: Snapshot
 
-This approach is similar to [Vue's compiler-informed virtual DOM](https://vuejs.org/guide/extras/rendering-mechanism#compiler-informed-virtual-dom), [Owl's BlockDOM](https://odoo.github.io/owl/documentation/v2/miscellaneous/architecture.html#blockdom), and [Million.js](https://github.com/aidenybai/million): each uses information known at build time to reduce the amount of work required at runtime.
+This idea of using information known at build time to reduce runtime work is not unique to ReactLynx. [Vue's compiler-informed virtual DOM](https://vuejs.org/guide/extras/rendering-mechanism#compiler-informed-virtual-dom), [Owl's BlockDOM](https://odoo.github.io/owl/documentation/v2/miscellaneous/architecture.html#blockdom), and [Million.js](https://github.com/aidenybai/million) all take a similar approach. From a broader computational perspective, it can also be understood as a form of [partial evaluation](https://en.wikipedia.org/wiki/Partial_evaluation): using host structures known from JSX to specialize the generic rendering process, leaving only the parts that cannot be determined ahead of time for runtime and producing an effect similar to “[partial prerendering](https://nextjs.org/docs/15/app/getting-started/partial-prerendering).”
 
-From a compiler perspective, it can also be understood as a form of [partial evaluation](https://en.wikipedia.org/wiki/Partial_evaluation): ReactLynx specializes the generic rendering process with host structures known from JSX, leaving only the parts that cannot be determined ahead of time for the runtime.
-
-ReactLynx currently uses an Intermediate Representation (IR) called a **Snapshot** to store the compilation information described above. We are also exploring other representations with better performance.
-
-Snapshot follows the simplified model above and can be summarized in four core parts:
+In ReactLynx, this approach is currently implemented through an Intermediate Representation (IR) called a **Snapshot**. We are also exploring other representations with better performance. Snapshot follows the conceptual model above and can be summarized in four core parts:
 
 | Compiled result     | Purpose                                                                                                  |
 | ------------------- | -------------------------------------------------------------------------------------------------------- |

--- a/docs/en/react/compiler-informed-rendering.mdx
+++ b/docs/en/react/compiler-informed-rendering.mdx
@@ -86,7 +86,7 @@ This approach is similar to [Vue's compiler-informed virtual DOM](https://vuejs.
 
 From a compiler perspective, it can also be understood as a form of [partial evaluation](https://en.wikipedia.org/wiki/Partial_evaluation): ReactLynx specializes the generic rendering process with host structures known from JSX, leaving only the parts that cannot be determined ahead of time for the runtime.
 
-::::details Current implementation: Snapshot IR
+:::details Current implementation: Snapshot IR
 
 ReactLynx currently represents these templates with an Intermediate Representation (IR) called a **Snapshot**. Snapshot is only the IR used by the current implementation, not the name of the rendering mechanism. It is also unrelated to snapshot testing or the `getSnapshotBeforeUpdate()` method on React class components.
 
@@ -102,8 +102,6 @@ The current IR has four core parts:
 | Representation ID   | Identifies a reusable template so multiple template instances can share its static data.                 |
 
 The simplified example below shows how the current IR represents the `Greeting` template through [Element PAPI](/api/engine/element-api) creation and update operations. It preserves the static creator, dynamic updater, and slot information while omitting compiler metadata for CSS, entry points, and compatibility.
-
-:::details View a simplified definition of the current IR
 
 ```js
 ReactLynx.snapshotCreatorMap[__snapshot_xxx] = (__snapshot_xxx) =>
@@ -136,15 +134,9 @@ ReactLynx.snapshotCreatorMap[__snapshot_xxx] = (__snapshot_xxx) =>
   );
 ```
 
-:::
-
-:::warning
-
-The `$0` and `__DynamicPartSlotV2` representation shown here reflects `@lynx-js/react` 0.120.0 or later. `createSnapshot`, `snapshotCreatorMap`, the global element operation functions, and generated IDs are internal implementation details. Their names and parameters may change with the source code, compiler configuration, or ReactLynx version. Do not depend on or copy these outputs in application code.
+**Warning:** The `$0` and `__DynamicPartSlotV2` representation shown here reflects `@lynx-js/react` 0.120.0 or later. `createSnapshot`, `snapshotCreatorMap`, the global element operation functions, and generated IDs are internal implementation details. Their names and parameters may change with the source code, compiler configuration, or ReactLynx version. Do not depend on or copy these outputs in application code.
 
 :::
-
-::::
 
 ## Writing Compiler-Friendly JSX
 

--- a/docs/en/react/compiler-informed-rendering.mdx
+++ b/docs/en/react/compiler-informed-rendering.mdx
@@ -38,9 +38,17 @@ export function Greeting({ name, highlighted }) {
 }
 ```
 
-On every render, `jsx()` creates virtual nodes (VNodes) that describe the UI structure. The ReactLynx reconciler then compares these nodes level by level to decide which host elements to reuse, create, or update. This process is known as reconciliation.
+On every render, `jsx()` creates virtual nodes (VNodes) that describe the UI structure. ReactLynx then compares these nodes level by level to decide which host elements to reuse, create, or update. This process is known as [reconciliation](https://react.dev/learn/render-and-commit).
 
-In this example, only `className` and `name` can change. The types, hierarchy, and parent-child relationship of `view → text` remain fixed. The compiler can extract this stable information ahead of time into a template. After optimization, the generated template and call site are conceptually similar to the following code:
+But in this example, only `className` and `name` can change. The types, hierarchy, and parent-child relationship of `view → text` remain fixed. The compiler separates the JSX into:
+
+- **Static structure**: `view`, `text`, the fixed text `Hello, `, and their known parent-child relationships.
+- **Dynamic property**: the `className` determined by `highlighted`.
+- **Dynamic child**: the text generated from `name`.
+
+The compiler can therefore record static creation logic, targeted update functions, and dynamic child slots ahead of time. The runtime reuses this template and only supplies each template instance's own dynamic values and children.
+
+After optimization, the generated template and call site are conceptually similar to the following code:
 
 ```js
 const GreetingTemplate = '__compiled_greeting';
@@ -73,14 +81,6 @@ export function Greeting({ name, highlighted }) {
 ```
 
 These names and function shapes are conceptual and exist only to explain the mechanism; they are not actual compiler output that applications can rely on. `GreetingTemplate_create()` expands the stable host structure through Element PAPI, while `GreetingTemplate_update()` applies the dynamic `className` directly to the root element. These functions illustrate the creation and property-update parts of `GreetingTemplate`; the current IR also records its dynamic child slot. The call site references this reusable template and supplies only the dynamic data required for that render.
-
-The compiler separates the JSX into:
-
-- **Static structure**: `view`, `text`, the fixed text `Hello, `, and their known parent-child relationships.
-- **Dynamic property**: the `className` determined by `highlighted`.
-- **Dynamic child**: the text generated from `name`.
-
-The compiler can therefore record static creation logic, targeted update functions, and dynamic child slots ahead of time. The runtime reuses this template and only supplies each template instance's own dynamic values and children.
 
 This approach is similar to [Vue's compiler-informed virtual DOM](https://vuejs.org/guide/extras/rendering-mechanism#compiler-informed-virtual-dom), [Owl's BlockDOM](https://odoo.github.io/owl/documentation/v2/miscellaneous/architecture.html#blockdom), and [Million.js](https://github.com/aidenybai/million): each uses information known at build time to reduce the amount of work required at runtime.
 

--- a/docs/zh/react/compiler-informed-rendering.mdx
+++ b/docs/zh/react/compiler-informed-rendering.mdx
@@ -76,13 +76,9 @@ export function Greeting({ name, highlighted }) {
 
 :::details 历史经验与当前实现：Snapshot
 
-这种思路与 [Vue 的编译器信息增强虚拟 DOM](https://vuejs.org/guide/extras/rendering-mechanism#compiler-informed-virtual-dom)、[Owl 的 BlockDOM](https://odoo.github.io/owl/documentation/v2/miscellaneous/architecture.html#blockdom) 和 [Million.js](https://github.com/aidenybai/million) 有相似之处：都利用编译阶段已知的信息，缩小运行时需要处理的范围。
+这种利用编译阶段已知信息缩小运行时工作范围的思路并非 ReactLynx 独创。[Vue 的编译器信息增强虚拟 DOM](https://vuejs.org/guide/extras/rendering-mechanism#compiler-informed-virtual-dom)、[Owl 的 BlockDOM](https://odoo.github.io/owl/documentation/v2/miscellaneous/architecture.html#blockdom) 和 [Million.js](https://github.com/aidenybai/million) 都采用了类似的思路。从更宽泛的计算视角，也可以把它理解为一种[部分求值（partial evaluation）](https://en.wikipedia.org/wiki/Partial_evaluation)：使用 JSX 中已知的宿主结构对通用渲染过程进行特化，只把无法提前确定的部分留到运行时，达到一种“[部分预渲染](https://nextjs.org/docs/15/app/getting-started/partial-prerendering)”的效果。
 
-从编译原理的视角，也可以把它理解为一种[部分求值（partial evaluation）](https://en.wikipedia.org/wiki/Partial_evaluation)：ReactLynx 使用 JSX 中已知的宿主结构对通用渲染过程进行特化，只把无法提前确定的部分留到运行时。
-
-ReactLynx 当前使用一种名为 **Snapshot** 的中间表示（Intermediate Representation，IR）保存上述编译信息。我们也在尝试演进成性能更好的其他表示。
-
-Snapshot 和上述简化的概念一致，可以归纳为以下四个核心部分：
+在 ReactLynx 中，这套思路当前通过一种名为 **Snapshot** 的中间表示（Intermediate Representation，IR）实现。我们也在尝试演进成性能更好的其他表示。Snapshot 与上面的概念模型一致，可以归纳为以下四个核心部分：
 
 | 编译结果       | 作用                                                             |
 | -------------- | ---------------------------------------------------------------- |

--- a/docs/zh/react/compiler-informed-rendering.mdx
+++ b/docs/zh/react/compiler-informed-rendering.mdx
@@ -170,17 +170,17 @@ export function Greeting({ name, highlighted }) {
 在这个例子中，真正会变化的只有 `className` 和 `name`；`view → text` 的类型、层级和父子关系始终不变。编译器可以提前提取这些稳定信息。经过优化后，调用部分在概念上类似：
 
 ```js
-const __compiled_greeting = '__compiled_greeting';
+const GreetingTemplate = '__compiled_greeting';
 
 export function Greeting({ name, highlighted }) {
-  return jsx(__compiled_greeting, {
+  return jsx(GreetingTemplate, {
     values: [highlighted ? 'card active' : 'card'], // 动态属性位置 0
     $0: name, // 动态子节点插槽 0
   });
 }
 ```
 
-这里的名称只是帮助理解的概念表示，并不是可以依赖的实际编译产物。关键区别是：常规产物在运行时展开完整的宿主 VNode 层级；优化后的产物引用一份可复用的编译定义，并只传入这次渲染所需的动态数据。
+这里的名称只是帮助理解的概念表示，并不是可以依赖的实际编译产物。关键区别是：常规产物在运行时展开完整的宿主 VNode 层级；优化后的产物引用一份可复用的模板，并只传入这次渲染所需的动态数据。
 
 编译器会从 JSX 中区分出：
 
@@ -188,7 +188,7 @@ export function Greeting({ name, highlighted }) {
 - **动态属性**：由 `highlighted` 决定的 `className`。
 - **动态子节点**：由 `name` 生成的文本。
 
-因此，编译产物可以提前记录静态创建逻辑、定向更新函数和动态子节点插槽。运行时复用这份定义，只为每个组件实例提供自己的动态值和子节点。
+因此，编译产物可以提前记录静态创建逻辑、定向更新函数和动态子节点插槽。运行时复用这份模板，只为每个模板实例提供自己的动态值和子节点。
 
 这种思路与 [Vue 的编译器信息增强虚拟 DOM](https://vuejs.org/guide/extras/rendering-mechanism#compiler-informed-virtual-dom)、[Owl 的 BlockDOM](https://odoo.github.io/owl/documentation/v2/miscellaneous/architecture.html#blockdom) 和 [Million.js](https://github.com/aidenybai/million) 有相似之处：都利用编译阶段已知的信息，缩小运行时需要处理的范围。
 
@@ -196,9 +196,9 @@ export function Greeting({ name, highlighted }) {
 
 ### 当前的中间表示
 
-ReactLynx 当前使用一种名为 **Snapshot** 的中间表示（Intermediate Representation，IR）保存上述编译信息。Snapshot 只是当前实现采用的 IR，不是这项渲染机制的名称，也与快照测试或 React 类组件的 `getSnapshotBeforeUpdate()` 无关。
+ReactLynx 当前使用一种名为 **Snapshot** 的中间表示（Intermediate Representation，IR）表示这些模板。Snapshot 只是当前实现采用的 IR，不是这项渲染机制的名称，也与快照测试或 React 类组件的 `getSnapshotBeforeUpdate()` 无关。
 
-IR 属于内部实现，未来可能继续演进，或替换为 Template 等其他表示。应用代码无需创建或操作它，也不应依赖生成名称和数据结构。
+IR 属于内部实现，未来可能继续演进，或替换为其他表示。应用代码无需创建或操作它，也不应依赖生成名称和数据结构。
 
 当前 IR 可以归纳为以下四个核心部分：
 
@@ -207,9 +207,9 @@ IR 属于内部实现，未来可能继续演进，或替换为 Template 等其�
 | 静态创建函数   | 直接创建确定的 Lynx 元件，并建立父子关系。                       |
 | 动态更新函数   | 按索引更新某个属性、事件或展开属性，不需要重新遍历整段静态结构。 |
 | 动态子节点插槽 | 标记组件、条件分支、文本表达式和列表等动态子树的插入位置。       |
-| 表示标识       | 标识可复用的编译定义，让多个组件实例共享同一份静态信息。         |
+| 表示标识       | 标识可复用的模板，让多个模板实例共享同一份静态信息。             |
 
-下面的简化示例展示了当前 IR 如何通过 [Element PAPI](/api/engine/element-api) 的创建和更新操作表达 `Greeting`。示例保留了静态创建函数、动态更新函数和插槽，省略了 CSS、entry 和兼容性等编译元数据。
+下面的简化示例展示了当前 IR 如何通过 [Element PAPI](/api/engine/element-api) 的创建和更新操作表示 `Greeting` 模板。示例保留了静态创建函数、动态更新函数和插槽，省略了 CSS、entry 和兼容性等编译元数据。
 
 :::details 查看当前 IR 的简化定义
 
@@ -256,37 +256,37 @@ ReactLynx.snapshotCreatorMap[__snapshot_xxx] = (__snapshot_xxx) =>
 
 ReactLynx 的一个特点是：这份编译表示不仅参与更新阶段的协调，也参与 Lynx 双线程的[首帧直出（IFR）](/guide/interaction/ifr)链路。
 
-同一份编译定义可以被多个 `Greeting` 实例复用。每次实际渲染都会产生一组彼此对应的运行时实例：主线程实例持有创建出的 Lynx 元件，后台实例保存参与协调的逻辑树和动态数据。运行时消费编译产物的过程可以分为首屏创建和后续更新两个阶段。
+同一份模板可以被多个已挂载的 `Greeting` 组件复用。每个已挂载的 `Greeting` 都有一组彼此对应的模板实例：主线程模板实例持有创建出的 Lynx 元件，后台模板实例保存参与协调的逻辑树和动态数据。运行时消费编译产物的过程可以分为首屏创建和后续更新两个阶段。
 
-#### 首屏：根据编译定义创建实例
+#### 首屏：创建模板实例
 
-首屏的 UI 元件由主线程直接创建。运行时先根据 VNode 的类型找到编译定义，再为这次 `Greeting` 创建主线程实例。静态创建函数返回的 Lynx 元件由这个实例持有；初始动态值随后交给对应的更新函数，动态子节点则插入编译器预留的插槽。
+首屏的 UI 元件由主线程直接创建。运行时先根据 VNode 的类型找到模板，再为这次 `Greeting` 创建主线程模板实例。静态创建函数返回的 Lynx 元件由这个模板实例持有；初始动态值随后交给对应的更新函数，动态子节点则插入编译器预留的插槽。
 
 下面是这一过程的概念伪代码：
 
 ```js
 function renderFirstScreen(vnode) {
-  const definition = getCompiledDefinition(vnode.type);
-  const instance = createMainThreadInstance(vnode.type);
+  const template = getTemplate(vnode.type);
+  const instance = createMainThreadTemplateInstance(vnode.type);
 
-  instance.elements = definition.create(instance);
+  instance.elements = template.create(instance);
   instance.values = vnode.props.values;
-  definition.update[0](instance); // 将 values[0] 写入 className
+  template.update[0](instance); // 将 values[0] 写入 className
   insertDynamicChild(instance, 0, vnode.props.$0);
 
   return instance;
 }
 ```
 
-对于当前例子，`definition.create()` 创建 `view`、`text` 和固定文本；`definition.update[0]()` 将 `values[0]` 写入 `className`；`insertDynamicChild()` 则把 `$0` 对应的 `name` 放进预留插槽。这里仍会创建完整的 Lynx 元件树，差别在于静态层级由 `definition.create()` 直接展开，不再通过每个宿主 VNode 逐层协调。
+对于当前例子，`template.create()` 创建 `view`、`text` 和固定文本；`template.update[0]()` 将 `values[0]` 写入 `className`；`insertDynamicChild()` 则把 `$0` 对应的 `name` 放进预留插槽。这里仍会创建完整的 Lynx 元件树，差别在于静态层级由 `template.create()` 直接展开，不再通过每个宿主 VNode 逐层协调。
 
 换一个角度，也可以把它理解为预先计算一部分渲染工作，类似于 [Next.js 的 Partial Prerendering](https://nextjs.org/docs/app/getting-started/partial-prerendering)。不过，两者的产物不同：Next.js 生成静态 HTML 外壳和序列化的 React Server Component 载荷；ReactLynx 则把稳定的宿主结构继续降级为 Lynx 平台可以直接理解的元件创建操作。动态值和动态子树仍会在页面启动时传入。
 
-后台首轮协调也会生成与主线程实例树对应的逻辑实例树。首屏同步通过 hydration 建立两侧实例的对应关系，使后续更新可以用 `instanceId` 定位首屏时创建的主线程实例。
+后台首轮协调也会生成与主线程模板实例树对应的后台模板实例树。首屏同步通过 hydration 建立两侧模板实例的对应关系，使后续更新可以用 `instanceId` 定位首屏时创建的主线程模板实例。
 
 #### 更新：只处理动态位置的变化
 
-对应关系建立后，后台线程比较新旧动态数据并生成更新，主线程再找到实际实例并应用变化。
+对应关系建立后，后台线程比较新旧动态数据并生成更新，主线程再找到对应的模板实例并应用变化。
 
 下面的伪代码继续使用 `Greeting`。`highlighted` 对应动态位置 `0`，因此它变化时会生成一条属性更新；`name` 位于动态子节点插槽中，继续由 React 协调：
 
@@ -308,17 +308,17 @@ function reconcileGreeting(previous, next, instanceId) {
   });
 }
 
-// 主线程根据实例和动态位置应用属性更新
+// 主线程根据模板实例和动态位置应用属性更新
 function applyAttributePatch(patch) {
-  const instance = findCompiledInstance(patch.instanceId);
+  const instance = findMainThreadTemplateInstance(patch.instanceId);
   const index = patch.dynamicPartIndex;
 
   instance.values[index] = patch.value;
-  instance.definition.update[index](instance);
+  instance.template.update[index](instance);
 }
 ```
 
-对于属性路径，`reconcileGreeting()` 只描述“哪个实例的哪个动态位置发生了变化”，`applyAttributePatch()` 再调用编译器生成的定向更新函数。动态子节点不经过这组属性更新函数，而是由 React 协调后产生相应的树操作。当前实现会将这些操作编码进序列化的 Patch。
+对于属性路径，`reconcileGreeting()` 只描述“哪个模板实例的哪个动态位置发生了变化”，`applyAttributePatch()` 再调用编译器生成的定向更新函数。动态子节点不经过这组属性更新函数，而是由 React 协调后产生相应的树操作。当前实现会将这些操作编码进序列化的 Patch。
 
 ## 回到应用代码
 

--- a/docs/zh/react/compiler-informed-rendering.mdx
+++ b/docs/zh/react/compiler-informed-rendering.mdx
@@ -11,14 +11,12 @@ ReactLynx 会在构建时分析 JSX，提前提取其中稳定的宿主元件结
 
 这里的“宿主元件”（host elements）是 ReactLynx 通过 Lynx 引擎渲染的 [Lynx 元件](/guide/ui/elements-components)，例如 `<view>` 和 `<text>`；`<ProductCard>` 这样的用户组件则不是宿主元件。
 
-## 如何编写编译友好的 JSX
+## 编译器提前优化了什么
 
 先看一个常规组件：
 
 ```tsx
 export function Greeting({ name, highlighted }) {
-  // 静态：view/text 层级和 "Hello, "。
-  // 动态：className 和 name。
   return (
     <view className={highlighted ? 'card active' : 'card'}>
       <text>Hello, {name}</text>
@@ -27,8 +25,128 @@ export function Greeting({ name, highlighted }) {
 }
 ```
 
-这段 JSX 已经对编译器很友好：`view → text` 的宿主类型和层级直接出现在源码中，`className` 和 `name` 则作为运行时数据正常传入。
-编译器可以提取稳定结构，并把两个表达式保留为动态位置。
+如果只像传统的纯运行时 Virtual DOM 那样进行常规 JSX 转换、不提取静态结构，`Greeting` 的编译结果在语义上类似：
+
+```js
+export function Greeting({ name, highlighted }) {
+  return jsx('view', {
+    className: highlighted ? 'card active' : 'card',
+    children: jsx('text', {
+      children: ['Hello, ', name],
+    }),
+  });
+}
+```
+
+每次渲染时，`jsx()` 都会创建描述 UI 结构的虚拟节点（VNode）。ReactLynx 的协调器再沿着这些节点逐层比较，决定复用、创建或更新哪些宿主元件。这个过程通常称为协调（Reconciliation）。
+
+在这个例子中，真正会变化的只有 `className` 和 `name`；`view → text` 的类型、层级和父子关系始终不变。编译器可以提前提取这些稳定信息，形成一份模板。经过优化后，生成的模板和调用部分在概念上类似：
+
+```js
+const GreetingTemplate = '__compiled_greeting';
+
+function GreetingTemplate_create() {
+  const pageId = ReactLynx.__pageId;
+  const view = __CreateView(pageId);
+  const text = __CreateText(pageId);
+  const fixedText = __CreateRawText('Hello, ');
+  const nameSlot = __CreateWrapperElement(pageId);
+
+  __AppendElement(view, text);
+  __AppendElement(text, fixedText);
+  __AppendElement(text, nameSlot);
+
+  return [view, text, fixedText, nameSlot];
+}
+
+function GreetingTemplate_update(instance) {
+  const className = instance.values[0];
+  __SetClasses(instance.elements[0], className || '');
+}
+
+export function Greeting({ name, highlighted }) {
+  return jsx(GreetingTemplate, {
+    values: [highlighted ? 'card active' : 'card'], // 动态属性位置 0
+    $0: name, // 动态子节点插槽 0
+  });
+}
+```
+
+这里的名称和函数形式只是帮助理解的概念表示，并不是可以依赖的实际编译产物。`GreetingTemplate_create()` 通过 Element PAPI 展开稳定的宿主结构，`GreetingTemplate_update()` 则把动态 `className` 直接应用到根元件。这两个函数展示了 `GreetingTemplate` 的创建和属性更新部分；当前 IR 还会记录它的动态子节点插槽。调用部分引用这份可复用的模板，并只传入这次渲染所需的动态数据。
+
+编译器会从 JSX 中区分出：
+
+- **静态结构**：`view`、`text`、固定文本 `Hello, `，以及确定的父子关系。
+- **动态属性**：由 `highlighted` 决定的 `className`。
+- **动态子节点**：由 `name` 生成的文本。
+
+因此，编译产物可以提前记录静态创建逻辑、定向更新函数和动态子节点插槽。运行时复用这份模板，只为每个模板实例提供自己的动态值和子节点。
+
+这种思路与 [Vue 的编译器信息增强虚拟 DOM](https://vuejs.org/guide/extras/rendering-mechanism#compiler-informed-virtual-dom)、[Owl 的 BlockDOM](https://odoo.github.io/owl/documentation/v2/miscellaneous/architecture.html#blockdom) 和 [Million.js](https://github.com/aidenybai/million) 有相似之处：都利用编译阶段已知的信息，缩小运行时需要处理的范围。
+
+从编译原理的视角，也可以把它理解为一种[部分求值（partial evaluation）](https://en.wikipedia.org/wiki/Partial_evaluation)：ReactLynx 使用 JSX 中已知的宿主结构对通用渲染过程进行特化，只把无法提前确定的部分留到运行时。
+
+::::details 当前实现：Snapshot IR
+
+ReactLynx 当前使用一种名为 **Snapshot** 的中间表示（Intermediate Representation，IR）表示这些模板。Snapshot 只是当前实现采用的 IR，不是这项渲染机制的名称，也与快照测试或 React 类组件的 `getSnapshotBeforeUpdate()` 无关。
+
+IR 属于内部实现，未来可能继续演进，或替换为其他表示。应用代码无需创建或操作它，也不应依赖生成名称和数据结构。
+
+当前 IR 可以归纳为以下四个核心部分：
+
+| 编译结果       | 作用                                                             |
+| -------------- | ---------------------------------------------------------------- |
+| 静态创建函数   | 直接创建确定的 Lynx 元件，并建立父子关系。                       |
+| 动态更新函数   | 按索引更新某个属性、事件或展开属性，不需要重新遍历整段静态结构。 |
+| 动态子节点插槽 | 标记组件、条件分支、文本表达式和列表等动态子树的插入位置。       |
+| 表示标识       | 标识可复用的模板，让多个模板实例共享同一份静态信息。             |
+
+下面的简化示例展示了当前 IR 如何通过 [Element PAPI](/api/engine/element-api) 的创建和更新操作表示 `Greeting` 模板。示例保留了静态创建函数、动态更新函数和插槽，省略了 CSS、entry 和兼容性等编译元数据。
+
+:::details 查看当前 IR 的简化定义
+
+```js
+ReactLynx.snapshotCreatorMap[__snapshot_xxx] = (__snapshot_xxx) =>
+  ReactLynx.createSnapshot(
+    __snapshot_xxx,
+    () => {
+      // 这部分只依赖 JSX 中可以静态确定的结构。
+      const pageId = ReactLynx.__pageId;
+      const view = __CreateView(pageId);
+      const text = __CreateText(pageId);
+      const rawText = __CreateRawText('Hello, ');
+      const slot = __CreateWrapperElement(pageId); // 为 $0 预留插入位置
+
+      __AppendElement(view, text);
+      __AppendElement(text, rawText);
+      __AppendElement(text, slot);
+
+      // 更新函数和插槽描述通过这些数组索引定位元件。
+      return [view, text, rawText, slot];
+    },
+    [
+      function (ctx) {
+        if (ctx.__elements) {
+          // values[0] 只更新 elements[0]，也就是根 view。
+          __SetClasses(ctx.__elements[0], ctx.__values[0] || '');
+        }
+      },
+    ],
+    [[ReactLynx.__DynamicPartSlotV2, 3]], // $0 对应 elements[3]
+  );
+```
+
+:::
+
+:::warning
+
+这里的 `$0` 和 `__DynamicPartSlotV2` 表示方式对应 `@lynx-js/react` 0.120.0 及以上版本。`createSnapshot`、`snapshotCreatorMap`、全局元件操作函数和生成的标识都属于内部实现，具体名称和参数可能随源码、编译配置及 ReactLynx 版本变化。请勿在应用代码中依赖或复制这些产物。
+
+:::
+
+::::
+
+## 如何编写编译友好的 JSX
 
 动态属性、文本和子节点本身不会阻止编译优化。对于大多数组件，遵循下面三个原则就足够了：
 
@@ -152,134 +270,11 @@ function UserCard({ id, name, selected }) {
 
 ## 编译器与运行时如何协作
 
-### 编译器提前完成了什么
-
-如果只进行常规 JSX 转换、不提取静态结构，`Greeting` 的编译结果在语义上类似：
-
-```js
-export function Greeting({ name, highlighted }) {
-  return jsx('view', {
-    className: highlighted ? 'card active' : 'card',
-    children: jsx('text', {
-      children: ['Hello, ', name],
-    }),
-  });
-}
-```
-
-每次渲染时，`jsx()` 都会创建描述 UI 结构的虚拟节点（VNode）。ReactLynx 的协调器再沿着这些节点逐层比较，决定复用、创建或更新哪些宿主元件。这个过程通常称为协调（Reconciliation）。
-
-在这个例子中，真正会变化的只有 `className` 和 `name`；`view → text` 的类型、层级和父子关系始终不变。编译器可以提前提取这些稳定信息。经过优化后，生成的模板和调用部分在概念上类似：
-
-```js
-const GreetingTemplate = '__compiled_greeting';
-
-function GreetingTemplate_create() {
-  const pageId = ReactLynx.__pageId;
-  const view = __CreateView(pageId);
-  const text = __CreateText(pageId);
-  const fixedText = __CreateRawText('Hello, ');
-  const nameSlot = __CreateWrapperElement(pageId);
-
-  __AppendElement(view, text);
-  __AppendElement(text, fixedText);
-  __AppendElement(text, nameSlot);
-
-  return [view, text, fixedText, nameSlot];
-}
-
-function GreetingTemplate_update(instance) {
-  const className = instance.values[0];
-  __SetClasses(instance.elements[0], className || '');
-}
-
-export function Greeting({ name, highlighted }) {
-  return jsx(GreetingTemplate, {
-    values: [highlighted ? 'card active' : 'card'], // 动态属性位置 0
-    $0: name, // 动态子节点插槽 0
-  });
-}
-```
-
-这里的名称和函数形式只是帮助理解的概念表示，并不是可以依赖的实际编译产物。`GreetingTemplate_create()` 通过 Element PAPI 展开稳定的宿主结构，`GreetingTemplate_update()` 则把动态 `className` 直接应用到根元件。这两个函数展示了 `GreetingTemplate` 的创建和属性更新部分；当前 IR 还会记录它的动态子节点插槽。调用部分引用这份可复用的模板，并只传入这次渲染所需的动态数据。
-
-编译器会从 JSX 中区分出：
-
-- **静态结构**：`view`、`text`、固定文本 `Hello, `，以及确定的父子关系。
-- **动态属性**：由 `highlighted` 决定的 `className`。
-- **动态子节点**：由 `name` 生成的文本。
-
-因此，编译产物可以提前记录静态创建逻辑、定向更新函数和动态子节点插槽。运行时复用这份模板，只为每个模板实例提供自己的动态值和子节点。
-
-这种思路与 [Vue 的编译器信息增强虚拟 DOM](https://vuejs.org/guide/extras/rendering-mechanism#compiler-informed-virtual-dom)、[Owl 的 BlockDOM](https://odoo.github.io/owl/documentation/v2/miscellaneous/architecture.html#blockdom) 和 [Million.js](https://github.com/aidenybai/million) 有相似之处：都利用编译阶段已知的信息，缩小运行时需要处理的范围。
-
-从编译原理的视角，也可以把它理解为一种[部分求值（partial evaluation）](https://en.wikipedia.org/wiki/Partial_evaluation)：ReactLynx 使用 JSX 中已知的宿主结构对通用渲染过程进行特化，只把无法提前确定的部分留到运行时。
-
-### 当前的中间表示
-
-ReactLynx 当前使用一种名为 **Snapshot** 的中间表示（Intermediate Representation，IR）表示这些模板。Snapshot 只是当前实现采用的 IR，不是这项渲染机制的名称，也与快照测试或 React 类组件的 `getSnapshotBeforeUpdate()` 无关。
-
-IR 属于内部实现，未来可能继续演进，或替换为其他表示。应用代码无需创建或操作它，也不应依赖生成名称和数据结构。
-
-当前 IR 可以归纳为以下四个核心部分：
-
-| 编译结果       | 作用                                                             |
-| -------------- | ---------------------------------------------------------------- |
-| 静态创建函数   | 直接创建确定的 Lynx 元件，并建立父子关系。                       |
-| 动态更新函数   | 按索引更新某个属性、事件或展开属性，不需要重新遍历整段静态结构。 |
-| 动态子节点插槽 | 标记组件、条件分支、文本表达式和列表等动态子树的插入位置。       |
-| 表示标识       | 标识可复用的模板，让多个模板实例共享同一份静态信息。             |
-
-下面的简化示例展示了当前 IR 如何通过 [Element PAPI](/api/engine/element-api) 的创建和更新操作表示 `Greeting` 模板。示例保留了静态创建函数、动态更新函数和插槽，省略了 CSS、entry 和兼容性等编译元数据。
-
-:::details 查看当前 IR 的简化定义
-
-```js
-ReactLynx.snapshotCreatorMap[__snapshot_xxx] = (__snapshot_xxx) =>
-  ReactLynx.createSnapshot(
-    __snapshot_xxx,
-    () => {
-      // 这部分只依赖 JSX 中可以静态确定的结构。
-      const pageId = ReactLynx.__pageId;
-      const view = __CreateView(pageId);
-      const text = __CreateText(pageId);
-      const rawText = __CreateRawText('Hello, ');
-      const slot = __CreateWrapperElement(pageId); // 为 $0 预留插入位置
-
-      __AppendElement(view, text);
-      __AppendElement(text, rawText);
-      __AppendElement(text, slot);
-
-      // 更新函数和插槽描述通过这些数组索引定位元件。
-      return [view, text, rawText, slot];
-    },
-    [
-      function (ctx) {
-        if (ctx.__elements) {
-          // values[0] 只更新 elements[0]，也就是根 view。
-          __SetClasses(ctx.__elements[0], ctx.__values[0] || '');
-        }
-      },
-    ],
-    [[ReactLynx.__DynamicPartSlotV2, 3]], // $0 对应 elements[3]
-  );
-```
-
-:::
-
-:::warning
-
-这里的 `$0` 和 `__DynamicPartSlotV2` 表示方式对应 `@lynx-js/react` 0.120.0 及以上版本。`createSnapshot`、`snapshotCreatorMap`、全局元件操作函数和生成的标识都属于内部实现，具体名称和参数可能随源码、编译配置及 ReactLynx 版本变化。请勿在应用代码中依赖或复制这些产物。
-
-:::
-
-### 编译产物如何进入运行时
-
 ReactLynx 的一个特点是：这份编译表示不仅参与更新阶段的协调，也参与 Lynx 双线程的[首帧直出（IFR）](/guide/interaction/ifr)链路。
 
 同一份模板可以被多个已挂载的 `Greeting` 组件复用。每个已挂载的 `Greeting` 都有一组彼此对应的模板实例：主线程模板实例持有创建出的 Lynx 元件，后台模板实例保存参与协调的逻辑树和动态数据。运行时消费编译产物的过程可以分为首屏创建和后续更新两个阶段。
 
-#### 首屏：创建模板实例
+### 首屏：创建模板实例
 
 首屏的 UI 元件由主线程直接创建。运行时先根据 VNode 的类型找到模板，再为这次 `Greeting` 创建主线程模板实例。静态创建函数返回的 Lynx 元件由这个模板实例持有；初始动态值随后交给对应的更新函数，动态子节点则插入编译器预留的插槽。
 
@@ -305,7 +300,7 @@ function renderFirstScreen(vnode) {
 
 后台首轮协调也会生成与主线程模板实例树对应的后台模板实例树。首屏同步通过 hydration 建立两侧模板实例的对应关系，使后续更新可以用 `instanceId` 定位首屏时创建的主线程模板实例。
 
-#### 更新：只处理动态位置的变化
+### 更新：只处理动态位置的变化
 
 对应关系建立后，后台线程比较新旧动态数据并生成更新，主线程再找到对应的模板实例并应用变化。
 

--- a/docs/zh/react/compiler-informed-rendering.mdx
+++ b/docs/zh/react/compiler-informed-rendering.mdx
@@ -40,47 +40,45 @@ export function Greeting({ name, highlighted }) {
 
 每次渲染时，`jsx()` 都会创建描述 UI 结构的虚拟节点（VNode）。ReactLynx 再沿着这些节点逐层比较，决定复用、创建或更新哪些宿主元件。这个过程通常称为[协调（Reconciliation）](https://react.dev/learn/render-and-commit)。
 
-但在这个例子中，`view`、`text`、固定文本 `Hello, ` 及其父子关系都是静态的，只有 `className` 和 `name` 会变化。编译器可以据此提取一份可复用的模板，让运行时只传入每次渲染所需的动态数据。概念上类似：
+但在这个例子中，`view`、`text`、固定文本 `Hello, ` 及其父子关系都是静态的，只有 `className` 和 `name` 会变化。编译器可以据此提取一份可复用的模板，将静态结构编译为 [Element PAPI](/api/engine/element-api) 操作，让运行时只传入每次渲染所需的动态数据。概念上类似：
 
 ```js
-const GreetingTemplate = '__compiled_greeting';
+const GreetingTemplate = {
+  // 首次创建模板实例：直接执行编译生成的 Element PAPI 操作。
+  create() {
+    const pageId = ReactLynx.__pageId;
+    const view = __CreateView(pageId);
+    const text = __CreateText(pageId);
+    const nameSlot = __CreateWrapperElement(pageId);
 
-// 将静态结构提前编译为 Element PAPI 操作。
-function GreetingTemplate_create() {
-  const pageId = ReactLynx.__pageId;
-  const view = __CreateView(pageId);
-  const text = __CreateText(pageId);
-  const fixedText = __CreateRawText('Hello, ');
-  const nameSlot = __CreateWrapperElement(pageId);
+    __AppendElement(view, text);
+    __AppendElement(text, __CreateRawText('Hello, '));
+    __AppendElement(text, nameSlot);
 
-  __AppendElement(view, text);
-  __AppendElement(text, fixedText);
-  __AppendElement(text, nameSlot);
+    return { view, nameSlot };
+  },
 
-  return [view, text, fixedText, nameSlot];
-}
-
-// 为动态属性生成细粒度更新逻辑。
-function GreetingTemplate_update(instance) {
-  const className = instance.values[0];
-  __SetClasses(instance.elements[0], className || '');
-}
+  // 后续更新：直接更新已知元件，不遍历静态结构。
+  update(instance, { className }) {
+    __SetClasses(instance.view, className);
+  },
+};
 
 export function Greeting({ name, highlighted }) {
-  return jsx(GreetingTemplate, {
-    values: [highlighted ? 'card active' : 'card'], // 动态属性位置 0
-    $0: name, // 动态子节点插槽 0
+  return renderTemplate(GreetingTemplate, {
+    className: highlighted ? 'card active' : 'card',
+    nameSlot: name,
   });
 }
 ```
 
-这里的名称和函数形式只用于解释机制，并不是可以依赖的实际编译产物。`GreetingTemplate_create()` 创建静态结构，`GreetingTemplate_update()` 定向更新 `className`，`$0` 表示 `name` 所在的动态子节点插槽。
+这里的名称和函数形式只用于解释机制，并不是可以依赖的实际编译产物。首次渲染时，编译生成的 `create()` 直接建立已知的宿主结构；后续渲染时，`update()` 直接修改已知元件。运行时不需要为这部分结构反复创建和比较 VNode，而 `name` 等无法提前确定的子节点仍通过动态插槽处理。
+
+:::details 当前的内部表示：Snapshot
 
 这种思路与 [Vue 的编译器信息增强虚拟 DOM](https://vuejs.org/guide/extras/rendering-mechanism#compiler-informed-virtual-dom)、[Owl 的 BlockDOM](https://odoo.github.io/owl/documentation/v2/miscellaneous/architecture.html#blockdom) 和 [Million.js](https://github.com/aidenybai/million) 有相似之处：都利用编译阶段已知的信息，缩小运行时需要处理的范围。
 
 从编译原理的视角，也可以把它理解为一种[部分求值（partial evaluation）](https://en.wikipedia.org/wiki/Partial_evaluation)：ReactLynx 使用 JSX 中已知的宿主结构对通用渲染过程进行特化，只把无法提前确定的部分留到运行时。
-
-:::details 当前的内部表示：Snapshot
 
 ReactLynx 当前使用一种名为 **Snapshot** 的中间表示（Intermediate Representation，IR）保存上述编译信息。我们也在尝试演进成性能更好的其他表示。
 
@@ -93,40 +91,7 @@ Snapshot 和上述简化的概念一致，可以归纳为以下四个核心部�
 | 动态子节点插槽 | 标记组件、条件分支、文本表达式和列表等动态子树的插入位置。       |
 | 表示标识       | 标识可复用的模板，让多个模板实例共享同一份静态信息。             |
 
-下面的简化示例展示了当前 IR 如何通过 [Element PAPI](/api/engine/element-api) 的创建和更新操作表示 `Greeting` 模板。示例保留了静态创建函数、动态更新函数和插槽，省略了 CSS、entry 和兼容性等编译元数据。
-
-```js
-ReactLynx.snapshotCreatorMap[__snapshot_xxx] = (__snapshot_xxx) =>
-  ReactLynx.createSnapshot(
-    __snapshot_xxx,
-    () => {
-      // 这部分只依赖 JSX 中可以静态确定的结构。
-      const pageId = ReactLynx.__pageId;
-      const view = __CreateView(pageId);
-      const text = __CreateText(pageId);
-      const rawText = __CreateRawText('Hello, ');
-      const slot = __CreateWrapperElement(pageId); // 为 $0 预留插入位置
-
-      __AppendElement(view, text);
-      __AppendElement(text, rawText);
-      __AppendElement(text, slot);
-
-      // 更新函数和插槽描述通过这些数组索引定位元件。
-      return [view, text, rawText, slot];
-    },
-    [
-      function (ctx) {
-        if (ctx.__elements) {
-          // values[0] 只更新 elements[0]，也就是根 view。
-          __SetClasses(ctx.__elements[0], ctx.__values[0] || '');
-        }
-      },
-    ],
-    [[ReactLynx.__DynamicPartSlotV2, 3]], // $0 对应 elements[3]
-  );
-```
-
-**注意：**IR 属于内部实现，请勿在应用代码中依赖或复制这些产物。这里的 `$0` 和 `__DynamicPartSlotV2` 表示方式对应 `@lynx-js/react` 0.120.0 及以上版本。`createSnapshot`、`snapshotCreatorMap`、全局元件操作函数和生成的标识都属于内部实现，具体名称和参数可能随源码、编译配置及 ReactLynx 版本变化。
+**注意：**IR 属于内部实现，请勿在应用代码中依赖或复制这些产物。具体名称、参数和数据结构可能随源码、编译配置及 ReactLynx 版本变化。
 
 :::
 

--- a/docs/zh/react/compiler-informed-rendering.mdx
+++ b/docs/zh/react/compiler-informed-rendering.mdx
@@ -17,6 +17,8 @@ ReactLynx 会在构建时分析 JSX，提前提取其中稳定的宿主元件结
 
 ```tsx
 export function Greeting({ name, highlighted }) {
+  // 静态：view/text 层级和 "Hello, "。
+  // 动态：className 和 name。
   return (
     <view className={highlighted ? 'card active' : 'card'}>
       <text>Hello, {name}</text>
@@ -167,10 +169,29 @@ export function Greeting({ name, highlighted }) {
 
 每次渲染时，`jsx()` 都会创建描述 UI 结构的虚拟节点（VNode）。ReactLynx 的协调器再沿着这些节点逐层比较，决定复用、创建或更新哪些宿主元件。这个过程通常称为协调（Reconciliation）。
 
-在这个例子中，真正会变化的只有 `className` 和 `name`；`view → text` 的类型、层级和父子关系始终不变。编译器可以提前提取这些稳定信息。经过优化后，调用部分在概念上类似：
+在这个例子中，真正会变化的只有 `className` 和 `name`；`view → text` 的类型、层级和父子关系始终不变。编译器可以提前提取这些稳定信息。经过优化后，生成的模板和调用部分在概念上类似：
 
 ```js
 const GreetingTemplate = '__compiled_greeting';
+
+function GreetingTemplate_create() {
+  const pageId = ReactLynx.__pageId;
+  const view = __CreateView(pageId);
+  const text = __CreateText(pageId);
+  const fixedText = __CreateRawText('Hello, ');
+  const nameSlot = __CreateWrapperElement(pageId);
+
+  __AppendElement(view, text);
+  __AppendElement(text, fixedText);
+  __AppendElement(text, nameSlot);
+
+  return [view, text, fixedText, nameSlot];
+}
+
+function GreetingTemplate_update(instance) {
+  const className = instance.values[0];
+  __SetClasses(instance.elements[0], className || '');
+}
 
 export function Greeting({ name, highlighted }) {
   return jsx(GreetingTemplate, {
@@ -180,7 +201,7 @@ export function Greeting({ name, highlighted }) {
 }
 ```
 
-这里的名称只是帮助理解的概念表示，并不是可以依赖的实际编译产物。关键区别是：常规产物在运行时展开完整的宿主 VNode 层级；优化后的产物引用一份可复用的模板，并只传入这次渲染所需的动态数据。
+这里的名称和函数形式只是帮助理解的概念表示，并不是可以依赖的实际编译产物。`GreetingTemplate_create()` 通过 Element PAPI 展开稳定的宿主结构，`GreetingTemplate_update()` 则把动态 `className` 直接应用到根元件。这两个函数展示了 `GreetingTemplate` 的创建和属性更新部分；当前 IR 还会记录它的动态子节点插槽。调用部分引用这份可复用的模板，并只传入这次渲染所需的动态数据。
 
 编译器会从 JSX 中区分出：
 

--- a/docs/zh/react/compiler-informed-rendering.mdx
+++ b/docs/zh/react/compiler-informed-rendering.mdx
@@ -45,6 +45,7 @@ export function Greeting({ name, highlighted }) {
 ```js
 const GreetingTemplate = '__compiled_greeting';
 
+// 将静态结构提前编译为 Element PAPI 操作。
 function GreetingTemplate_create() {
   const pageId = ReactLynx.__pageId;
   const view = __CreateView(pageId);
@@ -59,6 +60,7 @@ function GreetingTemplate_create() {
   return [view, text, fixedText, nameSlot];
 }
 
+// 为动态属性生成细粒度更新逻辑。
 function GreetingTemplate_update(instance) {
   const className = instance.values[0];
   __SetClasses(instance.elements[0], className || '');

--- a/docs/zh/react/compiler-informed-rendering.mdx
+++ b/docs/zh/react/compiler-informed-rendering.mdx
@@ -74,7 +74,7 @@ export function Greeting({ name, highlighted }) {
 
 这里的名称和函数形式只用于解释机制，并不是可以依赖的实际编译产物。首次渲染时，编译生成的 `create()` 直接建立已知的宿主结构；后续渲染时，`update()` 直接修改已知元件。运行时不需要为这部分结构反复创建和比较 VNode，而 `name` 等无法提前确定的子节点仍通过动态插槽处理。
 
-:::details 当前的内部表示：Snapshot
+:::details 相关工作与当前实现：Snapshot
 
 这种思路与 [Vue 的编译器信息增强虚拟 DOM](https://vuejs.org/guide/extras/rendering-mechanism#compiler-informed-virtual-dom)、[Owl 的 BlockDOM](https://odoo.github.io/owl/documentation/v2/miscellaneous/architecture.html#blockdom) 和 [Million.js](https://github.com/aidenybai/million) 有相似之处：都利用编译阶段已知的信息，缩小运行时需要处理的范围。
 

--- a/docs/zh/react/compiler-informed-rendering.mdx
+++ b/docs/zh/react/compiler-informed-rendering.mdx
@@ -40,7 +40,7 @@ export function Greeting({ name, highlighted }) {
 
 每次渲染时，`jsx()` 都会创建描述 UI 结构的虚拟节点（VNode）。ReactLynx 再沿着这些节点逐层比较，决定复用、创建或更新哪些宿主元件。这个过程通常称为[协调（Reconciliation）](https://react.dev/learn/render-and-commit)。
 
-但在这个例子中，`view`、`text`、固定文本 `Hello, ` 及其父子关系都是静态的，只有 `className` 和 `name` 会变化。编译器可以据此提取一份可复用的模板，将静态结构编译为 [Element PAPI](/api/engine/element-api) 操作，让运行时只传入每次渲染所需的动态数据。概念上类似：
+但在这个例子中，`view`、`text`、固定文本 `Hello, ` 及其父子关系都是静态的，只有 `className` 和 `name` 会变化。编译器可以提前生成用于创建静态结构的 [Element PAPI](/api/engine/element-api) 操作。由此得到的静态模板定义可以在不同实例的首次渲染以及后续重新渲染中复用；运行时只需提供每次渲染所需的动态数据。概念上类似：
 
 ```js
 const GreetingTemplate = {

--- a/docs/zh/react/compiler-informed-rendering.mdx
+++ b/docs/zh/react/compiler-informed-rendering.mdx
@@ -74,7 +74,7 @@ export function Greeting({ name, highlighted }) {
 
 这里的名称和函数形式只用于解释机制，并不是可以依赖的实际编译产物。首次渲染时，编译生成的 `create()` 直接建立已知的宿主结构；后续渲染时，`update()` 直接修改已知元件。运行时不需要为这部分结构反复创建和比较 VNode，而 `name` 等无法提前确定的子节点仍通过动态插槽处理。
 
-:::details 相关工作与当前实现：Snapshot
+:::details 历史经验与当前实现：Snapshot
 
 这种思路与 [Vue 的编译器信息增强虚拟 DOM](https://vuejs.org/guide/extras/rendering-mechanism#compiler-informed-virtual-dom)、[Owl 的 BlockDOM](https://odoo.github.io/owl/documentation/v2/miscellaneous/architecture.html#blockdom) 和 [Million.js](https://github.com/aidenybai/million) 有相似之处：都利用编译阶段已知的信息，缩小运行时需要处理的范围。
 

--- a/docs/zh/react/compiler-informed-rendering.mdx
+++ b/docs/zh/react/compiler-informed-rendering.mdx
@@ -80,13 +80,11 @@ export function Greeting({ name, highlighted }) {
 
 从编译原理的视角，也可以把它理解为一种[部分求值（partial evaluation）](https://en.wikipedia.org/wiki/Partial_evaluation)：ReactLynx 使用 JSX 中已知的宿主结构对通用渲染过程进行特化，只把无法提前确定的部分留到运行时。
 
-:::details 当前实现：Snapshot IR
+:::details 当前的内部表示：Snapshot
 
-ReactLynx 当前使用一种名为 **Snapshot** 的中间表示（Intermediate Representation，IR）表示这些模板。Snapshot 只是当前实现采用的 IR，不是这项渲染机制的名称，也与快照测试或 React 类组件的 `getSnapshotBeforeUpdate()` 无关。
+ReactLynx 当前使用一种名为 **Snapshot** 的中间表示（Intermediate Representation，IR）保存上述编译信息。我们也在尝试演进成性能更好的其他表示。
 
-IR 属于内部实现，未来可能继续演进，或替换为其他表示。应用代码无需创建或操作它，也不应依赖生成名称和数据结构。
-
-将上面的概念对应到当前 Snapshot IR，可以归纳为以下四个核心部分：
+Snapshot 和上述简化的概念一致，可以归纳为以下四个核心部分：
 
 | 编译结果       | 作用                                                             |
 | -------------- | ---------------------------------------------------------------- |
@@ -128,7 +126,7 @@ ReactLynx.snapshotCreatorMap[__snapshot_xxx] = (__snapshot_xxx) =>
   );
 ```
 
-**注意：**这里的 `$0` 和 `__DynamicPartSlotV2` 表示方式对应 `@lynx-js/react` 0.120.0 及以上版本。`createSnapshot`、`snapshotCreatorMap`、全局元件操作函数和生成的标识都属于内部实现，具体名称和参数可能随源码、编译配置及 ReactLynx 版本变化。请勿在应用代码中依赖或复制这些产物。
+**注意：**IR 属于内部实现，请勿在应用代码中依赖或复制这些产物。这里的 `$0` 和 `__DynamicPartSlotV2` 表示方式对应 `@lynx-js/react` 0.120.0 及以上版本。`createSnapshot`、`snapshotCreatorMap`、全局元件操作函数和生成的标识都属于内部实现，具体名称和参数可能随源码、编译配置及 ReactLynx 版本变化。
 
 :::
 

--- a/docs/zh/react/compiler-informed-rendering.mdx
+++ b/docs/zh/react/compiler-informed-rendering.mdx
@@ -86,7 +86,7 @@ export function Greeting({ name, highlighted }) {
 
 从编译原理的视角，也可以把它理解为一种[部分求值（partial evaluation）](https://en.wikipedia.org/wiki/Partial_evaluation)：ReactLynx 使用 JSX 中已知的宿主结构对通用渲染过程进行特化，只把无法提前确定的部分留到运行时。
 
-::::details 当前实现：Snapshot IR
+:::details 当前实现：Snapshot IR
 
 ReactLynx 当前使用一种名为 **Snapshot** 的中间表示（Intermediate Representation，IR）表示这些模板。Snapshot 只是当前实现采用的 IR，不是这项渲染机制的名称，也与快照测试或 React 类组件的 `getSnapshotBeforeUpdate()` 无关。
 
@@ -102,8 +102,6 @@ IR 属于内部实现，未来可能继续演进，或替换为其他表示。�
 | 表示标识       | 标识可复用的模板，让多个模板实例共享同一份静态信息。             |
 
 下面的简化示例展示了当前 IR 如何通过 [Element PAPI](/api/engine/element-api) 的创建和更新操作表示 `Greeting` 模板。示例保留了静态创建函数、动态更新函数和插槽，省略了 CSS、entry 和兼容性等编译元数据。
-
-:::details 查看当前 IR 的简化定义
 
 ```js
 ReactLynx.snapshotCreatorMap[__snapshot_xxx] = (__snapshot_xxx) =>
@@ -136,15 +134,9 @@ ReactLynx.snapshotCreatorMap[__snapshot_xxx] = (__snapshot_xxx) =>
   );
 ```
 
-:::
-
-:::warning
-
-这里的 `$0` 和 `__DynamicPartSlotV2` 表示方式对应 `@lynx-js/react` 0.120.0 及以上版本。`createSnapshot`、`snapshotCreatorMap`、全局元件操作函数和生成的标识都属于内部实现，具体名称和参数可能随源码、编译配置及 ReactLynx 版本变化。请勿在应用代码中依赖或复制这些产物。
+**注意：**这里的 `$0` 和 `__DynamicPartSlotV2` 表示方式对应 `@lynx-js/react` 0.120.0 及以上版本。`createSnapshot`、`snapshotCreatorMap`、全局元件操作函数和生成的标识都属于内部实现，具体名称和参数可能随源码、编译配置及 ReactLynx 版本变化。请勿在应用代码中依赖或复制这些产物。
 
 :::
-
-::::
 
 ## 如何编写编译友好的 JSX
 

--- a/docs/zh/react/compiler-informed-rendering.mdx
+++ b/docs/zh/react/compiler-informed-rendering.mdx
@@ -40,15 +40,7 @@ export function Greeting({ name, highlighted }) {
 
 每次渲染时，`jsx()` 都会创建描述 UI 结构的虚拟节点（VNode）。ReactLynx 再沿着这些节点逐层比较，决定复用、创建或更新哪些宿主元件。这个过程通常称为[协调（Reconciliation）](https://react.dev/learn/render-and-commit)。
 
-但在这个例子中，真正会变化的只有 `className` 和 `name`；`view → text` 的类型、层级和父子关系始终不变。编译器会从 JSX 中区分出：
-
-- **静态结构**：`view`、`text`、固定文本 `Hello, `，以及确定的父子关系。
-- **动态属性**：由 `highlighted` 决定的 `className`。
-- **动态子节点**：由 `name` 生成的文本。
-
-因此，编译产物可以提前记录静态创建逻辑、定向更新函数和动态子节点插槽。运行时复用这份模板，只为每个模板实例提供自己的动态值和子节点。
-
-经过优化后，生成的模板和调用部分在概念上类似：
+但在这个例子中，`view`、`text`、固定文本 `Hello, ` 及其父子关系都是静态的，只有 `className` 和 `name` 会变化。编译器可以据此提取一份可复用的模板，让运行时只传入每次渲染所需的动态数据。概念上类似：
 
 ```js
 const GreetingTemplate = '__compiled_greeting';
@@ -80,7 +72,7 @@ export function Greeting({ name, highlighted }) {
 }
 ```
 
-这里的名称和函数形式只是帮助理解的概念表示，并不是可以依赖的实际编译产物。`GreetingTemplate_create()` 通过 Element PAPI 展开稳定的宿主结构，`GreetingTemplate_update()` 则把动态 `className` 直接应用到根元件。这两个函数展示了 `GreetingTemplate` 的创建和属性更新部分；当前 IR 还会记录它的动态子节点插槽。调用部分引用这份可复用的模板，并只传入这次渲染所需的动态数据。
+这里的名称和函数形式只用于解释机制，并不是可以依赖的实际编译产物。`GreetingTemplate_create()` 创建静态结构，`GreetingTemplate_update()` 定向更新 `className`，`$0` 表示 `name` 所在的动态子节点插槽。
 
 这种思路与 [Vue 的编译器信息增强虚拟 DOM](https://vuejs.org/guide/extras/rendering-mechanism#compiler-informed-virtual-dom)、[Owl 的 BlockDOM](https://odoo.github.io/owl/documentation/v2/miscellaneous/architecture.html#blockdom) 和 [Million.js](https://github.com/aidenybai/million) 有相似之处：都利用编译阶段已知的信息，缩小运行时需要处理的范围。
 
@@ -92,7 +84,7 @@ ReactLynx 当前使用一种名为 **Snapshot** 的中间表示（Intermediate R
 
 IR 属于内部实现，未来可能继续演进，或替换为其他表示。应用代码无需创建或操作它，也不应依赖生成名称和数据结构。
 
-当前 IR 可以归纳为以下四个核心部分：
+将上面的概念对应到当前 Snapshot IR，可以归纳为以下四个核心部分：
 
 | 编译结果       | 作用                                                             |
 | -------------- | ---------------------------------------------------------------- |

--- a/docs/zh/react/compiler-informed-rendering.mdx
+++ b/docs/zh/react/compiler-informed-rendering.mdx
@@ -38,9 +38,17 @@ export function Greeting({ name, highlighted }) {
 }
 ```
 
-每次渲染时，`jsx()` 都会创建描述 UI 结构的虚拟节点（VNode）。ReactLynx 的协调器再沿着这些节点逐层比较，决定复用、创建或更新哪些宿主元件。这个过程通常称为协调（Reconciliation）。
+每次渲染时，`jsx()` 都会创建描述 UI 结构的虚拟节点（VNode）。ReactLynx 再沿着这些节点逐层比较，决定复用、创建或更新哪些宿主元件。这个过程通常称为[协调（Reconciliation）](https://react.dev/learn/render-and-commit)。
 
-在这个例子中，真正会变化的只有 `className` 和 `name`；`view → text` 的类型、层级和父子关系始终不变。编译器可以提前提取这些稳定信息，形成一份模板。经过优化后，生成的模板和调用部分在概念上类似：
+但在这个例子中，真正会变化的只有 `className` 和 `name`；`view → text` 的类型、层级和父子关系始终不变。编译器会从 JSX 中区分出：
+
+- **静态结构**：`view`、`text`、固定文本 `Hello, `，以及确定的父子关系。
+- **动态属性**：由 `highlighted` 决定的 `className`。
+- **动态子节点**：由 `name` 生成的文本。
+
+因此，编译产物可以提前记录静态创建逻辑、定向更新函数和动态子节点插槽。运行时复用这份模板，只为每个模板实例提供自己的动态值和子节点。
+
+经过优化后，生成的模板和调用部分在概念上类似：
 
 ```js
 const GreetingTemplate = '__compiled_greeting';
@@ -73,14 +81,6 @@ export function Greeting({ name, highlighted }) {
 ```
 
 这里的名称和函数形式只是帮助理解的概念表示，并不是可以依赖的实际编译产物。`GreetingTemplate_create()` 通过 Element PAPI 展开稳定的宿主结构，`GreetingTemplate_update()` 则把动态 `className` 直接应用到根元件。这两个函数展示了 `GreetingTemplate` 的创建和属性更新部分；当前 IR 还会记录它的动态子节点插槽。调用部分引用这份可复用的模板，并只传入这次渲染所需的动态数据。
-
-编译器会从 JSX 中区分出：
-
-- **静态结构**：`view`、`text`、固定文本 `Hello, `，以及确定的父子关系。
-- **动态属性**：由 `highlighted` 决定的 `className`。
-- **动态子节点**：由 `name` 生成的文本。
-
-因此，编译产物可以提前记录静态创建逻辑、定向更新函数和动态子节点插槽。运行时复用这份模板，只为每个模板实例提供自己的动态值和子节点。
 
 这种思路与 [Vue 的编译器信息增强虚拟 DOM](https://vuejs.org/guide/extras/rendering-mechanism#compiler-informed-virtual-dom)、[Owl 的 BlockDOM](https://odoo.github.io/owl/documentation/v2/miscellaneous/architecture.html#blockdom) 和 [Million.js](https://github.com/aidenybai/million) 有相似之处：都利用编译阶段已知的信息，缩小运行时需要处理的范围。
 


### PR DESCRIPTION
## Summary

- name the reusable compiler result a template and its thread-specific runtime objects template instances
- connect the Greeting JSX to conceptual template create and update functions
- keep Snapshot documented as the current internal representation

## Validation

- Prettier
- CSpell
- zhlint
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Clarify compiler-informed rendering terminology with “template” and “template instance.”
- Explain template creation, targeted updates, and dynamic child slots through the `Greeting` example.
- Preserve `Snapshot` as the current internal representation and describe template-instance behavior across threads.
- Align the English and Chinese React documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->