### PR TITLE
fix(lynx-compat-data): pack generated CSS compat data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,12 @@ jobs:
       - name: Format Check
         run: pnpm run format:check
 
+      - name: Lynx Compat Data Test
+        run: pnpm --filter @lynx-js/lynx-compat-data run test
+
+      - name: Lynx Compat Data Pack Check
+        run: pnpm --filter @lynx-js/lynx-compat-data run pack:check
+
       - name: Build
         run: pnpm run build
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,15 @@ pnpm run format:check
 pnpm run build
 ```
 
+For changes under `packages/lynx-compat-data`, also run:
+
+```bash
+pnpm --filter @lynx-js/lynx-compat-data run pack:check
+```
+
+This verifies that generated CSS property compatibility data is present in the
+package tarball without committing `css/properties/*.json` to git.
+
 ## Pull Requests
 
 - Base normal changes on `main`.

--- a/packages/lynx-compat-data/README.md
+++ b/packages/lynx-compat-data/README.md
@@ -39,6 +39,10 @@ Data for CSS e.g. properties like `background`, `color`, etc.
 >
 > 1. **`@lynx-js/css-defines`** — the primary source of truth. To update a property, change the upstream definition and bump the dependency, then regenerate.
 > 2. **`css/properties-manual/`** — hand-maintained files for properties not yet covered by `css-defines` (e.g. `css-variable`, `custom-property`, `filter-properties`). The directory listing itself is the allowlist; no name is hardcoded in the generator. A filename collision between the two sources fails the build, so once `css-defines` adds coverage, remove the corresponding file from `properties-manual/`.
+>
+> The package `prepack` lifecycle runs the CSS generator and validation before
+> packing or publishing, so generated `css/properties/*.json` files are included
+> in the package tarball without being committed to git.
 
 #### [`lynx-api`](./lynx-api)
 
@@ -182,6 +186,22 @@ Run all build steps at once:
 ```bash
 pnpm run build
 ```
+
+### Package
+
+Before packing or publishing, the `prepack` lifecycle generates CSS property
+compatibility data, fixes generated key names, and validates the package data.
+
+To verify the packed package contract locally:
+
+```bash
+pnpm run pack:check
+```
+
+This check creates a package tarball, verifies that generated
+`css/properties/*.json` files are included, installs the tarball into a clean
+temporary consumer with scripts disabled, and reads
+`css/properties/custom-property.json`.
 
 ### Test
 

--- a/packages/lynx-compat-data/package.json
+++ b/packages/lynx-compat-data/package.json
@@ -27,6 +27,8 @@
     "gen-types": "node --loader=ts-node/esm --no-warnings=ExperimentalWarning scripts/gen-types.ts",
     "lint": "node --loader=ts-node/esm --no-warnings=ExperimentalWarning scripts/validate.ts",
     "lint:keys": "node --loader=ts-node/esm --no-warnings=ExperimentalWarning scripts/lint-key-names.ts",
+    "prepack": "npm run gen-css && npm run lint:keys -- --fix && npm run lint",
+    "pack:check": "node scripts/check-pack-contents.mjs",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/lynx-compat-data/scripts/check-pack-contents.mjs
+++ b/packages/lynx-compat-data/scripts/check-pack-contents.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageRoot = path.resolve(fileURLToPath(new URL('..', import.meta.url)));
+const packageJson = JSON.parse(
+  fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8'),
+);
+const pnpm = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+const tar = process.platform === 'win32' ? 'tar.exe' : 'tar';
+
+const packDir = fs.mkdtempSync(
+  path.join(os.tmpdir(), 'lynx-compat-data-pack-'),
+);
+let consumerDir;
+
+function fail(message) {
+  throw new Error(`[pack-check] ${message}`);
+}
+
+function run(command, args, options) {
+  try {
+    return execFileSync(command, args, {
+      ...options,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      maxBuffer: 10 * 1024 * 1024,
+    });
+  } catch (error) {
+    if (error.stdout) {
+      process.stdout.write(error.stdout);
+    }
+    if (error.stderr) {
+      process.stderr.write(error.stderr);
+    }
+    throw error;
+  }
+}
+
+function listJsonFiles(dir) {
+  if (!fs.existsSync(dir)) {
+    return [];
+  }
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.json'))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+try {
+  run(pnpm, ['pack', '--pack-destination', packDir], {
+    cwd: packageRoot,
+  });
+
+  const tarballs = fs
+    .readdirSync(packDir)
+    .filter((entry) => entry.endsWith('.tgz'));
+  if (tarballs.length !== 1) {
+    fail(`expected one tarball in ${packDir}, found ${tarballs.length}`);
+  }
+
+  const tarballPath = path.join(packDir, tarballs[0]);
+  const tarballEntries = new Set(
+    run(tar, ['-tzf', tarballPath]).trim().split('\n').filter(Boolean),
+  );
+
+  const generatedPropertiesDir = path.join(packageRoot, 'css', 'properties');
+  const manualPropertiesDir = path.join(
+    packageRoot,
+    'css',
+    'properties-manual',
+  );
+  const generatedFiles = listJsonFiles(generatedPropertiesDir);
+  const manualFiles = listJsonFiles(manualPropertiesDir);
+
+  if (generatedFiles.length === 0) {
+    fail('css/properties/*.json was not generated before packing');
+  }
+
+  const missingGeneratedEntries = generatedFiles.filter(
+    (file) => !tarballEntries.has(`package/css/properties/${file}`),
+  );
+  if (missingGeneratedEntries.length > 0) {
+    fail(
+      `tarball is missing generated CSS property files: ${missingGeneratedEntries.join(
+        ', ',
+      )}`,
+    );
+  }
+
+  const missingManualOutputs = manualFiles.filter(
+    (file) => !generatedFiles.includes(file),
+  );
+  if (missingManualOutputs.length > 0) {
+    fail(
+      `generated CSS output is missing manual property files: ${missingManualOutputs.join(
+        ', ',
+      )}`,
+    );
+  }
+
+  const requiredEntries = [
+    'package/css/properties/align-content.json',
+    'package/css/properties/background-color.json',
+    'package/css/properties/custom-property.json',
+    'package/css/properties-manual/custom-property.json',
+  ];
+  const missingRequiredEntries = requiredEntries.filter(
+    (entry) => !tarballEntries.has(entry),
+  );
+  if (missingRequiredEntries.length > 0) {
+    fail(
+      `tarball is missing required entries: ${missingRequiredEntries.join(', ')}`,
+    );
+  }
+
+  consumerDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'lynx-compat-data-consumer-'),
+  );
+  fs.writeFileSync(
+    path.join(consumerDir, 'package.json'),
+    JSON.stringify({ private: true, type: 'module' }, null, 2),
+  );
+  run(pnpm, ['add', '--ignore-scripts', tarballPath], {
+    cwd: consumerDir,
+  });
+
+  const installedJsonPath = path.join(
+    consumerDir,
+    'node_modules',
+    ...packageJson.name.split('/'),
+    'css',
+    'properties',
+    'custom-property.json',
+  );
+  JSON.parse(fs.readFileSync(installedJsonPath, 'utf8'));
+
+  console.log(
+    `[pack-check] ${packageJson.name} tarball contains ${generatedFiles.length} CSS property files and installs cleanly.`,
+  );
+} finally {
+  fs.rmSync(packDir, { recursive: true, force: true });
+  if (consumerDir) {
+    fs.rmSync(consumerDir, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
## Summary

- run CSS compatibility generation and validation from the `@lynx-js/lynx-compat-data` `prepack` lifecycle
- add a `pack:check` contract test that verifies generated CSS property data is included in the package tarball and installable with scripts disabled
- run compat-data tests and the package contract check in CI
- document the generated CSS property packaging workflow

Fixes #1395

## Validation

- `pnpm --filter @lynx-js/lynx-compat-data run pack:check`
- `pnpm --filter @lynx-js/lynx-compat-data run test`
- `pnpm run format:check`
- `pnpm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Run CSS compatibility generation and validation during `prepack`.
- Verify generated and manual CSS property files in a clean package installation.
- Run compatibility-data tests and `pack:check` in CI.
- Document the CSS property packaging workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->