### PR TITLE
fix(ci): cover release branches and deduplicate PR runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,12 @@ on:
   push:
     branches:
       - main
+      - 'release/[3-9].*'
+      - 'release/[1-9][0-9].*'
+
+concurrency:
+  group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.event.pull_request.number || format('{0}-{1}', github.ref, github.sha) }}
+  cancel-in-progress: true
 
 jobs:
   validate:


### PR DESCRIPTION
Run CI on versioned release branches starting with 3.x. Existing release branches pick up this behavior only when the workflow is backported to them.
    
Cancel superseded pull request runs without canceling push or merge queue runs for distinct commits.

Change-Id: I456d25acc83ae50ecd6b4e721685609302ec86ae

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Run CI on supported `release/*` branches while excluding suffixed variants.
- Cancel superseded pull request runs without canceling push or merge queue runs for distinct commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->