### PR TITLE
fix(compat-data): reverse-drift — 6 elements' bounding/scroll methods + the whole markdown element already work on web

### DIFF
--- a/packages/lynx-compat-data/elements/blur-view.json
+++ b/packages/lynx-compat-data/elements/blur-view.json
@@ -498,7 +498,7 @@
                 "version_added": "4.0"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": true
               },
               "clay_android": {
                 "version_added": false
@@ -536,7 +536,7 @@
                 "version_added": "4.0"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": true
               },
               "clay_android": {
                 "version_added": false

--- a/packages/lynx-compat-data/elements/markdown.json
+++ b/packages/lynx-compat-data/elements/markdown.json
@@ -1273,7 +1273,7 @@
               "version_added": "2.16"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": "2.15"
@@ -1349,7 +1349,7 @@
               "version_added": "2.17"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": "2.15"

--- a/packages/lynx-compat-data/elements/markdown.json
+++ b/packages/lynx-compat-data/elements/markdown.json
@@ -95,7 +95,7 @@
               "version_added": "3.1"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": false
@@ -133,7 +133,7 @@
               "version_added": "3.1"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": false
@@ -171,7 +171,7 @@
               "version_added": "3.1"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": false
@@ -209,7 +209,7 @@
               "version_added": false
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": false
@@ -247,7 +247,7 @@
               "version_added": false
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": false
@@ -285,7 +285,7 @@
               "version_added": "3.1"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": false
@@ -399,7 +399,7 @@
               "version_added": "3.1"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": false
@@ -437,7 +437,7 @@
               "version_added": false
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": false
@@ -475,7 +475,7 @@
               "version_added": "3.1"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": false
@@ -513,7 +513,7 @@
               "version_added": "3.1"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": false
@@ -551,7 +551,7 @@
               "version_added": "3.1"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": false
@@ -589,7 +589,7 @@
               "version_added": false
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": false
@@ -627,7 +627,7 @@
               "version_added": false
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": false
@@ -665,7 +665,7 @@
               "version_added": false
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": false
@@ -703,7 +703,7 @@
               "version_added": false
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": false
@@ -741,7 +741,7 @@
               "version_added": false
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": false
@@ -779,7 +779,7 @@
               "version_added": false
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": false
@@ -817,7 +817,7 @@
               "version_added": false
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": false
@@ -855,7 +855,7 @@
               "version_added": false
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": false
@@ -893,7 +893,7 @@
               "version_added": false
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": false
@@ -931,7 +931,7 @@
               "version_added": false
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": false
@@ -1007,7 +1007,7 @@
               "version_added": "3.1"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": false
@@ -1045,7 +1045,7 @@
               "version_added": false
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": false
@@ -1083,7 +1083,7 @@
               "version_added": "4.0"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": false
@@ -1121,7 +1121,7 @@
               "version_added": "3.1"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": false
@@ -1159,7 +1159,7 @@
               "version_added": false
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": false
@@ -1197,7 +1197,7 @@
               "version_added": false
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": false
@@ -1235,7 +1235,7 @@
               "version_added": "3.1"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true
             },
             "clay_android": {
               "version_added": false

--- a/packages/lynx-compat-data/elements/overlay.json
+++ b/packages/lynx-compat-data/elements/overlay.json
@@ -500,7 +500,7 @@
                 "version_added": "4.0"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": true
               },
               "clay_android": {
                 "version_added": "3.5"
@@ -576,7 +576,7 @@
                 "version_added": "3.5"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": true
               },
               "clay_android": {
                 "version_added": "3.5"

--- a/packages/lynx-compat-data/elements/refresh.json
+++ b/packages/lynx-compat-data/elements/refresh.json
@@ -368,7 +368,7 @@
                 "version_added": "4.1"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": true
               },
               "clay_android": {
                 "version_added": false
@@ -444,7 +444,7 @@
                 "version_added": "4.1"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": true
               },
               "clay_android": {
                 "version_added": false

--- a/packages/lynx-compat-data/elements/viewpager.json
+++ b/packages/lynx-compat-data/elements/viewpager.json
@@ -672,7 +672,7 @@
                 "version_added": "3.9"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": true
               },
               "clay_android": {
                 "version_added": "3.9"
@@ -748,7 +748,7 @@
                 "version_added": "3.9"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": true
               },
               "clay_android": {
                 "version_added": "3.9"

--- a/packages/lynx-compat-data/elements/webview.json
+++ b/packages/lynx-compat-data/elements/webview.json
@@ -938,7 +938,7 @@
                 "version_added": "4.0"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": true
               },
               "clay_android": {
                 "version_added": false
@@ -976,7 +976,7 @@
                 "version_added": "4.0"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": true
               },
               "clay_android": {
                 "version_added": false


### PR DESCRIPTION
## What

Weekly web-gap audit reverse-drift check: fixes `web_lynx: false` compat-data entries that no longer match (or, for `markdown`, never matched) the actual `lynx-family/lynx-stack` web implementation. Two commits:

### 1. `boundingClientRect` / `scrollIntoView` for 6 elements

Flips `web_lynx.version_added` from `false` to `true` for the `boundingClientRect` and `scrollIntoView` methods of `blur-view`, `markdown`, `overlay`, `refresh`, `viewpager`, `webview`.

All six are implemented on web as plain custom elements extending `HTMLElement` (`XBlurView`, `XMarkdown`, `XOverlayNg`, `XRefreshView`, `XViewpagerNg`, `XWebView` in `packages/web-platform/web-elements/src/elements/`). The `invokeUIMethod` handler in web-core:

```ts
// packages/web-platform/web-core/ts/client/mainthread/elementAPIs/createInvokeUIMethod.ts
if (method === 'boundingClientRect') {
  const rect = element.getBoundingClientRect();
  // ...
} else if (typeof (element as any)[method] === 'function') {
  data = (element as any)[method](params);
  // ...
}
```

special-cases `boundingClientRect` via `Element.getBoundingClientRect()` for every element, and falls back to calling any same-named method on the underlying DOM node otherwise — so the inherited `Element.scrollIntoView()` already works for any of these six, exactly like it already does for `view`, `component`, `list`, `scroll-view`, and the other elements already marked `true` in this dataset. `takeScreenshot` is left untouched (`false`) on all six — not implemented anywhere.

### 2. The whole `markdown` element

`packages/lynx-compat-data/elements/markdown.json` was added on 2026-08-28 by #1381 with every sub-feature marked `web_lynx: false`. But `packages/web-platform/web-elements/src/elements/XMarkdown/` (`XMarkdown.ts`, `XMarkdownAttributes.ts`) landed in `lynx-stack` on **2026-08-20** (`lynx-stack@703bd16`) — over a week before #1381 merged. That PR's "verified against the lynx-stack Web implementation" pass appears to have missed this custom element entirely.

I cross-checked each attribute/event/method against the actual implementation and flipped 28 of the 36 entries to `true`:

- **Attributes** (via `@registerAttributeHandler` in `XMarkdownAttributes.ts`): `content`, `content-id`, `content-range`, `content-complete`, `markdown-style`, `markdown-effect`, `text-selection`, `text-maxline`, `animation-type`, `animation-velocity`, `initial-animation-step`, `typewriter-dynamic-height`, `typewriter-height-transition-duration`.
- **Events** (dispatched as `CustomEvent`s from `XMarkdownAttributes.ts`): `bindlink`, `bindimageTap`, `bindoverflow`, `bindparseEnd`, `binddrawStart`, `binddrawEnd`, `bindanimationStep`, `bindselectionchange`.
- **Methods** (public methods on `XMarkdown`, reachable through the generic `invokeUIMethod` fallback): `getContent`, `getImages`, `getParseResult`, `getSelectedText`, `pauseAnimation`, `resumeAnimation`, `setTextSelection`.
- Plus `boundingClientRect`/`scrollIntoView` from commit 1.

Left as `web_lynx: false` (confirmed no match anywhere in `lynx-stack`): `allow-break-around-punctuation`, `animation-frame-rate`, `enable-break-around-punctuation`, `enable-selection`, `getCharIndexByPoint`, `requestAccessibilityFocus`.

## Testing

- `pnpm lint` (in `packages/lynx-compat-data`) passes on both commits.
- `pnpm gen-stats` regenerated `api-stats.json` (gitignored, not included in this diff); `web_lynx` overall support moved 965 → 977 → 1005 out of 1612 across the two commits.