### PR TITLE
fix(docs): scroll-coordinator does not support desktop Clay

### DIFF
--- a/docs/en/api/elements/built-in/scroll-coordinator-API.mdx
+++ b/docs/en/api/elements/built-in/scroll-coordinator-API.mdx
@@ -1,7 +1,8 @@
 import {
   AndroidOnly,
   IOSOnly,
-  ClayOnly,
+  ClayAndroidOnly,
+  ClayIOSOnly,
   ClayWindowsOnly,
   ClayMacOSOnly,
   HarmonyOnly,
@@ -38,7 +39,7 @@ Enable the bounce effect when the coordinator scrolls past its boundary.
 
 ### `enable-scroll`
 
-<AndroidOnly /> <IOSOnly /> <ClayOnly /> <HarmonyOnly />
+<AndroidOnly /> <IOSOnly /> <HarmonyOnly /> <ClayAndroidOnly /> <ClayIOSOnly />
 
 ```tsx
 // @defaultValue: true
@@ -60,7 +61,7 @@ Set whether the scrollbar is visible during coordinator scrolling.
 
 ### `granularity`
 
-<AndroidOnly /> <IOSOnly /> <ClayOnly /> <HarmonyOnly />
+<AndroidOnly /> <IOSOnly /> <HarmonyOnly /> <ClayAndroidOnly /> <ClayIOSOnly />
 
 ```tsx
 // @defaultValue: 0.01
@@ -71,7 +72,7 @@ The event response granularity of bindoffset, once the scroll distance exceeds t
 
 ### `header-over-slot`
 
-<AndroidOnly /> <IOSOnly /> <ClayOnly /> <HarmonyOnly />
+<AndroidOnly /> <IOSOnly /> <HarmonyOnly /> <ClayAndroidOnly /> <ClayIOSOnly />
 
 ```tsx
 // @defaultValue: false
@@ -119,7 +120,7 @@ Frontend can bind corresponding event callbacks to listen for runtime behaviors 
 
 ### `bindoffset`
 
-<AndroidOnly /> <IOSOnly /> <ClayOnly /> <HarmonyOnly />
+<AndroidOnly /> <IOSOnly /> <HarmonyOnly /> <ClayAndroidOnly /> <ClayIOSOnly />
 
 ```tsx
 bindoffset = (e: ScrollCoordinatorOffsetEvent) => {};
@@ -127,8 +128,8 @@ bindoffset = (e: ScrollCoordinatorOffsetEvent) => {};
 
 | Field  | Type   | Optional | Default | Platforms                                                | Since | Description                                                                           |
 | ------ | ------ | -------- | ------- | -------------------------------------------------------- | ----- | ------------------------------------------------------------------------------------- |
-| height | number | No       | –       | <AndroidOnly /> <IOSOnly /> <ClayOnly /> <HarmonyOnly /> |       | The absolute value of the scrollable distance (header height - toolbar height), in px |
-| offset | number | No       | –       | <AndroidOnly /> <IOSOnly /> <ClayOnly /> <HarmonyOnly /> |       | The absolute value of the header scroll offset, in px                                 |
+| height | number | No       | –       | <AndroidOnly /> <IOSOnly /> <HarmonyOnly /> <ClayAndroidOnly /> <ClayIOSOnly /> |       | The absolute value of the scrollable distance (header height - toolbar height), in px |
+| offset | number | No       | –       | <AndroidOnly /> <IOSOnly /> <HarmonyOnly /> <ClayAndroidOnly /> <ClayIOSOnly /> |       | The absolute value of the header scroll offset, in px                                 |
 
 Callback for folding progress
 

--- a/docs/zh/api/elements/built-in/scroll-coordinator-API.mdx
+++ b/docs/zh/api/elements/built-in/scroll-coordinator-API.mdx
@@ -1,7 +1,8 @@
 import {
   AndroidOnly,
   IOSOnly,
-  ClayOnly,
+  ClayAndroidOnly,
+  ClayIOSOnly,
   ClayWindowsOnly,
   ClayMacOSOnly,
   HarmonyOnly,
@@ -38,7 +39,7 @@ bounces?: boolean;
 
 ### `enable-scroll`
 
-<AndroidOnly /> <IOSOnly /> <ClayOnly /> <HarmonyOnly />
+<AndroidOnly /> <IOSOnly /> <HarmonyOnly /> <ClayAndroidOnly /> <ClayIOSOnly />
 
 ```tsx
 // @默认值: true
@@ -60,7 +61,7 @@ bounces?: boolean;
 
 ### `granularity`
 
-<AndroidOnly /> <IOSOnly /> <ClayOnly /> <HarmonyOnly />
+<AndroidOnly /> <IOSOnly /> <HarmonyOnly /> <ClayAndroidOnly /> <ClayIOSOnly />
 
 ```tsx
 // @默认值: 0.01
@@ -71,7 +72,7 @@ bindoffset 的事件响应粒度，一旦滚动距离超过可滚动距离的 gr
 
 ### `header-over-slot`
 
-<AndroidOnly /> <IOSOnly /> <ClayOnly /> <HarmonyOnly />
+<AndroidOnly /> <IOSOnly /> <HarmonyOnly /> <ClayAndroidOnly /> <ClayIOSOnly />
 
 ```tsx
 // @默认值: false
@@ -119,7 +120,7 @@ foldview 的下拉刷新模式，none（无，默认值）、page（分类下拉
 
 ### `bindoffset`
 
-<AndroidOnly /> <IOSOnly /> <ClayOnly /> <HarmonyOnly />
+<AndroidOnly /> <IOSOnly /> <HarmonyOnly /> <ClayAndroidOnly /> <ClayIOSOnly />
 
 ```tsx
 bindoffset = (e: ScrollCoordinatorOffsetEvent) => {};
@@ -127,8 +128,8 @@ bindoffset = (e: ScrollCoordinatorOffsetEvent) => {};
 
 | 字段   | 类型 | 是否可选 | 默认值 | 平台                                                     | 版本 | 描述                                                        |
 | ------ | ---- | -------- | ------ | -------------------------------------------------------- | ---- | ----------------------------------------------------------- |
-| height | 数字 | 否       | –      | <AndroidOnly /> <IOSOnly /> <ClayOnly /> <HarmonyOnly /> |      | 可滚动距离的绝对值（header 高度 - toolbar 高度），单位为 px |
-| offset | 数字 | 否       | –      | <AndroidOnly /> <IOSOnly /> <ClayOnly /> <HarmonyOnly /> |      | header 滚动偏移量的绝对值，单位为 px                        |
+| height | 数字 | 否       | –      | <AndroidOnly /> <IOSOnly /> <HarmonyOnly /> <ClayAndroidOnly /> <ClayIOSOnly /> |      | 可滚动距离的绝对值（header 高度 - toolbar 高度），单位为 px |
+| offset | 数字 | 否       | –      | <AndroidOnly /> <IOSOnly /> <HarmonyOnly /> <ClayAndroidOnly /> <ClayIOSOnly /> |      | header 滚动偏移量的绝对值，单位为 px                        |
 
 折叠进度回调
 


### PR DESCRIPTION
`enable-scroll`, `granularity`, `header-over-slot` and `bindoffset` carry a bare `<ClayOnly />`, which renders as **Desktop** — `mapPlatformNameToLabel` maps bare `clay` to that label. The compat data says desktop Clay is exactly where they do not work:

```
clay_android: 3.9    clay_ios: 3.9
clay_macos:  false   clay_windows: false
```

So the badge claims the two platforms that are `false`, and the two that are supported had no badge saying so.

## The runtime agrees with the data

The conformance suite measured Clay/macOS rejecting scroll-coordinator's methods while the compat data still claimed Clay — the same measurements behind #1363 and #1377. #1381's regenerated data has since caught up; this page had not.

## The change

`<AndroidOnly /> <IOSOnly /> <ClayOnly /> <HarmonyOnly />` → `<AndroidOnly /> <IOSOnly /> <HarmonyOnly /> <ClayAndroidOnly /> <ClayIOSOnly />`

on all six occurrences in each locale — the four attribute headings and the two `bindoffset` event-table rows. `ClayOnly` is now unused on the page and dropped from the import.

`ClayIOSOnly` only became importable in #1404, so before that the accurate badge could not be written at all.

## Deliberately not changed

Five entries on the same page record `clay_ios` support with no Clay badge: `bounces`, `enable-scroll-bar`, `ios-force-scroll-detach`, `ios-scrolls-to-top`, `refresh-mode`.

That is an omission rather than a wrong claim, and since `ClayIOSOnly` has existed for a day there is no established convention for whether `<IOSOnly />` is meant to cover Clay iOS. Happy to include them if you would like that convention set — it seemed better to ask than to decide it in this PR.

## Verification

Badge-vs-compat agreement on this page goes from **eight mismatches to zero** in both locales, checked mechanically against `packages/lynx-compat-data/elements/scroll-coordinator.json`.

Passing: `pnpm build` (3190 pages), `pnpm check-docs` (1725 files), `pnpm format:check`, `pnpm cspell:check` (2443 files), and `scripts/ci/check-case-collisions.mjs`, `check-asset-urls.mjs`, `check-lynx-ui-routes.mjs`.