### PR TITLE
docs(rspeedy): build an external bundle of plain TypeScript

### DIFF
--- a/docs/en/rspeedy/external-bundle.mdx
+++ b/docs/en/rspeedy/external-bundle.mdx
@@ -72,6 +72,48 @@ After a successful build, you will get an output directory like this:
 │   └── comp-lib.template.js
 ```
 
+### Without A DSL
+
+A bundle of plain TypeScript needs no DSL plugin. `pluginLynx` is the Lynx build engine, and `LAYERS` picks the thread the bundle runs on:
+
+```ts title="rslib-utils.config.ts"
+import {
+  defineExternalBundleRslibConfig,
+  LAYERS,
+} from '@lynx-js/lynx-bundle-rslib-config';
+import { pluginLynx } from '@lynx-js/rsbuild-plugin';
+
+export default defineExternalBundleRslibConfig({
+  id: 'utils',
+  source: {
+    entry: {
+      './utils.js': {
+        import: './src/utils.ts',
+        layer: LAYERS.BACKGROUND,
+      },
+    },
+  },
+  plugins: [pluginLynx()],
+});
+```
+
+An entry without a `layer` is emitted for both threads. Pick one when the host app only calls into the bundle from that thread: the bundle then carries a single section, and the host declares the external for that thread only.
+
+```ts title="lynx.config.ts"
+pluginExternalBundle({
+  externals: {
+    './utils.js': {
+      bundlePath: 'utils.lynx.bundle',
+      libraryName: './utils.js',
+      background: { sectionPath: './utils.js' },
+      async: true,
+    },
+  },
+});
+```
+
+The string shorthand (`'./utils.js': 'utils.lynx.bundle'`) declares the external for both threads, so a bundle built for one of them fails to load on the other.
+
 ### Bundle CSS
 
 <VersionBadge v={3.7} />

--- a/docs/en/rspeedy/external-bundle.mdx
+++ b/docs/en/rspeedy/external-bundle.mdx
@@ -76,6 +76,8 @@ After a successful build, you will get an output directory like this:
 
 A bundle of plain TypeScript needs no DSL plugin. `pluginLynx` is the Lynx build engine, and `LAYERS` picks the thread the bundle runs on:
 
+<PackageManagerTabs command="install @lynx-js/rsbuild-plugin -D" />
+
 ```ts title="rslib-utils.config.ts"
 import {
   defineExternalBundleRslibConfig,

--- a/docs/zh/rspeedy/external-bundle.mdx
+++ b/docs/zh/rspeedy/external-bundle.mdx
@@ -78,6 +78,8 @@ export default defineExternalBundleRslibConfig({
 
 打包纯 TypeScript 不需要 DSL 插件。`pluginLynx` 就是 Lynx 构建引擎，`LAYERS` 用来指定 bundle 运行在哪个线程：
 
+<PackageManagerTabs command="install @lynx-js/rsbuild-plugin -D" />
+
 ```ts title="rslib-utils.config.ts"
 import {
   defineExternalBundleRslibConfig,

--- a/docs/zh/rspeedy/external-bundle.mdx
+++ b/docs/zh/rspeedy/external-bundle.mdx
@@ -74,6 +74,48 @@ export default defineExternalBundleRslibConfig({
 │   └── comp-lib.template.js
 ```
 
+### 不使用 DSL
+
+打包纯 TypeScript 不需要 DSL 插件。`pluginLynx` 就是 Lynx 构建引擎，`LAYERS` 用来指定 bundle 运行在哪个线程：
+
+```ts title="rslib-utils.config.ts"
+import {
+  defineExternalBundleRslibConfig,
+  LAYERS,
+} from '@lynx-js/lynx-bundle-rslib-config';
+import { pluginLynx } from '@lynx-js/rsbuild-plugin';
+
+export default defineExternalBundleRslibConfig({
+  id: 'utils',
+  source: {
+    entry: {
+      './utils.js': {
+        import: './src/utils.ts',
+        layer: LAYERS.BACKGROUND,
+      },
+    },
+  },
+  plugins: [pluginLynx()],
+});
+```
+
+不指定 `layer` 的入口会同时产出两个线程的产物。当宿主只从某一个线程调用时指定其中之一：bundle 只会包含一个 section，宿主也只需为该线程声明 external。
+
+```ts title="lynx.config.ts"
+pluginExternalBundle({
+  externals: {
+    './utils.js': {
+      bundlePath: 'utils.lynx.bundle',
+      libraryName: './utils.js',
+      background: { sectionPath: './utils.js' },
+      async: true,
+    },
+  },
+});
+```
+
+字符串简写（`'./utils.js': 'utils.lynx.bundle'`）会为两个线程都声明 external，因此只产出单线程的 bundle 在另一个线程上会加载失败。
+
 ### 打包 CSS
 
 <VersionBadge v={3.7} />


### PR DESCRIPTION
Documents building an external bundle of plain TypeScript, without `pluginReactLynx`.

Depends on lynx-family/lynx-stack#3814, which makes `pluginLynx` supply the runtime wrapper and the encoder such a bundle needs, and exports the `LAYERS` an entry picks a thread with. The section also covers declaring the external for one thread only — the string shorthand declares it for both, which fails to load a bundle built for one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Document plain TypeScript external bundles with `pluginLynx` and `LAYERS`.
- Explain single-thread and both-thread bundle outputs.
- Show matching external declarations in English and Chinese examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
