### PR TITLE
fix(compat-data): restore two support entries dropped by the element data regeneration

### DIFF
--- a/packages/lynx-compat-data/elements/overlay.json
+++ b/packages/lynx-compat-data/elements/overlay.json
@@ -337,7 +337,7 @@
             },
             "support": {
               "android": {
-                "version_added": false
+                "version_added": "3.5"
               },
               "ios": {
                 "version_added": false

--- a/packages/lynx-compat-data/elements/video.json
+++ b/packages/lynx-compat-data/elements/video.json
@@ -161,7 +161,7 @@
                 "version_added": "4.1"
               },
               "harmony": {
-                "version_added": false
+                "version_added": "4.1"
               },
               "clay_android": {
                 "version_added": false


### PR DESCRIPTION
The element compatibility data regeneration in #1381 left two leaves marked unsupported on platforms where the page, the type declarations and the surrounding data all say they work. The site now shows a platform badge and a support entry that contradict each other.

Both values are restored to what the same file held immediately before that commit, so neither is a new claim.

### `<overlay>` `binderror` — `android: false` → `"3.5"`

| evidence | says |
| --- | --- |
| `overlay-API.mdx` | `<AndroidOnly />`, with the `errorCode` / `errorMsg` field table |
| `@lynx-js/types` | `OverlayProps.binderror?: (e: OverlayErrorEvent) => void` |
| the file, before #1381 | `android: "3.5"` |
| the file, now | `false` on all nine platforms |

`OverlayProps extends Omit<StandardProps, 'binderror'>` — the element deliberately replaces the standard `binderror` with its own event type. That is a plausible reason a generator looking for element-specific event registrations would miss it; the other four overlay events kept their support through the same regeneration. The entry is flagged neither `deprecated` nor `experimental`.

### `<video>` `volume` — `harmony: false` → `"4.1"`

| evidence | says |
| --- | --- |
| `video-API.mdx`, both locales | `<AndroidOnly /> <IOSOnly /> <HarmonyOnly />` |
| sibling attribute `muted` | `harmony: "4.1"` |
| parent `attributes` container | `harmony: "4.1"` |
| the `video` element itself | `harmony: "4.1"` |
| the file, before #1381 | `harmony: "4.1"` |

`volume` reading `false` is the only entry in its neighbourhood that does. No Harmony device was available to me, so the evidence for this one is documentary rather than measured.

### Verification

- `pnpm --filter @lynx-js/lynx-compat-data run lint` (schema validation), `lint:keys`, and the package's vitest suite (18 tests) — pass
- `pnpm build` — 3190 pages
- `format:check`, `cspell:check` (2443 files), `check-docs` (1725 files), and the five `scripts/ci` checks — pass
- an independent sweep comparing every element page's badges against the compat data reports **2 mismatches before this change and 0 after**

### Not included

The same regeneration also left several *container* nodes disagreeing with their members — `scroll-coordinator.methods` still claims `clay_macos`/`clay_windows` 3.9 where none of its six methods does, and `text.methods` still says `harmony: false` where four of its members now claim support. Those are left alone deliberately: no `api:` key in `docs/{en,zh}` resolves to a container path, so nothing renders them, and picking version numbers for them would be a guess. They are worth fixing in whatever produced #1381, along with the two leaves here — otherwise the next regeneration will drop these again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Restore Android support for `overlay` `binderror` in version `3.5`.
- Restore Harmony support for `video` `volume` in version `4.1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->