### PR TITLE
docs: refresh the 4.0 SDK version and stop quick-start hardcoding it

### DIFF
--- a/docs/en/guide/start/quick-start.mdx
+++ b/docs/en/guide/start/quick-start.mdx
@@ -6,6 +6,8 @@ import { QRCodeSVG } from 'qrcode.react';
 import { PackageManagerTabs, Steps } from '@theme';
 import { ChoiceTabs, Go, PlatformTabs } from '@lynx';
 import * as NextSteps from '@lynx/NextSteps';
+import { Link } from '@theme';
+import versionJson from '@site/docs/public/version.json';
 
 # Try with Explorer
 
@@ -76,7 +78,7 @@ Open up the Mac App Store, search for [Xcode](https://apps.apple.com/us/app/xcod
 
 <PlatformTabs.Tab platform="macos-arm64">
 
-Download [`LynxExplorer-arm64.app.tar.gz`](https://github.com/lynx-family/lynx/releases/download/4.0.0/LynxExplorer-arm64.app.tar.gz).
+Download <Link href={'https://github.com/lynx-family/lynx/releases/download/' + versionJson.LYNX_VERSION + '/LynxExplorer-arm64.app.tar.gz'}><code>LynxExplorer-arm64.app.tar.gz</code></Link>.
 
 Then extract the downloaded archive:
 
@@ -93,7 +95,7 @@ Open Xcode, choose **Open Developer Tool** from the Xcode menu. Click the **Simu
 
 <PlatformTabs.Tab platform="macos-intel">
 
-Download [`LynxExplorer-x86_64.app.tar.gz`](https://github.com/lynx-family/lynx/releases/download/4.0.0/LynxExplorer-x86_64.app.tar.gz).
+Download <Link href={'https://github.com/lynx-family/lynx/releases/download/' + versionJson.LYNX_VERSION + '/LynxExplorer-x86_64.app.tar.gz'}><code>LynxExplorer-x86_64.app.tar.gz</code></Link>.
 
 Then, extract the downloaded archive:
 
@@ -114,12 +116,16 @@ Open Xcode, choose **Open Developer Tool** from the Xcode menu. Click the **Simu
 
 <PlatformTabs.Tab platform="android">
 
-Scan the QR code to download the pre-built app from [GitHub Release 4.0.0](https://github.com/lynx-family/lynx/releases/tag/4.0.0).
+Scan the QR code to download the pre-built app from <Link href={'https://github.com/lynx-family/lynx/releases/tag/' + versionJson.LYNX_VERSION}>GitHub Release {versionJson.LYNX_VERSION}</Link>.
 
 <QRCodeSVG
   style={{ border: '2px solid #fff' }}
   size={220}
-  value="https://github.com/lynx-family/lynx/releases/download/4.0.0/LynxExplorer-noasan-release.apk"
+  value={
+    'https://github.com/lynx-family/lynx/releases/download/' +
+    versionJson.LYNX_VERSION +
+    '/LynxExplorer-noasan-release.apk'
+  }
 />
 
 Or, you may build from source by following the [Build Lynx Explorer for Android](https://github.com/lynx-family/lynx/tree/develop/explorer/android) guide.
@@ -140,7 +146,7 @@ Download the latest DevEco Studio from the [official website](https://developer.
 
 2. **<div id="download-lynx-explorer">Download Lynx Explorer</div>**
 
-Download the pre-built app [`lynx_explorer-default-unsigned.hap`](https://github.com/lynx-family/lynx/releases/download/4.0.0/lynx_explorer-default-unsigned.hap).
+Download the pre-built app <Link href={'https://github.com/lynx-family/lynx/releases/download/' + versionJson.LYNX_VERSION + '/lynx_explorer-default-unsigned.hap'}><code>lynx_explorer-default-unsigned.hap</code></Link>.
 
 Or, you may build from source by following the [Build Lynx Explorer for Harmony](https://github.com/lynx-family/lynx/tree/develop/explorer/harmony) guide.
 

--- a/docs/public/version.json
+++ b/docs/public/version.json
@@ -1,6 +1,6 @@
 {
   "current_version": "next",
-  "LYNX_VERSION": "4.0.0",
+  "LYNX_VERSION": "4.0.2",
   "PRIMJS_VERSION": "4.0.0",
   "versions": [
     {
@@ -14,7 +14,7 @@
       "version_number": "4.0",
       "repo_branch": "release/4.0",
       "docs_link": "/",
-      "release_number": "4.0.0"
+      "release_number": "4.0.2"
     },
     {
       "type": "previous",

--- a/docs/zh/guide/start/quick-start.mdx
+++ b/docs/zh/guide/start/quick-start.mdx
@@ -6,6 +6,8 @@ import { QRCodeSVG } from 'qrcode.react';
 import { PackageManagerTabs, Steps } from '@theme';
 import { ChoiceTabs, Go, PlatformTabs } from '@lynx';
 import * as NextSteps from '@lynx/NextSteps';
+import { Link } from '@theme';
+import versionJson from '@site/docs/public/version.json';
 
 # 用 Explorer 体验
 
@@ -76,7 +78,7 @@ Lynx Explorer 是一个可以快速试用 Lynx 的沙盒环境。
 
 <PlatformTabs.Tab platform="macos-arm64">
 
-下载 [`LynxExplorer-arm64.app.tar.gz`](https://github.com/lynx-family/lynx/releases/download/4.0.0/LynxExplorer-arm64.app.tar.gz)。
+下载 <Link href={'https://github.com/lynx-family/lynx/releases/download/' + versionJson.LYNX_VERSION + '/LynxExplorer-arm64.app.tar.gz'}><code>LynxExplorer-arm64.app.tar.gz</code></Link>。
 
 然后，解压下载的压缩包：
 
@@ -93,7 +95,7 @@ tar -zxf LynxExplorer-arm64.app.tar.gz -C LynxExplorer-arm64.app/
 
 <PlatformTabs.Tab platform="macos-intel">
 
-下载 [`LynxExplorer-x86_64.app.tar.gz`](https://github.com/lynx-family/lynx/releases/download/4.0.0/LynxExplorer-x86_64.app.tar.gz)。
+下载 <Link href={'https://github.com/lynx-family/lynx/releases/download/' + versionJson.LYNX_VERSION + '/LynxExplorer-x86_64.app.tar.gz'}><code>LynxExplorer-x86_64.app.tar.gz</code></Link>。
 
 然后，解压下载的压缩包：
 
@@ -114,12 +116,16 @@ tar -zxf LynxExplorer-x86_64.app.tar.gz -C LynxExplorer-x86_64.app/
 
 <PlatformTabs.Tab platform="android">
 
-扫描二维码从 [GitHub Release 4.0.0](https://github.com/lynx-family/lynx/releases/tag/4.0.0) 下载预编译应用。
+扫描二维码从 <Link href={'https://github.com/lynx-family/lynx/releases/tag/' + versionJson.LYNX_VERSION}>GitHub Release {versionJson.LYNX_VERSION}</Link> 下载预编译应用。
 
 <QRCodeSVG
   style={{ border: '2px solid #fff' }}
   size={220}
-  value="https://github.com/lynx-family/lynx/releases/download/4.0.0/LynxExplorer-noasan-release.apk"
+  value={
+    'https://github.com/lynx-family/lynx/releases/download/' +
+    versionJson.LYNX_VERSION +
+    '/LynxExplorer-noasan-release.apk'
+  }
 />
 
 或者，你可以按照[为 Android 构建 Lynx Explorer](https://github.com/lynx-family/lynx/tree/develop/explorer/android) 指南从源代码构建。
@@ -140,7 +146,7 @@ tar -zxf LynxExplorer-x86_64.app.tar.gz -C LynxExplorer-x86_64.app/
 
 2. **<div id="download-lynx-explorer">下载 Lynx Explorer</div>**
 
-下载预编译应用 [`lynx_explorer-default-unsigned.hap`](https://github.com/lynx-family/lynx/releases/download/4.0.0/lynx_explorer-default-unsigned.hap)。
+下载预编译应用 <Link href={'https://github.com/lynx-family/lynx/releases/download/' + versionJson.LYNX_VERSION + '/lynx_explorer-default-unsigned.hap'}><code>lynx_explorer-default-unsigned.hap</code></Link>。
 
 或者，你可以按照[为 Harmony 构建 Lynx Explorer](https://github.com/lynx-family/lynx/tree/develop/explorer/harmony) 指南从源代码构建。
 


### PR DESCRIPTION
`docs/public/version.json` is not a changelog. `LYNX_VERSION` is interpolated straight into the integration guides' Gradle and Podfile snippets, so whatever it says is what every new integrator copies into their build. It has been sitting on `4.0.0` since 4.0.1 shipped on 2026-07-31 and 4.0.2 on 2026-09-04.

### What changed

| | before | after |
| --- | --- | --- |
| `LYNX_VERSION` | `4.0.0` | `4.0.2` |
| `versions[4.0].release_number` | `4.0.0` | `4.0.2` |
| quick-start download links (en + zh) | hardcoded `4.0.0` | `versionJson.LYNX_VERSION` |

`PRIMJS_VERSION` is unchanged and still correct: `4.0.0` is the newest stable in its line — 4.0.1 exists only as alphas, and 4.1.x is a different line, which is a maintainer's call rather than a refresh.

### Why quick-start is interpolated rather than retyped

The macOS and Windows fragments in this same directory already build the release URL from the manifest:

```jsx
<Link href={'https://github.com/lynx-family/lynx/releases/tag/' + versionJson.LYNX_VERSION}>
```

quick-start hardcoded the version in five places instead, which is how it drifted two patches behind while its siblings stayed current. Pointing it at the same source of truth means the next release bump is one edit, not six, and this page cannot silently fall behind again. All four assets it links exist under identical names in 4.0.2 (`LynxExplorer-arm64.app.tar.gz`, `LynxExplorer-x86_64.app.tar.gz`, `LynxExplorer-noasan-release.apk`, `lynx_explorer-default-unsigned.hap`).

### Verification

The version bump is not just "a newer number is published" — the guides' own instructions were followed at the new version:

- Built the Android host app from `guide/start/fragments/android/integrating-lynx-with-existing-app-android` with `lynxVersion=4.0.2`. Every coordinate resolves — `lynx`, `lynx-jssdk`, `lynx-trace`, `lynx-devtool`, the five `lynx-service-*`, `service-api`, and all ten `xelement-*` artifacts at 4.0.2 — paired with `primjs:4.0.0` exactly as the manifest specifies, producing a working debug APK. That is the pairing this change asks readers to use.
- 4.0.2 is a normal GitHub release: `prerelease=false`, `draft=false`, published 2026-09-04.
- `pnpm build` renders 3190 pages; the built HTML carries `releases/download/4.0.2/…` and `releases/tag/4.0.2` in **both** locales.
- `format:check`, `cspell:check` (2443 files), `check-docs` (1725 files) and the five `scripts/ci` checks pass.
- A full four-platform conformance run (web / Android / iOS / Clay-macOS, three rounds each) reports no new findings against its baselines.

### Two related things left alone

**Older lines in the picker.** `versions[3.9].release_number` says `3.9.0` while 3.9.1 shipped 2026-08-25, and `versions[3.3]` says `3.3.2` while 3.3.3 shipped 2025-11-13. Same pattern, but those entries label documentation built from `release/3.9` and `release/3.3`, so whether the label should track the newest patch or the patch that branch documents is a maintainer's call, not mine. Happy to include them if you want them refreshed.

**The Harmony fragment** pins `@lynx/lynx`, `@lynx/primjs` and the four `lynx_*_service` ohpm packages to `4.0.0` as literals, outside the manifest. I could not check what ohpm publishes and have no Harmony toolchain to verify against, so I have not touched them — someone with Harmony access should confirm whether they are current, and they would benefit from the same interpolation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Set the documented SDK release to `4.0.2` in `version.json`.
- Use `versionJson.LYNX_VERSION` for English and Chinese quick-start download links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->