### PR TITLE
fix(compat-data): flip web_lynx to supported for createIntersectionObserver and reload

### DIFF
--- a/packages/lynx-compat-data/lynx-api/intersection-observer/IntersectionObserver.json
+++ b/packages/lynx-compat-data/lynx-api/intersection-observer/IntersectionObserver.json
@@ -22,7 +22,8 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented since `@lynx-js/web-core@0.25.0` (lynx-family/lynx-stack#3383)."
             }
           }
         },
@@ -47,7 +48,8 @@
                 "version_added": "3.5"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": true,
+                "notes": "Implemented since `@lynx-js/web-core@0.25.0` (lynx-family/lynx-stack#3383)."
               }
             }
           }
@@ -73,7 +75,8 @@
                 "version_added": "3.5"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": true,
+                "notes": "Implemented since `@lynx-js/web-core@0.25.0` (lynx-family/lynx-stack#3383)."
               }
             }
           }
@@ -99,7 +102,8 @@
                 "version_added": "3.5"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": true,
+                "notes": "Implemented since `@lynx-js/web-core@0.25.0` (lynx-family/lynx-stack#3383)."
               }
             }
           }
@@ -125,7 +129,8 @@
                 "version_added": "3.5"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": true,
+                "notes": "Implemented since `@lynx-js/web-core@0.25.0` (lynx-family/lynx-stack#3383)."
               }
             }
           }
@@ -151,7 +156,8 @@
                 "version_added": "3.5"
               },
               "web_lynx": {
-                "version_added": false
+                "version_added": true,
+                "notes": "Implemented since `@lynx-js/web-core@0.25.0` (lynx-family/lynx-stack#3383)."
               }
             }
           }

--- a/packages/lynx-compat-data/lynx-api/intersection-observer/disconnect.json
+++ b/packages/lynx-compat-data/lynx-api/intersection-observer/disconnect.json
@@ -22,7 +22,8 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented since `@lynx-js/web-core@0.25.0` (lynx-family/lynx-stack#3383)."
             }
           }
         }

--- a/packages/lynx-compat-data/lynx-api/intersection-observer/observe.json
+++ b/packages/lynx-compat-data/lynx-api/intersection-observer/observe.json
@@ -22,7 +22,8 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented since `@lynx-js/web-core@0.25.0` (lynx-family/lynx-stack#3383)."
             }
           }
         }

--- a/packages/lynx-compat-data/lynx-api/intersection-observer/relativeTo.json
+++ b/packages/lynx-compat-data/lynx-api/intersection-observer/relativeTo.json
@@ -22,7 +22,8 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented since `@lynx-js/web-core@0.25.0` (lynx-family/lynx-stack#3383)."
             }
           }
         }

--- a/packages/lynx-compat-data/lynx-api/intersection-observer/relativeToScreen.json
+++ b/packages/lynx-compat-data/lynx-api/intersection-observer/relativeToScreen.json
@@ -22,7 +22,8 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented since `@lynx-js/web-core@0.25.0` (lynx-family/lynx-stack#3383)."
             }
           }
         }

--- a/packages/lynx-compat-data/lynx-api/intersection-observer/relativeToViewport.json
+++ b/packages/lynx-compat-data/lynx-api/intersection-observer/relativeToViewport.json
@@ -22,7 +22,8 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented since `@lynx-js/web-core@0.25.0` (lynx-family/lynx-stack#3383)."
             }
           }
         }

--- a/packages/lynx-compat-data/lynx-api/lynx/createIntersectionObserver.json
+++ b/packages/lynx-compat-data/lynx-api/lynx/createIntersectionObserver.json
@@ -28,7 +28,8 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented since `@lynx-js/web-core@0.25.0` (lynx-family/lynx-stack#3383)."
             }
           }
         }

--- a/packages/lynx-compat-data/lynx-api/lynx/reload.json
+++ b/packages/lynx-compat-data/lynx-api/lynx/reload.json
@@ -33,7 +33,8 @@
               "version_added": "3.5"
             },
             "web_lynx": {
-              "version_added": false
+              "version_added": true,
+              "notes": "Implemented since `@lynx-js/web-core@0.19.6` (lynx-family/lynx-stack#2127)."
             }
           }
         }


### PR DESCRIPTION
## What

Found via the weekly Lynx Web Platform gap audit's reverse-drift check: two `lynx-api/lynx/*` entries were still marked `web_lynx: false` in compat-data even though both are fully implemented and shipped in `@lynx-js/web-core`.

### `lynx.createIntersectionObserver()`

Fully implemented end-to-end on web-core:
- Background-thread module: `packages/web-platform/web-core/ts/client/background/background-apis/createIntersectionObserverModule.ts`
- Main-thread service backing all six operations (`create`/`relativeTo`/`relativeToViewport`/`relativeToScreen`/`observe`/`disconnect`) using the real browser `IntersectionObserver`: `packages/web-platform/web-core/ts/client/mainthread/IntersectionObserverService.ts`
- Unit tests: `packages/web-platform/web-core/tests/intersection-observer-service.spec.ts`
- Shipped and changelogged in `@lynx-js/web-core@0.25.0`: "Support `lynx.createIntersectionObserver` in Lynx for Web." (lynx-family/lynx-stack#3383)

Flipped 7 files: `lynx-api/lynx/createIntersectionObserver.json` and all 6 `lynx-api/intersection-observer/*.json` files (the `IntersectionObserver` class entry plus its 5 methods).

### `lynx.reload()`

Implemented via `packages/web-platform/web-core/ts/client/mainthread/crossThreadHandlers/registerReloadHandler.ts` (calls the browser's `location.reload()` on the LynxView's parent), wired through `createBackgroundLynx.ts`. Shipped since `@lynx-js/web-core@0.19.6`: "feat: support lynx.reload()" (lynx-family/lynx-stack#2127), with several follow-up bugfixes since (freeze-after-reload, globalProps refresh, etc.), confirming it's a real, maintained feature rather than a stub.

Flipped `lynx-api/lynx/reload.json`.

## Why

`web_lynx: false` on an already-implemented API is a false negative that causes the weekly web-gap audit (and anyone reading the compat-data / lynxjs.org compat tables) to treat a shipped feature as a gap.

## Validation

- `node --loader=ts-node/esm scripts/generate-stats.ts` — regenerated `api-stats.json` (gitignored, not committed); `web_lynx` coverage moved from 965/1612 to 978/1612.
- `node --loader=ts-node/esm scripts/validate.ts` (the `lint` script) — passes clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QaC27o2spJ2PFveewsQuLt

---
_Generated by [Claude Code](https://claude.ai/code/session_01QaC27o2spJ2PFveewsQuLt)_