### PR TITLE
fix(living-spec): declare repository metadata

### DIFF
--- a/packages/lynx-living-spec/src/index.bs
+++ b/packages/lynx-living-spec/src/index.bs
@@ -5,6 +5,7 @@ Markup Shorthands: biblio yes
 Shortname: LynxLivingSpec
 Title: Lynx Living Spec
 Abstract: This module introduces living specification for Lynx.
+Repository: lynx-family/lynx-website
 Boilerplate: omit document-revision
 Date: 2025-03-06
 </pre>


### PR DESCRIPTION
## Summary

Make Living Spec generation independent of the caller's Git repository.

## Problem

Bikeshed automatically discovers repository metadata from the Git remote of the
source working directory.

Generation from the OSS repository includes:

```text
Issue Tracking: GitHub
```

The downstream in-house workflow executes the same generator from its own
repository root. Although the source and Bikeshed version are identical, the
generated HTML omits the GitHub issue tracker because the current Git remote is
not the OSS GitHub repository.

## Fix

Declare the repository explicitly in the Living Spec metadata:

```text
Repository: lynx-family/lynx-website
```

This is Bikeshed's canonical `owner/repo` syntax. It causes Bikeshed to recognize
the GitHub repository and generate its issue tracker regardless of the caller
working directory, without duplicating the automatically generated link in OSS.

## Validation

- Generated from the OSS repository with Bikeshed 7.1.2.
- Generated through the downstream in-house orchestration layer.
- Confirmed both generated HTML files are byte-for-byte identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Declare `lynx-family/lynx-website` as the Living Spec repository.
- Enable consistent GitHub issue-tracking metadata across working directories.
- Verify byte-for-byte identical output with Bikeshed 7.1.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->