### PR TITLE
fix(docs): correct misaligned Go code preview highlight ranges

### DIFF
--- a/docs/en/api/elements/built-in/text.mdx
+++ b/docs/en/api/elements/built-in/text.mdx
@@ -101,7 +101,7 @@ When `direction` is set to `lynx-rtl`, `text-align:left` will be converted to `t
 
 <Go
   img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/doc/text_direction_rtl_demo.jpeg"
-  highlight="{303-356}"
+  highlight="{304-356}"
   example="text"
   defaultFile="src/text_style/index.tsx"
   defaultEntryFile="dist/text_style.lynx.bundle"

--- a/docs/en/api/lynx-api/performance-api/performance-observer/observe.mdx
+++ b/docs/en/api/lynx-api/performance-api/performance-observer/observe.mdx
@@ -54,7 +54,7 @@ This example creates a `PerformanceObserver` that observes the entire `Performan
   defaultEntryFile="dist/performance-observer-observe.lynx.bundle"
   img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/doc/performance-observer-observe-demo.jpeg"
   entry="src/performance-observer-observe"
-  highlight="{12-38}"
+  highlight="{12-37}"
 />
 
 ### Observing specific performance events
@@ -67,7 +67,7 @@ This example creates a `PerformanceObserver` that observes `MetricFcpEntry` and 
   defaultEntryFile="dist/performance-observer-observe.lynx.bundle"
   img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/doc/performance-observer-observe-demo.jpeg"
   entry="src/performance-observer-observe"
-  highlight="{42-61}"
+  highlight="{42-60}"
 />
 
 ## Compatibility

--- a/docs/en/guide/interaction/event-handling/event-propagation.mdx
+++ b/docs/en/guide/interaction/event-handling/event-propagation.mdx
@@ -170,7 +170,7 @@ In the following example, when the user clicks on the page, the developer broadc
   defaultFile="src/event_emitter_toggle/index.tsx"
   defaultEntryFile="dist/event_emitter_toggle.lynx.bundle"
   img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/doc/event/event_emitter_toggle.gif"
-  highlight="{8-10,22-24,41}"
+  highlight="{8-10,22-24,44}"
   entry="src/event_emitter_toggle"
 />
 
@@ -225,6 +225,6 @@ In the following example, users can receive the [`onWindowResize`](../../../api/
   defaultFile="src/event_emitter_listen/index.tsx"
   defaultEntryFile="dist/event_emitter_listen.lynx.bundle"
   img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/doc/event/event_emitter_listen.gif"
-  highlight="{7-9}"
+  highlight="{6-8}"
   entry="src/event_emitter_listen"
 />

--- a/docs/en/react/lifecycle.mdx
+++ b/docs/en/react/lifecycle.mdx
@@ -32,7 +32,7 @@ Here's a simple example modified from [Measuring layout before the browser repai
   defaultEntryFile="dist/measuring-layout.lynx.bundle"
   defaultFile="src/measuring-layout/Tooltip.tsx"
   entry="src/measuring-layout"
-  highlight="{4-18}"
+  highlight="{10-24}"
 />
 
 ## Special Characteristics of `<list />` Child Components

--- a/docs/zh/api/elements/built-in/text.mdx
+++ b/docs/zh/api/elements/built-in/text.mdx
@@ -101,7 +101,7 @@ import {
 
 <Go
   img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/doc/text_direction_rtl_demo.jpeg"
-  highlight="{303-356}"
+  highlight="{304-356}"
   example="text"
   defaultFile="src/text_style/index.tsx"
   defaultEntryFile="dist/text_style.lynx.bundle"

--- a/docs/zh/api/lynx-api/performance-api/performance-observer/observe.mdx
+++ b/docs/zh/api/lynx-api/performance-api/performance-observer/observe.mdx
@@ -52,7 +52,7 @@ entryIdentifiers: string[];
   defaultEntryFile="dist/performance-observer-observe.lynx.bundle"
   img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/doc/performance-observer-observe-demo.jpeg"
   entry="src/performance-observer-observe"
-  highlight="{12-38}"
+  highlight="{12-37}"
 />
 
 ### 观察某些特定的性能事件
@@ -65,7 +65,7 @@ entryIdentifiers: string[];
   defaultEntryFile="dist/performance-observer-observe.lynx.bundle"
   img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/doc/performance-observer-observe-demo.jpeg"
   entry="src/performance-observer-observe"
-  highlight="{42-61}"
+  highlight="{42-60}"
 />
 
 ## 兼容性

--- a/docs/zh/blog/lynx-3-2.mdx
+++ b/docs/zh/blog/lynx-3-2.mdx
@@ -112,7 +112,7 @@ Lynx 3.2 添加了三个 CSS 函数 `minmax()`、`max-content` 和 `fit-content`
   example="text"
   defaultFile="src/cross_text_selection/index.tsx"
   defaultEntryFile="dist/cross_text_selection.lynx.bundle"
-  highlight="{30}"
+  highlight="{31}"
   entry="src/cross_text_selection"
 />
 

--- a/docs/zh/guide/inclusion/accessibility.mdx
+++ b/docs/zh/guide/inclusion/accessibility.mdx
@@ -91,7 +91,6 @@ iOS 和 Android 系统都会默认以从上到下、从左到右的顺序排列�
   defaultEntryFile="dist/main.lynx.bundle"
   defaultFile="src/ReOrder.tsx"
   entry="src/ReOrder.tsx"
-  highlight="{304}"
   highlight="{3,5,6}"
 />
 

--- a/docs/zh/guide/interaction/event-handling/event-propagation.mdx
+++ b/docs/zh/guide/interaction/event-handling/event-propagation.mdx
@@ -170,7 +170,7 @@ import { PlatformTabs, Go, NoWeb } from '@lynx';
   defaultFile="src/event_emitter_toggle/index.tsx"
   defaultEntryFile="dist/event_emitter_toggle.lynx.bundle"
   img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/doc/event/event_emitter_toggle.gif"
-  highlight="{8-10,22-24,41}"
+  highlight="{8-10,22-24,44}"
   entry="src/event_emitter_toggle"
 />
 
@@ -225,6 +225,6 @@ LynxContext.sendGlobalEvent('eventName', args);
   defaultFile="src/event_emitter_listen/index.tsx"
   defaultEntryFile="dist/event_emitter_listen.lynx.bundle"
   img="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/doc/event/event_emitter_listen.gif"
-  highlight="{7-9}"
+  highlight="{6-8}"
   entry="src/event_emitter_listen"
 />

--- a/docs/zh/react/lifecycle.mdx
+++ b/docs/zh/react/lifecycle.mdx
@@ -32,7 +32,7 @@ Lynx 采用双线程架构设计，这使得 ReactLynx 的渲染流程和组件�
   defaultEntryFile="dist/measuring-layout.lynx.bundle"
   defaultFile="src/measuring-layout/Tooltip.tsx"
   entry="src/measuring-layout"
-  highlight="{4-18}"
+  highlight="{10-24}"
 />
 
 ## `<list />` 子组件的特殊性


### PR DESCRIPTION
## Summary

Fix incorrect `highlight` line ranges in `<Go>` code preview components across multiple docs pages.

## Changes

| File | Before | After | Issue |
|---|---|---|---|
| `lifecycle.mdx` (zh & en) | `{4-18}` | `{10-24}` | Highlight started at empty line, cut mid-function; now covers full `handleLayoutChange` |
| `accessibility.mdx` (zh) | `{304}` + `{3,5,6}` | `{3,5,6}` | Removed dead `highlight="{304}"` (file has only 10 lines), duplicate prop masked it |
| `lynx-3-2.mdx` (zh) | `{30}` | `{31}` | Line 30 is empty; en version already had `{31}` (component declaration) |
| `text.mdx` (zh & en) | `{303-356}` | `{304-356}` | Line 303 is empty; now starts at `TextDirectionRtlExample` declaration |
| `observe.mdx` (zh & en) | `{12-38}`, `{42-61}` | `{12-37}`, `{42-60}` | Trim trailing empty lines from highlight ranges |
| `event-propagation.mdx` (zh & en) | `{7-9}` | `{6-8}` | Now correctly covers `useLynxGlobalEventListener` call instead of ending on empty line |
| `event-propagation.mdx` (zh & en) | `{…,41}` | `{…,44}` | Line 41 was `alignItems: "center"` (irrelevant CSS); line 44 is `bindtap={handleTap}` |

## Verification

- Ran automated scan on all 239 `<Go>` components with highlights
- All lint hooks passed (`prettier`, `cspell`, `check-asset-urls`, `check-api-summary`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Align `<Go>` highlight ranges with the intended code across Chinese and English documentation.
- Correct lifecycle, text, `PerformanceObserver.observe()`, and event-propagation examples.
- Remove the invalid duplicate highlight prop from the Chinese accessibility guide.
- Align the Chinese `lynx-3-2` highlight with its source line.
- Verify all 239 highlighted `<Go>` components and pass documentation quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->