### PR TITLE
fix(compat-data): refresh CSS documentation paths

### DIFF
--- a/packages/lynx-compat-data/package.json
+++ b/packages/lynx-compat-data/package.json
@@ -40,7 +40,7 @@
     "json-schema-to-typescript": "^15.0.2"
   },
   "devDependencies": {
-    "@lynx-js/css-defines": "0.0.16",
+    "@lynx-js/css-defines": "0.0.18",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.2",
     "vitest": "^2.1.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,8 +269,8 @@ importers:
         version: 15.0.4
     devDependencies:
       '@lynx-js/css-defines':
-        specifier: 0.0.16
-        version: 0.0.16
+        specifier: 0.0.18
+        version: 0.0.18
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@18.19.130)(typescript@5.9.3)
@@ -1658,8 +1658,8 @@ packages:
   '@lynx-example/webview@0.1.0':
     resolution: {integrity: sha512-7qBlXlqr5F+Jt1kCDAI4vyyTbzMnJo/EJea/6I+Iq6fzM8/6+qSmqvvT9sR1pxnNPYLKIIJc0wZT5M3GtavcGw==}
 
-  '@lynx-js/css-defines@0.0.16':
-    resolution: {integrity: sha512-eeOzMWp4bO1y1gd+uMthaRr3HPaWjWsR92CTPjiaSS4JUqX92mM17pG97MNe+OFeHTm5ltIBjhCJa8TuE3ir5w==}
+  '@lynx-js/css-defines@0.0.18':
+    resolution: {integrity: sha512-llRQy2S46Bqx3QTIEqd/G07P4CgREjlQ37ACku1c+3GKhifA8aOMtuI24lY9ivwi6DtFugpvFpo0OLv9lS2Zwg==}
 
   '@lynx-js/genui@0.0.3':
     resolution: {integrity: sha512-okzTQl2Qg60UIOHn3Rpk5Jgv3QazJH35j4+jfLTM4zd7uSkteVeov0wd7vUGLm9AgOWqyI38sN02ZeOwb8QVug==}
@@ -8318,7 +8318,7 @@ snapshots:
       - '@lynx-js/types'
       - '@types/react'
 
-  '@lynx-js/css-defines@0.0.16': {}
+  '@lynx-js/css-defines@0.0.18': {}
 
   '@lynx-js/genui@0.0.3(@lynx-js/lynx-ui@3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(preact@10.29.2)(typescript@5.0.4)':
     dependencies:


### PR DESCRIPTION
## Summary

- Upgrade `@lynx-js/css-defines` from `0.0.16` to `0.0.18`.
- Regenerate CSS compatibility data and API statistics.
- Consume the corrected `lynx_path` values after the documentation restructure.

## Impact

Stale `docs/zh` paths are removed. Route validation still reports six intentionally retained paths for pending documentation pages.

## Verification

- `pnpm --filter @lynx-js/lynx-compat-data run lint`
- `pnpm --filter @lynx-js/lynx-compat-data run test`
- `pnpm run prepare`
- `pnpm run build`

Issue: lynx-family/lynx#9015

## Related

-  lynx-family/lynx#9015
- #1337 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Upgrade `@lynx-js/css-defines` to `0.0.18`.
- Refresh the lockfile, CSS compatibility data, and API statistics.
- Consume corrected `lynx_path` values and remove stale `docs/zh` paths.
- Retain six route-validation paths for pending documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->