### PR TITLE
chore(version): record 4.1 as the latest release

### DIFF
--- a/docs/public/version.json
+++ b/docs/public/version.json
@@ -1,7 +1,7 @@
 {
   "current_version": "next",
-  "LYNX_VERSION": "4.0.0",
-  "PRIMJS_VERSION": "4.0.0",
+  "LYNX_VERSION": "4.1.0",
+  "PRIMJS_VERSION": "4.1.1",
   "versions": [
     {
       "type": "developing",
@@ -11,9 +11,16 @@
     },
     {
       "type": "latest",
+      "version_number": "4.1",
+      "repo_branch": "release/4.1",
+      "docs_link": "/",
+      "release_number": "4.1.0"
+    },
+    {
+      "type": "previous",
       "version_number": "4.0",
       "repo_branch": "release/4.0",
-      "docs_link": "/",
+      "docs_link": "/4.0",
       "release_number": "4.0.0"
     },
     {


### PR DESCRIPTION
## Summary

Lynx 4.1 ships as the new stable release, so the version list has to name it. Every deployment resolves its version dropdown by fetching this file from the developing build, and `LYNX_VERSION` / `PRIMJS_VERSION` are substituted into the Gradle and CocoaPods snippets, so both have to name a version that resolves.

4.0 moves to `previous` and takes the `/4.0` base it will be built with once release/4.0 is demoted, so its links stay version-local instead of falling through to the site root, which 4.1 owns from then on.

`current_version` stays `next`: this branch is still the developing build, and the promotion happens on release/4.1.

## Published dependency check

Every coordinate the docs substitute these two values into, checked against the registries today:

| Coordinate | Registry | 4.1.0 | 4.1.1 |
| --- | --- | --- | --- |
| `org.lynxsdk.lynx:lynx` and the other 18 Lynx artifacts | Maven Central | resolves, POM and AAR both 200 | — |
| `org.lynxsdk.lynx:primjs` | Maven Central | **absent** | resolves |
| `pod 'PrimJS'` | CocoaPods | present | present |
| `pod 'Lynx'`, `LynxService`, `LynxDevtool`, `XElement` | lynx-family/Specs | resolves | — |

`PRIMJS_VERSION` is therefore 4.1.1, not 4.1.0. PrimJS is versioned on its own cadence and the manifest has carried a different PrimJS version before, on release/3.9.

Lynx no longer publishes its iOS pods to the CocoaPods trunk; they are hosted in [lynx-family/Specs](https://github.com/lynx-family/Specs), which has 4.1.0 for all four. `Lynx/4.1.0` there pins `PrimJS/quickjs` at 4.1.1, which is where the value below comes from. The docs have to declare that source, which #1429 and #1430 do.

Note that `maven-metadata.xml` for `org.lynxsdk.lynx:lynx` has `<release>` and `<latest>` pointing at a nightly, so a check that reads only those fields concludes there is no stable 4.1.0. The `<versions>` list contains it and the artifacts are served.

## Verification

`pnpm run build` passes. The published `version.json` lists 4.1 as `latest`, integration snippets render `4.1.0` with no page left rendering `4.0.0`, and the developing base stays `/next`.

## Ordering

The dropdown starts offering `/4.1/*` as soon as this lands, and those URLs only resolve once release/4.1 is promoted and served. This should land next to the switch, the way #1161 and #1196 did for the previous two releases.

## Related Links

- #1161 — the same change for 3.9
- #1196 — the same change for 4.0
- #1425 — promotes release/4.1
- #1426 — demotes release/4.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Set Lynx 4.1 as the latest stable version.
- Move Lynx 4.0 to `previous` with `/4.0` documentation links.
- Keep `current_version` at `next` for the developing build.
- Update `LYNX_VERSION` and `PRIMJS_VERSION` for integration snippets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->