### PR TITLE
chore(version): move 4.0 off the site root

### DIFF
--- a/docs/public/version.json
+++ b/docs/public/version.json
@@ -13,7 +13,7 @@
       "type": "latest",
       "version_number": "4.0",
       "repo_branch": "release/4.0",
-      "docs_link": "/",
+      "docs_link": "/4.0",
       "release_number": "4.0.0"
     },
     {

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,18 +5,15 @@
 [context.deploy-preview.environment]
   RSPRESS_LIGHTWEIGHT_BUILD = "true"
 
-# Version homes are directory-style URLs, so redirect `/4.0` to `/4.0/` and
-# `/next` to `/next/` instead of serving the same page at two URLs. Netlify
-# normalizes trailing slashes before evaluating redirect rules, so either
-# static redirect would also match its target and cause a loop. Edge Functions
-# run first and can inspect the original pathname.
+# The version home is a directory-style URL, so redirect `/4.0` to `/4.0/`
+# instead of serving the same page at two URLs. Netlify normalizes trailing
+# slashes before evaluating redirect rules, so a static redirect would also
+# match its target and cause a loop. Edge Functions run first and can inspect
+# the original pathname. `/next` is gone from this branch along with the rest
+# of the cross-version routing.
 [[edge_functions]]
   function = "redirect-version-root"
   path = "/4.0"
-
-[[edge_functions]]
-  function = "redirect-version-root"
-  path = "/next"
 
 [[headers]]
   for = "/*"
@@ -156,47 +153,11 @@
   status = 301
   force = true
 
-# Serve current development docs from the site root.
-[[redirects]]
-  from = "/next/*"
-  to = "https://main--lynx-doc.netlify.app/:splat"
-  status = 200
-
-# 4.0 is canonical at the site root. Keep versioned URLs as permanent
-# compatibility redirects.
+# This branch is no longer the site root: 4.1 serves it and owns the
+# cross-version routing table. What is left is this deploy's own base,
+# which every built link and asset carries, rewritten to the files it
+# actually publishes.
 [[redirects]]
   from = "/4.0/*"
   to = "/:splat"
-  status = 301
-  force = true
-
-# Serve previous releases from their branch deploys.
-[[redirects]]
-  from = "/3.9/*"
-  to = "https://release-3-9--lynx-doc.netlify.app/:splat"
-  status = 200
-
-[[redirects]]
-  from = "/3.8/*"
-  to = "https://release-3-8--lynx-doc.netlify.app/:splat"
-  status = 200
-
-[[redirects]]
-  from = "/3.7/*"
-  to = "https://release-3-7--lynx-doc.netlify.app/:splat"
-  status = 200
-
-[[redirects]]
-  from = "/3.6/*"
-  to = "https://release-3-6--lynx-doc.netlify.app/:splat"
-  status = 200
-
-[[redirects]]
-  from = "/3.5/*"
-  to = "https://release-3-5--lynx-doc.netlify.app/:splat"
-  status = 200
-
-[[redirects]]
-  from = "/3.4/*"
-  to = "https://release-3-4--lynx-doc.netlify.app/:splat"
   status = 200

--- a/theme/index.tsx
+++ b/theme/index.tsx
@@ -354,7 +354,7 @@ const Search = () => {
       docSearchProps={{
         appId: 'V4ET1OFZ5S', // cspell:disable-line
         apiKey: '15236c16e0f335c0cb2a67bc3ac06bcb', // cspell:disable-line
-        indexName: 'lynx',
+        indexName: 'lynx_4.0',
         searchParameters: {
           facetFilters: [`lang:${lang}`],
         },


### PR DESCRIPTION
## Summary

4.1 becomes the released version, so this branch goes back to being an archived version site.

- Its own `docs_link` becomes `/4.0`, which is what moves the build: `SITE_BASE` reads that entry, so the versioned base follows without touching the Rspress config (#1221).
- The cross-version routing table moves with the root to release/4.1. What is left here is the rewrite from this deployment's own base to the files it publishes, which has to serve rather than redirect, because every published link and asset carries the `/4.0` prefix. This matches how release/3.9 was demoted in #1198.
- The Edge Function keeps `/4.0` and drops `/next`, which this branch no longer serves.
- `indexName` becomes `lynx_4.0`, since `lynx` now belongs to 4.1.

The entry stays `type: latest` and no 4.1 entry is added, matching release/3.9 and release/3.8: the dropdown is resolved at runtime from the developing build, and dropping `latest` here would only empty the table on this branch's own `/versions` page.

## Verification

`pnpm run build` passes and publishes under `/4.0`: assets and links carry the version prefix, the published `version.json` resolves to `docs_link: /4.0`, and the client bundle queries `lynx_4.0`.

#1290 is not included. It reports that server rendering under the `/4.0` base loses the subsite marker, so it looked like a prerequisite for this change. Building this branch both with and without that patch produces `data-subsite="ui"` in `doc_build/ui/index.html` and `doc_build/zh/ui/index.html` either way, so the symptom does not reproduce on the current branch and there is nothing here for it to fix. Worth a look on the deploy preview before the switch, in case the original report depended on something the build does not exercise.

## Ordering

Draft on purpose. This branch is production until Netlify's production branch moves to release/4.1, and merging before that would take the live site off the root. Merge right after the switch.

## Related Links

- #1198, #1201 — the same steps for 3.9
- #1424 — records 4.1 on main
- #1425 — promotes release/4.1