### PR TITLE
fix(version): redirect the bare version home with 308

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,16 @@
   command = "node scripts/ci/check-build-prereqs.mjs && pnpm gen:og && NODE_OPTIONS=--max-old-space-size=3072 RSPRESS_SSG_WORKER_THREAD_COUNT=2 pnpm exec rspress build"
   publish = "doc_build"
 
+# The version home is a directory-style URL, so redirect `/next` to `/next/`
+# instead of serving the same page at two URLs. Netlify normalizes trailing
+# slashes before evaluating redirect rules, so a static redirect would also
+# match its target and cause a loop. Edge Functions run first and can inspect
+# the original pathname. A release branch serves a second version home at its
+# own base and registers it here alongside `/next`.
+[[edge_functions]]
+  function = "redirect-version-root"
+  path = "/next"
+
 [[headers]]
   for = "/*"
   [headers.values]

--- a/netlify/edge-functions/redirect-version-root.ts
+++ b/netlify/edge-functions/redirect-version-root.ts
@@ -1,0 +1,10 @@
+export default (request: Request) => {
+  const url = new URL(request.url);
+
+  if (url.pathname.endsWith('/')) {
+    return;
+  }
+
+  url.pathname += '/';
+  return Response.redirect(url, 308);
+};


### PR DESCRIPTION
## Summary

`/next` and `/next/` both serve the same page today, on this branch's deploy and on every branch cut from it. Netlify normalizes trailing slashes before it evaluates redirect rules, so a static redirect would match its own target and loop; an Edge Function runs first and still sees the original path.

This is the fix from #1231. That PR landed on release/4.0 only, so nothing cut from main afterwards has it, release/4.1 included, and each release has been re-adding it by hand. Keeping it here means the next cut carries it.

Only `/next` is registered, since that is the version home this branch serves. A release branch that serves a second home at its own base registers that base alongside it; one that only keeps its version prefix as a compatibility redirect does not need an entry, because the redirect already matches the bare form.

## Verification

The Edge Function file is byte-identical to the one on release/4.0 (blob `f39c51b95`). `netlify.toml` parses and the route contract check passes. Measured today: `main--lynx-doc.netlify.app/next` and `/next/` both return 200, while `lynxjs.org/next`, which is served by release/4.0 and has this Edge Function, returns 308 to `/next/`.

## Related Links

- #1231 — the original fix on release/4.0
- #1428 — the same commit cherry-picked to release/4.1
- #1425 — the 4.1 promotion, which no longer has to carry this file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Configure `redirect-version-root` to run before the `/next/*` rewrite.
- Redirect bare `/next` requests to `/next/` with HTTP 308.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->