### PR TITLE
fix(version): redirect the bare version home with 308

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,16 @@
   command = "node scripts/ci/check-build-prereqs.mjs && pnpm gen:og && NODE_OPTIONS=--max-old-space-size=3072 RSPRESS_SSG_WORKER_THREAD_COUNT=2 pnpm exec rspress build"
   publish = "doc_build"
 
+# The version home is a directory-style URL, so redirect `/next` to `/next/`
+# instead of serving the same page at two URLs. Netlify normalizes trailing
+# slashes before evaluating redirect rules, so a static redirect would also
+# match its target and cause a loop. Edge Functions run first and can inspect
+# the original pathname. A release branch serves a second version home at its
+# own base and registers it here alongside `/next`.
+[[edge_functions]]
+  function = "redirect-version-root"
+  path = "/next"
+
 [[headers]]
   for = "/*"
   [headers.values]

--- a/netlify/edge-functions/redirect-version-root.ts
+++ b/netlify/edge-functions/redirect-version-root.ts
@@ -1,0 +1,10 @@
+export default (request: Request) => {
+  const url = new URL(request.url);
+
+  if (url.pathname.endsWith('/')) {
+    return;
+  }
+
+  url.pathname += '/';
+  return Response.redirect(url, 308);
+};


### PR DESCRIPTION
## Summary

Cherry-pick of #1427 onto release/4.1, so this branch has the Edge Function before it is promoted.

`/next` and `/next/` both serve the same page today. Netlify normalizes trailing slashes before it evaluates redirect rules, so a static redirect would match its own target and loop; an Edge Function runs first and still sees the original path. The fix originally landed on release/4.0 only (#1231), which is why this branch, cut from main, does not have it.

## Verification

The Edge Function file is byte-identical to the one on release/4.0 (blob `f39c51b95`). `netlify.toml` parses and the route contract check passes.

## Related Links

- #1427 — the same commit on main, which is where it should land first
- #1231 — the original fix on release/4.0
- #1425 — the 4.1 promotion, which now stacks on this