### PR TITLE
docs(ios): point the Podfile at the lynx-family Specs source

### DIFF
--- a/docs/en/guide/start/fragments/ios/integrating-lynx-with-existing-app-ios.mdx
+++ b/docs/en/guide/start/fragments/ios/integrating-lynx-with-existing-app-ios.mdx
@@ -34,10 +34,13 @@ The core capabilities of [Lynx Engine](/guide/spec.html#engine) include basic ca
 
 Get the latest version of Lynx from Cocoapods. Then add Lynx to your Podfile:
 
+Lynx publishes its pods to the [`lynx-family` Specs repository](https://github.com/lynx-family/Specs), so the Podfile declares that source as well. PrimJS and third-party pods still come from the CocoaPods CDN.
+
 <CodeFold height={360} toggle>
 
-```ruby title="Podfile" {1,6-8,10}
+```ruby title="Podfile" {1-2,7-9,11}
 source 'https://cdn.cocoapods.org/'
+source 'https://github.com/lynx-family/Specs.git'
 
 platform :ios, '10.0'
 
@@ -61,8 +64,9 @@ Get the latest version of Lynx Service from Cocoapods. Then add Lynx Service to 
 
 <CodeFold height={360} toggle>
 
-```ruby title="Podfile" {13-17,20-21}
+```ruby title="Podfile" {14-18,21-22}
 source 'https://cdn.cocoapods.org/'
+source 'https://github.com/lynx-family/Specs.git'
 
 platform :ios, '10.0'
 
@@ -93,8 +97,9 @@ end
 ​​XElement​​ is an extend native elements library maintained by the Lynx team. It provides richer component capabilities, enabling faster adoption of Lynx in production environments and enhancing the vibrancy of the Lynx ecosystem.
 
 <CodeFold height={360} toggle>
-```ruby title="Podfile" {23}
+```ruby title="Podfile" {24}
 source 'https://cdn.cocoapods.org/'
+source 'https://github.com/lynx-family/Specs.git'
 
 platform :ios, '10.0'
 

--- a/docs/zh/guide/start/fragments/ios/integrating-lynx-with-existing-app-ios.mdx
+++ b/docs/zh/guide/start/fragments/ios/integrating-lynx-with-existing-app-ios.mdx
@@ -32,9 +32,12 @@ import versionJson from '@site/docs/public/version.json';
 
 从 Cocoapods 中获取 Lynx 的最新版本。然后将 Lynx 添加到你的 Podfile 中：
 
+Lynx 的 pod 发布在 [`lynx-family` Specs 仓库](https://github.com/lynx-family/Specs)，因此 Podfile 中需要额外声明该源。PrimJS 和第三方 pod 仍然来自 CocoaPods CDN。
+
 <CodeFold height={360} toggle>
-```ruby title="Podfile" {1,6-8,10}
+```ruby title="Podfile" {1-2,7-9,11}
 source 'https://cdn.cocoapods.org/'
+source 'https://github.com/lynx-family/Specs.git'
 
 platform :ios, '10.0'
 
@@ -56,8 +59,9 @@ Lynx 提供了标准的原生 Image、Log、Http 服务的能力，接入方可�
 从 Cocoapods 中获取 Lynx Service 的最新版本。然后将 Lynx Service 添加到你的 Podfile 中：
 
 <CodeFold height={360} toggle>
-```ruby title="Podfile" {13-17,20-21}
+```ruby title="Podfile" {14-18,21-22}
 source 'https://cdn.cocoapods.org/'
+source 'https://github.com/lynx-family/Specs.git'
 
 platform :ios, '10.0'
 
@@ -89,8 +93,9 @@ XElement 是 Lynx 团队维护的客户端扩展元件集合，提供更丰富�
 从 Cocoapods 中获取 XElement 的最新版本。然后将 XElement 添加到你的 Podfile 中：
 
 <CodeFold height={360} toggle>
-```ruby title="Podfile" {23}
+```ruby title="Podfile" {24}
 source 'https://cdn.cocoapods.org/'
+source 'https://github.com/lynx-family/Specs.git'
 
 platform :ios, '10.0'
 


### PR DESCRIPTION
## Summary

Lynx stopped publishing its iOS pods to the CocoaPods trunk and now hosts them in [lynx-family/Specs](https://github.com/lynx-family/Specs). The integration Podfile still lists the trunk CDN alone, so following these instructions cannot resolve `pod 'Lynx'` at any version that only exists in the new repository.

The three Podfile snippets now declare both sources, and a sentence above the first one says which pods come from where. The highlighted line ranges shift with the added line.

## Why this is needed now

4.1 is the first release affected. Checked against both indexes today:

| Pod | CocoaPods CDN | lynx-family/Specs |
| --- | --- | --- |
| `Lynx`, `LynxService`, `LynxDevtool`, `XElement` | newest stable 4.0.2 | 4.1.0 present |
| `PrimJS` | 4.1.0 and 4.1.1 present | not hosted there |

So both sources are required: the Specs repository for the Lynx pods, the CDN for PrimJS and the third-party pods the snippets also install (`SDWebImage`, `SDWebImageWebPCoder`).

Older releases are unaffected — their pods are still resolvable from the trunk, so the archived version sites need no change.

## Verification

Prettier and the asset-url and case-collision checks pass. Every highlighted range was re-derived against the rendered block, so each still marks the line it marked before, plus the two source lines in the first snippet.

`Lynx/4.1.0` in the Specs repository resolves to the `Lynx-4.1.0.zip` asset of the engine's 4.1.0 GitHub release, and its `Framework` subspec depends on `PrimJS/quickjs` pinned at 4.1.1, which is consistent with the `PRIMJS_VERSION` in #1424 and #1425.

## Related Links

- #1424 — records 4.1 on main
- #1425 — promotes release/4.1