### PR TITLE
docs(ios): point the Podfile at the lynx-family Specs source

### DIFF
--- a/docs/en/guide/start/fragments/ios/integrating-lynx-with-existing-app-ios.mdx
+++ b/docs/en/guide/start/fragments/ios/integrating-lynx-with-existing-app-ios.mdx
@@ -34,10 +34,13 @@ The core capabilities of [Lynx Engine](/guide/spec.html#engine) include basic ca
 
 Get the latest version of Lynx from Cocoapods. Then add Lynx to your Podfile:
 
+Lynx publishes its pods to the [`lynx-family` Specs repository](https://github.com/lynx-family/Specs), so the Podfile declares that source as well. PrimJS and third-party pods still come from the CocoaPods CDN.
+
 <CodeFold height={360} toggle>
 
-```ruby title="Podfile" {1,6-8,10}
+```ruby title="Podfile" {1-2,7-9,11}
 source 'https://cdn.cocoapods.org/'
+source 'https://github.com/lynx-family/Specs.git'
 
 platform :ios, '10.0'
 
@@ -61,8 +64,9 @@ Get the latest version of Lynx Service from Cocoapods. Then add Lynx Service to 
 
 <CodeFold height={360} toggle>
 
-```ruby title="Podfile" {13-17,20-21}
+```ruby title="Podfile" {14-18,21-22}
 source 'https://cdn.cocoapods.org/'
+source 'https://github.com/lynx-family/Specs.git'
 
 platform :ios, '10.0'
 
@@ -93,8 +97,9 @@ end
 ​​XElement​​ is an extend native elements library maintained by the Lynx team. It provides richer component capabilities, enabling faster adoption of Lynx in production environments and enhancing the vibrancy of the Lynx ecosystem.
 
 <CodeFold height={360} toggle>
-```ruby title="Podfile" {23}
+```ruby title="Podfile" {24}
 source 'https://cdn.cocoapods.org/'
+source 'https://github.com/lynx-family/Specs.git'
 
 platform :ios, '10.0'
 

--- a/docs/zh/guide/start/fragments/ios/integrating-lynx-with-existing-app-ios.mdx
+++ b/docs/zh/guide/start/fragments/ios/integrating-lynx-with-existing-app-ios.mdx
@@ -32,9 +32,12 @@ import versionJson from '@site/docs/public/version.json';
 
 从 Cocoapods 中获取 Lynx 的最新版本。然后将 Lynx 添加到你的 Podfile 中：
 
+Lynx 的 pod 发布在 [`lynx-family` Specs 仓库](https://github.com/lynx-family/Specs)，因此 Podfile 中需要额外声明该源。PrimJS 和第三方 pod 仍然来自 CocoaPods CDN。
+
 <CodeFold height={360} toggle>
-```ruby title="Podfile" {1,6-8,10}
+```ruby title="Podfile" {1-2,7-9,11}
 source 'https://cdn.cocoapods.org/'
+source 'https://github.com/lynx-family/Specs.git'
 
 platform :ios, '10.0'
 
@@ -56,8 +59,9 @@ Lynx 提供了标准的原生 Image、Log、Http 服务的能力，接入方可�
 从 Cocoapods 中获取 Lynx Service 的最新版本。然后将 Lynx Service 添加到你的 Podfile 中：
 
 <CodeFold height={360} toggle>
-```ruby title="Podfile" {13-17,20-21}
+```ruby title="Podfile" {14-18,21-22}
 source 'https://cdn.cocoapods.org/'
+source 'https://github.com/lynx-family/Specs.git'
 
 platform :ios, '10.0'
 
@@ -89,8 +93,9 @@ XElement 是 Lynx 团队维护的客户端扩展元件集合，提供更丰富�
 从 Cocoapods 中获取 XElement 的最新版本。然后将 XElement 添加到你的 Podfile 中：
 
 <CodeFold height={360} toggle>
-```ruby title="Podfile" {23}
+```ruby title="Podfile" {24}
 source 'https://cdn.cocoapods.org/'
+source 'https://github.com/lynx-family/Specs.git'
 
 platform :ios, '10.0'
 


### PR DESCRIPTION
## Summary

Cherry-pick of #1429 onto release/4.1. This is the release that needs it: `Lynx`, `LynxService`, `LynxDevtool` and `XElement` 4.1.0 exist only in [lynx-family/Specs](https://github.com/lynx-family/Specs), while the CocoaPods CDN still stops at 4.0.2. Without the extra source, the Podfile these docs publish cannot install the version they name.

`PrimJS` is not in the Specs repository and is still served by the CDN, so both sources stay.

## Verification

Prettier and the asset-url and case-collision checks pass. The highlighted ranges were re-derived against the rendered blocks.

## Related Links

- #1429 — the same change on main
- #1425 — the promotion, which sets `LYNX_VERSION` to 4.1.0