### PR TITLE
fix(compat-data): refresh CSS documentation paths

### DIFF
--- a/packages/lynx-compat-data/package.json
+++ b/packages/lynx-compat-data/package.json
@@ -40,7 +40,7 @@
     "json-schema-to-typescript": "^15.0.2"
   },
   "devDependencies": {
-    "@lynx-js/css-defines": "0.0.16",
+    "@lynx-js/css-defines": "0.0.18",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.2",
     "vitest": "^2.1.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,8 +269,8 @@ importers:
         version: 15.0.4
     devDependencies:
       '@lynx-js/css-defines':
-        specifier: 0.0.16
-        version: 0.0.16
+        specifier: 0.0.18
+        version: 0.0.18
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@18.19.130)(typescript@5.9.3)
@@ -1658,8 +1658,8 @@ packages:
   '@lynx-example/webview@0.1.0':
     resolution: {integrity: sha512-7qBlXlqr5F+Jt1kCDAI4vyyTbzMnJo/EJea/6I+Iq6fzM8/6+qSmqvvT9sR1pxnNPYLKIIJc0wZT5M3GtavcGw==}
 
-  '@lynx-js/css-defines@0.0.16':
-    resolution: {integrity: sha512-eeOzMWp4bO1y1gd+uMthaRr3HPaWjWsR92CTPjiaSS4JUqX92mM17pG97MNe+OFeHTm5ltIBjhCJa8TuE3ir5w==}
+  '@lynx-js/css-defines@0.0.18':
+    resolution: {integrity: sha512-llRQy2S46Bqx3QTIEqd/G07P4CgREjlQ37ACku1c+3GKhifA8aOMtuI24lY9ivwi6DtFugpvFpo0OLv9lS2Zwg==}
 
   '@lynx-js/genui@0.0.3':
     resolution: {integrity: sha512-okzTQl2Qg60UIOHn3Rpk5Jgv3QazJH35j4+jfLTM4zd7uSkteVeov0wd7vUGLm9AgOWqyI38sN02ZeOwb8QVug==}
@@ -8318,7 +8318,7 @@ snapshots:
       - '@lynx-js/types'
       - '@types/react'
 
-  '@lynx-js/css-defines@0.0.16': {}
+  '@lynx-js/css-defines@0.0.18': {}
 
   '@lynx-js/genui@0.0.3(@lynx-js/lynx-ui@3.133.1(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(@lynx-js/types@3.9.0)(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@lynx-js/react@0.121.1(@lynx-js/types@3.9.0)(@types/react@18.3.18))(preact@10.29.2)(typescript@5.0.4)':
     dependencies:


### PR DESCRIPTION
## Summary

Cherry-pick of #1422 onto release/4.1, which was cut before it landed and still resolves `@lynx-js/css-defines` at 0.0.16.

The compat table turns `lynx_path` into a link with `withBase('/' + lynxPath)`. In 0.0.16, 31 of the 189 values are still repository file paths left over from the docs restructuring — `docs/zh/api/css/properties/left` and similar — so those links point at URLs the site does not publish. 0.0.18 emits site routes for all 190.

## Verification

Applied cleanly; after it, `packages/lynx-compat-data/package.json` and `pnpm-lock.yaml` are identical to main on these paths.

- `pnpm install --frozen-lockfile` succeeds, so the lockfile matches the bumped manifest, and the installed package is 0.0.18.
- `pnpm --filter @lynx-js/lynx-compat-data run test` passes, 18 tests.
- `pnpm --filter @lynx-js/lynx-compat-data run gen-css` regenerates 205 property files and leaves the working tree clean: that output is gitignored, so nothing generated needs to be checked in here.

Comparing the two published packages directly, 0.0.16 carries 31 repository-relative `lynx_path` values and 0.0.18 carries none. The effect is visible today: `lynxjs.org/docs/zh/api/css/properties/left`, the URL the current data produces, returns 404, while the route 0.0.18 points at, `lynxjs.org/api/css/properties/left`, returns 200. The same 404 reproduces on the release/4.1 branch deploy.

Six `lynx_path` values resolve to no page in this branch's docs tree, all of them properties without a page in the repository at all. Main is in exactly the same state, so this is not something the cherry-pick introduces.

## Related Links

- #1422 — the original change on main
- https://github.com/lynx-family/lynx/issues/9015