### PR TITLE
docs: point Quick Start at the 4.1.0 Explorer and correct the Edge Function comment

### DIFF
--- a/docs/en/guide/start/quick-start.mdx
+++ b/docs/en/guide/start/quick-start.mdx
@@ -76,7 +76,7 @@ Open up the Mac App Store, search for [Xcode](https://apps.apple.com/us/app/xcod
 
 <PlatformTabs.Tab platform="macos-arm64">
 
-Download [`LynxExplorer-arm64.app.tar.gz`](https://github.com/lynx-family/lynx/releases/download/4.0.0/LynxExplorer-arm64.app.tar.gz).
+Download [`LynxExplorer-arm64.app.tar.gz`](https://github.com/lynx-family/lynx/releases/download/4.1.0/LynxExplorer-arm64.app.tar.gz).
 
 Then extract the downloaded archive:
 
@@ -93,7 +93,7 @@ Open Xcode, choose **Open Developer Tool** from the Xcode menu. Click the **Simu
 
 <PlatformTabs.Tab platform="macos-intel">
 
-Download [`LynxExplorer-x86_64.app.tar.gz`](https://github.com/lynx-family/lynx/releases/download/4.0.0/LynxExplorer-x86_64.app.tar.gz).
+Download [`LynxExplorer-x86_64.app.tar.gz`](https://github.com/lynx-family/lynx/releases/download/4.1.0/LynxExplorer-x86_64.app.tar.gz).
 
 Then, extract the downloaded archive:
 
@@ -114,12 +114,12 @@ Open Xcode, choose **Open Developer Tool** from the Xcode menu. Click the **Simu
 
 <PlatformTabs.Tab platform="android">
 
-Scan the QR code to download the pre-built app from [GitHub Release 4.0.0](https://github.com/lynx-family/lynx/releases/tag/4.0.0).
+Scan the QR code to download the pre-built app from [GitHub Release 4.1.0](https://github.com/lynx-family/lynx/releases/tag/4.1.0).
 
 <QRCodeSVG
   style={{ border: '2px solid #fff' }}
   size={220}
-  value="https://github.com/lynx-family/lynx/releases/download/4.0.0/LynxExplorer-noasan-release.apk"
+  value="https://github.com/lynx-family/lynx/releases/download/4.1.0/LynxExplorer-noasan-release.apk"
 />
 
 Or, you may build from source by following the [Build Lynx Explorer for Android](https://github.com/lynx-family/lynx/tree/develop/explorer/android) guide.
@@ -140,7 +140,7 @@ Download the latest DevEco Studio from the [official website](https://developer.
 
 2. **<div id="download-lynx-explorer">Download Lynx Explorer</div>**
 
-Download the pre-built app [`lynx_explorer-default-unsigned.hap`](https://github.com/lynx-family/lynx/releases/download/4.0.0/lynx_explorer-default-unsigned.hap).
+Download the pre-built app [`lynx_explorer-default-unsigned.hap`](https://github.com/lynx-family/lynx/releases/download/4.1.0/lynx_explorer-default-unsigned.hap).
 
 Or, you may build from source by following the [Build Lynx Explorer for Harmony](https://github.com/lynx-family/lynx/tree/develop/explorer/harmony) guide.
 

--- a/docs/zh/guide/start/quick-start.mdx
+++ b/docs/zh/guide/start/quick-start.mdx
@@ -76,7 +76,7 @@ Lynx Explorer 是一个可以快速试用 Lynx 的沙盒环境。
 
 <PlatformTabs.Tab platform="macos-arm64">
 
-下载 [`LynxExplorer-arm64.app.tar.gz`](https://github.com/lynx-family/lynx/releases/download/4.0.0/LynxExplorer-arm64.app.tar.gz)。
+下载 [`LynxExplorer-arm64.app.tar.gz`](https://github.com/lynx-family/lynx/releases/download/4.1.0/LynxExplorer-arm64.app.tar.gz)。
 
 然后，解压下载的压缩包：
 
@@ -93,7 +93,7 @@ tar -zxf LynxExplorer-arm64.app.tar.gz -C LynxExplorer-arm64.app/
 
 <PlatformTabs.Tab platform="macos-intel">
 
-下载 [`LynxExplorer-x86_64.app.tar.gz`](https://github.com/lynx-family/lynx/releases/download/4.0.0/LynxExplorer-x86_64.app.tar.gz)。
+下载 [`LynxExplorer-x86_64.app.tar.gz`](https://github.com/lynx-family/lynx/releases/download/4.1.0/LynxExplorer-x86_64.app.tar.gz)。
 
 然后，解压下载的压缩包：
 
@@ -114,12 +114,12 @@ tar -zxf LynxExplorer-x86_64.app.tar.gz -C LynxExplorer-x86_64.app/
 
 <PlatformTabs.Tab platform="android">
 
-扫描二维码从 [GitHub Release 4.0.0](https://github.com/lynx-family/lynx/releases/tag/4.0.0) 下载预编译应用。
+扫描二维码从 [GitHub Release 4.1.0](https://github.com/lynx-family/lynx/releases/tag/4.1.0) 下载预编译应用。
 
 <QRCodeSVG
   style={{ border: '2px solid #fff' }}
   size={220}
-  value="https://github.com/lynx-family/lynx/releases/download/4.0.0/LynxExplorer-noasan-release.apk"
+  value="https://github.com/lynx-family/lynx/releases/download/4.1.0/LynxExplorer-noasan-release.apk"
 />
 
 或者，你可以按照[为 Android 构建 Lynx Explorer](https://github.com/lynx-family/lynx/tree/develop/explorer/android) 指南从源代码构建。
@@ -140,7 +140,7 @@ tar -zxf LynxExplorer-x86_64.app.tar.gz -C LynxExplorer-x86_64.app/
 
 2. **<div id="download-lynx-explorer">下载 Lynx Explorer</div>**
 
-下载预编译应用 [`lynx_explorer-default-unsigned.hap`](https://github.com/lynx-family/lynx/releases/download/4.0.0/lynx_explorer-default-unsigned.hap)。
+下载预编译应用 [`lynx_explorer-default-unsigned.hap`](https://github.com/lynx-family/lynx/releases/download/4.1.0/lynx_explorer-default-unsigned.hap)。
 
 或者，你可以按照[为 Harmony 构建 Lynx Explorer](https://github.com/lynx-family/lynx/tree/develop/explorer/harmony) 指南从源代码构建。
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,8 +6,10 @@
 # instead of serving the same page at two URLs. Netlify normalizes trailing
 # slashes before evaluating redirect rules, so a static redirect would also
 # match its target and cause a loop. Edge Functions run first and can inspect
-# the original pathname. A release branch serves a second version home at its
-# own base and registers it here alongside `/next`.
+# the original pathname. A release branch adds an entry only for a base it
+# serves: an archived release builds at `/x.y` and needs one, while the
+# current release builds at the root, where `/x.y/*` is a compatibility
+# redirect that already matches the bare form.
 [[edge_functions]]
   function = "redirect-version-root"
   path = "/next"


### PR DESCRIPTION
## Summary

Two loose ends from the 4.1 release preparation, kept as separate commits.

**Quick Start Explorer links.** The page still hands out the 4.0.0 build while describing 4.1. All four artifacts it links are published on the [4.1.0 release](https://github.com/lynx-family/lynx/releases/tag/4.1.0): both simulator archives, the Android APK behind the QR code, and the Harmony HAP. Same five substitutions per language as #1185 did for 4.0.

**Edge Function comment.** #1427 landed the trailing-slash Edge Function here with a comment telling every release branch to register its own base. That is only true for an archived release, which builds at `/x.y` and serves a version home there. The current release builds at the root, where `/x.y/*` is a compatibility redirect that a bare `/x.y` already matches — registering it there only inserts a hop before the redirect, which is what #1425 measured and dropped. Comment only, no behavior change.

## Verification

Each of the four 4.1.0 artifacts returns content over HTTP. Prettier, the asset-url check and the lynx-ui route contract check pass, and `netlify.toml` still parses with the same single `/next` entry and 29 redirects.

## Related Links

- #1185, #1186 — the same Explorer bump for 4.0
- #1427 — where the comment came from
- #1425 — where the promoted-branch behavior was measured

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Update Quick Start Lynx Explorer links and QR-code references to release 4.1.0.
- Clarify `netlify.toml` release-branch documentation without changing Edge Function behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->