### PR TITLE
docs(start): point the remaining iOS guides at the Specs source

### DIFF
--- a/docs/en/guide/autolink.mdx
+++ b/docs/en/guide/autolink.mdx
@@ -78,7 +78,7 @@ lynx-app/
 
 - `package.json` is required so the app can declare Autolink library packages as dependencies.
 - For Android, the project needs a Gradle settings file, such as `settings.gradle` or `settings.gradle.kts`, and an Android application build file, such as `app/build.gradle` or `app/build.gradle.kts`.
-- For iOS, the project needs a CocoaPods entry point, usually `Podfile`. If your team manages Ruby dependencies with Bundler, keep the `cocoapods-lynx-library` gem in `Gemfile`.
+- For iOS, the project needs a CocoaPods entry point, usually `Podfile`. The Podfile must declare the [`lynx-family` Specs repository](https://github.com/lynx-family/Specs) as a source. If your team manages Ruby dependencies with Bundler, keep the `cocoapods-lynx-library` gem in `Gemfile`.
 - For HarmonyOS, the project needs a root `hvigorconfig.ts` and an entry or feature HAP module that depends on `@lynx/lynx`.
 - `shared/` is used when the host app owns cross-platform native source code and CMake build entry points; build these sources yourself.
 - For Lynxtron, the app needs a host-side Rspack build that can install npm packages and load native libraries through `pluginLynxtron()`; it generally consumes the compiled `dist/` artifacts.
@@ -115,9 +115,12 @@ After Gradle sync/build, Autolink generates a fixed Android registry entry and a
 
 <PlatformTabs.Tab platform="ios">
 
-Install the `cocoapods-lynx-library` gem in your iOS build environment. Then add the CocoaPods plugin to the app's Podfile and call `use_lynx_library!` so podspecs from installed libraries and the generated registry pod are added during `pod install`:
+Install the `cocoapods-lynx-library` gem in your iOS build environment. Then add the pod sources and the CocoaPods plugin to the app's Podfile and call `use_lynx_library!` so podspecs from installed libraries and the generated registry pod are added during `pod install`:
 
 ```ruby
+source 'https://cdn.cocoapods.org/'
+source 'https://github.com/lynx-family/Specs.git'
+
 plugin 'cocoapods-lynx-library'
 
 target 'LynxApp' do

--- a/docs/en/guide/start/integrate-lynx-dev-version.mdx
+++ b/docs/en/guide/start/integrate-lynx-dev-version.mdx
@@ -35,6 +35,7 @@ Refer to the [Lynx DevTool integration guide](/guide/start/integrate-lynx-devtoo
 ### Switch to the dev version of Lynx
 
 Update your `Podfile` to use the dev version of the Lynx component.
+Make sure the Podfile declares the `lynx-family` Specs repository as a source, as shown in the [Lynx integration guide](/guide/start/integrate-with-existing-apps.html?platform=ios).
 
 ```ruby title="Podfile"
 pod 'Lynx', '{versionJson.LYNX_VERSION}' # [!code --]

--- a/docs/en/guide/start/integrate-lynx-devtool.mdx
+++ b/docs/en/guide/start/integrate-lynx-devtool.mdx
@@ -29,6 +29,7 @@ All code examples in this documentation can be found in the [integrating-lynx-de
 ### Adding Dependencies
 
 You need to add these components: the `Devtool` subcomponent of `LynxService`, `LynxDevTool`, and `DebugRouter`.
+Make sure the Podfile declares the `lynx-family` Specs repository as a source, as shown in the [Lynx integration guide](/guide/start/integrate-with-existing-apps.html?platform=ios).
 
 ```ruby title="Podfile" {2-8}
 # Ensure Lynx DevTool version matches the Lynx version when integrating

--- a/docs/zh/guide/autolink.mdx
+++ b/docs/zh/guide/autolink.mdx
@@ -78,7 +78,7 @@ lynx-app/
 
 - `package.json` 是必需的，用来声明 Autolink 库依赖。
 - Android 接入需要 Gradle settings 文件，例如 `settings.gradle` 或 `settings.gradle.kts`，以及 Android application 的构建文件，例如 `app/build.gradle` 或 `app/build.gradle.kts`。
-- iOS 接入需要 CocoaPods 入口，通常是 `Podfile`。如果团队通过 Bundler 管理 Ruby 依赖，可以在 `Gemfile` 中维护 `cocoapods-lynx-library` gem。
+- iOS 接入需要 CocoaPods 入口，通常是 `Podfile`。Podfile 需要声明 [`lynx-family` Specs 仓库](https://github.com/lynx-family/Specs) 作为源。如果团队通过 Bundler 管理 Ruby 依赖，可以在 `Gemfile` 中维护 `cocoapods-lynx-library` gem。
 - HarmonyOS 接入需要根目录的 `hvigorconfig.ts`，以及一个依赖 `@lynx/lynx` 的 entry 或 feature HAP 模块。
 - `shared/` 用于宿主应用自有的跨端原生源码和 CMake 构建入口，需要自行编译。
 - Lynxtron 接入需要应用具备宿主侧 Rspack 构建，并通过 `pluginLynxtron()` 安装和加载原生库；一般消费编译后的 `dist/` 产物。
@@ -115,9 +115,12 @@ Gradle sync/build 后，Autolink 会生成固定的 Android registry 入口并�
 
 <PlatformTabs.Tab platform="ios">
 
-在 iOS 构建环境中安装 `cocoapods-lynx-library` gem。然后在应用的 Podfile 中加入 CocoaPods plugin，并调用 `use_lynx_library!`。执行 `pod install` 时，插件会加入库的 podspec 和生成的 registry pod：
+在 iOS 构建环境中安装 `cocoapods-lynx-library` gem。然后在应用的 Podfile 中加入 pod 源和 CocoaPods plugin，并调用 `use_lynx_library!`。执行 `pod install` 时，插件会加入库的 podspec 和生成的 registry pod：
 
 ```ruby
+source 'https://cdn.cocoapods.org/'
+source 'https://github.com/lynx-family/Specs.git'
+
 plugin 'cocoapods-lynx-library'
 
 target 'LynxApp' do

--- a/docs/zh/guide/start/integrate-lynx-dev-version.mdx
+++ b/docs/zh/guide/start/integrate-lynx-dev-version.mdx
@@ -34,7 +34,8 @@ import versionJson from '@site/docs/public/version.json';
 
 ### 切换为 Lynx 开发版本
 
-在 `Podfile` 里，将 Lynx 组件版本号改为开发版本：
+在 `Podfile` 里，将 Lynx 组件版本号改为开发版本。
+请确保 Podfile 已按 [Lynx 集成指南](/guide/start/integrate-with-existing-apps.html?platform=ios) 声明 `lynx-family` Specs 仓库作为源。
 
 ```ruby title="Podfile"
 pod 'Lynx', '{versionJson.LYNX_VERSION}' # [!code --]

--- a/docs/zh/guide/start/integrate-lynx-devtool.mdx
+++ b/docs/zh/guide/start/integrate-lynx-devtool.mdx
@@ -29,6 +29,7 @@ import versionJson from '@site/docs/public/version.json';
 ### 引入依赖
 
 你需要新增以下组件：`LynxService` 的 `Devtool` 子组件、 `LynxDevTool` 和 `DebugRouter`。
+请确保 Podfile 已按 [Lynx 集成指南](/guide/start/integrate-with-existing-apps.html?platform=ios) 声明 `lynx-family` Specs 仓库作为源。
 
 ```ruby title="Podfile" {2-8}
 target 'YourTarget' do


### PR DESCRIPTION
Rebased continuation of #1304 by @gongfeng98 — **not a replacement decision, just an option**.

## Why this exists

While preparing the 4.1 release we did not notice #1304 and landed the same fix
twice: #1429 (main) and #1430 (release/4.1). Those PRs implement a **subset** of
#1304, which is why #1304 now shows as conflicting.

This branch is #1304 rebased onto current `main` with only the parts that are
**still missing** from `main`.

## Kept from #1304

| File (en + zh) | Change |
| --- | --- |
| `guide/start/integrate-lynx-dev-version.mdx` | Remind the reader that the Podfile must declare the Specs source, linking to the iOS integration guide |
| `guide/start/integrate-lynx-devtool.mdx` | Same reminder |
| `guide/autolink.mdx` | Requirements bullet mentions the Specs source; the Autolink Podfile snippet now declares both sources |

## Dropped from #1304

`guide/start/fragments/ios/integrating-lynx-with-existing-app-ios.mdx` (en + zh) —
already landed in `main` via #1429: the three Podfile snippets declare
`https://github.com/lynx-family/Specs.git`, the highlight ranges were shifted, and
an explanatory paragraph was added above the first snippet.

Two purely editorial hunks from #1304 on that fragment were **not** carried over,
because `main` now covers the same information in different words:

- the intro sentence "Lynx iOS Pods are published through the Lynx CocoaPods
  specs repo…" — `main` already has an equivalent paragraph above the first
  Podfile snippet.
- "Get the latest version of Lynx **from Cocoapods**" → "**from the Lynx specs
  repo**" (2 spots en, 3 spots zh). Happy to add this back if maintainers want
  it; it is a wording refresh rather than missing information.

## Wording

`main` (from #1429) says "the [`lynx-family` Specs repository](https://github.com/lynx-family/Specs)" /
"[`lynx-family` Specs 仓库](https://github.com/lynx-family/Specs)". #1304 used
"Lynx specs repo" / "Lynx specs 源". The new text follows `main`'s terminology so
the pages do not use two names for one thing. The Podfile snippet in `autolink.mdx`
also lists `cdn.cocoapods.org` first and the Specs repo second, matching the order
already used in the integration guide.

Authorship stays with @gongfeng98 via `Co-authored-by`.

## For @gongfeng98 and maintainers

Please decide which route you prefer — I have deliberately **not** closed #1304:

1. merge this PR and close #1304, or
2. close this PR and let @gongfeng98 rebase #1304 directly.

Either is fine; this is only here so the remaining work is not blocked on a
conflict resolution.

## Verification

- `node scripts/ci/check-asset-urls.mjs`, `node scripts/ci/check-case-collisions.mjs`,
  `node scripts/ci/check-lynx-ui-routes.mjs` — pass
- `pnpm run format:check` scope (prettier on the six changed files) and
  `cspell lint` — pass
- `pnpm run build` — succeeds; the new links render as
  `/next/{,zh/}guide/start/integrate-with-existing-apps.html?platform=ios`, which
  is an existing page in both locales.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Configure iOS Podfile examples with the CocoaPods CDN and `lynx-family` Specs repository.
- Clarify Lynx pod resolution in English and Chinese integration guides.
- Link development-version and DevTool guides to the iOS integration instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->