### PR TITLE
Revert "fix(docs): drop Android dependencies that do not resolve at LYNX_VERSION (#1386)"

### DIFF
--- a/docs/en/guide/start/fragments/android/integrating-lynx-with-existing-app-android.mdx
+++ b/docs/en/guide/start/fragments/android/integrating-lynx-with-existing-app-android.mdx
@@ -605,8 +605,12 @@ dependencies {
     implementation "androidx.viewpager2:viewpager2:1.1.0"
     // Required when templates use <blur-view>.
     implementation "org.lynxsdk.lynx:xelement-blur-view:{versionJson.LYNX_VERSION}"
+    // Required when templates use <video>.
+    implementation "org.lynxsdk.lynx:xelement-video:{versionJson.LYNX_VERSION}"
     // Required when templates use <webview>.
     implementation "org.lynxsdk.lynx:xelement-webview:{versionJson.LYNX_VERSION}"
+    // Required when templates use AnimaX animations.
+    implementation "org.lynxsdk.lynx:xelement-animax:{versionJson.LYNX_VERSION}"
 }
 ```
 
@@ -665,8 +669,12 @@ dependencies {
     implementation("androidx.viewpager2:viewpager2:1.1.0")
     // Required when templates use <blur-view>.
     implementation("org.lynxsdk.lynx:xelement-blur-view:{versionJson.LYNX_VERSION}")
+    // Required when templates use <video>.
+    implementation("org.lynxsdk.lynx:xelement-video:{versionJson.LYNX_VERSION}")
     // Required when templates use <webview>.
     implementation("org.lynxsdk.lynx:xelement-webview:{versionJson.LYNX_VERSION}")
+    // Required when templates use AnimaX animations.
+    implementation("org.lynxsdk.lynx:xelement-animax:{versionJson.LYNX_VERSION}")
 }
 ```
 

--- a/docs/zh/guide/start/fragments/android/integrating-lynx-with-existing-app-android.mdx
+++ b/docs/zh/guide/start/fragments/android/integrating-lynx-with-existing-app-android.mdx
@@ -187,8 +187,12 @@ dependencies {
     implementation "androidx.viewpager2:viewpager2:1.1.0"
     // 仅在模板使用 <blur-view> 时需要。
     implementation "org.lynxsdk.lynx:xelement-blur-view:{versionJson.LYNX_VERSION}"
+    // 仅在模板使用 <video> 时需要。
+    implementation "org.lynxsdk.lynx:xelement-video:{versionJson.LYNX_VERSION}"
     // 仅在模板使用 <webview> 时需要。
     implementation "org.lynxsdk.lynx:xelement-webview:{versionJson.LYNX_VERSION}"
+    // 仅在模板使用 AnimaX 动画时需要。
+    implementation "org.lynxsdk.lynx:xelement-animax:{versionJson.LYNX_VERSION}"
 }
 ```
 
@@ -247,8 +251,12 @@ dependencies {
     implementation("androidx.viewpager2:viewpager2:1.1.0")
     // 仅在模板使用 <blur-view> 时需要。
     implementation("org.lynxsdk.lynx:xelement-blur-view:{versionJson.LYNX_VERSION}")
+    // 仅在模板使用 <video> 时需要。
+    implementation("org.lynxsdk.lynx:xelement-video:{versionJson.LYNX_VERSION}")
     // 仅在模板使用 <webview> 时需要。
     implementation("org.lynxsdk.lynx:xelement-webview:{versionJson.LYNX_VERSION}")
+    // 仅在模板使用 AnimaX 动画时需要。
+    implementation("org.lynxsdk.lynx:xelement-animax:{versionJson.LYNX_VERSION}")
 }
 ```
 


### PR DESCRIPTION
Reverts the dependency removal from #1386 (1573bc7b) now that its premise no longer holds.

## Why the original commit was right, and why it no longer is

The Android integration guide pins every coordinate in its dependency block to `{versionJson.LYNX_VERSION}`. When #1386 landed, that was `4.0.0`, and `org.lynxsdk.lynx:xelement-video` and `org.lynxsdk.lynx:xelement-animax` did not resolve at `4.0.0`, so a reader copying the block hit a Gradle failure that named only the coordinate. Removing them was the correct call at the time.

a15bbc4c has since moved `LYNX_VERSION` to `4.1.0` and `PRIMJS_VERSION` to `4.1.1`, and both coordinates now have a stable release at that version. The condition the removal was based on is gone, so the two lines belong back in the block.

## Maven Central

| coordinate | 4.0.0 | 4.1.0 |
| --- | --- | --- |
| `org.lynxsdk.lynx:xelement-video` | 404 (nightly builds only) | stable release, AAR 72638 bytes |
| `org.lynxsdk.lynx:xelement-animax` | 404 | stable release, AAR 52272 bytes (its only published version) |

## Build check

Rebuilt a Gradle project from the guide's own dependency block (JDK 17, Gradle 8.7, AGP 8.4.0, compileSdk 34), substituting the placeholders exactly as the site does at build time:

- **4.1.0 / 4.1.1** — all 29 coordinates in the block resolve, `assembleDebug` `BUILD SUCCESSFUL`.
- **4.0.0 (control)** — `Could not find org.lynxsdk.lynx:xelement-video:4.0.0` and `Could not find org.lynxsdk.lynx:xelement-animax:4.0.0`, `BUILD FAILED`. This reproduces the `UNRESOLVED 2` the reverted commit recorded, so the removal was justified against 4.0.0 and only against 4.0.0.

The dependency tree shows `xelement-animax:4.1.0` transitively pulling in `animax-sdk`, `animax-napi` and `animax-textra` (all `1.0.1-alpha.12`) — the independent publishing layout #1386 described — and the resulting APK carries `libanimax.so` and two sibling native libraries.

**Scope of verification:** this covers dependency resolution and compilation only. The restored elements were **not** exercised at runtime on a device or emulator; no rendering or behavioral check was performed.

## Highlight ranges recover on their own

#1386 deleted the lines without adjusting the highlight ranges on the enclosing fences, so `{20-48}` sat on a 45-line block and `{26-54}` on a 51-line block, each overshooting by 3. Restoring the lines brings those blocks back to 49 and 55 lines and both ranges land inside their block again — no separate fix needed here.

## Follow-up (not in this PR)

The restored comment reads `// Required when templates use AnimaX animations.`, but AnimaX still has no documentation page anywhere on the site and no compat-data entry. Readers who add the artifact have nothing to read about what it enables. Worth tracking separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Restore `xelement-video` and `xelement-animax` dependencies in the Android integration guide.
- Use `LYNX_VERSION` 4.1.0 with stable Maven Central releases.
- Keep Gradle Groovy and Kotlin examples aligned across English and Chinese guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->