### PR TITLE
docs(start): restore the DevTool bootstrap defaults on main (partial revert of #1388)

### DIFF
--- a/docs/en/guide/start/integrate-lynx-devtool.mdx
+++ b/docs/en/guide/start/integrate-lynx-devtool.mdx
@@ -75,7 +75,7 @@ You can configure these switches during [Lynx Environment Initialization](/guide
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   // ...
-  // set devtool bootstrap defaults
+  // set DevTool bootstrap defaults
   [[DevToolSettings sharedInstance].bootstrap applyDevelopmentDefaultsIfUnset];
   LynxEnv *lynxEnv = [LynxEnv sharedInstance];
   // Enable all sessions debugging for DevTool (required for Lynx DevTool Desktop connection)

--- a/docs/en/guide/start/integrate-lynx-devtool.mdx
+++ b/docs/en/guide/start/integrate-lynx-devtool.mdx
@@ -65,7 +65,8 @@ You can configure these switches during [Lynx Environment Initialization](/guide
 <Tabs groupId='integrating-lynx-with-existing-app-ios'>
 <Tab label="Objective-C">
 
-```objective-c title=AppDelegate.m {9-16}
+```objective-c title=AppDelegate.m {10-19}
+#import <Lynx/DevToolSettings.h>
 #import <Lynx/LynxEnv.h>
 #import <Lynx/LynxService.h>
 #import <Lynx/LynxServiceDevToolProtocol.h>
@@ -74,6 +75,8 @@ You can configure these switches during [Lynx Environment Initialization](/guide
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   // ...
+  // set devtool bootstrap defaults
+  [[DevToolSettings sharedInstance].bootstrap applyDevelopmentDefaultsIfUnset];
   LynxEnv *lynxEnv = [LynxEnv sharedInstance];
   // Enable all sessions debugging for DevTool (required for Lynx DevTool Desktop connection)
   [LynxService(LynxServiceDevToolProtocol) enableAllSessions];
@@ -89,16 +92,19 @@ You can configure these switches during [Lynx Environment Initialization](/guide
 <Tab label="Swift">
 
 ```objective-c title="YourTarget-Bridging-Header.h"
+#import <Lynx/DevToolSettings.h>
 #import <Lynx/LynxEnv.h>
 #import <Lynx/LynxService.h>
 #import <Lynx/LynxServiceDevToolProtocol.h>
 ```
 
-```swift title=AppDelegate.swift {5-12}
+```swift title=AppDelegate.swift {5-14}
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     // ...
+    // set devtool bootstrap defaults
+    DevToolSettings.sharedInstance().bootstrap.applyDevelopmentDefaultsIfUnset()
     let lynxEnv = LynxEnv.sharedInstance()
     // Enable all sessions debugging for DevTool (required for Lynx DevTool Desktop connection)
     (LynxServices.getInstanceWith(LynxServiceDevToolProtocol.self) as? LynxServiceDevToolProtocol)?.enableAllSessions()
@@ -158,10 +164,12 @@ It is recommended to use the latest [Lynx version](https://github.com/lynx-famil
 
 ### Registering DevTool Service
 
+DevTool Service provides some bootstrap values to control default behaviors. You can configure them as needed; the snippets below apply the development defaults to the values that have not been set.
+
 <Tabs groupId='register-devtool-service-android'>
 <Tab label="Java">
 
-```java title=YourApplication.java {3-7}
+```java title=YourApplication.java {3-10}
 private void initLynxService() {
   // ...
   // register DevTool service
@@ -169,6 +177,9 @@ private void initLynxService() {
 
   // enable all sessions debug for DevTool (required for Lynx DevTool Desktop connection)
   LynxDevToolService.getINSTANCE().enableAllSessions();
+
+  // set devtool bootstrap defaults
+  DevToolSettings.inst().bootstrap().applyDevelopmentDefaultsIfUnset();
 }
 
 ```
@@ -176,7 +187,7 @@ private void initLynxService() {
 </Tab>
 <Tab label="Kotlin">
 
-```kotlin title=YourApplication.kt {3-7}
+```kotlin title=YourApplication.kt {3-10}
 private fun initLynxService() {
   // ...
   // register DevTool service
@@ -184,6 +195,9 @@ private fun initLynxService() {
 
   // enable all sessions debug for DevTool (required for Lynx DevTool Desktop connection)
   LynxDevToolService.INSTANCE.enableAllSessions()
+
+  // set devtool bootstrap defaults
+  DevToolSettings.inst().bootstrap().applyDevelopmentDefaultsIfUnset()
 }
 ```
 

--- a/docs/zh/guide/start/integrate-lynx-devtool.mdx
+++ b/docs/zh/guide/start/integrate-lynx-devtool.mdx
@@ -64,7 +64,8 @@ DevTool 提供了一些调试功能开关，
 <Tabs groupId='integrating-lynx-with-existing-app-ios'>
 <Tab label="Objective-C">
 
-```objective-c title=AppDelegate.m {9-16}
+```objective-c title=AppDelegate.m {10-19}
+#import <Lynx/DevToolSettings.h>
 #import <Lynx/LynxEnv.h>
 #import <Lynx/LynxService.h>
 #import <Lynx/LynxServiceDevToolProtocol.h>
@@ -73,6 +74,8 @@ DevTool 提供了一些调试功能开关，
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   // ...
+  // 设置 DevTool 启动配置的默认值
+  [[DevToolSettings sharedInstance].bootstrap applyDevelopmentDefaultsIfUnset];
   LynxEnv *lynxEnv = [LynxEnv sharedInstance];
   // 允许 DevTool 调试所有 Lynx 页面（连接 Lynx DevTool 桌面应用必需）
   [LynxService(LynxServiceDevToolProtocol) enableAllSessions];
@@ -88,16 +91,19 @@ DevTool 提供了一些调试功能开关，
 <Tab label="Swift">
 
 ```objective-c title="YourTarget-Bridging-Header.h"
+#import <Lynx/DevToolSettings.h>
 #import <Lynx/LynxEnv.h>
 #import <Lynx/LynxService.h>
 #import <Lynx/LynxServiceDevToolProtocol.h>
 ```
 
-```swift title=AppDelegate.swift {5-12}
+```swift title=AppDelegate.swift {5-14}
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     // ...
+    // 设置 DevTool 启动配置的默认值
+    DevToolSettings.sharedInstance().bootstrap.applyDevelopmentDefaultsIfUnset()
     let lynxEnv = LynxEnv.sharedInstance()
     // 允许 DevTool 调试所有 Lynx 页面（连接 DevTool 桌面应用必需）
     (LynxServices.getInstanceWith(LynxServiceDevToolProtocol.self) as? LynxServiceDevToolProtocol)?.enableAllSessions()
@@ -157,10 +163,12 @@ dependencies {
 
 ### 注册 DevTool Service
 
+DevTool Service 提供了一些启动配置值，以控制默认行为，可以根据实际需求进行配置。下面的示例会为尚未设置的配置值应用开发环境下的默认值。
+
 <Tabs groupId='register-devtool-service-android'>
 <Tab label="Java">
 
-```java title=YourApplication.java {3-7}
+```java title=YourApplication.java {3-10}
 private void initLynxService() {
   // ...
   // register DevTool service
@@ -168,6 +176,9 @@ private void initLynxService() {
 
   // 允许 DevTool 调试所有 Lynx 页面（连接 Lynx DevTool 桌面应用必需）
   LynxDevToolService.getINSTANCE().enableAllSessions();
+
+  // 设置 DevTool 启动配置的默认值
+  DevToolSettings.inst().bootstrap().applyDevelopmentDefaultsIfUnset();
 }
 
 ```
@@ -175,7 +186,7 @@ private void initLynxService() {
 </Tab>
 <Tab label="Kotlin">
 
-```kotlin title=YourApplication.kt {3-7}
+```kotlin title=YourApplication.kt {3-10}
 private fun initLynxService() {
   // ...
   // register DevTool service
@@ -183,6 +194,9 @@ private fun initLynxService() {
 
   // 允许 DevTool 调试所有 Lynx 页面（连接 Lynx DevTool 桌面应用必需）
   LynxDevToolService.INSTANCE.enableAllSessions()
+
+  // 设置 DevTool 启动配置的默认值
+  DevToolSettings.inst().bootstrap().applyDevelopmentDefaultsIfUnset()
 }
 ```
 


### PR DESCRIPTION
## Summary

This is a **partial revert** of 50f1b99b ("fix(docs): make the DevTool integration snippets compile", #1388).

#1388 bundled two unrelated changes to `guide/start/integrate-lynx-devtool`:

1. It removed the "set devtool bootstrap defaults" step from all four snippets (ObjC / Swift / Java / Kotlin), together with the ObjC `#import <Lynx/DevToolSettings.h>`, the matching bridging-header line, the two sentences that introduced the step, and it shortened the code-fence highlight ranges. The stated reason was that the call does not build against the published **4.0.0** SDKs.
2. It dropped the `bizID:` argument from the Swift `LynxServices` call.

Only (1) was version-specific, and it no longer applies now that main documents 4.1. Change (2) is version-independent and correct, so it is kept. Reverting the commit as a whole would re-break the Swift snippet.

## Why (1) is restored

`bootstrap` / `applyDevelopmentDefaultsIfUnset` is a **4.1 API**. It was introduced into the docs by ccd0376e (#1134); the site was still rendering 4.0.0 when #1388 landed, and `docs/public/version.json` on main now has `LYNX_VERSION: 4.1.0`.

In `lynx-family/lynx` on `release/4.1` (`7c7af2a75a378a1a873106a5ab0e5a62b9c8818e`):

| File | Line | Declaration |
| --- | --- | --- |
| `platform/android/lynx_android/src/main/java/com/lynx/devtoolwrapper/DevToolSettings.java` | 106 | `public BootstrapSettings bootstrap()` |
| `platform/android/lynx_android/src/main/java/com/lynx/devtoolwrapper/DevToolSettings.java` | 182 | `public void applyDevelopmentDefaultsIfUnset()` |
| `platform/darwin/common/lynx/public/devtool_wrapper/DevToolSettings.h` | 40 | `- (void)applyDevelopmentDefaultsIfUnset` |
| `platform/darwin/common/lynx/public/devtool_wrapper/DevToolSettings.h` | 59 | `@property ... DevToolBootstrapSettings *bootstrap` |

On `release/4.0` (`c8d810d75a33995bdec523394124ebc932de5b8b`), neither `bootstrap` nor `applyDevelopmentDefaultsIfUnset` occurs in either of those two files (0 matches). That is exactly the "not in the shipped artifacts" observation #1388 made — it was true for 4.0, and it is no longer true for 4.1.

So this PR restores:

- `DevToolSettings.inst().bootstrap().applyDevelopmentDefaultsIfUnset()` in the Java and Kotlin snippets
- `[[DevToolSettings sharedInstance].bootstrap applyDevelopmentDefaultsIfUnset]` in the ObjC snippet
- `DevToolSettings.sharedInstance().bootstrap.applyDevelopmentDefaultsIfUnset()` in the Swift snippet
- the ObjC `#import <Lynx/DevToolSettings.h>` and the bridging-header line
- the paragraph introducing the step (reworded, see below)
- highlight ranges covering the restored lines

## Why the Swift `bizID` fix is kept

`platform/darwin/ios/lynx_service_api/ServiceAPI.h` is **identical on `release/4.0` and `release/4.1`**; both declare only:

```objective-c
+ (id)getInstanceWithProtocol:(Protocol *)protocol;
```

There is no `bizID` parameter in either version, so `getInstanceWith(_:bizID:)` was wrong before 4.1 and is still wrong on 4.1. The snippet therefore keeps the corrected form from #1388:

```swift
(LynxServices.getInstanceWith(LynxServiceDevToolProtocol.self) as? LynxServiceDevToolProtocol)?.enableAllSessions()
```

## Why the prose is reworded instead of restored verbatim

The removed text was two sentences; the second one read:

> In the next chapter, we will introduce these bootstrap values in detail.

(with a corresponding sentence in the zh page). That promise was never fulfilled: the only other mention of a bootstrap value on the page today is the `LoadQJSBridge` / `LoadV8Bridge` note, and there is still no section covering the bootstrap values. Restoring it verbatim would re-add a dangling pointer to a chapter that does not exist, so the paragraph now only describes what the values are for:

> DevTool Service provides some bootstrap values to control default behaviors. You can configure them as needed; the snippets below apply the development defaults to the values that have not been set.

The zh page carries an equivalent sentence in natural Chinese.

## Highlight ranges

The ObjC (`{10-19}`) and Swift (`{5-14}`) ranges are restored to their pre-#1388 values, which line up with the restored blocks. The Java/Kotlin blocks are set to `{3-10}` rather than the pre-#1388 `{3-13}`: with the restored lines those blocks are 12 and 11 lines long, so `{3-13}` ran past the end of the fence. `{3-10}` covers the same configuration lines, from "register DevTool service" through the bootstrap-defaults call.

## Validation

- `pnpm run format:check` — passes
- `cspell lint` on both changed files — 0 issues
- The API-availability conclusions come from **reading the SDK headers/sources on the two `lynx-family/lynx` release branches** cited above. **No iOS or Android app was actually compiled** as part of this change; the claim here is only that the symbols the snippets reference are declared in the 4.1 SDK and were not declared in 4.0.

## Affected pages

- `docs/en/guide/start/integrate-lynx-devtool.mdx`
- `docs/zh/guide/start/integrate-lynx-devtool.mdx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Restore `DevToolSettings` bootstrap defaults in Objective-C, Swift, Java, and Kotlin integration examples.
- Retain the Swift `LynxServices` correction that removes the unsupported `bizID` argument.
- Align English and Chinese DevTool documentation with Lynx 4.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->