### PR TITLE
docs: restore the Android XElement dependencies and the DevTool bootstrap defaults on release/4.1 (#1436, #1437)

### DIFF
--- a/docs/en/guide/start/fragments/android/integrating-lynx-with-existing-app-android.mdx
+++ b/docs/en/guide/start/fragments/android/integrating-lynx-with-existing-app-android.mdx
@@ -605,8 +605,12 @@ dependencies {
     implementation "androidx.viewpager2:viewpager2:1.1.0"
     // Required when templates use <blur-view>.
     implementation "org.lynxsdk.lynx:xelement-blur-view:{versionJson.LYNX_VERSION}"
+    // Required when templates use <video>.
+    implementation "org.lynxsdk.lynx:xelement-video:{versionJson.LYNX_VERSION}"
     // Required when templates use <webview>.
     implementation "org.lynxsdk.lynx:xelement-webview:{versionJson.LYNX_VERSION}"
+    // Required when templates use AnimaX animations.
+    implementation "org.lynxsdk.lynx:xelement-animax:{versionJson.LYNX_VERSION}"
 }
 ```
 
@@ -665,8 +669,12 @@ dependencies {
     implementation("androidx.viewpager2:viewpager2:1.1.0")
     // Required when templates use <blur-view>.
     implementation("org.lynxsdk.lynx:xelement-blur-view:{versionJson.LYNX_VERSION}")
+    // Required when templates use <video>.
+    implementation("org.lynxsdk.lynx:xelement-video:{versionJson.LYNX_VERSION}")
     // Required when templates use <webview>.
     implementation("org.lynxsdk.lynx:xelement-webview:{versionJson.LYNX_VERSION}")
+    // Required when templates use AnimaX animations.
+    implementation("org.lynxsdk.lynx:xelement-animax:{versionJson.LYNX_VERSION}")
 }
 ```
 

--- a/docs/en/guide/start/integrate-lynx-devtool.mdx
+++ b/docs/en/guide/start/integrate-lynx-devtool.mdx
@@ -64,7 +64,8 @@ You can configure these switches during [Lynx Environment Initialization](/guide
 <Tabs groupId='integrating-lynx-with-existing-app-ios'>
 <Tab label="Objective-C">
 
-```objective-c title=AppDelegate.m {9-16}
+```objective-c title=AppDelegate.m {10-19}
+#import <Lynx/DevToolSettings.h>
 #import <Lynx/LynxEnv.h>
 #import <Lynx/LynxService.h>
 #import <Lynx/LynxServiceDevToolProtocol.h>
@@ -73,6 +74,8 @@ You can configure these switches during [Lynx Environment Initialization](/guide
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   // ...
+  // set DevTool bootstrap defaults
+  [[DevToolSettings sharedInstance].bootstrap applyDevelopmentDefaultsIfUnset];
   LynxEnv *lynxEnv = [LynxEnv sharedInstance];
   // Enable all sessions debugging for DevTool (required for Lynx DevTool Desktop connection)
   [LynxService(LynxServiceDevToolProtocol) enableAllSessions];
@@ -88,16 +91,19 @@ You can configure these switches during [Lynx Environment Initialization](/guide
 <Tab label="Swift">
 
 ```objective-c title="YourTarget-Bridging-Header.h"
+#import <Lynx/DevToolSettings.h>
 #import <Lynx/LynxEnv.h>
 #import <Lynx/LynxService.h>
 #import <Lynx/LynxServiceDevToolProtocol.h>
 ```
 
-```swift title=AppDelegate.swift {5-12}
+```swift title=AppDelegate.swift {5-14}
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     // ...
+    // set devtool bootstrap defaults
+    DevToolSettings.sharedInstance().bootstrap.applyDevelopmentDefaultsIfUnset()
     let lynxEnv = LynxEnv.sharedInstance()
     // Enable all sessions debugging for DevTool (required for Lynx DevTool Desktop connection)
     (LynxServices.getInstanceWith(LynxServiceDevToolProtocol.self) as? LynxServiceDevToolProtocol)?.enableAllSessions()
@@ -157,10 +163,12 @@ It is recommended to use the latest [Lynx version](https://github.com/lynx-famil
 
 ### Registering DevTool Service
 
+DevTool Service provides some bootstrap values to control default behaviors. You can configure them as needed; the snippets below apply the development defaults to the values that have not been set.
+
 <Tabs groupId='register-devtool-service-android'>
 <Tab label="Java">
 
-```java title=YourApplication.java {3-7}
+```java title=YourApplication.java {3-10}
 private void initLynxService() {
   // ...
   // register DevTool service
@@ -168,6 +176,9 @@ private void initLynxService() {
 
   // enable all sessions debug for DevTool (required for Lynx DevTool Desktop connection)
   LynxDevToolService.getINSTANCE().enableAllSessions();
+
+  // set devtool bootstrap defaults
+  DevToolSettings.inst().bootstrap().applyDevelopmentDefaultsIfUnset();
 }
 
 ```
@@ -175,7 +186,7 @@ private void initLynxService() {
 </Tab>
 <Tab label="Kotlin">
 
-```kotlin title=YourApplication.kt {3-7}
+```kotlin title=YourApplication.kt {3-10}
 private fun initLynxService() {
   // ...
   // register DevTool service
@@ -183,6 +194,9 @@ private fun initLynxService() {
 
   // enable all sessions debug for DevTool (required for Lynx DevTool Desktop connection)
   LynxDevToolService.INSTANCE.enableAllSessions()
+
+  // set devtool bootstrap defaults
+  DevToolSettings.inst().bootstrap().applyDevelopmentDefaultsIfUnset()
 }
 ```
 

--- a/docs/zh/guide/start/fragments/android/integrating-lynx-with-existing-app-android.mdx
+++ b/docs/zh/guide/start/fragments/android/integrating-lynx-with-existing-app-android.mdx
@@ -187,8 +187,12 @@ dependencies {
     implementation "androidx.viewpager2:viewpager2:1.1.0"
     // 仅在模板使用 <blur-view> 时需要。
     implementation "org.lynxsdk.lynx:xelement-blur-view:{versionJson.LYNX_VERSION}"
+    // 仅在模板使用 <video> 时需要。
+    implementation "org.lynxsdk.lynx:xelement-video:{versionJson.LYNX_VERSION}"
     // 仅在模板使用 <webview> 时需要。
     implementation "org.lynxsdk.lynx:xelement-webview:{versionJson.LYNX_VERSION}"
+    // 仅在模板使用 AnimaX 动画时需要。
+    implementation "org.lynxsdk.lynx:xelement-animax:{versionJson.LYNX_VERSION}"
 }
 ```
 
@@ -247,8 +251,12 @@ dependencies {
     implementation("androidx.viewpager2:viewpager2:1.1.0")
     // 仅在模板使用 <blur-view> 时需要。
     implementation("org.lynxsdk.lynx:xelement-blur-view:{versionJson.LYNX_VERSION}")
+    // 仅在模板使用 <video> 时需要。
+    implementation("org.lynxsdk.lynx:xelement-video:{versionJson.LYNX_VERSION}")
     // 仅在模板使用 <webview> 时需要。
     implementation("org.lynxsdk.lynx:xelement-webview:{versionJson.LYNX_VERSION}")
+    // 仅在模板使用 AnimaX 动画时需要。
+    implementation("org.lynxsdk.lynx:xelement-animax:{versionJson.LYNX_VERSION}")
 }
 ```
 

--- a/docs/zh/guide/start/integrate-lynx-devtool.mdx
+++ b/docs/zh/guide/start/integrate-lynx-devtool.mdx
@@ -63,7 +63,8 @@ DevTool 提供了一些调试功能开关，
 <Tabs groupId='integrating-lynx-with-existing-app-ios'>
 <Tab label="Objective-C">
 
-```objective-c title=AppDelegate.m {9-16}
+```objective-c title=AppDelegate.m {10-19}
+#import <Lynx/DevToolSettings.h>
 #import <Lynx/LynxEnv.h>
 #import <Lynx/LynxService.h>
 #import <Lynx/LynxServiceDevToolProtocol.h>
@@ -72,6 +73,8 @@ DevTool 提供了一些调试功能开关，
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   // ...
+  // 设置 DevTool 启动配置的默认值
+  [[DevToolSettings sharedInstance].bootstrap applyDevelopmentDefaultsIfUnset];
   LynxEnv *lynxEnv = [LynxEnv sharedInstance];
   // 允许 DevTool 调试所有 Lynx 页面（连接 Lynx DevTool 桌面应用必需）
   [LynxService(LynxServiceDevToolProtocol) enableAllSessions];
@@ -87,16 +90,19 @@ DevTool 提供了一些调试功能开关，
 <Tab label="Swift">
 
 ```objective-c title="YourTarget-Bridging-Header.h"
+#import <Lynx/DevToolSettings.h>
 #import <Lynx/LynxEnv.h>
 #import <Lynx/LynxService.h>
 #import <Lynx/LynxServiceDevToolProtocol.h>
 ```
 
-```swift title=AppDelegate.swift {5-12}
+```swift title=AppDelegate.swift {5-14}
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     // ...
+    // 设置 DevTool 启动配置的默认值
+    DevToolSettings.sharedInstance().bootstrap.applyDevelopmentDefaultsIfUnset()
     let lynxEnv = LynxEnv.sharedInstance()
     // 允许 DevTool 调试所有 Lynx 页面（连接 DevTool 桌面应用必需）
     (LynxServices.getInstanceWith(LynxServiceDevToolProtocol.self) as? LynxServiceDevToolProtocol)?.enableAllSessions()
@@ -156,10 +162,12 @@ dependencies {
 
 ### 注册 DevTool Service
 
+DevTool Service 提供了一些启动配置值，以控制默认行为，可以根据实际需求进行配置。下面的示例会为尚未设置的配置值应用开发环境下的默认值。
+
 <Tabs groupId='register-devtool-service-android'>
 <Tab label="Java">
 
-```java title=YourApplication.java {3-7}
+```java title=YourApplication.java {3-10}
 private void initLynxService() {
   // ...
   // register DevTool service
@@ -167,6 +175,9 @@ private void initLynxService() {
 
   // 允许 DevTool 调试所有 Lynx 页面（连接 Lynx DevTool 桌面应用必需）
   LynxDevToolService.getINSTANCE().enableAllSessions();
+
+  // 设置 DevTool 启动配置的默认值
+  DevToolSettings.inst().bootstrap().applyDevelopmentDefaultsIfUnset();
 }
 
 ```
@@ -174,7 +185,7 @@ private void initLynxService() {
 </Tab>
 <Tab label="Kotlin">
 
-```kotlin title=YourApplication.kt {3-7}
+```kotlin title=YourApplication.kt {3-10}
 private fun initLynxService() {
   // ...
   // register DevTool service
@@ -182,6 +193,9 @@ private fun initLynxService() {
 
   // 允许 DevTool 调试所有 Lynx 页面（连接 Lynx DevTool 桌面应用必需）
   LynxDevToolService.INSTANCE.enableAllSessions()
+
+  // 设置 DevTool 启动配置的默认值
+  DevToolSettings.inst().bootstrap().applyDevelopmentDefaultsIfUnset()
 }
 ```
 


### PR DESCRIPTION
Backport of two documentation fixes that already landed on `main`, cherry-picked
in order onto `release/4.1`:

- `968e0379` — Revert "fix(docs): drop Android dependencies that do not resolve at LYNX_VERSION (#1386)" (#1436)
- `18c85100` — docs(start): restore the DevTool bootstrap defaults on main (partial revert of #1388) (#1437)

Both applied cleanly; the four touched files had no other changes on this branch
since `1573bc7b` / `50f1b99b`. The patches are byte-identical to the originals
(matching `git patch-id`), and both commits are kept separate with their
`(cherry picked from commit ...)` trailers.

## What changed

`#1436` restores `org.lynxsdk.lynx:xelement-video` and
`org.lynxsdk.lynx:xelement-animax` to the Android integration guide's dependency
block, in both locales and in both the Groovy and the Kotlin DSL snippet, and
brings the `{20-48}` / `{26-54}` fence highlight ranges back inside their blocks.

`#1437` restores the "set devtool bootstrap defaults" step to all four DevTool
integration snippets (Objective-C, Swift, Java, Kotlin), along with the
`<Lynx/DevToolSettings.h>` import and its bridging-header line, the paragraph
introducing the step, and the shifted highlight ranges. The Swift `LynxServices`
correction from #1388 is preserved: `getInstanceWith` keeps taking only the
protocol, with no `bizID` argument, since `ServiceAPI.h` declares only
`+ (id)getInstanceWithProtocol:` on both `release/4.0` and `release/4.1`.

## Dependency on #1425 — please read before merging

`docs/public/version.json` on `release/4.1` still carries `LYNX_VERSION: 4.0.0`.
The Android dependency block pins every coordinate to
`{versionJson.LYNX_VERSION}`, so on this branch as it stands today the two
restored lines render as `xelement-video:4.0.0` and `xelement-animax:4.0.0`, and
neither of those resolves on Maven Central. That is exactly the condition #1386
originally fixed.

This is known and acceptable, because `release/4.1` is not yet the default site,
and draft PR #1425 ("chore(version): promote 4.1 to the released site", base
`release/4.1`) moves `LYNX_VERSION` to `4.1.0`, `PRIMJS_VERSION` to `4.1.1` and
`current_version` to `4.1`. At those versions both coordinates resolve and the
restored `applyDevelopmentDefaultsIfUnset` API exists in the SDK.

So: **this PR should be in place together with #1425 before `release/4.1` is
promoted.** If this lands and #1425 does not, the Android dependency block on
this branch is not installable as rendered. This is a sequencing note for
reviewers, not an argument against the backport.

## Verification

- `git cherry-pick -x 968e0379 18c85100` — no conflicts.
- `xelement-video` and `xelement-animax` each appear in all 4 dependency code
  blocks (en/zh x Groovy/Kotlin DSL).
- `applyDevelopmentDefaultsIfUnset` appears 4 times in each of
  `docs/{en,zh}/guide/start/integrate-lynx-devtool.mdx`.
- No `bizID` anywhere in either DevTool guide.
- `pnpm run format:check` — clean.
- `pnpm run prepare && pnpm run build` — succeeded, 3198 pages, no new warnings.

Test: pnpm run format:check; pnpm run prepare; pnpm run build
