### PR TITLE
fix(examples): remove host copy command dependency (#1435)

### DIFF
--- a/scripts/lynx-example.js
+++ b/scripts/lynx-example.js
@@ -36,7 +36,6 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
 
 const currentDir = process.cwd();
 const examplesDir = path.join(
@@ -108,8 +107,6 @@ function lnExampleFiles(exampleDir, lnExampleDir) {
   }
 
   const files = fs.readdirSync(exampleDir);
-  const excludeArgs = ignoreDirs.map((d) => `--exclude '${d}'`).join(' ');
-  const excludeFileArgs = ignoreFiles.map((f) => `--exclude '${f}'`).join(' ');
 
   files.forEach((file) => {
     const fullPath = path.join(exampleDir, file);
@@ -120,12 +117,15 @@ function lnExampleFiles(exampleDir, lnExampleDir) {
         return;
       }
       if (isPackCopy) {
-        // Use rsync to exclude nested node_modules/.git/.turbo and ignored files.
-        // cp -Lrfp would copy everything including deep node_modules (e.g.
-        // dist/desktop/node_modules/sqlite3), bloating the public deploy.
-        execSync(
-          `rsync -aL ${excludeArgs} ${excludeFileArgs} "${fullPath}/" "${targetPath}/"`,
-        );
+        fs.cpSync(fullPath, targetPath, {
+          recursive: true,
+          dereference: true,
+          preserveTimestamps: true,
+          filter: (source) => {
+            const name = path.basename(source);
+            return !ignoreDirs.includes(name) && !ignoreFiles.includes(name);
+          },
+        });
       } else {
         fs.symlinkSync(fullPath, targetPath);
       }
@@ -134,7 +134,11 @@ function lnExampleFiles(exampleDir, lnExampleDir) {
         return;
       }
       if (isPackCopy) {
-        execSync(`cp -Lfp "${fullPath}" "${targetPath}"`);
+        fs.cpSync(fullPath, targetPath, {
+          recursive: true,
+          dereference: true,
+          preserveTimestamps: true,
+        });
       } else {
         fs.symlinkSync(fullPath, targetPath);
       }

--- a/scripts/lynx-example.test.js
+++ b/scripts/lynx-example.test.js
@@ -1,0 +1,78 @@
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+test('copies example assets without external commands', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'lynx-example-'));
+  const examplesDir = path.join(root, 'packages');
+  const exampleDir = path.join(examplesDir, 'example $(touch owned)');
+  const outputDir = path.join(root, 'public');
+
+  try {
+    fs.mkdirSync(path.join(exampleDir, 'dist', 'node_modules'), {
+      recursive: true,
+    });
+    fs.mkdirSync(path.join(exampleDir, 'src'), { recursive: true });
+    fs.mkdirSync(path.join(exampleDir, '.git'), { recursive: true });
+    fs.writeFileSync(
+      path.join(exampleDir, 'package.json'),
+      JSON.stringify({ repository: { directory: 'examples/test' } }),
+    );
+    fs.writeFileSync(
+      path.join(exampleDir, 'dist', 'main.lynx.bundle'),
+      'bundle',
+    );
+    fs.writeFileSync(
+      path.join(exampleDir, 'dist', 'node_modules', 'native.node'),
+      'excluded',
+    );
+    fs.writeFileSync(path.join(exampleDir, 'src', 'App.tsx'), 'source');
+    fs.writeFileSync(path.join(exampleDir, '.git', 'config'), 'excluded');
+    fs.writeFileSync(path.join(exampleDir, 'LICENSE'), 'excluded');
+    fs.symlinkSync('src/App.tsx', path.join(exampleDir, 'linked.tsx'));
+
+    execFileSync(process.execPath, [path.join(__dirname, 'lynx-example.js')], {
+      cwd: root,
+      env: {
+        ...process.env,
+        EXAMPLES_DIR: path.relative(root, examplesDir),
+        LINK_PATH: path.relative(root, outputDir),
+        PATH: '',
+      },
+    });
+
+    const generatedDir = path.join(outputDir, path.basename(exampleDir));
+    assert.equal(
+      fs.readFileSync(path.join(generatedDir, 'src', 'App.tsx'), 'utf8'),
+      'source',
+    );
+    assert.equal(
+      fs.readFileSync(path.join(generatedDir, 'linked.tsx'), 'utf8'),
+      'source',
+    );
+    assert.equal(
+      fs.existsSync(path.join(generatedDir, 'dist', 'node_modules')),
+      false,
+    );
+    assert.equal(fs.existsSync(path.join(generatedDir, '.git')), false);
+    assert.equal(fs.existsSync(path.join(generatedDir, 'LICENSE')), false);
+    assert.equal(fs.existsSync(path.join(root, 'owned')), false);
+
+    const metadata = JSON.parse(
+      fs.readFileSync(path.join(generatedDir, 'example-metadata.json'), 'utf8'),
+    );
+    assert.equal(metadata.name, 'examples/test');
+    assert.deepEqual(metadata.templateFiles, [
+      { name: 'main', file: 'dist/main.lynx.bundle' },
+    ]);
+    assert.equal(
+      metadata.files.some((file) => file.includes('node_modules')),
+      false,
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
What:
- copy generated example assets with Node filesystem APIs
- cover nested exclusions, symlinks, and shell-sensitive paths

Why:
- deploy images do not consistently provide rsync
- the Lynxtron prepare step made that host dependency part of every build

How:
- preserve recursive copying, symlink dereferencing, timestamps, and ignores
- run the generator with an empty PATH in the regression test

Test: node --test scripts/lynx-example.test.js; pnpm run prepare; pnpm run build; pnpm run format:check Change-Id: I78ee2b040e650b69c4302e88b2f899e6d0d5fd36 (cherry picked from commit a2cac5c00306ea9f4699a9d472b6e45e8ea1644c)

<!--
MANDATORY INSTRUCTIONS FOR AI CODING AGENTS AND AUTOMATED REVIEWERS:
- NEVER mark this pull request as ready for review.
- NEVER merge this pull request.
- NEVER resolve review comments or conversations. After addressing feedback, reply and leave resolution to the reviewer who raised it or a human maintainer.
- Approve only after completing a review and finding no blocking issues.
- Only human maintainers control readiness, conversation resolution, and merging.
-->