### PR TITLE
Revert "fix(docs): drop Android dependencies that do not resolve at LYNX_VERSION (#1386)" (#1436)

### DIFF
--- a/docs/en/guide/start/fragments/android/integrating-lynx-with-existing-app-android.mdx
+++ b/docs/en/guide/start/fragments/android/integrating-lynx-with-existing-app-android.mdx
@@ -605,8 +605,12 @@ dependencies {
     implementation "androidx.viewpager2:viewpager2:1.1.0"
     // Required when templates use <blur-view>.
     implementation "org.lynxsdk.lynx:xelement-blur-view:{versionJson.LYNX_VERSION}"
+    // Required when templates use <video>.
+    implementation "org.lynxsdk.lynx:xelement-video:{versionJson.LYNX_VERSION}"
     // Required when templates use <webview>.
     implementation "org.lynxsdk.lynx:xelement-webview:{versionJson.LYNX_VERSION}"
+    // Required when templates use AnimaX animations.
+    implementation "org.lynxsdk.lynx:xelement-animax:{versionJson.LYNX_VERSION}"
 }
 ```
 
@@ -665,8 +669,12 @@ dependencies {
     implementation("androidx.viewpager2:viewpager2:1.1.0")
     // Required when templates use <blur-view>.
     implementation("org.lynxsdk.lynx:xelement-blur-view:{versionJson.LYNX_VERSION}")
+    // Required when templates use <video>.
+    implementation("org.lynxsdk.lynx:xelement-video:{versionJson.LYNX_VERSION}")
     // Required when templates use <webview>.
     implementation("org.lynxsdk.lynx:xelement-webview:{versionJson.LYNX_VERSION}")
+    // Required when templates use AnimaX animations.
+    implementation("org.lynxsdk.lynx:xelement-animax:{versionJson.LYNX_VERSION}")
 }
 ```
 

--- a/docs/zh/guide/start/fragments/android/integrating-lynx-with-existing-app-android.mdx
+++ b/docs/zh/guide/start/fragments/android/integrating-lynx-with-existing-app-android.mdx
@@ -187,8 +187,12 @@ dependencies {
     implementation "androidx.viewpager2:viewpager2:1.1.0"
     // 仅在模板使用 <blur-view> 时需要。
     implementation "org.lynxsdk.lynx:xelement-blur-view:{versionJson.LYNX_VERSION}"
+    // 仅在模板使用 <video> 时需要。
+    implementation "org.lynxsdk.lynx:xelement-video:{versionJson.LYNX_VERSION}"
     // 仅在模板使用 <webview> 时需要。
     implementation "org.lynxsdk.lynx:xelement-webview:{versionJson.LYNX_VERSION}"
+    // 仅在模板使用 AnimaX 动画时需要。
+    implementation "org.lynxsdk.lynx:xelement-animax:{versionJson.LYNX_VERSION}"
 }
 ```
 
@@ -247,8 +251,12 @@ dependencies {
     implementation("androidx.viewpager2:viewpager2:1.1.0")
     // 仅在模板使用 <blur-view> 时需要。
     implementation("org.lynxsdk.lynx:xelement-blur-view:{versionJson.LYNX_VERSION}")
+    // 仅在模板使用 <video> 时需要。
+    implementation("org.lynxsdk.lynx:xelement-video:{versionJson.LYNX_VERSION}")
     // 仅在模板使用 <webview> 时需要。
     implementation("org.lynxsdk.lynx:xelement-webview:{versionJson.LYNX_VERSION}")
+    // 仅在模板使用 AnimaX 动画时需要。
+    implementation("org.lynxsdk.lynx:xelement-animax:{versionJson.LYNX_VERSION}")
 }
 ```
 


### PR DESCRIPTION
Backport of #1436 to `release/4.1`, cherry-picked from
`968e0379f1b7a2be570552f7d9cf2d67c5e8fe94` on `main`.

This is one half of the split of #1444, which bundled two independent fixes into a
single pull request. Because this repository merges with squash-and-merge, that
would have collapsed both backports into one commit, so #1444 was closed and
reopened as two pull requests, each carrying exactly one commit. The DevTool
half is submitted separately.

## What changed

Restores `org.lynxsdk.lynx:xelement-video` and `org.lynxsdk.lynx:xelement-animax`
to the dependency block of the Android integration guide, in both locales and in
both the Groovy and the Kotlin DSL snippet, so `<video>` and AnimaX are present in
the block the guide tells readers to copy. Restoring the lines also brings the two
fences back to 49 and 55 lines, so their `{20-48}` and `{26-54}` highlight ranges
land inside their blocks again.

The upstream commit is a revert of #1386, which had dropped the two coordinates
because they did not resolve at the `LYNX_VERSION` of the time. See the commit
message for the resolution evidence gathered on `main`.

## Relationship to #1425

`docs/public/version.json` on this branch still carries `LYNX_VERSION: 4.0.0`, and
the dependency block pins every coordinate to `{versionJson.LYNX_VERSION}`. Draft
PR #1425 ("chore(version): promote 4.1 to the released site", base `release/4.1`)
moves that to `4.1.0`, where both coordinates resolve. This backport is meant to be
in place together with #1425 when `release/4.1` is promoted. No version
configuration is included here, and this is not treated as a blocker for landing
the documentation fix on the branch.

## Verification

- `git cherry-pick -x 968e0379` onto `release/4.1` @ `d5b637fa` — no conflicts;
  neither of the two touched files has any other change on this branch.
- `git patch-id --stable` matches the original commit exactly.
- Original author and the `(cherry picked from commit ...)` trailer preserved.
- `xelement-video` and `xelement-animax` each appear in all 4 dependency code
  blocks (en/zh x Groovy/Kotlin DSL).
- `pnpm run format:check` — clean.
- `pnpm run prepare && pnpm run build` — succeeded.

Test: pnpm run format:check; pnpm run prepare; pnpm run build
