### PR TITLE
docs(start): restore the DevTool bootstrap defaults on release/4.1 (#1437)

### DIFF
--- a/docs/en/guide/start/integrate-lynx-devtool.mdx
+++ b/docs/en/guide/start/integrate-lynx-devtool.mdx
@@ -64,7 +64,8 @@ You can configure these switches during [Lynx Environment Initialization](/guide
 <Tabs groupId='integrating-lynx-with-existing-app-ios'>
 <Tab label="Objective-C">
 
-```objective-c title=AppDelegate.m {9-16}
+```objective-c title=AppDelegate.m {10-19}
+#import <Lynx/DevToolSettings.h>
 #import <Lynx/LynxEnv.h>
 #import <Lynx/LynxService.h>
 #import <Lynx/LynxServiceDevToolProtocol.h>
@@ -73,6 +74,8 @@ You can configure these switches during [Lynx Environment Initialization](/guide
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   // ...
+  // set DevTool bootstrap defaults
+  [[DevToolSettings sharedInstance].bootstrap applyDevelopmentDefaultsIfUnset];
   LynxEnv *lynxEnv = [LynxEnv sharedInstance];
   // Enable all sessions debugging for DevTool (required for Lynx DevTool Desktop connection)
   [LynxService(LynxServiceDevToolProtocol) enableAllSessions];
@@ -88,16 +91,19 @@ You can configure these switches during [Lynx Environment Initialization](/guide
 <Tab label="Swift">
 
 ```objective-c title="YourTarget-Bridging-Header.h"
+#import <Lynx/DevToolSettings.h>
 #import <Lynx/LynxEnv.h>
 #import <Lynx/LynxService.h>
 #import <Lynx/LynxServiceDevToolProtocol.h>
 ```
 
-```swift title=AppDelegate.swift {5-12}
+```swift title=AppDelegate.swift {5-14}
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     // ...
+    // set devtool bootstrap defaults
+    DevToolSettings.sharedInstance().bootstrap.applyDevelopmentDefaultsIfUnset()
     let lynxEnv = LynxEnv.sharedInstance()
     // Enable all sessions debugging for DevTool (required for Lynx DevTool Desktop connection)
     (LynxServices.getInstanceWith(LynxServiceDevToolProtocol.self) as? LynxServiceDevToolProtocol)?.enableAllSessions()
@@ -157,10 +163,12 @@ It is recommended to use the latest [Lynx version](https://github.com/lynx-famil
 
 ### Registering DevTool Service
 
+DevTool Service provides some bootstrap values to control default behaviors. You can configure them as needed; the snippets below apply the development defaults to the values that have not been set.
+
 <Tabs groupId='register-devtool-service-android'>
 <Tab label="Java">
 
-```java title=YourApplication.java {3-7}
+```java title=YourApplication.java {3-10}
 private void initLynxService() {
   // ...
   // register DevTool service
@@ -168,6 +176,9 @@ private void initLynxService() {
 
   // enable all sessions debug for DevTool (required for Lynx DevTool Desktop connection)
   LynxDevToolService.getINSTANCE().enableAllSessions();
+
+  // set devtool bootstrap defaults
+  DevToolSettings.inst().bootstrap().applyDevelopmentDefaultsIfUnset();
 }
 
 ```
@@ -175,7 +186,7 @@ private void initLynxService() {
 </Tab>
 <Tab label="Kotlin">
 
-```kotlin title=YourApplication.kt {3-7}
+```kotlin title=YourApplication.kt {3-10}
 private fun initLynxService() {
   // ...
   // register DevTool service
@@ -183,6 +194,9 @@ private fun initLynxService() {
 
   // enable all sessions debug for DevTool (required for Lynx DevTool Desktop connection)
   LynxDevToolService.INSTANCE.enableAllSessions()
+
+  // set devtool bootstrap defaults
+  DevToolSettings.inst().bootstrap().applyDevelopmentDefaultsIfUnset()
 }
 ```
 

--- a/docs/zh/guide/start/integrate-lynx-devtool.mdx
+++ b/docs/zh/guide/start/integrate-lynx-devtool.mdx
@@ -63,7 +63,8 @@ DevTool 提供了一些调试功能开关，
 <Tabs groupId='integrating-lynx-with-existing-app-ios'>
 <Tab label="Objective-C">
 
-```objective-c title=AppDelegate.m {9-16}
+```objective-c title=AppDelegate.m {10-19}
+#import <Lynx/DevToolSettings.h>
 #import <Lynx/LynxEnv.h>
 #import <Lynx/LynxService.h>
 #import <Lynx/LynxServiceDevToolProtocol.h>
@@ -72,6 +73,8 @@ DevTool 提供了一些调试功能开关，
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   // ...
+  // 设置 DevTool 启动配置的默认值
+  [[DevToolSettings sharedInstance].bootstrap applyDevelopmentDefaultsIfUnset];
   LynxEnv *lynxEnv = [LynxEnv sharedInstance];
   // 允许 DevTool 调试所有 Lynx 页面（连接 Lynx DevTool 桌面应用必需）
   [LynxService(LynxServiceDevToolProtocol) enableAllSessions];
@@ -87,16 +90,19 @@ DevTool 提供了一些调试功能开关，
 <Tab label="Swift">
 
 ```objective-c title="YourTarget-Bridging-Header.h"
+#import <Lynx/DevToolSettings.h>
 #import <Lynx/LynxEnv.h>
 #import <Lynx/LynxService.h>
 #import <Lynx/LynxServiceDevToolProtocol.h>
 ```
 
-```swift title=AppDelegate.swift {5-12}
+```swift title=AppDelegate.swift {5-14}
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     // ...
+    // 设置 DevTool 启动配置的默认值
+    DevToolSettings.sharedInstance().bootstrap.applyDevelopmentDefaultsIfUnset()
     let lynxEnv = LynxEnv.sharedInstance()
     // 允许 DevTool 调试所有 Lynx 页面（连接 DevTool 桌面应用必需）
     (LynxServices.getInstanceWith(LynxServiceDevToolProtocol.self) as? LynxServiceDevToolProtocol)?.enableAllSessions()
@@ -156,10 +162,12 @@ dependencies {
 
 ### 注册 DevTool Service
 
+DevTool Service 提供了一些启动配置值，以控制默认行为，可以根据实际需求进行配置。下面的示例会为尚未设置的配置值应用开发环境下的默认值。
+
 <Tabs groupId='register-devtool-service-android'>
 <Tab label="Java">
 
-```java title=YourApplication.java {3-7}
+```java title=YourApplication.java {3-10}
 private void initLynxService() {
   // ...
   // register DevTool service
@@ -167,6 +175,9 @@ private void initLynxService() {
 
   // 允许 DevTool 调试所有 Lynx 页面（连接 Lynx DevTool 桌面应用必需）
   LynxDevToolService.getINSTANCE().enableAllSessions();
+
+  // 设置 DevTool 启动配置的默认值
+  DevToolSettings.inst().bootstrap().applyDevelopmentDefaultsIfUnset();
 }
 
 ```
@@ -174,7 +185,7 @@ private void initLynxService() {
 </Tab>
 <Tab label="Kotlin">
 
-```kotlin title=YourApplication.kt {3-7}
+```kotlin title=YourApplication.kt {3-10}
 private fun initLynxService() {
   // ...
   // register DevTool service
@@ -182,6 +193,9 @@ private fun initLynxService() {
 
   // 允许 DevTool 调试所有 Lynx 页面（连接 Lynx DevTool 桌面应用必需）
   LynxDevToolService.INSTANCE.enableAllSessions()
+
+  // 设置 DevTool 启动配置的默认值
+  DevToolSettings.inst().bootstrap().applyDevelopmentDefaultsIfUnset()
 }
 ```
 


### PR DESCRIPTION
Backport of #1437 to `release/4.1`, cherry-picked from
`18c85100bd9969366f31acdb4ca7906632efefa2` on `main`.

This is one half of the split of #1444, which bundled two independent fixes into a
single pull request. Because this repository merges with squash-and-merge, that
would have collapsed both backports into one commit, so #1444 was closed and
reopened as two pull requests, each carrying exactly one commit. The Android
dependency half is submitted separately.

## What changed

Restores the "set devtool bootstrap defaults" step to all four DevTool integration
snippets (Objective-C, Swift, Java, Kotlin), together with the
`<Lynx/DevToolSettings.h>` import and its bridging-header line, the paragraph that
introduces the step, and the shifted code-fence highlight ranges.

`bootstrap()` and `applyDevelopmentDefaultsIfUnset` exist on `release/4.1` of
lynx-family/lynx and not on `release/4.0`, which is what #1388 was compiling
against when it removed the step; the API is correct for the version this branch
documents. The Swift `LynxServices` correction from #1388 is preserved:
`getInstanceWith` takes only the protocol and no `bizID` argument, because
`ServiceAPI.h` declares only `+ (id)getInstanceWithProtocol:` on both release
branches, so that argument is wrong regardless of version and stays removed.

## Relationship to #1425

Draft PR #1425 ("chore(version): promote 4.1 to the released site", base
`release/4.1`) is what makes this branch document 4.1.0 on the site. This backport
is meant to be in place together with #1425 when `release/4.1` is promoted. No
version configuration is included here, and this is not treated as a blocker for
landing the documentation fix on the branch.

## Verification

- `git cherry-pick -x 18c85100` onto `release/4.1` @ `d5b637fa` — no conflicts;
  neither of the two touched files has any other change on this branch.
- `git patch-id --stable` matches the original commit exactly.
- Original author, `Signed-off-by`, `Co-authored-by` and the
  `(cherry picked from commit ...)` trailer preserved.
- `applyDevelopmentDefaultsIfUnset` appears 4 times in each of
  `docs/{en,zh}/guide/start/integrate-lynx-devtool.mdx`.
- No `bizID` anywhere in either DevTool guide.
- `pnpm run format:check` — clean.
- `pnpm run prepare && pnpm run build` — succeeded.

Test: pnpm run format:check; pnpm run prepare; pnpm run build
