### PR TITLE
docs: add foldable device adaptation guide

### DIFF
--- a/docs/en/guide/inclusion/foldable-devices.mdx
+++ b/docs/en/guide/inclusion/foldable-devices.mdx
@@ -1,0 +1,138 @@
+---
+description: 'Sync dimensions through GlobalProps and screen metrics for low-effort foldable layouts.'
+---
+
+import { FoldableRenderFlow } from '../../../../src/components/foldable-render-flow';
+
+# Foldables
+
+At its September event, Apple unveiled its first foldable iPhone, [iPhone Duo](https://www.apple.com/newsroom/2026/09/apple-unveils-iphone-duo/). Unfold the screen and the page you were reading gains a fresh canvas; fold it back and the content has to settle into a smaller space. The job of an app is to make the interface flow gracefully between the two.
+
+Lynx now fully supports foldable scenarios, proven in production inside TikTok. Our goal was simple: keep the integration effortless. The host passes new dimensions to Lynx, the frontend keeps its familiar layout tools, and the page reflows with the window on its own.
+
+<div style={{ display: 'flex', flexWrap: 'wrap', gap: 16, margin: '24px 0' }}>
+  <figure style={{ flex: '1 1 260px', minWidth: 0, margin: 0 }}>
+    <img
+      src="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/resizeableBigToSmall.gif"
+      alt="A Lynx page in TikTok adjusts as the window shrinks"
+      width="480"
+      height="360"
+      loading="lazy"
+      style={{
+        display: 'block',
+        width: '100%',
+        height: 'auto',
+        borderRadius: 12,
+      }}
+    />
+    <figcaption style={{ marginTop: 8, textAlign: 'center', fontSize: 14 }}>
+      Folding
+    </figcaption>
+  </figure>
+  <figure style={{ flex: '1 1 260px', minWidth: 0, margin: 0 }}>
+    <img
+      src="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/resizeableSmallToBig.gif"
+      alt="A Lynx page in TikTok adjusts as the window grows"
+      width="480"
+      height="360"
+      loading="lazy"
+      style={{
+        display: 'block',
+        width: '100%',
+        height: 'auto',
+        borderRadius: 12,
+      }}
+    />
+    <figcaption style={{ marginTop: 8, textAlign: 'center', fontSize: 14 }}>
+      Unfolding
+    </figcaption>
+  </figure>
+</div>
+
+## New screen sizes
+
+Adaptation starts with the host. When the window changes size, the host finishes native layout first, then updates Lynx's **screen metrics, viewport, and GlobalProps** together, keeping the engine's sizing bases in step with the dimensions the frontend reads.
+
+Start with the data the frontend needs. [GlobalProps](/api/lynx-api/lynx/lynx-global-props) carries environment information from the host to the page, which reads it through [`lynx.__globalProps`](/api/lynx-api/lynx/lynx-global-props). In TikTok, we distinguish the window's dimensions from the space available to an individual page. The community can use the same convention:
+
+| Field                             | Meaning                                                                                    |
+| --------------------------------- | ------------------------------------------------------------------------------------------ |
+| `viewportWidth`, `viewportHeight` | The current LynxView's actual layout dimensions, for page layout                           |
+| `screenWidth`, `screenHeight`     | The current application window's dimensions; a LynxView in a dialog or card may be smaller |
+
+These host-defined fields use logical pixels: Lynx CSS [`px`](/api/css/data-type/length), corresponding to iOS `pt`. Set initial values through [`LynxLoadMeta.globalProps`](/api/lynx-native-api/lynx-load-meta#ios), then update each [LynxView](/api/lynx-native-api/lynx-view) as its dimensions change. The frontend treats them as read-only.
+
+Updates merge the fields and emit [`onGlobalPropsChanged`](/api/react/Document.global-events#onglobalpropschanged). With the default [`globalPropsMode: 'reactive'`](/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.globalpropsmode), **ReactLynx automatically re-renders the entire page**; components simply read the latest dimensions during render. The optional `'event'` mode disables this automatic render.
+
+The host also refreshes screen metrics for `rpx` and the viewport for `vw` and `vh`. ReactLynx applies UI changes through [Element PAPI](/api/engine/element-api), then the engine resolves styles and runs Layout using the new dimensions. The platform paints the result.
+
+<FoldableRenderFlow locale="en" />
+
+On iOS, this uses [`updateScreenMetricsWithWidth:height:`](https://github.com/lynx-family/lynx/blob/develop/platform/darwin/ios/lynx/public/LynxView.h#L262), [`updateViewport`](/api/lynx-native-api/lynx-view/update-viewport#ios), and [`updateGlobalPropsWithDictionary`](/api/lynx-api/lynx/lynx-global-props#ios). Once the view is attached and native layout is complete, call them on the main thread. Here, screen metrics use the window size, and the viewport uses the LynxView's size:
+
+```objc
+CGSize windowSize = lynxView.window.bounds.size;
+CGSize viewportSize = lynxView.bounds.size;
+
+[lynxView updateScreenMetricsWithWidth:windowSize.width
+                               height:windowSize.height];
+[lynxView updateViewportWithPreferredLayoutWidth:viewportSize.width
+                         preferredLayoutHeight:viewportSize.height
+                                    needLayout:YES];
+[lynxView updateGlobalPropsWithDictionary:@{
+  @"screenWidth": @(windowSize.width),
+  @"screenHeight": @(windowSize.height),
+  @"viewportWidth": @(viewportSize.width),
+  @"viewportHeight": @(viewportSize.height),
+}];
+```
+
+Initialize the same `rpx` basis through [`LynxViewBuilder.screenSize`](https://github.com/lynx-family/lynx/blob/develop/platform/darwin/ios/lynx/public/LynxBaseConfigurator.h#L81), and skip unchanged dimensions. Screen metrics updates do not trigger layout themselves; the example uses [`needLayout:YES`](/api/lynx-native-api/lynx-view/update-viewport#ios). With [`enableAutoLayout`](/api/lynx-native-api/lynx-view/enable-auto-layout) enabled, constraints drive viewport updates.
+
+## Familiar layout units
+
+Once this flow is connected, frontend adaptation usually takes little work. For pages that already use flexible layouts and relative units, **the frontend does not need to detect the folding state or trigger updates manually** — the layout adjusts to the newly available space on its own.
+
+That leaves a single decision: what each dimension should follow — its parent container, the whole viewport, or the size of the text. Pick the right reference, and your existing responsive layout keeps doing its job.
+
+In the table below, automatic adaptation describes how each unit follows its sizing basis once the host integration is in place.
+
+| Unit        | Automatic adaptation                                                                                  | Sizing basis and guidance                                                                                                                                                                              |
+| ----------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `%`         | <strong style={{ color: 'hsl(var(--status-supported-strong))' }}>Yes</strong>, follows the parent     | Width and height are relative to the containing block, usually the parent. Suitable for cards and dialogs; percentage heights require a definite parent height                                         |
+| `vw`, `vh`  | <strong style={{ color: 'hsl(var(--status-supported-strong))' }}>Yes</strong>, follows the viewport   | 1% of viewport width or height. Suitable for page-level dimensions; prefer `%` inside nested components                                                                                                |
+| `rpx`       | <strong style={{ color: 'hsl(var(--status-supported-strong))' }}>Yes</strong>, follows screen metrics | 1/750 of the logical width configured in screen metrics                                                                                                                                                |
+| `px`, `ppx` | <strong style={{ color: 'hsl(var(--status-unsupported-strong))' }}>No</strong>, fixed pixel units     | Logical and physical pixels, respectively. Keep `px` for font sizes, spacing, and controls; use `ppx` for pixel-level details                                                                          |
+| `rem`, `em` | <strong style={{ color: 'hsl(var(--status-partial-strong))' }}>Follows font size</strong>             | Relative to the root or current element's font size, respectively; `em` in [`font-size`](/api/css/properties/font-size) uses the inherited font size. Window resizing alone does not scale these units |
+
+In practice, [Flex](/guide/ui/layout/flexible-box-layout) and [`width: 100%`](/api/css/properties/width) make a good starting point, with [`max-width`](/api/css/properties/max-width) to keep content from stretching too far on wider screens. Font sizes, buttons, and spacing can keep sensible `px` values, so the content area grows with the screen while reading and interaction stay a constant size.
+
+`rpx` follows screen metrics: **`1rpx` equals 1/750 of the configured logical width**. When the host updates [screen metrics](https://github.com/lynx-family/lynx/blob/develop/platform/darwin/ios/lynx/public/LynxView.h#L262), Lynx recalculates `rpx` values during layout, so the frontend does not need to recompute them.
+
+```tsx
+export function ResponsiveCard() {
+  return (
+    <view
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        width: '100%', // Follow the parent.
+        maxWidth: '600px', // Limit content width when the foldable screen is unfolded.
+        padding: '16px', // Keep spacing and font size stable.
+        gap: '12px',
+      }}
+    >
+      <text style={{ fontSize: '16px' }}>A familiar layout</text>
+      <view
+        style={{
+          width: '100%',
+          height: '200rpx', // Recalculated when the host updates screen metrics.
+          backgroundColor: '#e6f4ff',
+        }}
+      />
+    </view>
+  );
+}
+```
+
+See [length units](/api/css/data-type/length) for more detail.

--- a/docs/zh/guide/inclusion/foldable-devices.mdx
+++ b/docs/zh/guide/inclusion/foldable-devices.mdx
@@ -1,0 +1,138 @@
+---
+description: '通过 GlobalProps 与 screen metrics 同步尺寸，让前端以低成本适配折叠屏。'
+---
+
+import { FoldableRenderFlow } from '../../../../src/components/foldable-render-flow';
+
+# 折叠屏
+
+苹果在秋季发布会上推出了首款折叠屏 iPhone——[iPhone Duo](https://www.apple.com.cn/newsroom/2026/09/apple-unveils-iphone-duo/)。展开屏幕，正在浏览的页面有了更多空间；合上屏幕，内容又回到较小的窗口。用户期待的，是页面能顺着屏幕的变化自然调整。
+
+Lynx 已经支持折叠屏适配，并在 TikTok 中投入使用。我们希望接入尽可能简单：客户端把尺寸变化同步给 Lynx，前端继续使用熟悉的布局方式，让页面随窗口大小自动调整。
+
+<div style={{ display: 'flex', flexWrap: 'wrap', gap: 16, margin: '24px 0' }}>
+  <figure style={{ flex: '1 1 260px', minWidth: 0, margin: 0 }}>
+    <img
+      src="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/resizeableBigToSmall.gif"
+      alt="TikTok 中的 Lynx 页面随窗口缩小重新布局"
+      width="480"
+      height="360"
+      loading="lazy"
+      style={{
+        display: 'block',
+        width: '100%',
+        height: 'auto',
+        borderRadius: 12,
+      }}
+    />
+    <figcaption style={{ marginTop: 8, textAlign: 'center', fontSize: 14 }}>
+      折叠
+    </figcaption>
+  </figure>
+  <figure style={{ flex: '1 1 260px', minWidth: 0, margin: 0 }}>
+    <img
+      src="https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/resizeableSmallToBig.gif"
+      alt="TikTok 中的 Lynx 页面随窗口放大重新布局"
+      width="480"
+      height="360"
+      loading="lazy"
+      style={{
+        display: 'block',
+        width: '100%',
+        height: 'auto',
+        borderRadius: 12,
+      }}
+    />
+    <figcaption style={{ marginTop: 8, textAlign: 'center', fontSize: 14 }}>
+      展开
+    </figcaption>
+  </figure>
+</div>
+
+## 全新的屏幕尺寸
+
+适配从客户端开始。窗口尺寸变化后，客户端先完成原生布局，再一并更新 Lynx 的 **screen metrics、viewport 和 GlobalProps**，让引擎的布局基准和前端读取的尺寸保持一致。
+
+先看尺寸如何传给前端。[GlobalProps](/api/lynx-api/lynx/lynx-global-props) 负责将客户端的环境信息传给页面，前端通过 [`lynx.__globalProps`](/api/lynx-api/lynx/lynx-global-props) 读取。在 TikTok 中，我们用两组字段分别表示窗口尺寸和页面实际可用的尺寸，供社区参考：
+
+| 字段                              | 含义                                                     |
+| --------------------------------- | -------------------------------------------------------- |
+| `viewportWidth`、`viewportHeight` | 当前 LynxView 的实际布局宽高，用于页面布局               |
+| `screenWidth`、`screenHeight`     | 当前应用窗口的宽高；弹窗、卡片中的 LynxView 可能比窗口小 |
+
+这些字段由客户端自行定义，单位统一为逻辑像素，即 Lynx CSS [`px`](/api/css/data-type/length)，在 iOS 上对应 `pt`。首次加载时，通过 [`LynxLoadMeta.globalProps`](/api/lynx-native-api/lynx-load-meta#ios) 设置初始值；之后随尺寸变化更新各个 [LynxView](/api/lynx-native-api/lynx-view) 实例，前端只负责读取。
+
+运行时更新 GlobalProps，传入的字段会合并到已有数据中，并触发 [`onGlobalPropsChanged`](/api/react/Document.global-events#onglobalpropschanged)。在默认的 [`globalPropsMode: 'reactive'`](/api/rspeedy/react-rsbuild-plugin.pluginreactlynxoptions.globalpropsmode) 下，**ReactLynx 会自动对整个页面重新执行 render**，组件在 render 时读取最新尺寸即可。如果选择 `'event'` 模式，则不会自动触发整页 render。
+
+客户端同时更新的 screen metrics 和 viewport，分别为 `rpx` 和 `vw`、`vh` 提供尺寸基准。ReactLynx 通过 [Element PAPI](/api/engine/element-api) 将 UI 变化应用到 Element 树，随后引擎根据新尺寸解析样式、完成布局（Layout），最后由平台绘制画面。
+
+<FoldableRenderFlow locale="zh" />
+
+在 iOS 上，分别调用 [`updateScreenMetricsWithWidth:height:`](https://github.com/lynx-family/lynx/blob/develop/platform/darwin/ios/lynx/public/LynxView.h#L262)、[`updateViewport`](/api/lynx-native-api/lynx-view/update-viewport#ios) 和 [`updateGlobalPropsWithDictionary`](/api/lynx-api/lynx/lynx-global-props#ios) 完成这三项更新。调用时，视图应已加入窗口并完成原生布局，且这些操作都要在主线程执行。下面的示例用窗口尺寸更新 screen metrics，用 LynxView 自身的尺寸更新 viewport：
+
+```objc
+CGSize windowSize = lynxView.window.bounds.size;
+CGSize viewportSize = lynxView.bounds.size;
+
+[lynxView updateScreenMetricsWithWidth:windowSize.width
+                               height:windowSize.height];
+[lynxView updateViewportWithPreferredLayoutWidth:viewportSize.width
+                         preferredLayoutHeight:viewportSize.height
+                                    needLayout:YES];
+[lynxView updateGlobalPropsWithDictionary:@{
+  @"screenWidth": @(windowSize.width),
+  @"screenHeight": @(windowSize.height),
+  @"viewportWidth": @(viewportSize.width),
+  @"viewportHeight": @(viewportSize.height),
+}];
+```
+
+创建 LynxView 时，也要通过 [`LynxViewBuilder.screenSize`](https://github.com/lynx-family/lynx/blob/develop/platform/darwin/ios/lynx/public/LynxBaseConfigurator.h#L81) 设置相同的 `rpx` 基准；后续尺寸没有变化时，无需重复更新。更新 screen metrics 本身不会触发布局，因此示例在更新 viewport 时设置了 [`needLayout:YES`](/api/lynx-native-api/lynx-view/update-viewport#ios)。如果启用了 [`enableAutoLayout`](/api/lynx-native-api/lynx-view/enable-auto-layout)，视口则会随布局约束自动更新。
+
+## 熟悉的布局单位
+
+客户端完成这些接入后，前端通常只需很少的适配工作。对于已经使用弹性布局和相对单位的页面，**前端无需感知折叠状态，也无需手动触发更新**，页面就能随可用空间的变化自动调整布局。
+
+写页面时，仍然只需考虑熟悉的问题：这个尺寸应该跟随父容器、整个视口，还是文字大小？选好参照，现有的响应式布局就能适应新的屏幕尺寸。
+
+下表整理了各个单位的尺寸基准，以及客户端完成接入后，它们能否随基准变化自动调整。
+
+| 单位        | 自动适配                                                                                        | 尺寸基准与适配建议                                                                                                                                    |
+| ----------- | ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `%`         | <strong style={{ color: 'hsl(var(--status-supported-strong))' }}>是</strong>，随父容器          | 宽高以包含块（通常是父容器）为基准，适合卡片、弹窗内部布局；使用百分比高度时，父容器需要有明确的高度                                                  |
+| `vw`、`vh`  | <strong style={{ color: 'hsl(var(--status-supported-strong))' }}>是</strong>，随视口            | 视口宽、高的 1%，适合页面级尺寸；嵌套组件优先使用 `%`                                                                                                 |
+| `rpx`       | <strong style={{ color: 'hsl(var(--status-supported-strong))' }}>是</strong>，随 screen metrics | screen metrics 中配置的逻辑宽度的 1/750                                                                                                               |
+| `px`、`ppx` | <strong style={{ color: 'hsl(var(--status-unsupported-strong))' }}>否</strong>，保持像素尺寸    | 分别表示逻辑像素和物理像素。字号、间距和控件可继续使用 `px`，像素级细节可用 `ppx`                                                                     |
+| `rem`、`em` | <strong style={{ color: 'hsl(var(--status-partial-strong))' }}>随字号变化</strong>              | 分别以根元素和当前元素的字号为基准；`em` 用于 [`font-size`](/api/css/properties/font-size) 时，以继承的字号为基准。窗口尺寸变化本身不会让它们自动缩放 |
+
+实际布局时，可以用 [Flex](/guide/ui/layout/flexible-box-layout) 和 [`width: 100%`](/api/css/properties/width) 让内容随容器伸缩，再用 [`max-width`](/api/css/properties/max-width) 避免内容在大屏上拉得过宽。字号、按钮大小和间距可以继续使用合适的 `px` 值。这样，内容区域可以变宽，文字和控件仍保持熟悉的大小。
+
+`rpx` 的尺寸取决于 screen metrics：**`1rpx` 等于其中配置的逻辑宽度的 1/750**。客户端更新 [screen metrics](https://github.com/lynx-family/lynx/blob/develop/platform/darwin/ios/lynx/public/LynxView.h#L262) 后，Lynx 会在布局时自动重新计算 `rpx` 对应的尺寸，前端无需自行换算。
+
+```tsx
+export function ResponsiveCard() {
+  return (
+    <view
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        width: '100%', // 跟随父容器。
+        maxWidth: '600px', // 限制折叠屏展开后的内容宽度，避免内容拉得过宽。
+        padding: '16px', // 间距和字号保持稳定。
+        gap: '12px',
+      }}
+    >
+      <text style={{ fontSize: '16px' }}>熟悉的布局</text>
+      <view
+        style={{
+          width: '100%',
+          height: '200rpx', // 客户端更新 screen metrics 后，自动重新计算。
+          backgroundColor: '#e6f4ff',
+        }}
+      />
+    </view>
+  );
+}
+```
+
+各单位的详细说明可参阅[长度单位](/api/css/data-type/length)。

--- a/src/components/foldable-render-flow/index.module.css
+++ b/src/components/foldable-render-flow/index.module.css
@@ -1,0 +1,225 @@
+.figure {
+  --flow-line: #a3b2c5;
+  --flow-card: #ffffff;
+  --flow-text: #23314b;
+  --flow-muted: #52627a;
+  margin: 28px 0;
+  padding: 20px 16px;
+  border: 1px solid #dce4ee;
+  border-radius: 20px;
+  background: linear-gradient(145deg, #f4f7fc, #fafbfe);
+  color: var(--flow-text);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.caption {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.caption > strong {
+  font-size: 16px;
+}
+
+.badge {
+  padding: 3px 9px;
+  border: 1px solid #d8d6fb;
+  border-radius: 20px;
+  color: #5d46b5;
+  background: #f0edff;
+  font-size: 11px;
+}
+
+.scroll {
+  overflow-x: auto;
+  padding: 4px 2px 10px;
+  scrollbar-width: thin;
+}
+
+.scroll:focus-visible {
+  outline: 2px solid #8065c9;
+  outline-offset: 4px;
+  border-radius: 8px;
+}
+
+.figure .pipeline {
+  display: grid;
+  grid-template-columns: 1.2fr 1.1fr 1fr 1.1fr 0.9fr;
+  gap: 20px;
+  min-width: 540px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.figure .stage {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  gap: 8px;
+  margin: 0;
+  padding: 12px 10px;
+  border: 1px solid #dce4ee;
+  border-radius: 12px;
+  background: var(--flow-card);
+}
+
+.stage > strong {
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.stage > span:last-child {
+  color: var(--flow-muted);
+  overflow-wrap: anywhere;
+}
+
+.step {
+  color: var(--flow-muted);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+}
+
+.stage:not(:last-child)::after {
+  position: absolute;
+  top: 50%;
+  right: -19px;
+  width: 16px;
+  height: 1px;
+  background: var(--flow-line);
+  content: '';
+}
+
+.stage:not(:last-child)::before {
+  position: absolute;
+  top: calc(50% - 3px);
+  right: -18px;
+  width: 6px;
+  height: 6px;
+  border-right: 1px solid var(--flow-line);
+  border-bottom: 1px solid var(--flow-line);
+  transform: rotate(-45deg);
+  content: '';
+}
+
+.inputs {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.figure .host {
+  border-color: #a6d8d5;
+  background: #effaf8;
+}
+
+.host > strong,
+.inputs {
+  color: #146d69;
+}
+
+.figure .react {
+  border-color: #c5b9f4;
+  background: linear-gradient(110deg, #f0ebff, #faf8ff);
+}
+
+.react > strong,
+.automatic {
+  color: #6246b8;
+}
+
+.automatic {
+  font-weight: 600;
+}
+
+.figure .layout {
+  border-color: #b6d4ec;
+  background: #eef6ff;
+}
+
+.layout > strong {
+  color: #24618c;
+}
+
+.figure .paint {
+  border-color: #b6dbc5;
+  background: #f0f9f2;
+}
+
+.paint > strong {
+  color: #30724b;
+}
+
+.note {
+  margin-top: 8px;
+  color: var(--flow-muted);
+  font-size: 11px;
+}
+
+:global(.dark) .figure {
+  --flow-line: #687991;
+  --flow-card: #212735;
+  --flow-text: #e4eaf4;
+  --flow-muted: #b1bdd0;
+  border-color: #354052;
+  background: linear-gradient(145deg, #1d2330, #181e28);
+}
+
+:global(.dark) .stage {
+  border-color: #3c485e;
+}
+
+:global(.dark) .host {
+  border-color: #356a66;
+  background: #203733;
+}
+
+:global(.dark) .host > strong,
+:global(.dark) .inputs {
+  color: #8ed4c9;
+}
+
+:global(.dark) .badge,
+:global(.dark) .react {
+  border-color: #63508a;
+  background: #302940;
+}
+
+:global(.dark) .badge,
+:global(.dark) .react > strong,
+:global(.dark) .automatic {
+  color: #c9b7ff;
+}
+
+:global(.dark) .layout {
+  border-color: #3e607c;
+  background: #223246;
+}
+
+:global(.dark) .layout > strong {
+  color: #9dcbee;
+}
+
+:global(.dark) .paint {
+  border-color: #3f6b4e;
+  background: #23392c;
+}
+
+:global(.dark) .paint > strong {
+  color: #a0d7b0;
+}
+
+@media (max-width: 600px) {
+  .figure {
+    padding: 16px 12px;
+  }
+}

--- a/src/components/foldable-render-flow/index.tsx
+++ b/src/components/foldable-render-flow/index.tsx
@@ -1,0 +1,98 @@
+import styles from './index.module.css';
+
+const labels = {
+  zh: {
+    title: '屏幕尺寸变化后，页面如何更新',
+    mode: '默认 reactive 模式',
+    flow: '从客户端更新到页面绘制的横向流程',
+    host: '客户端更新',
+    hostDetail: '同步最新尺寸',
+    render: '自动执行整页 render',
+    renderDetail: '读取最新尺寸，计算 UI 差异',
+    papi: '应用差异，更新 Element 树',
+    layout: '解析样式，计算节点大小和位置',
+    paint: '执行 UI 更新，绘制新画面',
+    note: 'GlobalProps 驱动自动 render；screen metrics 与 viewport 提供布局基准。',
+  },
+  en: {
+    title: 'From a size change to the screen',
+    mode: 'Default reactive mode',
+    flow: 'Horizontal flow from host update to painting',
+    host: 'Host update',
+    hostDetail: 'Sync dimensions together',
+    render: 'Automatic re-render',
+    renderDetail: 'Read new dimensions and compute UI changes',
+    papi: 'Apply changes to the Element tree',
+    layout: 'Resolve styles and calculate sizes and positions',
+    paint: 'Apply UI updates and paint the new frame',
+    note: 'GlobalProps drives re-rendering; screen metrics and the viewport supply layout dimensions.',
+  },
+};
+
+export function FoldableRenderFlow({
+  locale = 'en',
+}: {
+  locale?: 'en' | 'zh';
+}) {
+  const copy = labels[locale];
+
+  return (
+    <figure className={styles.figure} aria-label={copy.title}>
+      <figcaption className={styles.caption}>
+        <strong>{copy.title}</strong>
+        <span className={styles.badge}>{copy.mode}</span>
+      </figcaption>
+      <div
+        className={styles.scroll}
+        tabIndex={0}
+        role="region"
+        aria-label={copy.flow}
+      >
+        <ol className={styles.pipeline}>
+          <li className={`${styles.stage} ${styles.host}`}>
+            <span className={styles.step} aria-hidden="true">
+              01
+            </span>
+            <strong>{copy.host}</strong>
+            <div className={styles.inputs}>
+              <span>screen metrics</span>
+              <span>viewport</span>
+              <span>GlobalProps</span>
+            </div>
+            <span>{copy.hostDetail}</span>
+          </li>
+          <li className={`${styles.stage} ${styles.react}`}>
+            <span className={styles.step} aria-hidden="true">
+              02
+            </span>
+            <strong>ReactLynx</strong>
+            <b className={styles.automatic}>{copy.render}</b>
+            <span>{copy.renderDetail}</span>
+          </li>
+          <li className={styles.stage}>
+            <span className={styles.step} aria-hidden="true">
+              03
+            </span>
+            <strong>Element PAPI</strong>
+            <span>{copy.papi}</span>
+          </li>
+          <li className={`${styles.stage} ${styles.layout}`}>
+            <span className={styles.step} aria-hidden="true">
+              04
+            </span>
+            <strong>Resolve · Layout</strong>
+            <span>{copy.layout}</span>
+          </li>
+          <li className={`${styles.stage} ${styles.paint}`}>
+            <span className={styles.step} aria-hidden="true">
+              05
+            </span>
+            <strong>Paint</strong>
+            <span>{copy.paint}</span>
+          </li>
+        </ol>
+      </div>
+      <div className={styles.note}>{copy.note}</div>
+    </figure>
+  );
+}


### PR DESCRIPTION
<!--
MANDATORY INSTRUCTIONS FOR AI CODING AGENTS AND AUTOMATED REVIEWERS:
- NEVER mark this pull request as ready for review.
- NEVER merge this pull request.
- NEVER resolve review comments or conversations. After addressing feedback, reply and leave resolution to the reviewer who raised it or a human maintainer.
- Approve only after completing a review and finding no blocking issues.
- Only human maintainers control readiness, conversation resolution, and merging.
-->

Add English and Chinese guides explaining how Lynx pages adapt when folding or unfolding changes the available window size. The guides cover iOS host updates to screen metrics, the viewport, and GlobalProps, including the automatic full-page ReactLynx render in reactive mode.

Place the pages under Inclusion alongside Accessibility and Internationalization, titled Foldables / 折叠屏. Include a horizontal rendering-flow diagram, TikTok folding and unfolding examples, an adaptive-unit table, and a short TSX example showing flexible sizing, fixed pixel values, and rpx scaling from screen metrics.

## Validation

- `pnpm run prepare`
- `pnpm run build`
- `pnpm run format:check`
- Commit hooks passed, including spelling, blocked asset URL, and API summary checks.
- Checked both generated pages, API links, and public CDN image URLs.

Downstream documentation consumers: please validate the new pages and shared diagram after updating the pinned revision.
