### PR TITLE
chore(cherry-pick): offer release/4.1 as a target branch

### DIFF
--- a/.github/ISSUE_TEMPLATE/cherry_pick_request.yml
+++ b/.github/ISSUE_TEMPLATE/cherry_pick_request.yml
@@ -19,6 +19,7 @@ body:
       label: Target release branches
       description: Select one or more release branches.
       options:
+        - label: release/4.1
         - label: release/4.0
         - label: release/3.9
         - label: release/3.8

--- a/.github/cherry-pick-config.json
+++ b/.github/cherry-pick-config.json
@@ -1,5 +1,6 @@
 {
   "targetBranches": [
+    "release/4.1",
     "release/4.0",
     "release/3.9",
     "release/3.8",


### PR DESCRIPTION
## Summary

4.1 is the released version now, so it is the branch most fixes need to reach, but the cherry-pick request form does not list it and `validate` rejects it as an unknown target. This adds it to both the config and the issue form.

The entry goes first in each list, keeping the newest-first order, and both files are edited in the same position because `check-config` compares the form's checkbox labels to `targetBranches` as an ordered list and fails on any mismatch.

Nothing is removed: 4.0 and the older releases stay selectable.

## Verification

- `node .github/scripts/cherry-pick-request.mjs check-config` → `Cherry-pick config check passed.` This is what `.github/workflows/cherry-pick-config-check.yml` runs.
- `node --test .github/scripts/cherry-pick-request.test.mjs` → all tests pass, 0 failures.
- `prettier --check` on both files passes.

## Related Links

- #1425 — the promotion that made release/4.1 the released branch