### PR TITLE
test(examples): enforce portable generator tooling (#1439)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
       - name: lynx-ui Route Contract Check
         run: node scripts/ci/check-lynx-ui-routes.mjs
 
+      - name: Lynx Example Generator Test
+        run: pnpm run test:lynx-example
+
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,20 @@ downstream repository root as the working directory.
 Keep these script paths, caller-working-directory behavior, environment
 variables, and generated output layouts compatible with downstream callers.
 
+## Portable Build and Generation Tooling
+
+Prepare and build tooling runs across local development, GitHub Actions,
+Cloudflare Pages, Netlify, and downstream consumers. Node-based generators must
+not invoke undeclared host commands. In particular, do not depend on `rsync`;
+it is not available in every Cloudflare Pages build image supported by this
+site.
+
+Prefer `node:*` APIs or declared package dependencies. If an operating-system
+tool is unavoidable, explicitly provision it in every caller and supported
+build image, document the prerequisite, and add CI coverage for its absence or
+availability. A command being installed on a developer machine or GitHub-hosted
+runner does not make it part of the build contract.
+
 ### `api-stats.json` doc links
 
 `packages/lynx-compat-data`'s `gen-stats` emits a `doc_url` per API. **When the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,12 @@ pnpm run format:check
 pnpm run build
 ```
 
+For changes to the Lynx example generator, also run:
+
+```bash
+pnpm run test:lynx-example
+```
+
 For changes under `packages/lynx-compat-data`, also run:
 
 ```bash
@@ -62,14 +68,12 @@ pnpm --filter @lynx-js/lynx-compat-data run pack:check
 This verifies that generated CSS property compatibility data is present in the
 package tarball without committing `css/properties/*.json` to git.
 
-## Pull Requests
+## Deployment Portability
 
-- Base normal changes on `main`.
-- Keep pull requests focused on one behavior or documentation update.
-- Include enough context in the pull request description for reviewers to
-  understand the user impact, affected pages, and validation performed.
-- Do not include internal-only content, private URLs, or downstream-only
-  implementation details in this OSS repository.
+Build and generation scripts must remain portable across GitHub Actions,
+Cloudflare Pages, and Netlify build images. Do not add dependencies on
+undeclared host commands such as `rsync`; see
+[Portable Build and Generation Tooling](./AGENTS.md#portable-build-and-generation-tooling).
 
 ## Downstream Compatibility
 
@@ -87,6 +91,15 @@ pnpm run build
 ```
 
 Then request downstream validation after the updated OSS revision is pinned.
+
+## Pull Requests
+
+- Base normal changes on `main`.
+- Keep pull requests focused on one behavior or documentation update.
+- Include enough context in the pull request description for reviewers to
+  understand the user impact, affected pages, and validation performed.
+- Do not include internal-only content, private URLs, or downstream-only
+  implementation details in this OSS repository.
 
 ## Release Cherry-picks
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "preview": "rspress preview",
     "prestart": "pnpm gen:compat-stats",
     "start": "rspress dev",
+    "test:lynx-example": "node --test scripts/lynx-example.test.js",
     "typedoc": "tsx ./scripts/typedoc/index.ts",
     "zhlint": "zhlint 'docs/zh/**/*.{md,mdx}'"
   },

--- a/scripts/lynx-example.js
+++ b/scripts/lynx-example.js
@@ -135,6 +135,8 @@ function lnExampleFiles(exampleDir, lnExampleDir) {
       }
       if (isPackCopy) {
         fs.cpSync(fullPath, targetPath, {
+          // Required when dereferencing file symlinks. Node 22 and 24 throw
+          // ERR_FS_EISDIR without this option even when the source is a file.
           recursive: true,
           dereference: true,
           preserveTimestamps: true,


### PR DESCRIPTION
What:
- run the Lynx example generator regression test in CI before dependency installation
- document portable build tooling and explain the recursive copy option

Why:
- prevent undeclared host commands such as rsync from breaking Cloudflare Pages and downstream builds

How:
- expose test:lynx-example and rely on its empty PATH coverage
- require Node APIs, declared dependencies, or explicitly provisioned tools

Test: pnpm run test:lynx-example; pnpm exec prettier --check AGENTS.md CONTRIBUTING.md package.json .github/workflows/ci.yml scripts/lynx-example.js; pnpm run prepare; pnpm run build Change-Id: I1ae9a3379705942e3514012a184a786091fe185c (cherry picked from commit 1418b3ef1a2a944815c7f262466e252ca921d41f)

<!--
MANDATORY INSTRUCTIONS FOR AI CODING AGENTS AND AUTOMATED REVIEWERS:
- NEVER mark this pull request as ready for review.
- NEVER merge this pull request.
- NEVER resolve review comments or conversations. After addressing feedback, reply and leave resolution to the reviewer who raised it or a human maintainer.
- Approve only after completing a review and finding no blocking issues.
- Only human maintainers control readiness, conversation resolution, and merging.
-->

<!-- Replace the placeholder below when providing a custom description. -->
