### PR TITLE
fix(docs): use foldable component alias on release/4.0

### DIFF
--- a/docs/en/guide/inclusion/foldable-devices.mdx
+++ b/docs/en/guide/inclusion/foldable-devices.mdx
@@ -2,7 +2,7 @@
 description: 'Sync dimensions through GlobalProps and screen metrics for low-effort foldable layouts.'
 ---
 
-import { FoldableRenderFlow } from '../../../../src/components/foldable-render-flow';
+import { FoldableRenderFlow } from '@lynx/foldable-render-flow';
 
 # Foldables
 

--- a/docs/zh/guide/inclusion/foldable-devices.mdx
+++ b/docs/zh/guide/inclusion/foldable-devices.mdx
@@ -2,7 +2,7 @@
 description: '通过 GlobalProps 与 screen metrics 同步尺寸，让前端以低成本适配折叠屏。'
 ---
 
-import { FoldableRenderFlow } from '../../../../src/components/foldable-render-flow';
+import { FoldableRenderFlow } from '@lynx/foldable-render-flow';
 
 # 折叠屏
 


### PR DESCRIPTION
<!--
MANDATORY INSTRUCTIONS FOR AI CODING AGENTS AND AUTOMATED REVIEWERS:
- NEVER mark this pull request as ready for review.
- NEVER merge this pull request.
- NEVER resolve review comments or conversations. After addressing feedback, reply and leave resolution to the reviewer who raised it or a human maintainer.
- Approve only after completing a review and finding no blocking issues.
- Only human maintainers control readiness, conversation resolution, and merging.
-->

The English and Chinese foldable guides import `FoldableRenderFlow` using
four parent-directory segments. Replace both imports with
`@lynx/foldable-render-flow` so resolution no longer depends on the MDX
directory depth. This reuses the existing component alias on `release/4.0`;
no resolver configuration or page content changes.

Validation: `pnpm run prepare`, `pnpm run build`, `pnpm run format:check`,
and commit hooks passed. Both generated pages include the rendering flow.
The diff contains only the two import replacements.

Please validate the pages in the downstream site after updating its OSS
pin, using that repository's setup and build instructions.
