### PR TITLE
ci: guard documentation source import boundaries

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -1,0 +1,17 @@
+name: Setup Node and PNPM
+description: Set up repository-pinned Node and PNPM with a shared store cache.
+
+runs:
+  using: composite
+  steps:
+    - name: Setup PNPM
+      uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
+    - name: Setup Node.js
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version-file: '.node-version'
+        cache: 'pnpm'
+
+# Checkout must happen before this local action. Each caller installs its own
+# dependencies explicitly and chooses whether lifecycle scripts should run.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,14 +32,8 @@ jobs:
         with:
           python-version: '3.13'
 
-      - name: Setup PNPM
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version-file: '.node-version'
-          cache: 'pnpm'
+      - name: Setup Node and PNPM
+        uses: ./.github/actions/setup-node-pnpm
 
       - name: Case Check
         run: node scripts/ci/check-case-collisions.mjs
@@ -50,11 +44,23 @@ jobs:
       - name: lynx-ui Route Contract Check
         run: node scripts/ci/check-lynx-ui-routes.mjs
 
-      - name: Lynx Example Generator Test
-        run: pnpm run test:lynx-example
-
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Generated Documentation Consistency Check
+        run: |
+          # Installation runs prepare. Keep this list aligned with every
+          # committed documentation output generated during that lifecycle.
+          generated_documentation_outputs=(
+            "sharedDocs/packageDocs"
+            "sharedDocs/lynx-ui-intros.ts"
+          )
+          changes="$(git status --porcelain=v1 --untracked-files=all -- "${generated_documentation_outputs[@]}")"
+          if [ -n "$changes" ]; then
+            printf '%s\n' "$changes"
+            echo "::error::Generated documentation is out of date. Run pnpm run prepare and commit all changes reported above."
+            exit 1
+          fi
 
       - name: Install pipx
         run: python -m pip install pipx==1.17.1
@@ -77,10 +83,62 @@ jobs:
       - name: Build
         run: pnpm run build
 
+  # Keep generator portability tests dependency-free. Direct Node execution
+  # avoids pnpm 11 implicitly installing dependencies and running root prepare.
+  generator-portability:
+    name: Generator Portability
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: '.node-version'
+
+      - name: Lynx Example Generator Test
+        run: node --test scripts/lynx-example.test.js
+
+  # Check committed documents with MDX dependencies, without running prepare.
+  # Validate separately verifies generated documentation after root prepare.
+  # Keep installation explicit and separate from dependency-free generator tests.
+  documentation-imports:
+    name: Documentation Imports
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node and PNPM
+        uses: ./.github/actions/setup-node-pnpm
+
+      - name: Install Dependencies Without Lifecycle Scripts
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Documentation Import Boundary Check
+        run: |
+          node --test scripts/ci/check-doc-import-boundaries.test.mjs
+          node scripts/ci/check-doc-import-boundaries.mjs
+
+  # Branch protection requires Done as the aggregate status. Add every new
+  # required CI job to needs so its result cannot bypass this gate.
   done:
     name: Done
     needs:
       - validate
+      - generator-portability
+      - documentation-imports
     if: ${{ always() }}
     runs-on: ubuntu-latest
     permissions: {}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,43 @@ downstream repository root as the working directory.
 Keep these script paths, caller-working-directory behavior, environment
 variables, and generated output layouts compatible with downstream callers.
 
+### Mirrored Integration Contracts
+
+The downstream repository maintains local versions of
+`shared-route-config.ts`, `shared-og-config.ts`, `rspress.config.ts`, and
+`tsconfig.json`. These files are not copied from OSS, but their runtime
+contracts must remain compatible.
+
+Keep OSS runtime imports compatible with the downstream resolver aliases.
+Coordinate changes to shared configuration exports or resolver aliases with
+the downstream repository.
+
+### Compatibility Changes
+
+- Treat consumed paths, package names, script environment variables, output
+  directories, and exported configuration fields as interfaces. Do not rename,
+  remove, or change them without a compatibility plan and coordinated
+  downstream update.
+- Keep internal-only content and behavior in the in-house repository.
+
+The in-house scheduled sync runs daily at 09:30 UTC+8. For coordinated changes,
+especially those that must land internally first, plan the landing order around
+this window so an OSS change is not synced before its downstream counterpart is
+ready.
+
+### Verification
+
+When a change affects any downstream compatibility contract above, verify this
+repository with:
+
+```sh
+pnpm run prepare
+pnpm run build
+```
+
+Then request validation against the updated OSS pin in the in-house repository,
+following that repository's own setup and build instructions.
+
 ## Portable Build and Generation Tooling
 
 Prepare and build tooling runs across local development, GitHub Actions,
@@ -74,29 +111,75 @@ verification and emits every URL unchecked; naming a root that does not exist
 is an error rather than a silent skip, so a run either verifies against the
 tree it was told to use or does not verify at all.
 
-## Mirrored Integration Contracts
+## Generated Documentation
 
-The downstream repository maintains local versions of
-`shared-route-config.ts`, `shared-og-config.ts`, `rspress.config.ts`, and
-`tsconfig.json`. These files are not copied from OSS, but their runtime
-contracts must remain compatible.
+The contributor-facing rules in
+[Generated Documentation](./CONTRIBUTING.md#generated-documentation) are the
+source of truth.
 
-Keep OSS runtime imports compatible with the downstream resolver aliases.
-Coordinate changes to shared configuration exports or resolver aliases with
-the downstream repository.
+CI must run documentation syncs and generators whose outputs are committed,
+then fail on additions, modifications, deletions, or untracked output files.
+When adding such a tool, include its complete output set in the consistency
+check.
 
-The in-house scheduled sync runs daily at 09:30 UTC+8. For coordinated changes,
-especially those that must land internally first, plan the landing order around
-this window so an OSS change is not synced before its downstream counterpart is
-ready.
+## Documentation Runtime Imports
+
+The contributor-facing rules, examples, and alias selection table in
+[Portable Documentation Imports](./CONTRIBUTING.md#portable-documentation-imports)
+are the source of truth. Automated changes to `docs/` and `sharedDocs/` must
+follow them.
+
+### Resolver Details
+
+The `@` alias resolves directly to `src` in OSS, but downstream consumers may
+configure it as an ordered list of source roots. The resolver uses the first
+matching path; it does not merge directories or barrel exports. Existing `@/*`
+imports remain **temporarily** supported for compatibility, but do not add one
+for a new OSS documentation component when an `@lynx/*` import is available.
+
+Likewise, a downstream `@lynx` alias may search multiple component roots. A
+subpath such as `@lynx/example` can fall through until that component exists,
+while the bare `@lynx` import stops at the first resolvable barrel. Use the
+barrel only when the export is present in every consumer's first matching
+barrel.
+
+The OSS `@luna` alias is an exact-match barrel for `src/luna/index.ts`. Shared
+documentation must use only the bare `@luna` import so consumers need to
+provide the same barrel contract, not internal Luna subpaths.
+
+Do not add a new alias or change alias ordering without coordinating the exact
+contract with downstream consumers.
+
+### Boundary Check
+
+The `scripts/ci/check-doc-import-boundaries.mjs` check enforces this boundary.
+It parses documents using direct MDX and syntax-plugin dependencies aligned
+with Rspress, then checks static imports, re-exports, and statically known
+dynamic imports in the AST. It does not execute documents or evaluate computed
+import sources. Preserve Rspress's `.md`/`.mdx` distinction, frontmatter
+handling, and heading-ID escaping when updating the parser; plain Markdown
+examples are not executable imports. Parse failures must fail the check, not
+silently skip files. Relative imports into `src/` or `theme/` are forbidden;
+relative imports that remain within the documentation tree are allowed. The
+check does not enforce alias ownership or canonicalize existing alias imports.
+
+Replacement suggestions derive only from the resolved source path. They may
+normalize known JS/TS extensions and trailing `index` files, but must not infer
+ownership from imported symbol names or guess aliases for undocumented source
+roots.
+
+Keep parser dependencies explicit rather than importing Rspress internals.
+The `Documentation Imports` CI job installs dependencies with lifecycle scripts
+disabled and checks committed documents without root `prepare`. Keep the
+separate `Generator Portability` job dependency-free.
 
 ## Host-Root Imports
 
 `@site` resolves to the consuming site's repository root. Existing `@site/*`
-imports are part of the current OSS/downstream compatibility surface.
+imports remain **temporarily** supported as part of the current OSS/downstream
+compatibility surface.
 
-Do not add a new `@site/*` import merely to avoid a relative path or to reach
-consumer-specific configuration. For new code:
+Do not add new `@site/*` dependencies. For new code:
 
 - Use a relative import when the target remains inside the owning OSS module.
 - Use an OSS-owned package export for reusable shared code.
@@ -104,30 +187,13 @@ consumer-specific configuration. For new code:
   intentionally inject configuration. For example, `@og-config` is configured
   as the exact-match `@og-config$` alias in Rspress.
 
-Any new `@site/*` dependency requires a matching module and compatibility
-contract in every supported consumer.
-
 ## Change Rules
 
-- Do not rename or remove a consumed path without a compatibility plan and a
-  coordinated downstream update.
-- Treat package names, script environment variables, output directories, and
-  exported configuration fields as interfaces.
-- Keep internal-only content and behavior in the in-house repository.
-- Request downstream validation for changes affecting this contract.
-- Changes to CI, build or generation workflows, release behavior, or downstream
-  interfaces require human review and must be merged manually. Review agents
-  may approve these changes but must not auto-merge them.
+Apply the section-specific rules above, including the resolver, host-root, and
+generated-documentation constraints, to changes in those areas.
 
-## Verification
-
-When a change affects any downstream compatibility contract above, verify this
-repository with:
-
-```sh
-pnpm run prepare
-pnpm run build
-```
-
-Then request validation against the updated OSS pin in the in-house repository,
-following that repository's own setup and build instructions.
+- Call out changes to CI, build or generation workflows, release behavior, or
+  downstream interfaces explicitly in the commit message and pull request
+  description.
+- All pull requests require human review and must be merged manually. Review
+  agents may approve changes but must not auto-merge them.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,20 @@ For changes to the Lynx example generator, also run:
 pnpm run test:lynx-example
 ```
 
+For changes to imports in `docs/` or `sharedDocs/`, also run:
+
+```bash
+pnpm run check:doc-import-boundaries
+```
+
+The check parses documents without executing them, using Rspress-aligned
+Markdown/MDX syntax. It reports parse errors as well as import violations.
+For checker changes, also run:
+
+```bash
+node --test scripts/ci/check-doc-import-boundaries.test.mjs
+```
+
 For changes under `packages/lynx-compat-data`, also run:
 
 ```bash
@@ -67,6 +81,19 @@ pnpm --filter @lynx-js/lynx-compat-data run pack:check
 
 This verifies that generated CSS property compatibility data is present in the
 package tarball without committing `css/properties/*.json` to git.
+
+## Generated Documentation
+
+Generated or synchronized documentation committed to the repository must match
+the current source revision and generation tooling. Run the relevant generator
+after changing either input, and commit all resulting additions, modifications,
+and deletions. CI consistency checks must cover the complete output set.
+
+For example, `pnpm run prepare` fetches the revision in `lynx-ui.version`,
+copies its package documentation into `sharedDocs/packageDocs/`, and generates
+`sharedDocs/lynx-ui-intros.ts` from package introductions. After changing that
+revision or its sync and generation tooling, run `pnpm run prepare` and commit
+all changes in those output paths.
 
 ## Deployment Portability
 
@@ -91,6 +118,79 @@ pnpm run build
 ```
 
 Then request downstream validation after the updated OSS revision is pinned.
+
+### Portable Documentation Imports
+
+In this repository, `docs/` and `sharedDocs/` happen to have fixed relative
+positions next to `src/` and `theme/`, so imports such as
+`../../src/components/...` can appear to work. Downstream sites copy the
+documentation into their own trees but mount OSS runtime source and theme
+files at consumer-specific paths. The same relative import can therefore
+resolve to consumer code, or to no module at all, instead of the OSS module.
+
+The boundary check enforces only this layout rule: executable imports in
+`docs/` and `sharedDocs/` must not reach `src/` or `theme/` through relative
+paths. It does not validate the ownership of existing alias imports or reject
+historical forms such as `@lynx/index` and `@lynx-ui/index`.
+
+Do not rely on the relative position of a documentation file and runtime
+source. Use a shared resolver alias whenever a file under `docs/` or
+`sharedDocs/` imports runtime source:
+
+```ts
+// Incorrect: depends on the OSS checkout layout.
+import { Example } from '../../../../src/components/example';
+
+// Correct: resolves through the shared OSS/downstream contract.
+import { Example } from '@lynx/example';
+```
+
+For new imports of shared components, content modules, or assets, choose the
+narrowest shared entry points:
+
+| Dependencies used by documentation pages           | Import form         |
+| -------------------------------------------------- | ------------------- |
+| Components exported by the OSS shared entry point  | `@lynx`             |
+| Specific OSS modules under `src/components`        | `@lynx/<module>`    |
+| Components exported by the `lynx-ui` shared entry  | `@lynx-ui`          |
+| Specific modules under `src/lynx-ui/components`    | `@lynx-ui/<module>` |
+| Luna components exported by its exact entry point  | `@luna`             |
+| Shared package-document modules                    | `@docs/<path>`      |
+| Files under `docs/public/assets`                   | `@assets/<path>`    |
+| MDX fragments kept within `docs/` or `sharedDocs/` | Relative imports    |
+
+`@luna` is an exact-match barrel for `src/luna/index.ts`. Use only the bare
+alias; `@luna/*` subpaths are not part of the shared resolver contract.
+
+For new imports, omit JS/TS file extensions and a trailing `/index`. Existing
+imports that include `/index` remain supported and can be migrated separately.
+When replacing a relative import, retain its specific module subpath. Use a
+bare entry point only when every consumer exports the imported symbols from
+that shared entry point.
+
+Treat each alias as an ownership boundary. Import a symbol from the entry point
+that owns it, even if another site currently re-exports that symbol from an
+aggregate barrel:
+
+```ts
+// Incorrect: relies on a downstream @lynx barrel re-exporting lynx-ui.
+import { UIApiTable } from '@lynx';
+
+// Correct: owned by the lynx-ui documentation components.
+import { UIApiTable } from '@lynx-ui';
+```
+
+Some downstream resolvers map one alias to an ordered list of source roots.
+Those roots are fallbacks, not a merged namespace: resolution stops at the
+first matching module. Do not require a downstream consumer to add cross-root
+re-exports to make an OSS document compile. If a downstream root overrides an
+OSS-owned subpath, the replacement must preserve the module contract used by
+shared documentation.
+
+Existing `@/*` imports remain **temporarily** supported for compatibility, but do
+not add one for a new OSS documentation component when an `@lynx/*` import is
+available. Downstream consumers may resolve `@` through multiple source roots,
+where an earlier match shadows later roots.
 
 ## Commits
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "prebuild": "pnpm gen:compat-stats",
     "build": "pnpm gen:og && NODE_OPTIONS=--max-old-space-size=4096 RSPRESS_SSG_WORKER_THREAD_COUNT=2 rspress build",
+    "check:doc-import-boundaries": "node scripts/ci/check-doc-import-boundaries.mjs",
     "check-docs": "python3 -m scripts.check_api_doc.index",
     "cspell:check": "cspell lint -c cspell.json \"docs/**/*.md(x)\"",
     "predev": "pnpm gen:compat-stats",
@@ -36,7 +37,8 @@
     "*.{js,jsx,ts,tsx,md,mdx,json,yml,yaml,css,scss}": "prettier --write",
     "*.{md,mdx}": [
       "cspell lint -c cspell.json --no-must-find-files",
-      "node scripts/ci/check-api-summary.mjs"
+      "node scripts/ci/check-api-summary.mjs",
+      "node scripts/ci/check-doc-import-boundaries.mjs"
     ],
     "*.{js,jsx,ts,tsx,md,mdx,json,yml,yaml,html,svg,css,scss,less}": "node scripts/ci/check-asset-urls.mjs"
   },
@@ -88,6 +90,7 @@
     "@lynx-js/rspress-plugin-llms-postprocess": "workspace:*",
     "@lynx-js/testing-environment": "npm:@lynx-js/test-environment@0.0.1",
     "@mdn/minimalist": "^2.0.4",
+    "@mdx-js/mdx": "3.1.1",
     "@mdx-js/react": "^3.1.1",
     "@resvg/resvg-js": "^2.6.2",
     "@rsbuild/plugin-less": "^1.6.0",
@@ -110,6 +113,9 @@
     "prettier": "^3.4.2",
     "prettier-plugin-packagejson": "^3.0.2",
     "react-render-to-markdown": "18.3.1",
+    "remark-cjk-friendly": "2.3.1",
+    "remark-cjk-friendly-gfm-strikethrough": "2.3.1",
+    "remark-gfm": "4.0.1",
     "rsbuild-plugin-google-analytics": "^1.0.3",
     "satori": "^0.26.0",
     "tailwindcss": "^3.4.19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,9 @@ importers:
       '@mdn/minimalist':
         specifier: ^2.0.4
         version: 2.0.4
+      '@mdx-js/mdx':
+        specifier: 3.1.1
+        version: 3.1.1
       '@mdx-js/react':
         specifier: ^3.1.1
         version: 3.1.1(@types/react@18.3.18)(react@18.3.1)
@@ -213,6 +216,15 @@ importers:
       react-render-to-markdown:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
+      remark-cjk-friendly:
+        specifier: 2.3.1
+        version: 2.3.1(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.1)(unified@11.0.5)
+      remark-cjk-friendly-gfm-strikethrough:
+        specifier: 2.3.1
+        version: 2.3.1(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.1)(unified@11.0.5)
+      remark-gfm:
+        specifier: 4.0.1
+        version: 4.0.1
       rsbuild-plugin-google-analytics:
         specifier: ^1.0.3
         version: 1.0.5(@rsbuild/core@2.1.9)

--- a/scripts/ci/check-doc-import-boundaries.mjs
+++ b/scripts/ci/check-doc-import-boundaries.mjs
@@ -1,0 +1,262 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createProcessor } from '@mdx-js/mdx';
+import matter from 'gray-matter';
+import remarkCjkFriendly from 'remark-cjk-friendly';
+import remarkCjkStrikethrough from 'remark-cjk-friendly-gfm-strikethrough';
+import remarkGfm from 'remark-gfm';
+
+const repoRoot = fileURLToPath(new URL('../..', import.meta.url));
+const scriptPath = fileURLToPath(import.meta.url);
+const docExtensions = new Set(['.md', '.mdx']);
+
+// Match Rspress's syntax plugins and extension-based format selection, without
+// running its rendering plugins, importing site config, or executing documents.
+// Keep these direct dependency versions aligned with @rspress/core.
+const processors = new Map(
+  ['md', 'mdx'].map((format) => [
+    format,
+    createProcessor({
+      format,
+      remarkPlugins: [remarkGfm, remarkCjkFriendly, remarkCjkStrikethrough],
+    }),
+  ]),
+);
+
+/**
+ * Normalize native paths across Windows, macOS, and Linux. Windows uses `\`
+ * separators, while Git paths and the POSIX helpers below use `/`.
+ */
+function toPosix(value) {
+  return value.split(path.sep).join('/');
+}
+
+/**
+ * Match Rspress's frontmatter removal and heading-ID escaping before parsing.
+ * Restore removed line breaks so AST locations still refer to the source file.
+ * The site's version-placeholder remark plugin runs after parsing and rewrites
+ * only code nodes, so it is intentionally irrelevant to import discovery.
+ */
+function prepareSource(content) {
+  // Only metadata boundaries matter here. Never evaluate gray-matter's
+  // JavaScript frontmatter engine while inspecting a document.
+  const body = matter(content, { engines: { javascript: () => ({}) } }).content;
+  const removedLines = content.split('\n').length - body.split('\n').length;
+  return `${'\n'.repeat(removedLines)}${body}`.replace(
+    /(?:^|\n)#{1,6}(?!#).*/g,
+    (heading) => heading.replace('{#', '\\{#').replace('\\\\{#', '\\{#'),
+  );
+}
+
+/**
+ * Walk Markdown nodes and their embedded ESTree, including JSX attributes and
+ * template substitutions. Yield statically known import sources, including
+ * dynamic imports using template literals without substitutions. Only typed
+ * AST children are visited, not locations, comments, or arbitrary metadata.
+ * The parser decides what is executable.
+ */
+function* importNodes(node) {
+  if (
+    node.type === 'ImportDeclaration' ||
+    node.type === 'ExportNamedDeclaration' ||
+    node.type === 'ExportAllDeclaration' ||
+    node.type === 'ImportExpression'
+  ) {
+    let specifier;
+    if (node.source?.type === 'Literal') {
+      specifier = node.source.value;
+    } else if (
+      node.type === 'ImportExpression' &&
+      node.source?.type === 'TemplateLiteral' &&
+      node.source.expressions.length === 0
+    ) {
+      specifier = node.source.quasis[0]?.value.cooked;
+    }
+    if (typeof specifier === 'string') {
+      yield { node, specifier };
+    }
+  }
+
+  if (node.data?.estree) {
+    yield* importNodes(node.data.estree);
+  }
+  for (const value of Object.values(node)) {
+    const children = Array.isArray(value) ? value : [value];
+    for (const child of children) {
+      if (
+        child &&
+        typeof child === 'object' &&
+        typeof child.type === 'string'
+      ) {
+        yield* importNodes(child);
+      }
+    }
+  }
+}
+
+/**
+ * Suggest only documented component aliases. Preserve resource extensions and
+ * query/hash modifiers; unknown source roots remain violations without a guess.
+ */
+function suggestedAlias(target, modifier) {
+  const aliasRoots = [
+    ['src/components', '@lynx'],
+    ['src/lynx-ui/components', '@lynx-ui'],
+  ];
+  for (const [sourceRoot, alias] of aliasRoots) {
+    if (target !== sourceRoot && !target.startsWith(`${sourceRoot}/`)) {
+      continue;
+    }
+    const subpath = (
+      target === sourceRoot ? '' : target.slice(sourceRoot.length + 1)
+    )
+      .replace(/\.(?:[cm]?[jt]s|[jt]sx)$/, '')
+      .replace(/(^|\/)index$/, '');
+    return `${alias}${subpath ? `/${subpath}` : ''}${modifier}`;
+  }
+  return undefined;
+}
+
+/**
+ * Find imports violating the OSS/downstream source boundary.
+ *
+ * Rules:
+ * - Use Rspress-aligned Markdown/MDX parsing, not text matching.
+ * - Check static imports, re-exports, and statically known dynamic imports.
+ * - Ignore examples, prose, comments, and strings, but visit JS expressions.
+ * - Reject relative sources resolving into src/ or theme/; do not migrate aliases.
+ * - Preserve query/hash modifiers and original one-based diagnostic lines.
+ * - Suggest documented aliases without JS/TS extensions or a final index.
+ * - Fail on parse errors; an unparsed document must not silently pass.
+ *
+ * Plain .md uses Markdown semantics, so import-looking text is not executable.
+ * Computed dynamic sources are not evaluated or checked.
+ */
+export function findSourceBoundaryImports(file, content) {
+  const normalizedFile = toPosix(file);
+  const format = path.posix.extname(normalizedFile).slice(1);
+  const tree = processors.get(format).parse({
+    path: normalizedFile,
+    value: prepareSource(content),
+  });
+  const violations = [];
+  for (const { node, specifier } of importNodes(tree)) {
+    if (!specifier.startsWith('./') && !specifier.startsWith('../')) {
+      continue;
+    }
+    const modifierIndex = specifier.search(/[?#]/);
+    const cleanSpecifier =
+      modifierIndex === -1 ? specifier : specifier.slice(0, modifierIndex);
+    const modifier = modifierIndex === -1 ? '' : specifier.slice(modifierIndex);
+    const target = path.posix.normalize(
+      path.posix.join(path.posix.dirname(normalizedFile), cleanSpecifier),
+    );
+    const crossesRuntimeBoundary = ['src', 'theme'].some(
+      (root) => target === root || target.startsWith(`${root}/`),
+    );
+    if (!crossesRuntimeBoundary) {
+      continue;
+    }
+    violations.push({
+      file: normalizedFile,
+      line: node.loc.start.line,
+      specifier,
+      target,
+      suggestion: suggestedAlias(target, modifier),
+    });
+  }
+  return violations.sort((a, b) => a.line - b.line);
+}
+
+/**
+ * Limit checks to Markdown sources copied into downstream documentation.
+ */
+function isDocumentationFile(file) {
+  return (
+    (file.startsWith('docs/') || file.startsWith('sharedDocs/')) &&
+    docExtensions.has(path.posix.extname(file))
+  );
+}
+
+/**
+ * Scan tracked documents without arguments, or normalize explicit file paths
+ * from lint-staged. NUL delimiters preserve spaces and non-ASCII Git filenames.
+ */
+function filesToCheck(args) {
+  if (args.length === 0) {
+    return execFileSync('git', ['ls-files', '-z', 'docs', 'sharedDocs'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    })
+      .split('\0')
+      .filter(Boolean);
+  }
+  return args
+    .map((file) =>
+      toPosix(
+        path.relative(
+          repoRoot,
+          path.isAbsolute(file) ? file : path.resolve(process.cwd(), file),
+        ),
+      ),
+    )
+    .filter((file) => !file.startsWith('../'));
+}
+
+/**
+ * Report all violations and parse/read failures, returning a nonzero exit code
+ * for either. Missing tracked files may be staged deletions and are skipped.
+ */
+function run() {
+  const violations = [];
+  for (const file of filesToCheck(process.argv.slice(2))) {
+    if (!isDocumentationFile(file)) {
+      continue;
+    }
+    let content;
+    try {
+      content = readFileSync(path.join(repoRoot, file), 'utf8');
+    } catch (error) {
+      if (error.code === 'ENOENT') {
+        continue;
+      }
+      console.error(`${file}: could not read document: ${error.message}`);
+      process.exitCode = 1;
+      continue;
+    }
+    try {
+      violations.push(...findSourceBoundaryImports(file, content));
+    } catch (error) {
+      const line = error.line ?? error.place?.start?.line ?? 1;
+      console.error(
+        `${file}:${line}: could not parse document: ${error.message}`,
+      );
+      process.exitCode = 1;
+    }
+  }
+  if (violations.length === 0) {
+    return;
+  }
+  console.error(
+    'Documentation imports must not cross into src/ or theme/ through relative paths.',
+  );
+  console.error(
+    'Use a resolver alias shared by the OSS and downstream builds instead:',
+  );
+  for (const violation of violations) {
+    const replacement = violation.suggestion
+      ? `; use '${violation.suggestion}'`
+      : '';
+    console.error(
+      `  - ${violation.file}:${violation.line}: '${violation.specifier}' resolves to '${violation.target}'${replacement}`,
+    );
+  }
+  process.exitCode = 1;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
+  run();
+}

--- a/scripts/ci/check-doc-import-boundaries.test.mjs
+++ b/scripts/ci/check-doc-import-boundaries.test.mjs
@@ -1,0 +1,602 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { findSourceBoundaryImports } from './check-doc-import-boundaries.mjs';
+
+const projectRequire = createRequire(import.meta.url);
+const projectPackage = JSON.parse(
+  readFileSync(new URL('../../package.json', import.meta.url), 'utf8'),
+);
+const rspressPackagePath = projectRequire.resolve('@rspress/core/package.json');
+const rspressPackage = JSON.parse(readFileSync(rspressPackagePath, 'utf8'));
+const rspressRequire = createRequire(rspressPackagePath);
+// Rspress does not expose its parser setup as a public API. A version bump must
+// therefore trigger a review of its MDX options and preprocessing behavior.
+const auditedRspressVersion = '2.0.19';
+const parserDependencies = [
+  '@mdx-js/mdx',
+  'remark-cjk-friendly',
+  'remark-cjk-friendly-gfm-strikethrough',
+  'remark-gfm',
+];
+const parserAuditTestCommand =
+  'node --test scripts/ci/check-doc-import-boundaries.test.mjs';
+
+function rspressVersionAuditMessage(installedVersion) {
+  return [
+    'Rspress parser audit required.',
+    `Audited @rspress/core version: ${auditedRspressVersion}`,
+    `Installed @rspress/core version: ${installedVersion}`,
+    '',
+    'Before updating auditedRspressVersion:',
+    '1. Compare @rspress/core/dist/node/mdx/options.js and processor.js.',
+    '2. Review .md/.mdx format selection, syntax plugins, frontmatter, and heading-ID preprocessing.',
+    '3. Align the parser dependencies in package.json and pnpm-lock.yaml.',
+    `4. Run: ${parserAuditTestCommand}`,
+  ].join('\n');
+}
+
+// Keep this path deeply nested so tests exercise the traversal that made an
+// OSS-local component import resolve differently in downstream layouts.
+const docPath = 'docs/en/guide/inclusion/foldable-devices.mdx';
+
+test('uses an audited Rspress parser contract', () => {
+  if (rspressPackage.version !== auditedRspressVersion) {
+    assert.fail(rspressVersionAuditMessage(rspressPackage.version));
+  }
+});
+
+test('reports actionable instructions for unaudited Rspress versions', () => {
+  const message = rspressVersionAuditMessage('2.0.21');
+  for (const expected of [
+    'Audited @rspress/core version: 2.0.19',
+    'Installed @rspress/core version: 2.0.21',
+    '@rspress/core/dist/node/mdx/options.js',
+    'frontmatter',
+    'parser dependencies in package.json and pnpm-lock.yaml',
+    parserAuditTestCommand,
+  ]) {
+    assert.ok(
+      message.includes(expected),
+      `missing audit instruction: ${expected}`,
+    );
+  }
+});
+
+test('resolves parser dependencies from the same installation as Rspress', () => {
+  const problems = [];
+  for (const dependency of parserDependencies) {
+    const projectRange = projectPackage.devDependencies[dependency];
+    const rspressRange = rspressPackage.dependencies[dependency];
+    if (!projectRange) {
+      problems.push(`- ${dependency} is not a direct project devDependency.`);
+    }
+    if (!rspressRange) {
+      problems.push(
+        `- ${dependency} is no longer a direct @rspress/core dependency.`,
+      );
+    }
+    if (
+      projectRange &&
+      rspressRange &&
+      projectRequire.resolve(dependency) !== rspressRequire.resolve(dependency)
+    ) {
+      problems.push(
+        [
+          `- ${dependency} resolves to different installations:`,
+          `  project (${projectRange}): ${projectRequire.resolve(dependency)}`,
+          `  @rspress/core (${rspressRange}): ${rspressRequire.resolve(dependency)}`,
+        ].join('\n'),
+      );
+    }
+  }
+
+  if (problems.length > 0) {
+    assert.fail(
+      [
+        'Rspress parser dependency alignment failed.',
+        ...problems,
+        '',
+        'Review the new Rspress parser setup, align direct devDependencies,',
+        'run pnpm install, and then rerun:',
+        `  ${parserAuditTestCommand}`,
+      ].join('\n'),
+    );
+  }
+});
+
+test('rejects relative imports that resolve into src', () => {
+  const violations = findSourceBoundaryImports(
+    docPath,
+    `import {
+  FoldableRenderFlow,
+} from '../../../../src/components/foldable-render-flow';
+`,
+  );
+
+  assert.deepEqual(violations, [
+    {
+      file: docPath,
+      line: 1,
+      specifier: '../../../../src/components/foldable-render-flow',
+      target: 'src/components/foldable-render-flow',
+      suggestion: '@lynx/foldable-render-flow',
+    },
+  ]);
+});
+
+test('canonicalizes suggestions for known component roots', () => {
+  // Suggestions should describe stable module entry points, not source file
+  // extensions or directory index files from the current checkout.
+  const cases = [
+    ['../../../../src/components/index.tsx', '@lynx'],
+    ['../../../../src/components/foo/index.tsx', '@lynx/foo'],
+    ['../../../../src/components/foo.tsx', '@lynx/foo'],
+    ['../../../../src/components/foo.css', '@lynx/foo.css'],
+    ['../../../../src/lynx-ui/components/index.tsx', '@lynx-ui'],
+    [
+      '../../../../src/lynx-ui/components/ui-api-table/index.tsx',
+      '@lynx-ui/ui-api-table',
+    ],
+    [
+      '../../../../src/components/foo/index.tsx?raw#example',
+      '@lynx/foo?raw#example',
+    ],
+  ];
+
+  for (const [specifier, suggestion] of cases) {
+    const violations = findSourceBoundaryImports(
+      docPath,
+      `import Example from '${specifier}';\n`,
+    );
+
+    assert.equal(violations[0].suggestion, suggestion, specifier);
+  }
+});
+
+test('allows shared aliases and document-local relative imports', () => {
+  const violations = findSourceBoundaryImports(
+    docPath,
+    `import { FoldableRenderFlow } from '@lynx/foldable-render-flow';
+import Example from './Example';
+`,
+  );
+
+  assert.deepEqual(violations, []);
+});
+
+test('ignores imports shown inside fenced code examples', () => {
+  // Different delimiters and Markdown containers still represent examples,
+  // not executable MDX imports.
+  const violations = findSourceBoundaryImports(
+    docPath,
+    [
+      '~~~tsx',
+      "import { Example } from '../../../../src/components/example';",
+      '~~~',
+      '',
+      '```tsx',
+      "import { OtherExample } from '../../../../src/components/other-example';",
+      '```',
+      '',
+      '> ````tsx',
+      "> import('../../../../src/components/blockquote-example');",
+      '> ````',
+      '',
+    ].join('\n'),
+  );
+
+  assert.deepEqual(violations, []);
+});
+
+test('resumes scanning after leaving an unclosed blockquote fence', () => {
+  const violations = findSourceBoundaryImports(
+    docPath,
+    [
+      '> ```tsx',
+      "> import('../../../../src/components/example');",
+      "import Example from '../../../../src/components/example';",
+      '',
+    ].join('\n'),
+  );
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].line, 3);
+});
+
+test('rejects side-effect imports and other src subtrees', () => {
+  const violations = findSourceBoundaryImports(
+    docPath,
+    `import '../../../../src/styles.css';
+`,
+  );
+
+  assert.deepEqual(violations, [
+    {
+      file: docPath,
+      line: 1,
+      specifier: '../../../../src/styles.css',
+      target: 'src/styles.css',
+      suggestion: undefined,
+    },
+  ]);
+});
+
+test('rejects relative theme imports without guessing an alias', () => {
+  const [violation] = findSourceBoundaryImports(
+    docPath,
+    "import Theme from '../../../../theme/index';",
+  );
+
+  assert.deepEqual(violation, {
+    file: docPath,
+    line: 1,
+    specifier: '../../../../theme/index',
+    target: 'theme/index',
+    suggestion: undefined,
+  });
+});
+
+test('rejects dynamic imports that resolve into src', () => {
+  // Executable MDX can load modules with import(), so it shares the boundary.
+  const violations = findSourceBoundaryImports(
+    docPath,
+    `export const loadExample = () =>
+  import('../../../../src/components/example');
+`,
+  );
+
+  assert.deepEqual(violations, [
+    {
+      file: docPath,
+      line: 2,
+      specifier: '../../../../src/components/example',
+      target: 'src/components/example',
+      suggestion: '@lynx/example',
+    },
+  ]);
+});
+
+test('recognizes comments between import tokens', () => {
+  // JavaScript comments can replace whitespace around module specifiers.
+  const violations = findSourceBoundaryImports(
+    docPath,
+    `import { StaticExample } from/* owner */'../../../../src/components/static-example';
+export { ReExport } from/* owner */'../../../../src/components/re-export';
+import/* styles */'../../../../src/components/styles.css';
+export const DynamicExample = import/* lazy */(/* source */'../../../../src/components/dynamic-example'/* end */);
+`,
+  );
+
+  assert.deepEqual(
+    violations.map(({ line, specifier, suggestion }) => ({
+      line,
+      specifier,
+      suggestion,
+    })),
+    [
+      {
+        line: 1,
+        specifier: '../../../../src/components/static-example',
+        suggestion: '@lynx/static-example',
+      },
+      {
+        line: 2,
+        specifier: '../../../../src/components/re-export',
+        suggestion: '@lynx/re-export',
+      },
+      {
+        line: 3,
+        specifier: '../../../../src/components/styles.css',
+        suggestion: '@lynx/styles.css',
+      },
+      {
+        line: 4,
+        specifier: '../../../../src/components/dynamic-example',
+        suggestion: '@lynx/dynamic-example',
+      },
+    ],
+  );
+});
+
+test('ignores a leading block comment followed by import-like prose', () => {
+  // MDX parses this line as a paragraph, not as an ESM declaration.
+  const violations = findSourceBoundaryImports(
+    docPath,
+    `/* import ownership */ import Example from '../../../../src/components/example';
+`,
+  );
+
+  assert.deepEqual(violations, []);
+});
+
+test('ignores imports inside JavaScript comments', () => {
+  const violations = findSourceBoundaryImports(
+    docPath,
+    `// import('../../../../src/components/line-comment');
+{/*
+import BlockComment from '../../../../src/components/block-comment';
+*/}
+`,
+  );
+
+  assert.deepEqual(violations, []);
+});
+
+test('ignores import-like text in quoted values and inline code', () => {
+  const violations = findSourceBoundaryImports(
+    docPath,
+    [
+      `export const example = "import('../../../../src/components/string')";`,
+      '',
+      "Use `import('../../../../src/components/inline-code')` to load a module.",
+      "Use ``import('../../../../src/components/double-inline-code')`` too.",
+      '',
+    ].join('\n'),
+  );
+
+  assert.deepEqual(violations, []);
+});
+
+test('does not extend a semicolonless import into following MDX content', () => {
+  const violations = findSourceBoundaryImports(
+    docPath,
+    `import ExternalComponent from '@scope/components'
+
+The prose says from '../../../../src/components/not-an-import'.
+
+export const example = "from '../../../../src/components/not-an-export'";
+`,
+  );
+
+  assert.deepEqual(violations, []);
+});
+
+test('reports the import line without consuming preceding blank lines', () => {
+  const violations = findSourceBoundaryImports(
+    docPath,
+    `
+
+import Example from '../../../../src/components/example';
+`,
+  );
+
+  assert.equal(violations[0].line, 3);
+});
+
+test('does not combine consecutive semicolonless imports', () => {
+  // MDX imports may omit semicolons; each declaration must remain independent.
+  const violations = findSourceBoundaryImports(
+    docPath,
+    `import ExternalComponent from '@scope/components'
+import LocalComponent from '../../../../src/components/local'
+`,
+  );
+
+  assert.deepEqual(violations, [
+    {
+      file: docPath,
+      line: 2,
+      specifier: '../../../../src/components/local',
+      target: 'src/components/local',
+      suggestion: '@lynx/local',
+    },
+  ]);
+});
+
+test('does not extend named imports into exported strings', () => {
+  assert.deepEqual(
+    findSourceBoundaryImports(
+      docPath,
+      `import { X } from '@scope/x'
+export const note = "} from '../../../../src/components/example'"
+`,
+    ),
+    [],
+  );
+});
+
+test('detects expressions after prose URLs and inside template substitutions', () => {
+  // A URL is Markdown text; a template substitution is executable JavaScript.
+  const content = [
+    "https://example.com {import('../../../../src/components/url')}",
+    '',
+    "export const value = `text ${import('../../../../src/components/template')}`",
+  ].join('\n');
+  assert.deepEqual(
+    findSourceBoundaryImports(docPath, content).map(({ line, suggestion }) => [
+      line,
+      suggestion,
+    ]),
+    [
+      [1, '@lynx/url'],
+      [3, '@lynx/template'],
+    ],
+  );
+});
+
+test('recognizes Unicode import identifiers', () => {
+  assert.equal(
+    findSourceBoundaryImports(
+      docPath,
+      "import \u793a\u4f8b from '../../../../src/components/example'",
+    )[0]?.suggestion,
+    '@lynx/example',
+  );
+});
+
+test('ends an unclosed list fence when leaving its container', () => {
+  const content = [
+    '- Example:',
+    '',
+    '  ```js',
+    "  import('../../../../src/components/ignored')",
+    '',
+    "import X from '../../../../src/components/example'",
+  ].join('\n');
+  assert.deepEqual(
+    findSourceBoundaryImports(docPath, content).map(({ line }) => line),
+    [6],
+  );
+});
+
+test('ignores longer backtick runs inside inline code', () => {
+  assert.deepEqual(
+    findSourceBoundaryImports(
+      docPath,
+      "Use `` ``` import('../../../../src/components/example') `` here.",
+    ),
+    [],
+  );
+});
+
+test('preserves frontmatter and heading-ID line numbers with LF and CRLF', () => {
+  for (const newline of ['\n', '\r\n']) {
+    const content = [
+      '---',
+      'title: "import ignored from ../../../../src/components/metadata"',
+      '---',
+      '',
+      '# Example {#custom}',
+      '',
+      "import X from '../../../../src/components/example'",
+    ].join(newline);
+    assert.equal(findSourceBoundaryImports(docPath, content)[0].line, 7);
+  }
+});
+
+test('visits JSX attribute expressions, spread attributes, and GFM table cells', () => {
+  const content = [
+    "<Example load={() => import('../../../../src/components/attr')} {...{load: import('../../../../src/components/spread')}} />",
+    '',
+    '| Example |',
+    '| --- |',
+    "| {import('../../../../src/components/table')} |",
+  ].join('\n');
+  assert.deepEqual(
+    findSourceBoundaryImports(docPath, content).map(({ line, suggestion }) => [
+      line,
+      suggestion,
+    ]),
+    [
+      [1, '@lynx/attr'],
+      [1, '@lynx/spread'],
+      [5, '@lynx/table'],
+    ],
+  );
+});
+
+test('checks export sources and decoded module strings without executing code', () => {
+  const content = [
+    "export * from '../../../../src/components/all'",
+    "export * as group from '../../../../src/components/group'",
+    "import X from '\\u002e\\u002e/../../../src/components/escaped'",
+    "export const crash = (() => { throw new Error('must not execute'); })()",
+  ].join('\n');
+  assert.deepEqual(
+    findSourceBoundaryImports(docPath, content).map(
+      ({ suggestion }) => suggestion,
+    ),
+    ['@lynx/all', '@lynx/group', '@lynx/escaped'],
+  );
+});
+
+test('uses plain Markdown semantics for .md and MDX semantics for .mdx', () => {
+  const content = "import X from '../../../../src/components/example'";
+  assert.deepEqual(
+    findSourceBoundaryImports(docPath.replace('.mdx', '.md'), content),
+    [],
+  );
+  assert.equal(findSourceBoundaryImports(docPath, content).length, 1);
+  assert.equal(
+    findSourceBoundaryImports(
+      'sharedDocs/packageDocs/example.mdx',
+      "import X from '../../src/components/example'",
+    )[0].suggestion,
+    '@lynx/example',
+  );
+});
+
+test('checks no-substitution template dynamic sources', () => {
+  assert.deepEqual(
+    findSourceBoundaryImports(
+      docPath,
+      'export const load = () => import(`../../../../src/components/example`)',
+    ).map(({ line, suggestion }) => [line, suggestion]),
+    [[1, '@lynx/example']],
+  );
+});
+
+test('does not evaluate computed dynamic sources or reject existing aliases', () => {
+  assert.deepEqual(
+    findSourceBoundaryImports(
+      docPath,
+      [
+        "import X from '@lynx/index'",
+        "export const load = (name) => import('../../../../src/' + name)",
+        'export const template = (name) => import(`../../../../src/components/${name}`)',
+        "export const local = () => import('./Example')",
+      ].join('\n'),
+    ),
+    [],
+  );
+});
+
+test('throws for invalid MDX instead of silently skipping the document', () => {
+  assert.throws(
+    () =>
+      findSourceBoundaryImports(docPath, "import X from './x'\nconst x = 1"),
+    /only import\/exports are supported/,
+  );
+});
+
+test('never evaluates JavaScript frontmatter', () => {
+  const content = [
+    '---javascript',
+    "(() => { throw new Error('must not execute metadata'); })()",
+    '---',
+    '',
+    "import X from '../../../../src/components/example'",
+  ].join('\n');
+  assert.equal(findSourceBoundaryImports(docPath, content)[0].line, 5);
+});
+
+test('CLI reports parse failures and violations together and ignores unrelated paths', (t) => {
+  // Temporary documents remain inside the repository so path selection is real.
+  const root = fileURLToPath(new URL('../..', import.meta.url));
+  const directory = mkdtempSync(path.join(root, 'docs', '.boundary-test-'));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const invalid = path.join(directory, 'invalid.mdx');
+  const violation = path.join(directory, 'violation.mdx');
+  const markdown = path.join(directory, 'example.md');
+  writeFileSync(invalid, "import X from './x'\nconst x = 1\n");
+  writeFileSync(violation, "import X from '../../src/components/example'\n");
+  writeFileSync(markdown, "import X from '../../src/components/example'\n");
+  const script = fileURLToPath(
+    new URL('./check-doc-import-boundaries.mjs', import.meta.url),
+  );
+  const result = spawnSync(process.execPath, [script, invalid, violation], {
+    cwd: directory,
+    encoding: 'utf8',
+    timeout: 30_000,
+  });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /invalid\.mdx:2: could not parse document/);
+  assert.match(result.stderr, /violation\.mdx:1:.*@lynx\/example/);
+  const allowed = spawnSync(
+    process.execPath,
+    [
+      script,
+      markdown,
+      path.join(directory, 'deleted.mdx'),
+      path.join(root, 'README.md'),
+    ],
+    { cwd: directory, encoding: 'utf8', timeout: 30_000 },
+  );
+  assert.equal(allowed.status, 0, allowed.stderr);
+});


### PR DESCRIPTION
## Summary

- reject relative imports from `docs/` and `sharedDocs/` into `src/` or
  `theme/`
- parse Markdown and MDX with Rspress-aligned dependencies and inspect
  executable imports through the AST
- run parser-backed checks in a dedicated `Documentation Imports` job while
  keeping `Generator Portability` dependency-free
- verify committed generated documentation after root `prepare`
- aggregate every required CI job through `Done`
- document portable aliases, generated documentation, and downstream contracts

## Rationale

PR #1456 exposed a relative MDX component import that worked in the OSS
checkout but failed when consumed from a different downstream layout. The
specific import was fixed by #1460. Downstream sites copy `docs/` and
`sharedDocs/` while mounting OSS runtime source and theme files at
consumer-specific paths, so documentation must not depend on their relative
positions in this checkout.

The checker uses the same Markdown/MDX syntax dependencies as Rspress. It
checks static imports, re-exports, and statically known dynamic imports,
including template literals without substitutions. It ignores prose, code
examples, comments, strings, and computed module sources without executing
documents. Parse failures fail closed.

Direct parser dependencies are explicit and covered by an Rspress-version
audit tripwire. The `Documentation Imports` job installs them with lifecycle
scripts disabled, avoiding root `prepare`. Generator portability tests remain
independent of installed dependencies.

The check enforces only relative-path boundaries. It does not migrate or
validate existing aliases. Contributor guidance records the shared resolver
contract, including the exact bare `@luna` entry point and the temporary status
of existing `@/*` and `@site/*` imports.

## Verification

- `node --test scripts/ci/check-doc-import-boundaries.test.mjs`
- `node scripts/ci/check-doc-import-boundaries.mjs`
- `node --test scripts/lynx-example.test.js`
- `pnpm run prepare`
- `pnpm run format:check`
- `pnpm run build`
- workflow structure and aggregate-job assertions

## Review

This intentionally changes CI and downstream compatibility enforcement. It
requires human review and manual merge; automated reviewers must not mark the
PR ready, resolve conversations, or merge it.
