### PR TITLE
docs(harmony): track LYNX_VERSION in the ohpm dependencies

### DIFF
--- a/docs/en/guide/start/fragments/harmony/integrating-lynx-with-existing-app-harmony.mdx
+++ b/docs/en/guide/start/fragments/harmony/integrating-lynx-with-existing-app-harmony.mdx
@@ -23,8 +23,8 @@ The core capabilities of [Lynx Engine](/guide/spec.html#engine) include basic ca
 ```json5 title=oh-package.json5 {3-4}
 "dependencies": {
   "@ohos/imageknife": "3.2.6",
-  "@lynx/lynx": "4.0.0",
-  "@lynx/primjs": "4.0.0",
+  "@lynx/lynx": "{versionJson.LYNX_VERSION}",
+  "@lynx/primjs": "{versionJson.PRIMJS_VERSION}",
 },
 ```
 
@@ -35,12 +35,12 @@ Lynx Service includes `LynxDevtoolService`, `LynxLogService`, etc. It aims to pr
 ```json5 title=oh-package.json5 {3-8}
 "dependencies": {
   "@ohos/imageknife": "3.2.6",
-  "@lynx/lynx": "4.0.0",
-  "@lynx/lynx_devtool": "4.0.0",
-  "@lynx/lynx_devtool_service": "4.0.0",
-  "@lynx/lynx_http_service": "4.0.0",
-  "@lynx/lynx_log_service": "4.0.0",
-  "@lynx/primjs": "4.0.0",
+  "@lynx/lynx": "{versionJson.LYNX_VERSION}",
+  "@lynx/lynx_devtool": "{versionJson.LYNX_VERSION}",
+  "@lynx/lynx_devtool_service": "{versionJson.LYNX_VERSION}",
+  "@lynx/lynx_http_service": "{versionJson.LYNX_VERSION}",
+  "@lynx/lynx_log_service": "{versionJson.LYNX_VERSION}",
+  "@lynx/primjs": "{versionJson.PRIMJS_VERSION}",
 },
 ```
 
@@ -108,7 +108,7 @@ And configure the `network` key field in `entry/src/main/resources/base/element/
 
 ```json5 title=oh-package.json5
 "dependencies": {
-  "@lynx/xelement_svg": "3.6.0",
+  "@lynx/xelement_svg": "{versionJson.LYNX_VERSION}",
 },
 ```
 

--- a/docs/zh/guide/start/fragments/harmony/integrating-lynx-with-existing-app-harmony.mdx
+++ b/docs/zh/guide/start/fragments/harmony/integrating-lynx-with-existing-app-harmony.mdx
@@ -21,8 +21,8 @@ import { Steps } from '@theme';
 ```json5 title=oh-package.json5 {3-4}
 "dependencies": {
   "@ohos/imageknife": "3.2.6",
-  "@lynx/lynx": "4.0.0",
-  "@lynx/primjs": "4.0.0",
+  "@lynx/lynx": "{versionJson.LYNX_VERSION}",
+  "@lynx/primjs": "{versionJson.PRIMJS_VERSION}",
 },
 ```
 
@@ -33,12 +33,12 @@ Lynx Service 包括 `LynxDevtoolService`、`LynxLogService` 等，旨在提供�
 ```json5 title=oh-package.json5 {3-8}
 "dependencies": {
   "@ohos/imageknife": "3.2.6",
-  "@lynx/lynx": "4.0.0",
-  "@lynx/lynx_devtool": "4.0.0",
-  "@lynx/lynx_devtool_service": "4.0.0",
-  "@lynx/lynx_http_service": "4.0.0",
-  "@lynx/lynx_log_service": "4.0.0",
-  "@lynx/primjs": "4.0.0",
+  "@lynx/lynx": "{versionJson.LYNX_VERSION}",
+  "@lynx/lynx_devtool": "{versionJson.LYNX_VERSION}",
+  "@lynx/lynx_devtool_service": "{versionJson.LYNX_VERSION}",
+  "@lynx/lynx_http_service": "{versionJson.LYNX_VERSION}",
+  "@lynx/lynx_log_service": "{versionJson.LYNX_VERSION}",
+  "@lynx/primjs": "{versionJson.PRIMJS_VERSION}",
 },
 ```
 
@@ -106,7 +106,7 @@ project(MyApplication)
 
 ```json5 title=oh-package.json5
 "dependencies": {
-  "@lynx/xelement_svg": "3.6.0",
+  "@lynx/xelement_svg": "{versionJson.LYNX_VERSION}",
 },
 ```
 


### PR DESCRIPTION
## Summary

Closes the first half of #1438. The HarmonyOS integration guide pinned every Lynx package as a string literal, so its snippets fell behind the moment a release shipped: they still said 4.0.0 while the site builds 4.1.0. Switching to `{versionJson.LYNX_VERSION}` and `{versionJson.PRIMJS_VERSION}` keeps them in step, the way the Android guide already works.

Two details the placeholders also settle:

- **PrimJS takes its own value.** It is versioned on its own cadence and ohpm has no `@lynx/primjs` 4.1.0 — its 4.1 line starts at 4.1.1, mirroring Maven Central and CocoaPods. `PRIMJS_VERSION` is already 4.1.1, so the snippet now renders an installable version instead of one that never existed.
- **`@lynx/xelement_svg` was broken, not just stale.** It named 3.6.0, which is not on ohpm at all; the oldest published version is 3.8.1. Anyone following that step got an unresolvable dependency. It now renders 4.1.0, which is published.

## Verification

Queried the ohpm registry for every package the guide names:

| Package | 4.1.0 | Note |
| --- | --- | --- |
| `@lynx/lynx`, `lynx_devtool`, `lynx_devtool_service`, `lynx_http_service`, `lynx_log_service` | published | |
| `@lynx/primjs` | **absent** | 4.1 line starts at 4.1.1, which is published |
| `@lynx/xelement_svg` | published | 3.6.0 absent; oldest published is 3.8.1 |

`pnpm run build` passes, and the generated `guide/start/integrate-with-existing-apps.html` renders `"@lynx/lynx": "4.1.0"` through `"@lynx/lynx_log_service": "4.1.0"`, `"@lynx/primjs": "4.1.1"` and `"@lynx/xelement_svg": "4.1.0"`. Prettier and the asset-url and case-collision checks pass. The line counts inside the fences are unchanged, and each `{3-4}` / `{3-8}` highlight range was re-checked against the rendered lines.

## Not in this PR

- The Quick Start Explorer links, the other half of #1438, are already handled by #1433.
- `integrate-lynx-dev-version.mdx` has the same defect in its HarmonyOS tab (`3.5.1` literals, while the iOS and Android tabs on that page use placeholders), but it cannot be converted yet: ohpm has no `@lynx/lynx` 4.1.0-dev, so a placeholder would render a version nobody can install. Its newest `-dev` builds are 4.0.3-dev. Left alone and reported on the issue.

## Related Links

- #1438
- #1433