### PR TITLE
docs(harmony): track LYNX_VERSION in the ohpm dependencies

### DIFF
--- a/docs/en/guide/start/fragments/harmony/integrating-lynx-with-existing-app-harmony.mdx
+++ b/docs/en/guide/start/fragments/harmony/integrating-lynx-with-existing-app-harmony.mdx
@@ -23,8 +23,8 @@ The core capabilities of [Lynx Engine](/guide/spec.html#engine) include basic ca
 ```json5 title=oh-package.json5 {3-4}
 "dependencies": {
   "@ohos/imageknife": "3.2.6",
-  "@lynx/lynx": "4.0.0",
-  "@lynx/primjs": "4.0.0",
+  "@lynx/lynx": "{versionJson.LYNX_VERSION}",
+  "@lynx/primjs": "{versionJson.PRIMJS_VERSION}",
 },
 ```
 
@@ -35,12 +35,12 @@ Lynx Service includes `LynxDevtoolService`, `LynxLogService`, etc. It aims to pr
 ```json5 title=oh-package.json5 {3-8}
 "dependencies": {
   "@ohos/imageknife": "3.2.6",
-  "@lynx/lynx": "4.0.0",
-  "@lynx/lynx_devtool": "4.0.0",
-  "@lynx/lynx_devtool_service": "4.0.0",
-  "@lynx/lynx_http_service": "4.0.0",
-  "@lynx/lynx_log_service": "4.0.0",
-  "@lynx/primjs": "4.0.0",
+  "@lynx/lynx": "{versionJson.LYNX_VERSION}",
+  "@lynx/lynx_devtool": "{versionJson.LYNX_VERSION}",
+  "@lynx/lynx_devtool_service": "{versionJson.LYNX_VERSION}",
+  "@lynx/lynx_http_service": "{versionJson.LYNX_VERSION}",
+  "@lynx/lynx_log_service": "{versionJson.LYNX_VERSION}",
+  "@lynx/primjs": "{versionJson.PRIMJS_VERSION}",
 },
 ```
 
@@ -108,7 +108,7 @@ And configure the `network` key field in `entry/src/main/resources/base/element/
 
 ```json5 title=oh-package.json5
 "dependencies": {
-  "@lynx/xelement_svg": "3.6.0",
+  "@lynx/xelement_svg": "{versionJson.LYNX_VERSION}",
 },
 ```
 

--- a/docs/zh/guide/start/fragments/harmony/integrating-lynx-with-existing-app-harmony.mdx
+++ b/docs/zh/guide/start/fragments/harmony/integrating-lynx-with-existing-app-harmony.mdx
@@ -21,8 +21,8 @@ import { Steps } from '@theme';
 ```json5 title=oh-package.json5 {3-4}
 "dependencies": {
   "@ohos/imageknife": "3.2.6",
-  "@lynx/lynx": "4.0.0",
-  "@lynx/primjs": "4.0.0",
+  "@lynx/lynx": "{versionJson.LYNX_VERSION}",
+  "@lynx/primjs": "{versionJson.PRIMJS_VERSION}",
 },
 ```
 
@@ -33,12 +33,12 @@ Lynx Service 包括 `LynxDevtoolService`、`LynxLogService` 等，旨在提供�
 ```json5 title=oh-package.json5 {3-8}
 "dependencies": {
   "@ohos/imageknife": "3.2.6",
-  "@lynx/lynx": "4.0.0",
-  "@lynx/lynx_devtool": "4.0.0",
-  "@lynx/lynx_devtool_service": "4.0.0",
-  "@lynx/lynx_http_service": "4.0.0",
-  "@lynx/lynx_log_service": "4.0.0",
-  "@lynx/primjs": "4.0.0",
+  "@lynx/lynx": "{versionJson.LYNX_VERSION}",
+  "@lynx/lynx_devtool": "{versionJson.LYNX_VERSION}",
+  "@lynx/lynx_devtool_service": "{versionJson.LYNX_VERSION}",
+  "@lynx/lynx_http_service": "{versionJson.LYNX_VERSION}",
+  "@lynx/lynx_log_service": "{versionJson.LYNX_VERSION}",
+  "@lynx/primjs": "{versionJson.PRIMJS_VERSION}",
 },
 ```
 
@@ -106,7 +106,7 @@ project(MyApplication)
 
 ```json5 title=oh-package.json5
 "dependencies": {
-  "@lynx/xelement_svg": "3.6.0",
+  "@lynx/xelement_svg": "{versionJson.LYNX_VERSION}",
 },
 ```
 


### PR DESCRIPTION
## Summary

Cherry-pick of #1463 onto release/4.1, which is the branch serving the released site, so it is where the stale and unresolvable pins are actually visible to users.

This branch's manifest is `LYNX_VERSION: 4.1.0` / `PRIMJS_VERSION: 4.1.1`, so the snippets render the versions published on ohpm for this release, including `@lynx/primjs` 4.1.1, which has no 4.1.0, and `@lynx/xelement_svg` 4.1.0, replacing a 3.6.0 pin that is not on ohpm at all.

## Verification

The two files are byte-identical to main before the change, so the cherry-pick is clean. Registry checks and the build verification are recorded in #1463; the rendered values here are the same because both branches carry the same two version fields.

## Related Links

- #1463 — the same change on main
- #1438