### PR TITLE
fix: restrict Luna imports to the public entry point

### DIFF
--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -74,7 +74,7 @@ export default defineConfig({
         '@assets': path.join(__dirname, 'docs', 'public', 'assets'),
         '@lynx': path.join(__dirname, 'src', 'components'),
         '@lynx-ui': path.join(__dirname, 'src', 'lynx-ui', 'components'),
-        '@luna': path.join(__dirname, 'src', 'luna', 'index.ts'),
+        '@luna$': path.join(__dirname, 'src', 'luna', 'index.ts'),
       },
     },
     source: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,8 +24,7 @@
       "@docs/*": ["./sharedDocs/packageDocs/*"],
       "@assets/*": ["./docs/public/assets/*"],
       "@examples/*": ["./examples/examples_output/*"],
-      "@luna": ["./src/luna/index.ts"],
-      "@luna/*": ["./src/luna/*"]
+      "@luna": ["./src/luna/index.ts"]
     }
   },
   "include": ["docs", "theme", "rspress.config.ts", "global.d.ts", "src"],


### PR DESCRIPTION
## Summary

- Make `@luna` an exact-match Rspress alias.
- Remove the TypeScript `@luna/*` wildcard.

## Rationale

This is an intentional restriction. The public Luna documentation API is
the barrel at `src/luna/index.ts`; files such as `interaction.ts`,
`layout.ts`, and `luna-studio.tsx` remain implementation details.

The previous TypeScript wildcard advertised subpath imports that the
Rspress file alias did not reliably support.

All existing consumers already import the bare `@luna` entry point.
Downstream sites continue resolving that entry point to the same OSS
barrel, so no copied documentation, exported symbols, runtime behavior,
or downstream configuration changes are required.

## Verification

- Confirmed there are no existing `@luna/*` imports.
- Ran `pnpm run prepare`.
- Ran `pnpm run build`.
