### PR TITLE
test(ci): verify documentation import boundary guard

### DIFF
--- a/docs/en/guide/inclusion/foldable-devices.mdx
+++ b/docs/en/guide/inclusion/foldable-devices.mdx
@@ -2,7 +2,7 @@
 description: 'Sync dimensions through GlobalProps and screen metrics for low-effort foldable layouts.'
 ---
 
-import { FoldableRenderFlow } from '@lynx/foldable-render-flow';
+import { FoldableRenderFlow } from '../../../../src/components/foldable-render-flow';
 
 # Foldables
 


### PR DESCRIPTION
## TEST ONLY - DO NOT MERGE

This draft PR intentionally restores the relative `src/` import fixed by
#1460. It exists only to verify the CI guard added by #1461.

## Expected result

- `Documentation Imports` fails on
  `docs/en/guide/inclusion/foldable-devices.mdx:5`.
- The diagnostic resolves the import to
  `src/components/foldable-render-flow`.
- The diagnostic suggests `@lynx/foldable-render-flow`.
- The aggregate `Done` check fails because it depends on
  `Documentation Imports`.

## Local verification

`node scripts/ci/check-doc-import-boundaries.mjs` fails as expected with the
intended diagnostic.

This PR must be closed without merging after the expected CI behavior is
confirmed.