### PR TITLE
fix(cherry-pick): harden execution lifecycle

### DIFF
--- a/.github/ISSUE_TEMPLATE/cherry_pick_request.yml
+++ b/.github/ISSUE_TEMPLATE/cherry_pick_request.yml
@@ -1,8 +1,6 @@
 name: Cherry-pick request
-description: Request cherry-picks into release branches
+description: Request cherry-picks into release branches for maintainer triage
 title: '[Cherry-pick]: '
-labels:
-  - cherry-pick:request
 body:
   - type: input
     id: source_pr

--- a/.github/scripts/cherry-pick-request-recovery.mjs
+++ b/.github/scripts/cherry-pick-request-recovery.mjs
@@ -1,0 +1,162 @@
+const SUMMARY_MARKER = '<!-- cherry-pick-request-summary -->';
+const APPROVED_FINGERPRINT_MARKER = '<!-- cherry-pick-approved-fingerprint:';
+const APPROVED_LABEL = 'cherry-pick:approved';
+const FAILED_LABEL = 'cherry-pick:failed';
+const STATE_LABELS = [
+  'cherry-pick:pending-approval',
+  'cherry-pick:running',
+  'cherry-pick:pr-created',
+  'cherry-pick:partial',
+  FAILED_LABEL,
+  'cherry-pick:invalid',
+];
+
+export const RETRY_APPROVAL_INSTRUCTION =
+  'Ensure `cherry-pick:approved` is absent, then add it to retry.';
+
+/** Normalizes REST Issue labels into a set of names. */
+function labelsOf(issue) {
+  return new Set(
+    (issue.labels || []).map((label) =>
+      typeof label === 'string' ? label : label.name,
+    ),
+  );
+}
+
+/** Returns whether a comment belongs to a GitHub bot account. */
+function isBotActor(comment) {
+  return (
+    comment.user?.type === 'Bot' ||
+    String(comment.user?.login || '').endsWith('[bot]')
+  );
+}
+
+/** Identifies the interrupted phase represented by current Issue state. */
+export function recoveryState(labels, summaryBody) {
+  const names = new Set(labels);
+  const status = (
+    String(summaryBody || '').match(/^Status: \*\*(.+?)\*\*$/m)?.[1] || ''
+  ).toLowerCase();
+  if (names.has('cherry-pick:running') || status === 'running') {
+    return 'running';
+  }
+  if (
+    status === 'approved' &&
+    String(summaryBody || '').includes(APPROVED_FINGERPRINT_MARKER)
+  ) {
+    return 'approved';
+  }
+  return '';
+}
+
+/** Marks an existing summary failed while preserving its target details. */
+export function renderRecoveredSummary(body, completedAt) {
+  let summary = String(body || '');
+  const statusLine = 'Status: **Failed**';
+  const nextActionLine = `Next action: Fix the failure. ${RETRY_APPROVAL_INSTRUCTION}`;
+
+  if (/^Status: \*\*.+\*\*$/m.test(summary)) {
+    summary = summary.replace(/^Status: \*\*.+\*\*$/m, statusLine);
+  } else {
+    summary = summary.replace(
+      '## Cherry-pick request summary',
+      `## Cherry-pick request summary\n\n${statusLine}`,
+    );
+  }
+  if (/^Next action: .*$/m.test(summary)) {
+    summary = summary.replace(/^Next action: .*$/m, nextActionLine);
+  } else {
+    summary = summary.replace(statusLine, `${statusLine}\n${nextActionLine}`);
+  }
+
+  const completedLine = `- Completed at: ${completedAt}`;
+  if (/^- Completed at: .*$/m.test(summary)) {
+    summary = summary.replace(/^- Completed at: .*$/m, completedLine);
+  } else if (/^### (?:Reason|Targets)$/m.test(summary)) {
+    summary = summary.replace(
+      /^### (Reason|Targets)$/m,
+      `${completedLine}\n\n### $1`,
+    );
+  } else {
+    summary = `${summary.trimEnd()}\n\n${completedLine}`;
+  }
+
+  return `${summary.trimEnd()}\n`;
+}
+
+/** Removes one known-present label while treating a concurrent 404 as success. */
+async function removeLabel(github, issue, labels, name) {
+  if (!labels.has(name)) return;
+  try {
+    await github.rest.issues.removeLabel({ ...issue, name });
+  } catch (error) {
+    if (error.status !== 404) throw error;
+  }
+  labels.delete(name);
+}
+
+/**
+ * Recovers an interrupted request using only GitHub Issues APIs supplied by
+ * actions/github-script.
+ */
+export default async function recoverRequest({ github, context, core }) {
+  const issue = {
+    ...context.repo,
+    issue_number: context.issue.number,
+  };
+  const { data: currentIssue } = await github.rest.issues.get(issue);
+  const labels = labelsOf(currentIssue);
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    ...issue,
+    per_page: 100,
+  });
+  const summary = comments.find(
+    (comment) =>
+      isBotActor(comment) &&
+      String(comment.body || '').includes(SUMMARY_MARKER),
+  );
+  const summaryBody = String(summary?.body || '');
+  const previousState = recoveryState(labels, summaryBody);
+
+  if (!previousState) {
+    core.info('Request has no interrupted execution state to recover.');
+    return '';
+  }
+
+  await removeLabel(github, issue, labels, APPROVED_LABEL);
+  for (const label of STATE_LABELS) {
+    if (label !== FAILED_LABEL) {
+      await removeLabel(github, issue, labels, label);
+    }
+  }
+  if (!labels.has(FAILED_LABEL)) {
+    await github.rest.issues.addLabels({
+      ...issue,
+      labels: [FAILED_LABEL],
+    });
+  }
+
+  if (summary) {
+    await github.rest.issues.updateComment({
+      ...context.repo,
+      comment_id: summary.id,
+      body: renderRecoveredSummary(summaryBody, new Date().toISOString()),
+    });
+  }
+
+  await github.rest.issues.createComment({
+    ...issue,
+    body: [
+      'Cherry-pick execution did not finish successfully.',
+      '',
+      `The request was moved from ${previousState} to failed.`,
+      '',
+      'Next steps:',
+      '- Inspect the failed workflow run.',
+      `- ${RETRY_APPROVAL_INSTRUCTION}`,
+      '',
+      `Workflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+    ].join('\n'),
+  });
+  return previousState;
+}

--- a/.github/scripts/cherry-pick-request.mjs
+++ b/.github/scripts/cherry-pick-request.mjs
@@ -4,6 +4,11 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import process from 'node:process';
 import { spawnSync } from 'node:child_process';
+import {
+  RETRY_APPROVAL_INSTRUCTION,
+  recoveryState,
+  renderRecoveredSummary,
+} from './cherry-pick-request-recovery.mjs';
 
 const CONFIG_PATH = '.github/cherry-pick-config.json';
 const ISSUE_FORM_PATH = '.github/ISSUE_TEMPLATE/cherry_pick_request.yml';
@@ -471,6 +476,7 @@ async function findBotComment(repo, issueNumber, marker) {
   );
 }
 
+/** Reads approval audit metadata from a canonical summary comment. */
 function approvedSnapshotFromBody(body) {
   const fingerprintMatch = String(body || '').match(APPROVED_FINGERPRINT_RE);
   if (!fingerprintMatch) return null;
@@ -481,10 +487,12 @@ function approvedSnapshotFromBody(body) {
   };
 }
 
+/** Finds the canonical bot-owned summary for one request. */
 async function getSummaryComment(repo, issueNumber) {
   return findBotComment(repo, issueNumber, SUMMARY_MARKER);
 }
 
+/** Maps a summary status and validation errors to maintainer instructions. */
 function nextActionForStatus(status, errors = []) {
   const normalized = String(status || '').toLowerCase();
   const hasUnmergedSource = errors.some((error) =>
@@ -516,10 +524,10 @@ function nextActionForStatus(status, errors = []) {
     return 'Review and merge the generated cherry-pick PRs.';
   }
   if (normalized === 'partial') {
-    return 'Fix failed or blocked targets, then remove and re-add `cherry-pick:approved` to retry. Successful targets will be skipped.';
+    return 'Fix failed or blocked targets. Ensure `cherry-pick:approved` is absent, then add it to retry. Successful targets will be skipped.';
   }
   if (normalized === 'failed') {
-    return 'Fix the failure, then remove and re-add `cherry-pick:approved` to retry.';
+    return `Fix the failure. ${RETRY_APPROVAL_INSTRUCTION}`;
   }
   return '';
 }
@@ -572,6 +580,7 @@ function renderWorkflowRunLine() {
   return `Workflow run: ${workflowRunUrl()}`;
 }
 
+/** Renders the canonical request summary and its persisted audit metadata. */
 function renderSummary({
   requestIssue,
   sourcePr,
@@ -653,6 +662,7 @@ function renderSummary({
   return `${body.join('\n')}\n`;
 }
 
+/** Creates or replaces the canonical request summary. */
 async function upsertSummary(repo, issueNumber, summaryBody) {
   const existing = await getSummaryComment(repo, issueNumber);
   if (existing) return updateIssueComment(repo, existing.id, summaryBody);
@@ -732,7 +742,11 @@ function shouldNoopValidate(event, issue) {
     const label = event.label?.name;
     // A request label may arrive after the opened event was skipped. Initialize
     // only requests that have not already entered the cherry-pick state machine.
-    if (label === TYPE_LABEL && !hasManagedStateLabel(issue)) {
+    if (
+      label === TYPE_LABEL &&
+      !hasLabel(issue, APPROVED_LABEL) &&
+      !hasManagedStateLabel(issue)
+    ) {
       return '';
     }
     if (label !== APPROVED_LABEL) {
@@ -982,7 +996,7 @@ async function validateCommand() {
           '',
           'Next steps:',
           '- Wait for the running workflow to finish.',
-          '- If it fails or is interrupted, remove and re-add `cherry-pick:approved` to retry.',
+          '- If it fails or is interrupted, ensure `cherry-pick:approved` is absent, then add it to retry.',
           '',
           renderWorkflowRunLine(),
         ].join('\n'),
@@ -1186,7 +1200,7 @@ function renderFinalResultComment(finalState, workflowUrl) {
       'Next steps:',
       '- Check the summary table for each target result.',
       '- Fix blocked or failed targets manually if needed.',
-      `- To retry remaining work, remove and re-add \`${APPROVED_LABEL}\`.`,
+      `- Ensure \`${APPROVED_LABEL}\` is absent, then add it to retry remaining work.`,
       '- Already successful targets will be skipped by idempotency checks.',
       '',
       `Workflow run: ${workflowUrl}`,
@@ -1202,7 +1216,7 @@ function renderFinalResultComment(finalState, workflowUrl) {
     'Next steps:',
     '- Check the failure comments and summary table.',
     '- Fix the underlying issue.',
-    `- Remove and re-add \`${APPROVED_LABEL}\` to retry after the issue is resolved.`,
+    `- Ensure \`${APPROVED_LABEL}\` is absent, then add it to retry after the issue is resolved.`,
     '',
     `Workflow run: ${workflowUrl}`,
   ].join('\n');
@@ -1524,7 +1538,7 @@ async function executeCommand() {
             'Next steps:',
             '- Inspect the remote branch manually.',
             '- Delete or rename the stale branch if it is safe.',
-            `- Re-add \`${APPROVED_LABEL}\` to retry after cleanup.`,
+            `- Ensure \`${APPROVED_LABEL}\` is absent, then add it to retry after cleanup.`,
             '',
             renderWorkflowRunLine(),
           ].join('\n'),
@@ -1605,7 +1619,7 @@ async function executeCommand() {
             '',
             'Next steps:',
             '- Resolve this target manually, or prepare a manual cherry-pick PR.',
-            '- If there are remaining targets to retry after cleanup, remove and re-add `cherry-pick:approved`.',
+            '- If targets remain after cleanup, ensure `cherry-pick:approved` is absent, then add it to retry.',
             '- Already successful targets will be skipped by idempotency checks.',
             '',
             renderWorkflowRunLine(),
@@ -1695,7 +1709,7 @@ async function executeCommand() {
           '',
           'Next steps:',
           '- Open the workflow run and inspect the logs.',
-          `- If this was a transient GitHub API, rate limit, or runner issue, remove and re-add \`${APPROVED_LABEL}\` to retry.`,
+          `- If this was transient, ensure \`${APPROVED_LABEL}\` is absent, then add it to retry.`,
           '- Already successful targets will be skipped by idempotency checks.',
           '',
           renderWorkflowRunLine(),
@@ -1716,9 +1730,9 @@ async function executeCommand() {
         : 'cherry-pick:failed';
   const finalStatus = finalState.replace('cherry-pick:', '');
 
+  await updateExecutionSummary(repo, issue, context, targets, finalStatus);
   issue = await getCurrentIssue(repo, issueNumber);
   await setStateLabel(repo, issue, finalState);
-  await updateExecutionSummary(repo, issue, context, targets, finalStatus);
   await createIssueComment(
     repo,
     issueNumber,
@@ -1761,6 +1775,7 @@ function parseIssueFormTargets(content) {
   return targets;
 }
 
+/** Rejects duplicate configuration values. */
 function assertNoDuplicates(name, values) {
   const seen = new Set();
   const duplicates = [];
@@ -1773,6 +1788,7 @@ function assertNoDuplicates(name, values) {
   }
 }
 
+/** Verifies that config, form targets, and workflow labels stay synchronized. */
 function checkConfigCommand() {
   const config = loadConfig();
   const form = fs.readFileSync(ISSUE_FORM_PATH, 'utf8');
@@ -1785,12 +1801,17 @@ function checkConfigCommand() {
     );
   }
   const defaultLabels = parseYamlListAfterKey(form, 'labels');
-  if (!defaultLabels.includes(TYPE_LABEL)) {
-    throw new Error(`Issue Form must include default label ${TYPE_LABEL}.`);
-  }
-  if (defaultLabels.includes('cherry-pick:pending-approval')) {
+  const reservedDefaultLabels = new Set([
+    TYPE_LABEL,
+    APPROVED_LABEL,
+    ...STATE_LABELS,
+  ]);
+  const unexpectedDefaultLabels = defaultLabels.filter((label) =>
+    reservedDefaultLabels.has(label),
+  );
+  if (unexpectedDefaultLabels.length > 0) {
     throw new Error(
-      'Issue Form must not default to cherry-pick:pending-approval.',
+      `Issue Form must not assign reserved workflow labels before maintainer triage: ${unexpectedDefaultLabels.join(', ')}.`,
     );
   }
   const requiredUsedLabels = [
@@ -1807,12 +1828,14 @@ function checkConfigCommand() {
   console.log('Cherry-pick config check passed.');
 }
 
+/** Reads the value immediately following a named CLI option. */
 function getArgValue(args, name) {
   const index = args.indexOf(name);
   if (index < 0) return '';
   return args[index + 1] || '';
 }
 
+/** Parses one request body locally and prints its normalized representation. */
 function dryRunValidate(args) {
   const config = loadConfig();
   const bodyFile = getArgValue(args, '--body-file');
@@ -1834,10 +1857,67 @@ function dryRunValidate(args) {
   );
 }
 
+/** Keeps the legacy parse command as an alias for dry-run validation. */
 function parseCommand(args) {
   dryRunValidate(args);
 }
 
+/**
+ * Repairs an execution interrupted either before or after it entered the
+ * running state. Other validation failures remain no-ops because recovery
+ * requires a committed Approved summary or a Running state.
+ */
+async function recoverExecutionState(repo, issueNumber) {
+  const issue = await getCurrentIssue(repo, issueNumber);
+  const summary = await getSummaryComment(repo, issueNumber);
+  const summaryBody = String(summary?.body || '');
+  const previousState = recoveryState(labelsOf(issue), summaryBody);
+
+  if (!previousState) return '';
+
+  if (hasLabel(issue, APPROVED_LABEL)) {
+    await removeLabel(repo, issueNumber, APPROVED_LABEL);
+  }
+  await setStateLabel(repo, issue, 'cherry-pick:failed');
+  if (summary) {
+    await updateIssueComment(
+      repo,
+      summary.id,
+      renderRecoveredSummary(summaryBody, new Date().toISOString()),
+    );
+  }
+  return previousState;
+}
+
+/** Repairs state after a failed or timed-out execute job. */
+async function cleanupCommand() {
+  const repo = repoFromEnv();
+  const event = getEvent();
+  const issueNumber = event.issue?.number;
+  if (!issueNumber) throw new Error('Cleanup requires an issue event.');
+  const recoveredState = await recoverExecutionState(repo, issueNumber);
+  if (!recoveredState) {
+    console.log('Request has no interrupted execution state to recover.');
+    return;
+  }
+  await createIssueComment(
+    repo,
+    issueNumber,
+    [
+      'Cherry-pick execution did not finish successfully.',
+      '',
+      `The request was moved from ${recoveredState} to failed.`,
+      '',
+      'Next steps:',
+      '- Inspect the failed workflow run.',
+      `- Ensure \`${APPROVED_LABEL}\` is absent, then add it to retry after addressing the failure.`,
+      '',
+      renderWorkflowRunLine(),
+    ].join('\n'),
+  );
+}
+
+/** Dispatches the requested validation, execution, or maintenance command. */
 async function main() {
   const [command, ...args] = process.argv.slice(2);
   if (command === 'parse') {
@@ -1860,11 +1940,16 @@ async function main() {
     await executeCommand();
     return;
   }
+  if (command === 'cleanup') {
+    await cleanupCommand();
+    return;
+  }
   throw new Error(
-    'Usage: cherry-pick-request.mjs parse --body-file <file> | validate [--dry-run --body-file <file>] | check-config | execute',
+    'Usage: cherry-pick-request.mjs parse --body-file <file> | validate [--dry-run --body-file <file>] | check-config | execute | cleanup',
   );
 }
 
+/** Reports unexpected failures and repairs interrupted execution state. */
 async function commentWorkflowFailure(error) {
   if (!process.env.GITHUB_TOKEN || !process.env.GITHUB_EVENT_PATH) {
     return;
@@ -1874,6 +1959,16 @@ async function commentWorkflowFailure(error) {
     const event = getEvent();
     const issueNumber = event.issue?.number;
     if (!issueNumber) return;
+    let recoveredState = '';
+    if (process.argv[2] === 'execute') {
+      try {
+        recoveredState = await recoverExecutionState(repo, issueNumber);
+      } catch (recoveryError) {
+        console.error(
+          `Failed to recover cherry-pick execution state: ${recoveryError.message}`,
+        );
+      }
+    }
     await createIssueComment(
       repo,
       issueNumber,
@@ -1882,6 +1977,9 @@ async function commentWorkflowFailure(error) {
         '',
         truncate(error.message || String(error), 1000),
         '',
+        ...(recoveredState
+          ? [`The request was moved from ${recoveredState} to failed.`, '']
+          : []),
         `Workflow run: ${workflowRunUrl()}`,
       ].join('\n'),
     );

--- a/.github/scripts/cherry-pick-request.test.mjs
+++ b/.github/scripts/cherry-pick-request.test.mjs
@@ -14,6 +14,15 @@ const REPO_ROOT = fileURLToPath(new URL('../../', import.meta.url));
 const CONFIG_PATH = fileURLToPath(
   new URL('../cherry-pick-config.json', import.meta.url),
 );
+const ISSUE_FORM_PATH = fileURLToPath(
+  new URL('../ISSUE_TEMPLATE/cherry_pick_request.yml', import.meta.url),
+);
+const WORKFLOW_PATH = fileURLToPath(
+  new URL('../workflows/cherry-pick-request.yml', import.meta.url),
+);
+const RECOVERY_SCRIPT_PATH = fileURLToPath(
+  new URL('./cherry-pick-request-recovery.mjs', import.meta.url),
+);
 const TYPE_LABEL = 'cherry-pick:request';
 const STATE_LABELS = [
   'cherry-pick:pending-approval',
@@ -34,6 +43,7 @@ afterEach(async () => {
   );
 });
 
+/** Builds the canonical single-target request body used by workflow tests. */
 function requestBody() {
   return [
     '### Source PR',
@@ -54,6 +64,45 @@ function requestBody() {
   ].join('\n');
 }
 
+/** Builds a canonical summary at the requested execution phase. */
+function executionSummary(status) {
+  const nextAction =
+    status === 'Approved'
+      ? 'Waiting for workflow execution to start.'
+      : status === 'Running'
+        ? 'Wait for target results.'
+        : 'A maintainer must approve this request.';
+  return {
+    id: 1,
+    body: [
+      '<!-- cherry-pick-request-summary -->',
+      '<!-- cherry-pick-approved-fingerprint: bc2d6fddd07e8fad -->',
+      '<!-- cherry-pick-approved-by: maintainer -->',
+      '<!-- cherry-pick-approved-at: 2026-09-11T10:00:00.000Z -->',
+      '',
+      '## Cherry-pick request summary',
+      '',
+      `Status: **${status}**`,
+      `Next action: ${nextAction}`,
+      '',
+      '- Request issue: #1403',
+      '- Source PR: #1358',
+      '',
+      '### Reason',
+      '',
+      'Backport a low-risk documentation change.',
+      '',
+      '### Targets',
+      '',
+      '| Target branch | Result | Detail |',
+      '| --- | --- | --- |',
+      '| `release/4.0` | Pending | Waiting to run |',
+    ].join('\n'),
+    user: { login: 'github-actions[bot]', type: 'Bot' },
+  };
+}
+
+/** Starts a mock GitHub API server on an available local port. */
 async function listen(server) {
   await new Promise((resolve, reject) => {
     server.once('error', reject);
@@ -63,17 +112,210 @@ async function listen(server) {
   return `http://127.0.0.1:${address.port}`;
 }
 
+/** Parses a JSON request body, returning null when no body is present. */
 async function readRequestBody(request) {
   const chunks = [];
   for await (const chunk of request) chunks.push(chunk);
   return chunks.length > 0 ? JSON.parse(Buffer.concat(chunks)) : null;
 }
 
+/** Sends one JSON response from the mock GitHub API. */
 function sendJson(response, value, statusCode = 200) {
   response.writeHead(statusCode, { 'content-type': 'application/json' });
   response.end(JSON.stringify(value));
 }
 
+/** Runs a recovery command against a stateful mock GitHub Issue. */
+async function runRecovery(stateLabels, status, command = 'cleanup') {
+  const issue = {
+    number: 1403,
+    state: 'open',
+    labels: [TYPE_LABEL, ...stateLabels].map((name) => ({ name })),
+    user: { login: 'external-contributor' },
+    body: requestBody(),
+  };
+  const comments = [executionSummary(status)];
+  const requests = [];
+
+  const server = http.createServer(async (request, response) => {
+    const url = new URL(request.url, 'http://localhost');
+    const body = await readRequestBody(request);
+    requests.push({ method: request.method, path: url.pathname, body });
+
+    if (
+      request.method === 'GET' &&
+      url.pathname === '/repos/lynx-family/lynx-website/issues/1403'
+    ) {
+      sendJson(response, issue);
+      return;
+    }
+    if (
+      request.method === 'GET' &&
+      url.pathname === '/repos/lynx-family/lynx-website/issues/1403/comments'
+    ) {
+      sendJson(response, comments);
+      return;
+    }
+    if (
+      request.method === 'DELETE' &&
+      url.pathname.startsWith(
+        '/repos/lynx-family/lynx-website/issues/1403/labels/',
+      )
+    ) {
+      const label = decodeURIComponent(url.pathname.split('/').at(-1));
+      issue.labels = issue.labels.filter((item) => item.name !== label);
+      response.writeHead(204);
+      response.end();
+      return;
+    }
+    if (
+      request.method === 'POST' &&
+      url.pathname === '/repos/lynx-family/lynx-website/issues/1403/labels'
+    ) {
+      for (const name of body.labels) {
+        if (!issue.labels.some((label) => label.name === name)) {
+          issue.labels.push({ name });
+        }
+      }
+      sendJson(response, issue.labels);
+      return;
+    }
+    if (
+      request.method === 'PATCH' &&
+      url.pathname === '/repos/lynx-family/lynx-website/issues/comments/1'
+    ) {
+      comments[0].body = body.body;
+      sendJson(response, comments[0]);
+      return;
+    }
+    if (
+      request.method === 'POST' &&
+      url.pathname === '/repos/lynx-family/lynx-website/issues/1403/comments'
+    ) {
+      const comment = {
+        id: comments.length + 1,
+        body: body.body,
+        user: { login: 'github-actions[bot]', type: 'Bot' },
+      };
+      comments.push(comment);
+      sendJson(response, comment, 201);
+      return;
+    }
+
+    sendJson(response, { message: 'Not Found' }, 404);
+  });
+
+  const apiUrl = await listen(server);
+  try {
+    const temporaryDirectory = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'cherry-pick-request-cleanup-test-'),
+    );
+    temporaryDirectories.push(temporaryDirectory);
+    const eventPath = path.join(temporaryDirectory, 'event.json');
+    await fs.writeFile(
+      eventPath,
+      JSON.stringify({
+        action: 'labeled',
+        issue,
+        label: { name: 'cherry-pick:approved' },
+        repository: { full_name: 'lynx-family/lynx-website' },
+        sender: { login: 'maintainer' },
+      }),
+    );
+
+    const result = await new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, [SCRIPT_PATH, command], {
+        cwd: REPO_ROOT,
+        env: {
+          ...process.env,
+          GITHUB_API_URL: apiUrl,
+          GITHUB_EVENT_PATH: eventPath,
+          GITHUB_REPOSITORY: 'lynx-family/lynx-website',
+          GITHUB_RUN_ID: '124',
+          GITHUB_SERVER_URL: 'https://github.com',
+          GITHUB_TOKEN: 'test-token',
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.setEncoding('utf8');
+      child.stderr.setEncoding('utf8');
+      child.stdout.on('data', (chunk) => {
+        stdout += chunk;
+      });
+      child.stderr.on('data', (chunk) => {
+        stderr += chunk;
+      });
+      child.once('error', reject);
+      child.once('close', (code) => resolve({ code, stdout, stderr }));
+    });
+
+    return { ...result, comments, issue, requests };
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+/** Extracts the API-only bootstrap from the recovery workflow step. */
+function recoveryWorkflowScript(workflow) {
+  const marker = '          script: |\n';
+  const start = workflow.indexOf(marker);
+  assert.notEqual(start, -1, 'Recovery workflow script is missing.');
+  const scriptLines = [];
+  for (const line of workflow.slice(start + marker.length).split('\n')) {
+    if (line && !line.startsWith('            ')) break;
+    scriptLines.push(line.slice(12));
+  }
+  return scriptLines.join('\n');
+}
+
+/** Runs the config check with controlled Issue Form default labels. */
+async function runConfigCheck(defaultLabels) {
+  const directory = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'cherry-pick-config-test-'),
+  );
+  temporaryDirectories.push(directory);
+  const configDirectory = path.join(directory, '.github');
+  const formDirectory = path.join(configDirectory, 'ISSUE_TEMPLATE');
+  await fs.mkdir(formDirectory, { recursive: true });
+  await fs.copyFile(
+    CONFIG_PATH,
+    path.join(configDirectory, 'cherry-pick-config.json'),
+  );
+  const form = await fs.readFile(ISSUE_FORM_PATH, 'utf8');
+  const labelBlock = [
+    'labels:',
+    ...defaultLabels.map((label) => `  - '${label}'`),
+    '',
+  ].join('\n');
+  await fs.writeFile(
+    path.join(formDirectory, 'cherry_pick_request.yml'),
+    form.replace(/^body:/m, `${labelBlock}body:`),
+  );
+
+  const child = spawn(process.execPath, [SCRIPT_PATH, 'check-config'], {
+    cwd: directory,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let stdout = '';
+  let stderr = '';
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  child.stdout.on('data', (chunk) => {
+    stdout += chunk;
+  });
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk;
+  });
+  return new Promise((resolve) => {
+    child.once('close', (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+/** Runs request validation against a minimal mock GitHub API. */
 async function runValidation(stateLabels = []) {
   const config = JSON.parse(await fs.readFile(CONFIG_PATH, 'utf8'));
   const issue = {
@@ -258,9 +500,9 @@ describe('cherry-pick request label initialization', () => {
     );
   });
 
-  for (const stateLabel of STATE_LABELS) {
-    it(`ignores a duplicate type-label event when ${stateLabel} exists`, async () => {
-      const result = await runValidation([stateLabel]);
+  for (const lifecycleLabel of ['cherry-pick:approved', ...STATE_LABELS]) {
+    it(`ignores a duplicate type-label event when ${lifecycleLabel} exists`, async () => {
+      const result = await runValidation([lifecycleLabel]);
 
       assert.equal(result.code, 0, result.stderr);
       assert.match(
@@ -273,4 +515,226 @@ describe('cherry-pick request label initialization', () => {
       );
     });
   }
+});
+
+describe('cherry-pick request config validation', () => {
+  it('rejects every reserved default label', async () => {
+    const lifecycleLabels = [
+      TYPE_LABEL,
+      'cherry-pick:approved',
+      ...STATE_LABELS,
+    ];
+    const result = await runConfigCheck(lifecycleLabels);
+
+    assert.equal(result.code, 1);
+    assert.match(
+      result.stderr,
+      /must not assign reserved workflow labels before maintainer triage/,
+    );
+    for (const lifecycleLabel of lifecycleLabels) {
+      assert.match(result.stderr, new RegExp(lifecycleLabel));
+    }
+  });
+
+  it('accepts a non-workflow default label', async () => {
+    const result = await runConfigCheck(['bug']);
+
+    assert.equal(result.code, 0, result.stderr);
+    assert.match(result.stdout, /Cherry-pick config check passed/);
+  });
+});
+
+describe('cherry-pick request execution recovery', () => {
+  for (const scenario of [
+    {
+      name: 'approved execution before the running state',
+      status: 'Approved',
+      stateLabels: ['cherry-pick:pending-approval', 'cherry-pick:approved'],
+      recoveredState: 'approved',
+    },
+    {
+      name: 'orphaned running execution',
+      status: 'Running',
+      stateLabels: ['cherry-pick:running'],
+      recoveredState: 'running',
+    },
+    {
+      name: 'terminal transition with a stale running summary',
+      status: 'Running',
+      stateLabels: ['cherry-pick:partial'],
+      recoveredState: 'running',
+    },
+  ]) {
+    it(`recovers ${scenario.name}`, async () => {
+      const result = await runRecovery(scenario.stateLabels, scenario.status);
+
+      assert.equal(result.code, 0, result.stderr);
+      assert.deepEqual(
+        result.issue.labels.map((label) => label.name).sort(),
+        [TYPE_LABEL, 'cherry-pick:failed'].sort(),
+      );
+      const summary = result.comments.find((comment) =>
+        comment.body.includes('<!-- cherry-pick-request-summary -->'),
+      );
+      assert.match(summary.body, /Status: \*\*Failed\*\*/);
+      assert.match(
+        summary.body,
+        /Next action: Fix the failure\. Ensure `cherry-pick:approved` is absent, then add it to retry\./,
+      );
+      assert.match(summary.body, /^- Completed at: .+$/m);
+      assert.ok(
+        result.comments.some((comment) =>
+          comment.body.includes(
+            `moved from ${scenario.recoveredState} to failed`,
+          ),
+        ),
+      );
+    });
+  }
+
+  it('recovers an approved request when execution fails before running', async () => {
+    const result = await runRecovery(
+      ['cherry-pick:pending-approval', 'cherry-pick:approved'],
+      'Approved',
+      'execute',
+    );
+
+    assert.equal(result.code, 1);
+    assert.deepEqual(
+      result.issue.labels.map((label) => label.name).sort(),
+      [TYPE_LABEL, 'cherry-pick:failed'].sort(),
+    );
+    const summary = result.comments.find((comment) =>
+      comment.body.includes('<!-- cherry-pick-request-summary -->'),
+    );
+    assert.match(summary.body, /Status: \*\*Failed\*\*/);
+    assert.ok(
+      result.comments.some(
+        (comment) =>
+          comment.body.includes(
+            'Cherry-pick workflow encountered an unexpected error',
+          ) && comment.body.includes('moved from approved to failed'),
+      ),
+    );
+  });
+
+  it('does not recover a request without an interrupted execution', async () => {
+    const result = await runRecovery(
+      ['cherry-pick:pending-approval'],
+      'Pending approval',
+    );
+
+    assert.equal(result.code, 0, result.stderr);
+    assert.deepEqual(
+      result.issue.labels.map((label) => label.name).sort(),
+      [TYPE_LABEL, 'cherry-pick:pending-approval'].sort(),
+    );
+    assert.match(result.stdout, /no interrupted execution state to recover/i);
+    assert.equal(
+      result.requests.some((request) => request.method !== 'GET'),
+      false,
+    );
+  });
+});
+
+describe('cherry-pick request recovery workflow', () => {
+  it('runs API-only recovery for validation and execution failures', async () => {
+    const workflow = await fs.readFile(WORKFLOW_PATH, 'utf8');
+    const cleanupJob = workflow.split('\n  cleanup:\n')[1];
+
+    assert.ok(cleanupJob);
+    assert.match(cleanupJob, /needs\.validate\.result != 'success'/);
+    assert.match(cleanupJob, /needs\.validate\.result != 'skipped'/);
+    assert.match(cleanupJob, /needs\.execute\.result != 'success'/);
+    assert.match(cleanupJob, /actions\/github-script@/);
+    assert.match(cleanupJob, /github\.rest\.repos\.getContent/);
+    assert.match(cleanupJob, /cherry-pick-request-recovery\.mjs/);
+    assert.doesNotMatch(cleanupJob, /actions\/checkout@/);
+    assert.doesNotMatch(cleanupJob, /actions\/setup-node@/);
+  });
+
+  it('executes API-only recovery for an approved request', async () => {
+    const workflow = await fs.readFile(WORKFLOW_PATH, 'utf8');
+    const script = recoveryWorkflowScript(workflow);
+    const recoverySource = await fs.readFile(RECOVERY_SCRIPT_PATH, 'utf8');
+    const issue = {
+      labels: [
+        TYPE_LABEL,
+        'cherry-pick:pending-approval',
+        'cherry-pick:approved',
+      ].map((name) => ({ name })),
+    };
+    const comments = [executionSummary('Approved')];
+    const createdComments = [];
+    const issues = {
+      get: async () => ({ data: issue }),
+      listComments: async () => ({ data: comments }),
+      removeLabel: async ({ name }) => {
+        issue.labels = issue.labels.filter((label) => label.name !== name);
+      },
+      addLabels: async ({ labels }) => {
+        for (const name of labels) issue.labels.push({ name });
+      },
+      updateComment: async ({ comment_id, body }) => {
+        comments.find((comment) => comment.id === comment_id).body = body;
+      },
+      createComment: async ({ body }) => {
+        createdComments.push(body);
+      },
+    };
+    const github = {
+      rest: {
+        issues,
+        repos: {
+          getContent: async ({ owner, repo, path, ref }) => {
+            assert.deepEqual(
+              { owner, repo, path, ref },
+              {
+                owner: 'lynx-family',
+                repo: 'lynx-website',
+                path: '.github/scripts/cherry-pick-request-recovery.mjs',
+                ref: 'abc123',
+              },
+            );
+            return {
+              data: {
+                type: 'file',
+                encoding: 'base64',
+                content: Buffer.from(recoverySource).toString('base64'),
+              },
+            };
+          },
+        },
+      },
+      paginate: async () => comments,
+    };
+    const context = {
+      issue: { number: 1403 },
+      repo: { owner: 'lynx-family', repo: 'lynx-website' },
+      runId: 125,
+      serverUrl: 'https://github.com',
+      sha: 'abc123',
+    };
+    const core = { info() {} };
+    const AsyncFunction = Object.getPrototypeOf(
+      async function () {},
+    ).constructor;
+
+    await new AsyncFunction('github', 'context', 'core', script)(
+      github,
+      context,
+      core,
+    );
+
+    assert.deepEqual(
+      issue.labels.map((label) => label.name).sort(),
+      [TYPE_LABEL, 'cherry-pick:failed'].sort(),
+    );
+    assert.match(comments[0].body, /Status: \*\*Failed\*\*/);
+    assert.ok(
+      createdComments.some((comment) =>
+        comment.includes('moved from approved to failed'),
+      ),
+    );
+  });
 });

--- a/.github/workflows/cherry-pick-request.yml
+++ b/.github/workflows/cherry-pick-request.yml
@@ -2,7 +2,7 @@ name: Cherry-pick Request
 
 on:
   issues:
-    types: [opened, edited, reopened, labeled, unlabeled, closed]
+    types: [edited, reopened, labeled, unlabeled, closed]
 
 permissions:
   contents: read
@@ -15,8 +15,10 @@ concurrency:
 
 jobs:
   validate:
+    name: Validate Request
     if: ${{ contains(github.event.issue.labels.*.name, 'cherry-pick:request') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: read
@@ -40,9 +42,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   execute:
+    name: Execute Cherry-picks
     needs: validate
     if: ${{ needs.validate.outputs.should_execute == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
       pull-requests: write
@@ -60,3 +64,58 @@ jobs:
       - run: node .github/scripts/cherry-pick-request.mjs execute
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  cleanup:
+    name: Recover Failed Execution
+    needs: [validate, execute]
+    if: >-
+      ${{
+        always() &&
+        (
+          (
+            needs.validate.result != 'success' &&
+            needs.validate.result != 'skipped'
+          ) ||
+          (
+            needs.validate.outputs.should_execute == 'true' &&
+            needs.execute.result != 'success'
+          )
+        )
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Recover Request State
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const path =
+              '.github/scripts/cherry-pick-request-recovery.mjs';
+            const { owner, repo } = context.repo;
+            const { data: file } = await github.rest.repos.getContent({
+              owner,
+              repo,
+              path,
+              ref: context.sha,
+            });
+            if (
+              Array.isArray(file) ||
+              file.type !== 'file' ||
+              file.encoding !== 'base64' ||
+              !file.content
+            ) {
+              throw new Error(`Unable to load ${path} at ${context.sha}.`);
+            }
+            const source = file.content.replace(/\s/g, '');
+            const recoveryModule = await import(
+              `data:text/javascript;base64,${source}`
+            );
+            await recoveryModule.default({
+              github,
+              context,
+              core,
+            });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -271,8 +271,10 @@ To request a release cherry-pick:
 2. Enter the merged source pull request.
 3. Select one or more target release branches.
 4. Explain why the change is needed and choose a risk level.
-5. Wait for validation to mark the request as pending approval.
-6. A user with write, maintain, or admin permission must add the
+5. Wait for a maintainer to triage the request by adding
+   `cherry-pick:request`. Automation does not run before this label is added.
+6. Wait for validation to mark the request as pending approval.
+7. A user with write, maintain, or admin permission must add the
    `cherry-pick:approved` label to start execution.
 
 The workflow creates pull requests only. Generated cherry-pick pull requests
@@ -280,8 +282,12 @@ still require the normal review, required checks, CODEOWNERS, and branch
 protection process.
 
 If a target conflicts or fails, fix the issue manually or update the request,
-then remove and re-add `cherry-pick:approved` to retry. Targets that already
-produced a valid generated pull request are skipped on retry.
+ensure `cherry-pick:approved` is absent, then add it to retry. Targets that
+already produced a valid generated pull request are skipped on retry.
+
+If validation or execution is interrupted after approval, the recovery job
+removes the approval label and moves the request to `cherry-pick:failed`. Inspect
+the failed workflow run before approving the request again.
 
 ### Configuration
 


### PR DESCRIPTION
## Summary

- Require a user with repository triage access or greater to admit a
  Cherry-pick request into automation.
- Reject reserved lifecycle labels from Issue Form defaults and fail closed when
  a request-label event finds pre-existing approval or state labels.
- Add explicit timeouts and readable names to validation, execution, and
  recovery jobs.
- Run recovery for failed or cancelled validation and execution jobs.
- Use an API-only recovery path independent of checkout and Node.js setup.
- Keep the state label, approval trigger, canonical summary, and retry guidance
  consistent after interruption.

## Rationale

The Issue Form previously applied `cherry-pick:request` immediately, allowing
Issue creation to start automation before repository triage. Any reserved
lifecycle default can also leave the request initialized or pre-approved without
the corresponding label event.

After validation records an approved request, later API calls, checkout, Node.js
setup, or execution can fail. Recovery must therefore handle both committed
**Approved** summaries and orphaned **Running** states without depending on the
same checkout/setup path that may have failed.

The recovery job loads a dedicated module from the exact workflow commit and
uses the GitHub API directly. It removes stale approval and state labels, marks
the canonical summary failed, and leaves one consistent retry instruction:
ensure `cherry-pick:approved` is absent, then add it. Terminal execution writes
its summary before changing the state label, keeping any intermediate failure
recoverable.

## Scope

This is the **Execution lifecycle hardening** part of #1476.

Approval webhook authorization and queued approval-event handling remain in the
separate **Approval event authorization** follow-up. Editing completed requests,
source immutability, and generated PR reuse remain in #1470 and #1472.

## Release Behavior

New Cherry-pick requests remain inert until a user with repository triage access
or greater adds `cherry-pick:request`. Execution still requires a separate
`cherry-pick:approved` event from a user with write, maintain, or admin
permission. Failed or timed-out validation and execution jobs recover the Issue
state and summary when approval was already committed.

## Verification

- `node --test .github/scripts/cherry-pick-request.test.mjs` (17 passed)
- `node .github/scripts/cherry-pick-request.mjs check-config`
- `pnpm run format:check`
- `pnpm exec cspell` on changed files
- `actionlint .github/workflows/cherry-pick-request.yml`
- `pnpm run build`

Refs #1476
